### PR TITLE
feat(document-model-libs): add initial state editor

### DIFF
--- a/packages/document-model-libs/editors/document-model-2/components/index.ts
+++ b/packages/document-model-libs/editors/document-model-2/components/index.ts
@@ -3,3 +3,4 @@ export * from "./label";
 export * from "./graphql-editor";
 export * from "./module-form";
 export * from "./input";
+export * from "./json-editor";

--- a/packages/document-model-libs/editors/document-model-2/components/model-metadata-form.tsx
+++ b/packages/document-model-libs/editors/document-model-2/components/model-metadata-form.tsx
@@ -2,7 +2,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { AuthorSchema } from "../schemas";
-import { getDifferences, getDocumentMetadata } from "../utils";
 import {
   Form,
   FormField,
@@ -13,63 +12,36 @@ import {
   FormMessage,
 } from "./form";
 import { Input } from "./input";
-import { DocumentActionHandlers, DocumentModelDocument } from "../types";
 
 export const MetadataFormSchema = z.object({
   name: z.string().min(1),
   extension: z.string().min(1),
   documentType: z.string().min(1),
-  description: z.string(),
-  author: AuthorSchema,
+  description: z.string().optional(),
+  author: AuthorSchema.optional(),
 });
 
-type MetadataFormValues = z.infer<typeof MetadataFormSchema>;
+export type MetadataFormValues = z.infer<typeof MetadataFormSchema>;
 
 type Props = {
-  document: DocumentModelDocument;
-  handlers: DocumentActionHandlers;
+  name: string;
+  documentType: string;
+  extension: string;
+  onSubmit: (values: MetadataFormValues) => void;
 };
 export function ModelMetadataForm(props: Props) {
-  const { document, handlers } = props;
-  const defaultValues = getDocumentMetadata(document);
+  const { name, documentType, extension, onSubmit } = props;
 
   const form = useForm<MetadataFormValues>({
     resolver: zodResolver(MetadataFormSchema),
-    defaultValues,
+    defaultValues: {
+      name: name || "",
+      documentType: documentType || "",
+      extension: extension || "",
+    },
   });
 
-  const { control, reset, handleSubmit } = form;
-
-  function onSubmit(values: MetadataFormValues) {
-    const diff = getDifferences(getDocumentMetadata(document), values);
-
-    const { name, documentType, description, extension, author } = diff;
-
-    if (name) {
-      handlers.setModelName(name);
-    }
-
-    if (documentType) {
-      handlers.setModelId(documentType);
-    }
-
-    if (description) {
-      handlers.setModuleDescription(description);
-    }
-
-    if (extension) {
-      handlers.setModelExtension(extension);
-    }
-
-    if (author?.name) {
-      handlers.setAuthorName(author.name);
-    }
-
-    if (author?.website) {
-      handlers.setAuthorWebsite(author.website);
-    }
-    reset();
-  }
+  const { control, handleSubmit } = form;
 
   return (
     <Form {...form}>
@@ -174,7 +146,7 @@ export function ModelMetadataForm(props: Props) {
           )}
         />
         <button
-          className="w-full rounded-lg border border-gray-500 bg-white px-5 py-1 text-gray-900 mb-4"
+          className="mb-4 w-full rounded-lg border border-gray-500 bg-white px-5 py-1 text-gray-900"
           type="submit"
         >
           Submit

--- a/packages/document-model-libs/editors/document-model-2/components/module-form.tsx
+++ b/packages/document-model-libs/editors/document-model-2/components/module-form.tsx
@@ -4,16 +4,9 @@ import { toLowercaseSnakeCase } from "../schemas";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "./form";
+import { Form, FormControl, FormField, FormItem, FormMessage } from "./form";
 import { Input } from "./input";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 
 const ModuleFormSchema = z.object({
   name: z.string(),
@@ -29,18 +22,9 @@ export function ModuleForm(props: Props) {
   const form = useForm<z.infer<typeof ModuleFormSchema>>({
     resolver: zodResolver(ModuleFormSchema),
     defaultValues: {
-      name: module?.name ? module.name : "",
+      name: module?.name ?? "",
     },
   });
-
-  // Update the form's default values when the module prop changes or for the new form with no module
-  useEffect(() => {
-    if (module) {
-      form.reset({ name: module.name }); // reset to module name if editing
-    } else {
-      form.reset({ name: "" }); // reset to empty string for new form
-    }
-  }, [module, form]);
 
   function onSubmit(values: z.infer<typeof ModuleFormSchema>) {
     const name = toLowercaseSnakeCase(values.name);
@@ -63,7 +47,7 @@ export function ModuleForm(props: Props) {
 
   return (
     <Form {...form}>
-      <form className="max-w-screen-sm">
+      <form className="w-1/2">
         <FormField
           control={form.control}
           name="name"
@@ -75,6 +59,12 @@ export function ModuleForm(props: Props) {
                   placeholder="Add module"
                   {...field}
                   onBlur={handleBlur}
+                  onKeyDown={(e) => {
+                    e.preventDefault();
+                    if (e.key === "Enter") {
+                      form.handleSubmit(onSubmit)();
+                    }
+                  }}
                 />
               </FormControl>
               <FormMessage />

--- a/packages/document-model-libs/editors/document-model-2/components/operation-form.tsx
+++ b/packages/document-model-libs/editors/document-model-2/components/operation-form.tsx
@@ -6,7 +6,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Form, FormControl, FormField, FormItem, FormMessage } from "./form";
 import { Input } from "./input";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 
 const OperationFormSchema = z.object({
   name: z.string(),
@@ -26,15 +26,6 @@ export function OperationForm(props: Props) {
       name: operation?.name ?? "",
     },
   });
-
-  // Update the form's default values when the operation prop changes or for the new form with no operation
-  useEffect(() => {
-    if (operation) {
-      form.reset({ name: operation.name ?? "" }); // reset to operation name if editing
-    } else {
-      form.reset({ name: "" }); // reset to empty string for new form
-    }
-  }, [operation, form]);
 
   function onSubmit(values: z.infer<typeof OperationFormSchema>) {
     const name = toConstantCase(values.name);
@@ -57,7 +48,7 @@ export function OperationForm(props: Props) {
 
   return (
     <Form {...form}>
-      <form className="max-w-screen-sm">
+      <form className="w-1/2">
         <FormField
           control={form.control}
           name="name"
@@ -69,6 +60,12 @@ export function OperationForm(props: Props) {
                   placeholder="Add operation"
                   {...field}
                   onBlur={handleBlur}
+                  onKeyDown={(e) => {
+                    e.preventDefault();
+                    if (e.key === "Enter") {
+                      form.handleSubmit(onSubmit)();
+                    }
+                  }}
                 />
               </FormControl>
               <FormMessage />

--- a/packages/document-model-libs/editors/document-model-2/constants/documents.ts
+++ b/packages/document-model-libs/editors/document-model-2/constants/documents.ts
@@ -1,4 +1,5 @@
 import { GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
+import { typeDefs } from "@powerhousedao/scalars";
 
 export const initialStateDoc = `type State {
   examples: [String!]!
@@ -10,7 +11,9 @@ export const initialLocalStateDoc = `type LocalState {
 
 export const hiddenQueryTypeDefDoc = `type Query {
   _hidden: String
-}`;
+}
+${typeDefs.join("\n")}
+`;
 
 export const query = new GraphQLObjectType({
   name: "Query",

--- a/packages/document-model-libs/editors/document-model-2/constants/documents.ts
+++ b/packages/document-model-libs/editors/document-model-2/constants/documents.ts
@@ -1,14 +1,6 @@
 import { GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
 import { typeDefs } from "@powerhousedao/scalars";
 
-export const initialStateDoc = `type State {
-  examples: [String!]!
-}`;
-
-export const initialLocalStateDoc = `type LocalState {
-  localExamples: [String!]!
-}`;
-
 export const hiddenQueryTypeDefDoc = `type Query {
   _hidden: String
 }
@@ -27,8 +19,3 @@ export const query = new GraphQLObjectType({
 export const initialSchema = new GraphQLSchema({
   query,
 });
-
-export const STATE_DOC_ID = "STATE_DOC_ID";
-export const LOCAL_STATE_DOC_ID = "LOCAL_STATE_DOC_ID";
-export const STANDARD_LIB_DOC_ID = "STANDARD_LIB_DOC_ID";
-export const HIDDEN_QUERY_TYPE_DEF_DOC_ID = "HIDDEN_QUERY_TYPE_DEF_DOC_ID";

--- a/packages/document-model-libs/editors/document-model-2/document-model-2.stories.tsx
+++ b/packages/document-model-libs/editors/document-model-2/document-model-2.stories.tsx
@@ -2,9 +2,178 @@ import { reducer, utils } from "document-model/document-model";
 import Editor from "./editor";
 import { createDocumentStory } from "document-model-libs/utils";
 
+const mockDocument = {
+  name: "test",
+  documentType: "powerhouse/document-model",
+  revision: {
+    global: 3,
+    local: 0,
+  },
+  created: "2024-10-28T09:33:47.282Z",
+  lastModified: "2021-03-10T08:00:00.000Z",
+  attachments: {},
+  state: {
+    global: {
+      id: "",
+      name: "test",
+      extension: ".test.ph",
+      description: "",
+      author: {
+        name: "",
+        website: "",
+      },
+      specifications: [
+        {
+          version: 1,
+          changeLog: [],
+          state: {
+            global: {
+              schema: "",
+              initialValue: "",
+              examples: [],
+            },
+            local: {
+              schema: "",
+              initialValue: "",
+              examples: [],
+            },
+          },
+          modules: [],
+        },
+      ],
+    },
+    local: {},
+  },
+  initialState: {
+    name: "",
+    documentType: "powerhouse/document-model",
+    revision: {
+      global: 0,
+      local: 0,
+    },
+    created: "2024-10-28T09:33:47.282Z",
+    lastModified: "2024-10-28T09:33:47.282Z",
+    attachments: {},
+    state: {
+      global: {
+        id: "",
+        name: "",
+        extension: "",
+        description: "",
+        author: {
+          name: "",
+          website: "",
+        },
+        specifications: [
+          {
+            version: 1,
+            changeLog: [],
+            state: {
+              global: {
+                schema: "",
+                initialValue: "",
+                examples: [],
+              },
+              local: {
+                schema: "",
+                initialValue: "",
+                examples: [],
+              },
+            },
+            modules: [],
+          },
+        ],
+      },
+      local: {},
+    },
+  },
+  operations: {
+    global: [
+      {
+        type: "SET_MODEL_NAME",
+        input: {
+          name: "test",
+        },
+        scope: "global",
+        context: {
+          signer: {
+            user: {
+              address: "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+              networkId: "eip155",
+              chainId: 1,
+            },
+            app: {
+              name: "storybook",
+              key: "storybook",
+            },
+            signatures: [],
+          },
+        },
+        id: "984c3a8d-0779-4613-a806-7e59e4adb8e7",
+        index: 0,
+        timestamp: "2021-03-10T08:00:00.000Z",
+        hash: "nWKpqR6ns0l8C/Khwrl+SyKy0sA=",
+        skip: 0,
+      },
+      {
+        type: "SET_NAME",
+        input: "test",
+        scope: "global",
+        context: {
+          signer: {
+            user: {
+              address: "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+              networkId: "eip155",
+              chainId: 1,
+            },
+            app: {
+              name: "storybook",
+              key: "storybook",
+            },
+            signatures: [],
+          },
+        },
+        id: "9b7bc444-6308-4566-8fd9-6474d02fd592",
+        index: 1,
+        timestamp: "2021-03-10T08:00:00.000Z",
+        hash: "nWKpqR6ns0l8C/Khwrl+SyKy0sA=",
+        skip: 0,
+      },
+      {
+        type: "SET_MODEL_EXTENSION",
+        input: {
+          extension: ".test.ph",
+        },
+        scope: "global",
+        context: {
+          signer: {
+            user: {
+              address: "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+              networkId: "eip155",
+              chainId: 1,
+            },
+            app: {
+              name: "storybook",
+              key: "storybook",
+            },
+            signatures: [],
+          },
+        },
+        id: "5e88e12c-380c-471a-a961-79fc49cd3065",
+        index: 2,
+        timestamp: "2021-03-10T08:00:00.000Z",
+        hash: "8nMiCxVFnYGv30xXM0tusiEYcic=",
+        skip: 0,
+      },
+    ],
+    local: [],
+  },
+  clipboard: [],
+};
 const { meta, CreateDocumentStory: DocumentModel2 } = createDocumentStory(
   Editor,
   reducer,
+  // mockDocument,
   utils.createExtendedState(),
 );
 

--- a/packages/document-model-libs/editors/document-model-2/document-model-editor.tsx
+++ b/packages/document-model-libs/editors/document-model-2/document-model-editor.tsx
@@ -1,0 +1,205 @@
+import { typeDefs } from "@powerhousedao/scalars";
+import { GraphqlEditor, JSONEditor, ModuleForm } from "./components";
+import { OperationForm } from "./components/operation-form";
+import {
+  makeMinimalObjectFromSDL,
+  makeInitialSchemaDoc,
+  makeOperationInitialDoc,
+} from "./utils";
+import { memo, useState } from "react";
+import { DocumentActionHandlers } from "./types";
+import { Module } from "document-model/document-model";
+import { GraphQLSchema } from "graphql";
+
+type Props = {
+  modelName: string;
+  schema: GraphQLSchema;
+  globalStateSchema: string;
+  globalStateInitialValue: string;
+  localStateSchema: string;
+  localStateInitialValue: string;
+  handlers: DocumentActionHandlers;
+  modules: Module[];
+};
+export function _DocumentModelEditor(props: Props) {
+  const {
+    modelName,
+    schema,
+    globalStateSchema,
+    globalStateInitialValue,
+    localStateSchema,
+    localStateInitialValue,
+    modules,
+    handlers,
+  } = props;
+  const [showStandardLib, setShowStandardLib] = useState(false);
+
+  return (
+    <div>
+      <div className="mt-4 flex gap-2">
+        {!!globalStateSchema && (
+          <div>
+            {showStandardLib ? (
+              <button
+                className="rounded bg-gray-800 px-2 py-1 text-white"
+                onClick={() => setShowStandardLib(false)}
+              >
+                Hide standard library
+              </button>
+            ) : (
+              <button
+                className="rounded bg-gray-800 px-2 py-1 text-white"
+                onClick={() => setShowStandardLib(true)}
+              >
+                Show standard library
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+      <div>
+        {showStandardLib && (
+          <GraphqlEditor
+            doc={typeDefs.join("\n")}
+            schema={schema}
+            readonly
+            updateDoc={() => {}}
+          />
+        )}
+        <div className="grid grid-cols-2 gap-2">
+          {!!globalStateSchema && (
+            <GraphqlEditor
+              doc={globalStateSchema}
+              schema={schema}
+              updateDoc={(newDoc) => {
+                handlers.setStateSchema(newDoc, "global");
+              }}
+            />
+          )}
+          <div>
+            {!!globalStateInitialValue && (
+              <JSONEditor
+                schema={schema}
+                doc={globalStateInitialValue}
+                updateDoc={(newDoc) => {
+                  handlers.setInitialState(newDoc, "global");
+                }}
+              />
+            )}
+            {!!globalStateSchema && (
+              <button
+                className="rounded bg-gray-800 px-2 py-1 text-white"
+                onClick={() => {
+                  const updatedStateDoc = makeMinimalObjectFromSDL(
+                    schema,
+                    globalStateSchema,
+                    JSON.parse(globalStateInitialValue),
+                  );
+                  handlers.setInitialState(updatedStateDoc, "global");
+                }}
+              >
+                Sync with schema
+              </button>
+            )}
+          </div>
+        </div>
+        {!localStateSchema && !!globalStateSchema && (
+          <button
+            className="rounded bg-gray-800 px-2 py-1 text-white"
+            onClick={() => {
+              const initialDoc = makeInitialSchemaDoc(
+                localStateSchema,
+                modelName,
+                "local",
+              );
+              handlers.setStateSchema(initialDoc, "local");
+              handlers.setInitialState("{}", "local");
+            }}
+          >
+            Add local state
+          </button>
+        )}
+        {!!localStateInitialValue && (
+          <div className="grid grid-cols-2 gap-2">
+            {!!localStateSchema && (
+              <GraphqlEditor
+                doc={localStateSchema}
+                schema={schema}
+                updateDoc={(newDoc) => {
+                  handlers.setStateSchema(newDoc, "local");
+                }}
+              />
+            )}
+            <div>
+              <JSONEditor
+                schema={schema}
+                doc={localStateInitialValue}
+                updateDoc={(newDoc) => {
+                  handlers.setInitialState(newDoc, "local");
+                }}
+              />
+              <button
+                className="rounded bg-gray-800 px-2 py-1 text-white"
+                onClick={() => {
+                  const updatedStateDoc = makeMinimalObjectFromSDL(
+                    schema,
+                    localStateSchema,
+                    JSON.parse(localStateInitialValue),
+                  );
+                  handlers.setInitialState(updatedStateDoc, "local");
+                }}
+              >
+                Sync with schema
+              </button>
+            </div>
+          </div>
+        )}
+        {!!globalStateSchema && (
+          <div>
+            {modules.map((module) => (
+              <div className="" key={module.id}>
+                <div className="mt-4">
+                  <ModuleForm
+                    key={module.id}
+                    handlers={handlers}
+                    module={module}
+                  />
+                </div>
+                <div className="mt-4">
+                  {module.operations.map((operation) => (
+                    <div key={operation.id}>
+                      <OperationForm
+                        operation={operation}
+                        handlers={handlers}
+                        module={module}
+                      />
+                      <GraphqlEditor
+                        schema={schema}
+                        doc={makeOperationInitialDoc(operation)}
+                        updateDoc={(newDoc) =>
+                          handlers.updateOperationSchema(operation.id, newDoc)
+                        }
+                      />
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-4">
+                  <OperationForm
+                    key={Math.random().toString()}
+                    handlers={handlers}
+                    module={module}
+                  />
+                </div>
+              </div>
+            ))}
+            <div className="mt-6">
+              <ModuleForm key={Math.random().toString()} handlers={handlers} />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const DocumentModelEditor = memo(_DocumentModelEditor);

--- a/packages/document-model-libs/editors/document-model-2/editor.tsx
+++ b/packages/document-model-libs/editors/document-model-2/editor.tsx
@@ -1,14 +1,5 @@
-import { buildSchema } from "graphql";
-import { useState, useEffect, useMemo, useCallback } from "react";
-import { initialSchema, hiddenQueryTypeDefDoc } from "./constants";
-import {
-  GraphqlEditor,
-  makeMinimalObjectFromSDL,
-  makeOperationInitialDoc,
-  makeStateInitialDoc,
-  ModuleForm,
-  Scope,
-} from ".";
+import { useMemo, useCallback } from "react";
+import { hiddenQueryTypeDefDoc, makeInitialSchemaDoc, Scope } from ".";
 import {
   DocumentModelState,
   DocumentModelAction,
@@ -16,9 +7,20 @@ import {
   actions,
 } from "document-model/document-model";
 import { EditorProps, OperationScope, utils } from "document-model/document";
-import { OperationForm } from "./components/operation-form";
-import { typeDefs } from "@powerhousedao/scalars";
-import { ModelMetadataForm } from "./components/model-metadata-form";
+import { DocumentModelEditor } from "./document-model-editor";
+import {
+  renameType,
+  mapSchema,
+  MapperKind,
+  astFromObjectType,
+} from "@graphql-tools/utils";
+import { pascalCase } from "change-case";
+import { buildSchema, isObjectType, print } from "graphql";
+import {
+  MetadataFormValues,
+  ModelMetadataForm,
+} from "./components/model-metadata-form";
+
 export default function Editor(
   props: EditorProps<
     DocumentModelState,
@@ -27,28 +29,40 @@ export default function Editor(
   >,
 ) {
   const { document, dispatch } = props;
-  const modelName = document.name;
-  const hasSetModelMetadata = !!modelName;
-  const globalStateSchema =
-    document.state.global.specifications[0].state.global.schema;
-  const globalStateInitialValue =
-    document.state.global.specifications[0].state.global.initialValue;
-  const localStateSchema =
-    document.state.global.specifications[0].state.local.schema;
-  const modules = useMemo(
-    () => document.state.global.specifications[0].modules,
-    [document.state.global.specifications],
+  const { name: modelName } = useMemo(
+    () => ({ name: document.name }),
+    [document.name],
   );
-  const operations = useMemo(
-    () => modules.flatMap((module) => module.operations),
-    [modules],
+  const {
+    state: {
+      global: {
+        schema: globalStateSchema,
+        initialValue: globalStateInitialValue,
+      },
+      local: { schema: localStateSchema, initialValue: localStateInitialValue },
+    },
+    modules,
+  } = useMemo(
+    () => document.state.global.specifications[0],
+    [
+      document.state.global.specifications[0].state.global,
+      document.state.global.specifications[0].state.local,
+      document.state.global.specifications[0].modules,
+    ],
   );
-  const operationSchemas = useMemo(
-    () => operations.map((op) => op.schema).filter(Boolean),
-    [operations],
-  );
-  const [schema, setSchema] = useState(initialSchema);
-  const [showStandardLib, setShowStandardLib] = useState(false);
+
+  const schema = buildSchema(`
+    ${hiddenQueryTypeDefDoc}
+    ${globalStateSchema}
+    ${localStateSchema}
+    ${modules
+      .flatMap((module) =>
+        module.operations.map((operation) => operation.schema),
+      )
+      .filter(Boolean)
+      .join("\n")}
+  `);
+
   const setModelId = useCallback((id: string) => {
     dispatch(actions.setModelId({ id }));
   }, []);
@@ -62,8 +76,8 @@ export default function Editor(
   }, []);
 
   const setModelName = useCallback((name: string) => {
-    dispatch(actions.setModelName({ name }));
     dispatch(actions.setName(name));
+    dispatch(actions.setModelName({ name }));
   }, []);
 
   const setAuthorName = useCallback((authorName: string) => {
@@ -144,152 +158,119 @@ export default function Editor(
       updateOperationScope,
       deleteOperation,
     }),
-    [
-      setModelId,
-      setModelExtension,
-      setModelName,
-      setAuthorName,
-      setAuthorWebsite,
-      setStateSchema,
-      setInitialState,
-      addModule,
-      setModuleDescription,
-      updateModuleName,
-      updateModuleDescription,
-      deleteModule,
-      addOperation,
-      updateOperationName,
-      updateOperationSchema,
-      updateOperationScope,
-      deleteOperation,
-    ],
+    [],
   );
+  function onSubmit(values: MetadataFormValues) {
+    const { name, documentType, description, extension, author } = values;
+    if (name) {
+      handlers.setModelName(name);
+      if (!globalStateSchema) {
+        const initialSchemaDoc = makeInitialSchemaDoc(
+          globalStateSchema,
+          name,
+          "global",
+        );
+        handlers.setStateSchema(initialSchemaDoc, "global");
 
-  useEffect(() => {
-    const newSchemaString = `
-      ${hiddenQueryTypeDefDoc}
-      ${globalStateSchema}
-      ${localStateSchema}
-      ${operationSchemas.join("\n")}
-    `;
-    if (!newSchemaString) return;
-    const newSchema = buildSchema(newSchemaString);
-    setSchema(newSchema);
-  }, [globalStateSchema, localStateSchema, modules]);
+        if (!globalStateInitialValue) {
+          const initialStateDoc = "{}";
+          handlers.setInitialState(initialStateDoc, "global");
+        }
+      } else {
+        const oldGlobalStateType = schema.getType(
+          `${pascalCase(modelName)}State`,
+        );
+        if (!oldGlobalStateType) {
+          throw new Error("Expected global state type");
+        }
+        const newGlobalStateType = renameType(
+          oldGlobalStateType,
+          `${pascalCase(name)}State`,
+        );
+        const schemaWithNewType = mapSchema(schema, {
+          [MapperKind.TYPE]: (type) => {
+            if (type.name === oldGlobalStateType.name) {
+              return newGlobalStateType;
+            }
+            return type;
+          },
+        });
+        if (!isObjectType(newGlobalStateType)) {
+          throw new Error("Expected object type");
+        }
+        handlers.setStateSchema(
+          print(astFromObjectType(newGlobalStateType, schemaWithNewType)),
+          "global",
+        );
+        const oldLocalStateType = schema.getType(
+          `${pascalCase(modelName)}LocalState`,
+        );
+        if (!oldLocalStateType) {
+          return;
+        }
+        const newLocalStateType = renameType(
+          oldLocalStateType,
+          `${pascalCase(name)}LocalState`,
+        );
+        const schemaWithNewLocalStateType = mapSchema(schema, {
+          [MapperKind.TYPE]: (type) => {
+            if (type.name === oldLocalStateType.name) {
+              return newLocalStateType;
+            }
+            return type;
+          },
+        });
+        if (!isObjectType(newLocalStateType)) {
+          throw new Error("Expected object type");
+        }
+        handlers.setStateSchema(
+          print(
+            astFromObjectType(newLocalStateType, schemaWithNewLocalStateType),
+          ),
+          "local",
+        );
+      }
+    }
+
+    if (documentType) {
+      handlers.setModelId(documentType);
+    }
+
+    if (description) {
+      handlers.setModuleDescription(description);
+    }
+
+    if (extension) {
+      handlers.setModelExtension(extension);
+    }
+
+    if (author?.name) {
+      handlers.setAuthorName(author.name);
+    }
+
+    if (author?.website) {
+      handlers.setAuthorWebsite(author.website);
+    }
+  }
 
   return (
     <main className="mx-auto min-h-dvh max-w-screen-xl px-4 pt-8">
-      {!hasSetModelMetadata ? (
-        <ModelMetadataForm document={document} handlers={handlers} />
-      ) : (
-        <div>
-          <div className="mt-4 flex gap-2">
-            {showStandardLib ? (
-              <button
-                className="rounded bg-gray-800 px-2 py-1 text-white"
-                onClick={() => setShowStandardLib(false)}
-              >
-                Hide standard library
-              </button>
-            ) : (
-              <button
-                className="rounded bg-gray-800 px-2 py-1 text-white"
-                onClick={() => setShowStandardLib(true)}
-              >
-                Show standard library
-              </button>
-            )}
-          </div>
-          <div>
-            {showStandardLib && (
-              <GraphqlEditor
-                doc={typeDefs.join("\n")}
-                schema={schema}
-                readonly
-                updateDoc={() => {}}
-              />
-            )}
-            <GraphqlEditor
-              doc={makeStateInitialDoc(globalStateSchema, modelName, "global")}
-              schema={schema}
-              updateDoc={(newDoc) => {
-                handlers.setStateSchema(newDoc, "global");
-                handlers.setInitialState(
-                  makeMinimalObjectFromSDL(schema, newDoc),
-                  "global",
-                );
-              }}
-            />
-            {!localStateSchema && (
-              <button
-                className="rounded bg-gray-800 px-2 py-1 text-white"
-                onClick={() => {
-                  const initialDoc = makeStateInitialDoc(
-                    localStateSchema,
-                    modelName,
-                    "local",
-                  );
-                  handlers.setStateSchema(initialDoc, "local");
-                }}
-              >
-                Add local state
-              </button>
-            )}
-            {!!localStateSchema && (
-              <GraphqlEditor
-                doc={localStateSchema}
-                schema={schema}
-                updateDoc={(newDoc) => {
-                  handlers.setStateSchema(newDoc, "local");
-                  handlers.setInitialState(
-                    makeMinimalObjectFromSDL(schema, newDoc),
-                    "local",
-                  );
-                }}
-              />
-            )}
-            {modules.map((module) => (
-              <div className="" key={module.id}>
-                <div className="mt-4">
-                  <ModuleForm
-                    key={module.id}
-                    handlers={handlers}
-                    module={module}
-                  />
-                </div>
-                <div className="mt-4">
-                  {module.operations.map((operation) => (
-                    <div key={operation.id}>
-                      <OperationForm
-                        operation={operation}
-                        handlers={handlers}
-                        module={module}
-                      />
-                      <GraphqlEditor
-                        schema={schema}
-                        doc={makeOperationInitialDoc(operation)}
-                        updateDoc={(newDoc) =>
-                          handlers.updateOperationSchema(operation.id, newDoc)
-                        }
-                      />
-                    </div>
-                  ))}
-                </div>
-                <div className="mt-4">
-                  <OperationForm
-                    key={Math.random().toString()}
-                    handlers={handlers}
-                    module={module}
-                  />
-                </div>
-              </div>
-            ))}
-            <div className="mt-6">
-              <ModuleForm key={Math.random().toString()} handlers={handlers} />
-            </div>
-          </div>
-        </div>
-      )}
+      <ModelMetadataForm
+        onSubmit={onSubmit}
+        name={modelName}
+        documentType="documentModel"
+        extension=".test.ph"
+      />
+      <DocumentModelEditor
+        schema={schema}
+        modelName={modelName}
+        globalStateSchema={globalStateSchema}
+        globalStateInitialValue={globalStateInitialValue}
+        localStateSchema={localStateSchema}
+        localStateInitialValue={localStateInitialValue}
+        handlers={handlers}
+        modules={modules}
+      />
     </main>
   );
 }

--- a/packages/document-model-libs/editors/document-model-2/editor.tsx
+++ b/packages/document-model-libs/editors/document-model-2/editor.tsx
@@ -19,7 +19,6 @@ import { EditorProps, OperationScope, utils } from "document-model/document";
 import { OperationForm } from "./components/operation-form";
 import { typeDefs } from "@powerhousedao/scalars";
 import { ModelMetadataForm } from "./components/model-metadata-form";
-
 export default function Editor(
   props: EditorProps<
     DocumentModelState,
@@ -50,7 +49,6 @@ export default function Editor(
   );
   const [schema, setSchema] = useState(initialSchema);
   const [showStandardLib, setShowStandardLib] = useState(false);
-
   const setModelId = useCallback((id: string) => {
     dispatch(actions.setModelId({ id }));
   }, []);

--- a/packages/document-model-libs/package.json
+++ b/packages/document-model-libs/package.json
@@ -140,6 +140,7 @@
     "dspot-powerhouse-components": "^1.1.0",
     "graphql": "^16.9.0",
     "graphql-codegen-typescript-validation-schema": "^0.16.0",
+    "jsonc-parser": "^3.3.1",
     "lucide-react": "^0.451.0",
     "lz-string": "^1.5.0",
     "microdiff": "^1.3.2",
@@ -170,6 +171,7 @@
   },
   "dependencies": {
     "@acaldas/graphql-codegen-typescript-validation-schema": "^0.12.3",
+    "@codemirror/lang-json": "^6.0.1",
     "@graphql-codegen/core": "^4.0.2",
     "@graphql-codegen/typescript": "^4.0.6",
     "@graphql-tools/schema": "^10.0.7",
@@ -179,7 +181,6 @@
     "copy-anything": "^3.0.5",
     "date-fns": "^3.3.1",
     "deep-object-diff": "^1.1.9",
-    "jsonc-parser": "^3.2.1",
     "jszip": "^3.10.1",
     "mathjs": "^13.0.0"
   }

--- a/packages/document-model-libs/package.json
+++ b/packages/document-model-libs/package.json
@@ -73,7 +73,10 @@
     "chromatic": "npx chromatic --project-token chpt_7f618da80620e4d",
     "prepublishOnly": "npm run build",
     "clean": "rimraf dist",
-    "clean:node_modules": "rimraf node_modules"
+    "clean:node_modules": "rimraf node_modules",
+    "dev:watch": "vite build --watch",
+    "yalc-push": "vite build && yalc push",
+    "dev": "npm-run-all --parallel dev:watch yalc-push"
   },
   "devDependencies": {
     "@codemirror/autocomplete": "^6.18.1",
@@ -91,7 +94,7 @@
     "@mui/material": "^5.15.5",
     "@powerhousedao/codegen": "0.9.0",
     "@powerhousedao/design-system": "1.4.1",
-    "@powerhousedao/scalars": "1.4.0",
+    "@powerhousedao/scalars": "workspace:*",
     "@prettier/sync": "^0.5.2",
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-icons": "^1.3.0",
@@ -161,14 +164,15 @@
     "zod": "^3.22.4"
   },
   "peerDependencies": {
+    "@powerhousedao/scalars": "latest",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "@powerhousedao/scalars": "latest"
+    "react-dom": "^18.2.0"
   },
   "dependencies": {
     "@acaldas/graphql-codegen-typescript-validation-schema": "^0.12.3",
     "@graphql-codegen/core": "^4.0.2",
     "@graphql-codegen/typescript": "^4.0.6",
+    "@graphql-tools/schema": "^10.0.7",
     "@graphql-tools/utils": "^10.5.5",
     "@internationalized/date": "^3.5.1",
     "@storybook/test": "^8.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,6 +509,9 @@ importers:
       '@acaldas/graphql-codegen-typescript-validation-schema':
         specifier: ^0.12.3
         version: 0.12.3(graphql@16.8.1)
+      '@codemirror/lang-json':
+        specifier: ^6.0.1
+        version: 6.0.1
       '@graphql-codegen/core':
         specifier: ^4.0.2
         version: 4.0.2(graphql@16.8.1)
@@ -536,9 +539,6 @@ importers:
       deep-object-diff:
         specifier: ^1.1.9
         version: 1.1.9
-      jsonc-parser:
-        specifier: ^3.2.1
-        version: 3.3.1
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -729,6 +729,9 @@ importers:
       graphql-codegen-typescript-validation-schema:
         specifier: ^0.16.0
         version: 0.16.0(graphql@16.8.1)
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       lucide-react:
         specifier: ^0.451.0
         version: 0.451.0(react@18.3.1)
@@ -2440,6 +2443,13 @@ packages:
       '@lezer/javascript': 1.4.19
     dev: true
 
+  /@codemirror/lang-json@6.0.1:
+    resolution: {integrity: sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==}
+    dependencies:
+      '@codemirror/language': 6.10.3
+      '@lezer/json': 1.0.2
+    dev: false
+
   /@codemirror/language@6.10.3:
     resolution: {integrity: sha512-kDqEU5sCP55Oabl6E7m5N+vZRoc0iWqgDVhEKifcHzPzjqCegcO4amfrYVL9PmPZpl4G0yjkpTpUO/Ui8CzO8A==}
     dependencies:
@@ -2449,7 +2459,6 @@ packages:
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
       style-mod: 4.1.2
-    dev: true
 
   /@codemirror/lint@6.8.2:
     resolution: {integrity: sha512-PDFG5DjHxSEjOXk9TQYYVjZDqlZTFaDBfhQixHnQOEVDDNHUbEh/hstAjcQJaA6FQdZTD1hquXTK0rVBLADR1g==}
@@ -2469,7 +2478,6 @@ packages:
 
   /@codemirror/state@6.4.1:
     resolution: {integrity: sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==}
-    dev: true
 
   /@codemirror/theme-one-dark@6.1.2:
     resolution: {integrity: sha512-F+sH0X16j/qFLMAfbciKTxVOwkdAS336b7AXTKOZhy8BR3eH/RelsnLgLFINrpST63mmN2OuwUt0W2ndUgYwUA==}
@@ -2486,7 +2494,6 @@ packages:
       '@codemirror/state': 6.4.1
       style-mod: 4.1.2
       w3c-keyname: 2.2.8
-    dev: true
 
   /@coinbase/wallet-sdk@3.9.3:
     resolution: {integrity: sha512-N/A2DRIf0Y3PHc1XAMvbBUu4zisna6qAdqABMZwBMNEfWrXpAwx16pZGkYCLGE+Rvv1edbcB2LYDRnACNcmCiw==}
@@ -4697,13 +4704,11 @@ packages:
 
   /@lezer/common@1.2.3:
     resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
-    dev: true
 
   /@lezer/highlight@1.2.1:
     resolution: {integrity: sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==}
     dependencies:
       '@lezer/common': 1.2.3
-    dev: true
 
   /@lezer/javascript@1.4.19:
     resolution: {integrity: sha512-j44kbR1QL26l6dMunZ1uhKBFteVGLVCBGNUD2sUaMnic+rbTviVuoK0CD1l9FTW31EueWvFFswCKMH7Z+M3JRA==}
@@ -4713,11 +4718,18 @@ packages:
       '@lezer/lr': 1.4.2
     dev: true
 
+  /@lezer/json@1.0.2:
+    resolution: {integrity: sha512-xHT2P4S5eeCYECyKNPhr4cbEL9tc8w83SPwRC373o9uEdrvGKTZoJVAGxpOsZckMlEh9W23Pc72ew918RWQOBQ==}
+    dependencies:
+      '@lezer/common': 1.2.3
+      '@lezer/highlight': 1.2.1
+      '@lezer/lr': 1.4.2
+    dev: false
+
   /@lezer/lr@1.4.2:
     resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
     dependencies:
       '@lezer/common': 1.2.3
-    dev: true
 
   /@lit-labs/ssr-dom-shim@1.2.1:
     resolution: {integrity: sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ==}
@@ -17426,6 +17438,7 @@ packages:
 
   /jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+    dev: true
 
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -22350,7 +22363,6 @@ packages:
 
   /style-mod@4.1.2:
     resolution: {integrity: sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==}
-    dev: true
 
   /styled-jsx@5.1.1(@babel/core@7.25.8)(react@18.3.1):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
@@ -24117,7 +24129,6 @@ packages:
 
   /w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
-    dev: true
 
   /w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -515,6 +515,9 @@ importers:
       '@graphql-codegen/typescript':
         specifier: ^4.0.6
         version: 4.1.0(graphql@16.8.1)
+      '@graphql-tools/schema':
+        specifier: ^10.0.7
+        version: 10.0.7(graphql@16.8.1)
       '@graphql-tools/utils':
         specifier: ^10.5.5
         version: 10.5.5(graphql@16.8.1)
@@ -589,7 +592,7 @@ importers:
         specifier: 1.4.1
         version: link:../design-system
       '@powerhousedao/scalars':
-        specifier: 1.4.0
+        specifier: workspace:*
         version: link:../scalars
       '@prettier/sync':
         specifier: ^0.5.2
@@ -3457,7 +3460,7 @@ packages:
       graphql: ^16.8.1
     dependencies:
       '@graphql-codegen/plugin-helpers': 5.0.4(graphql@16.8.1)
-      '@graphql-tools/schema': 10.0.6(graphql@16.8.1)
+      '@graphql-tools/schema': 10.0.7(graphql@16.8.1)
       '@graphql-tools/utils': 10.5.5(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.3
@@ -4007,6 +4010,17 @@ packages:
       '@graphql-tools/utils': 10.5.5(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.7.0
+    dev: false
+
+  /@graphql-tools/merge@9.0.8(graphql@16.8.1):
+    resolution: {integrity: sha512-RG9NEp4fi0MoFi0te4ahqTMYuavQnXlpEZxxMomdCa6CI5tfekcVm/rsLF5Zt8O4HY+esDt9+4dCL+aOKvG79w==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^16.8.1
+    dependencies:
+      '@graphql-tools/utils': 10.5.5(graphql@16.8.1)
+      graphql: 16.8.1
+      tslib: 2.7.0
 
   /@graphql-tools/optimize@2.0.0(graphql@16.8.1):
     resolution: {integrity: sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==}
@@ -4072,6 +4086,19 @@ packages:
       '@graphql-tools/utils': 10.5.5(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.3
+      value-or-promise: 1.0.12
+    dev: false
+
+  /@graphql-tools/schema@10.0.7(graphql@16.8.1):
+    resolution: {integrity: sha512-Cz1o+rf9cd3uMgG+zI9HlM5mPlnHQUlk/UQRZyUlPDfT+944taLaokjvj7AI6GcOFVf4f2D11XthQp+0GY31jQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^16.8.1
+    dependencies:
+      '@graphql-tools/merge': 9.0.8(graphql@16.8.1)
+      '@graphql-tools/utils': 10.5.5(graphql@16.8.1)
+      graphql: 16.8.1
+      tslib: 2.7.0
       value-or-promise: 1.0.12
 
   /@graphql-tools/schema@9.0.19(graphql@16.8.1):


### PR DESCRIPTION
Users want to be able to define and edit the initial state of document models. This is especially important for backwards compatibility.

What makes this annoying is that the initial state must conform to the shape of the graphql schema, and this code had to be written by hand.

I have added here JSON editors that start with an empty object, but have a "sync with schema" button which will update the json object such that it conforms to the schema with the minimal values. This function also is aware of existing json code, and will not overwrite values that are already correct and conforming, it will just add missing ones.

This editor also has syntax highlighting and basic linting.

I wanted to wire up the existing editor's validation logic, but I discovered that it is actually not working. In the implementation of the editor, we ignore the validator that is passed in completely:

```tsxasync function generateSchema(code: string, name: string) {
    // using callbacks instead of await due to rollup error
    codegen(code).then((result) => {
      import(/* @vite-ignore */ result).then((validators) => {
        const schemaName = `${name}StateSchema`;
        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
        const validator = validators[schemaName];
        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
        
        /* validation schema is set here */
        
        setValidationSchema(validator);
        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
        
        /* and passed to the onGenerate function here */
        
        onGenerate({ documentName: name, schema: code, validator });
      });
    });
  }
```

` ``tsx
<EditorSchema
          height={200}
          name={name}
          
          {/* but in the usage of onGenerate in the component, the validator is not used */
          
          onGenerate={(schema) => {
            setSchemaState((_state) => ({
              ..._state,
              ...schema,
            }));
            if (schema.schema !== specification?.state[scope].schema) {
              setStateSchema(schema.schema, scope);
            }
          }}
          scope={scope}
          theme={theme}
          value={specification?.state[scope].schema}
        />
```
        
        Considering that shipping the zod package adds so much to our bundle size, I think it would be worthwhile to pursue a more lightweight solution.
        
        I believe that JSON schemas present one such solution: https://json-schema.org/
        
        There are several libraries that convert graphql schemas to json schemas. we could then use something like this:  https://ajv.js.org/ to generate the  `Diagnostic` objects used by codemirror and eslint https://codemirror.net/docs/ref/#lint
        
      