### PR TITLE
feat(document-model-libs): remove wrapped editor to prevent loss of state

### DIFF
--- a/packages/document-model-libs/editors/rwa/rwa.stories.tsx
+++ b/packages/document-model-libs/editors/rwa/rwa.stories.tsx
@@ -1,11 +1,23 @@
-import { createDocumentStory } from 'document-model-libs/utils';
-import { reducer, utils } from '../../document-models/real-world-assets';
+import {
+    createDocumentStory,
+    EditorStoryComponent,
+} from 'document-model-libs/utils';
+import {
+    RealWorldAssetsAction,
+    RealWorldAssetsLocalState,
+    RealWorldAssetsState,
+    reducer,
+    utils,
+} from '../../document-models/real-world-assets';
 import { initialState } from '../../document-models/real-world-assets/mock-data/initial-state';
 import Editor from './editor';
 
-const { meta, CreateDocumentStory } = createDocumentStory(
-    // @ts-expect-error todo update type
-    Editor,
+const { meta, CreateDocumentStory: RealWorldAssets } = createDocumentStory(
+    Editor as EditorStoryComponent<
+        RealWorldAssetsState,
+        RealWorldAssetsAction,
+        RealWorldAssetsLocalState
+    >,
     reducer,
     utils.createExtendedState({
         state: {
@@ -13,23 +25,15 @@ const { meta, CreateDocumentStory } = createDocumentStory(
             local: {},
         },
     }),
+    {
+        isAllowedToCreateDocuments: true,
+        isAllowedToEditDocuments: true,
+    },
 );
 
 export default {
     ...meta,
     title: 'Real World Assets',
-    argTypes: {
-        ...meta.argTypes,
-        onExport: { control: { type: 'action' } },
-        onClose: { control: { type: 'action' } },
-    },
 };
 
-export const DocumentModel = {
-    ...CreateDocumentStory,
-    args: {
-        ...CreateDocumentStory.args,
-        isAllowedToCreateDocuments: true,
-        isAllowedToEditDocuments: true,
-    },
-};
+export { RealWorldAssets };

--- a/packages/document-model-libs/editors/utils/storybook/document-story.tsx
+++ b/packages/document-model-libs/editors/utils/storybook/document-story.tsx
@@ -115,12 +115,10 @@ export function createDocumentStory<S, A extends Action, L = unknown>(
 
             return (
                 <Editor
-                    context={args.context}
+                    {...args}
                     dispatch={dispatch}
                     document={document}
                     error={error}
-                    isAllowedToCreateDocuments
-                    isAllowedToEditDocuments
                 />
             );
         },


### PR DESCRIPTION
Dynamically creating the editor component we use in the story like this:

`const WrappedEditor = wrapEditor(Editor);`

Causes the story to destroy and rebuild the component every time the args change. This makes the component state reset when actions are dispatched, causing the storybook behavior not match the behavior in connect.

We can remove this function and achieve the same result by updating the definition of the editor component story type and the args we pass to it.

There was also an existing type error for the RWA editor because it needed other custom args. I have updated the createDocumentStory function to allow passing these other args. I have defined them as specific types because these are likely to be used by other editors.

