### PR TITLE
feat(scalars): add styles for toogle and fix the darkmode

### DIFF
--- a/packages/design-system/.storybook/preview-body.html
+++ b/packages/design-system/.storybook/preview-body.html
@@ -1,1 +1,1 @@
-<body id="root-background" class="bg-bg h-screen w-screen"></body>
+<body id="root-background" class="bg-[#ffffff] dark:bg-[#1c1e23] h-screen w-screen "></body>

--- a/packages/design-system/.storybook/preview.tsx
+++ b/packages/design-system/.storybook/preview.tsx
@@ -28,11 +28,11 @@ const preview: Preview = {
     ),
     withThemeByDataAttribute<ReactRenderer>({
       themes: {
-        light: "ph-light",
-        dark: "ph-dark",
+        light: "light",
+        dark: "dark",
       },
       defaultTheme: "light",
-      attributeName: "data-theme",
+      attributeName: 'data-mode',
     }),
   ],
 };

--- a/packages/design-system/src/globals.css
+++ b/packages/design-system/src/globals.css
@@ -247,17 +247,3 @@ h6,
 p {
   color: var(--gray-900);
 }
-
-/* Light Theme */
-.light {
-  --background-color: #ffffff; /* Background */
-  --text-color: #333333; /* Text */
-  --primary-color: #1d4ed8; /* Primary color */
-}
-
-/* Dark Theme */
-.dark {
-  --background-color: #1a1a2e; /* Background */
-  --text-color: #f5f5f5; /* Text */
-  --primary-color: #3b82f6; /* Primary color */
-}

--- a/packages/design-system/src/globals.css
+++ b/packages/design-system/src/globals.css
@@ -16,9 +16,6 @@
     -ms-overflow-style: none; /* IE and Edge */
     scrollbar-width: none; /* Firefox */
   }
-  body {
-		@apply dark:bg-black  min-h-screen relative;
-	}
   /* Modal */
   .modal-shadow {
     box-shadow:

--- a/packages/design-system/src/globals.css
+++ b/packages/design-system/src/globals.css
@@ -16,7 +16,9 @@
     -ms-overflow-style: none; /* IE and Edge */
     scrollbar-width: none; /* Firefox */
   }
-
+  body {
+		@apply dark:bg-black  min-h-screen relative;
+	}
   /* Modal */
   .modal-shadow {
     box-shadow:
@@ -244,4 +246,18 @@ h5,
 h6,
 p {
   color: var(--gray-900);
+}
+
+/* Light Theme */
+.light {
+  --background-color: #ffffff; /* Background */
+  --text-color: #333333; /* Text */
+  --primary-color: #1d4ed8; /* Primary color */
+}
+
+/* Dark Theme */
+.dark {
+  --background-color: #1a1a2e; /* Background */
+  --text-color: #f5f5f5; /* Text */
+  --primary-color: #3b82f6; /* Primary color */
 }

--- a/packages/design-system/src/scalars/components/toggle/__snapshots__/toggle-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/toggle/__snapshots__/toggle-field.test.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Toggle Component > should match snapshot 1`] = `
+exports[`ToggleField Component > should match snapshot 1`] = `
 <DocumentFragment>
   <div
     class="flex flex-col gap-1"

--- a/packages/design-system/src/scalars/components/toggle/__snapshots__/toggle-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/toggle/__snapshots__/toggle-field.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Toggle Component > should match snapshot 1`] = `
         aria-checked="true"
         aria-labelledby=":r0:-label"
         aria-required="false"
-        class="peer inline-flex h-4 w-8 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=checked]:bg-[#0084FF] data-[state=unchecked]:bg-[#9EA0A1]"
+        class="peer inline-flex h-4 w-8 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=checked]:bg-[#343839] data-[state=unchecked]:bg-[#D7D8D9] dark:data-[state=checked]:bg-[#3BBE5F] dark:data-[state=unchecked]:bg-[#404446]"
         data-state="checked"
         id=":r0:"
         role="switch"

--- a/packages/design-system/src/scalars/components/toggle/toggle-field.test.tsx
+++ b/packages/design-system/src/scalars/components/toggle/toggle-field.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, vi } from "vitest";
+import { ToggleField } from "./toggle-field";
+
+describe("Toggle Component", () => {
+  const mockOnChange = vi.fn();
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should match snapshot", () => {
+    const { asFragment } = render(<ToggleField />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("renders default status without a label at the left", () => {
+    render(<ToggleField />);
+    expect(screen.queryByText("Test Label")).not.toBeInTheDocument();
+  });
+
+  it("renders default status without a label at the left", () => {
+    render(<ToggleField label="Test Label" />);
+    expect(screen.getByText("Test Label")).toBeInTheDocument();
+  });
+
+  it("renders checked status without label", () => {
+    render(<ToggleField checked={true} />);
+    expect(screen.queryByText("Test Label")).not.toBeInTheDocument();
+  });
+
+  it("renders defaultd status with a label at the left", () => {
+    render(<ToggleField label="Test Label" checked={true} />);
+    expect(screen.getByText("Test Label")).toBeInTheDocument();
+  });
+
+  it("does not render the label when not provided", () => {
+    render(<ToggleField />);
+    expect(screen.queryByText("Test Label")).not.toBeInTheDocument();
+  });
+
+  it("displays an error message when hasMessage is true", () => {
+    render(<ToggleField label="Test Label" errors={["Error message"]} />);
+    expect(screen.getByText("Error message")).toBeInTheDocument();
+  });
+
+  it("calls onCheckedChange when clicked", () => {
+    render(<ToggleField label="Test Label" onCheckedChange={mockOnChange} />);
+    const toggleInput = screen.getByRole("switch");
+
+    fireEvent.click(toggleInput);
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(toggleInput).toBeInTheDocument();
+  });
+
+  it("disables the toggle when disabled prop is true", () => {
+    render(
+      <ToggleField
+        label="Test Label"
+        disabled
+        onCheckedChange={mockOnChange}
+      />,
+    );
+    const toggleInput = screen.getByRole("switch");
+    expect(toggleInput).toBeDisabled();
+  });
+
+  it("renders with custom className", () => {
+    // this is a custom class name for testing purposes
+    // eslint-disable-next-line tailwindcss/no-custom-classname
+    render(<ToggleField className="custom-class" />);
+    const toggle = screen.getByTestId("custom-class");
+    expect(toggle).toHaveClass("custom-class");
+  });
+});

--- a/packages/design-system/src/scalars/components/toggle/toggle-field.test.tsx
+++ b/packages/design-system/src/scalars/components/toggle/toggle-field.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, vi } from "vitest";
 import { ToggleField } from "./toggle-field";
@@ -14,37 +13,37 @@ describe("Toggle Component", () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it("renders default status without a label at the left", () => {
+  it("should render default status without a label on the left", () => {
     render(<ToggleField />);
     expect(screen.queryByText("Test Label")).not.toBeInTheDocument();
   });
 
-  it("renders default status without a label at the left", () => {
+  it("should render with a label when label prop is provided", () => {
     render(<ToggleField label="Test Label" />);
     expect(screen.getByText("Test Label")).toBeInTheDocument();
   });
 
-  it("renders checked status without label", () => {
+  it("should render checked status without label", () => {
     render(<ToggleField checked={true} />);
     expect(screen.queryByText("Test Label")).not.toBeInTheDocument();
   });
 
-  it("renders defaultd status with a label at the left", () => {
+  it("should render checked status with a label on the left", () => {
     render(<ToggleField label="Test Label" checked={true} />);
     expect(screen.getByText("Test Label")).toBeInTheDocument();
   });
 
-  it("does not render the label when not provided", () => {
+  it("should not render the label when not provided", () => {
     render(<ToggleField />);
     expect(screen.queryByText("Test Label")).not.toBeInTheDocument();
   });
 
-  it("displays an error message when hasMessage is true", () => {
+  it("should display an error message when hasMessage is true", () => {
     render(<ToggleField label="Test Label" errors={["Error message"]} />);
     expect(screen.getByText("Error message")).toBeInTheDocument();
   });
 
-  it("calls onCheckedChange when clicked", () => {
+  it("should call onCheckedChange when clicked", () => {
     render(<ToggleField label="Test Label" onCheckedChange={mockOnChange} />);
     const toggleInput = screen.getByRole("switch");
 
@@ -53,7 +52,7 @@ describe("Toggle Component", () => {
     expect(toggleInput).toBeInTheDocument();
   });
 
-  it("disables the toggle when disabled prop is true", () => {
+  it("should disable the toggle when disabled prop is true", () => {
     render(
       <ToggleField
         label="Test Label"
@@ -65,7 +64,7 @@ describe("Toggle Component", () => {
     expect(toggleInput).toBeDisabled();
   });
 
-  it("renders with custom className", () => {
+  it("should render with custom className", () => {
     // this is a custom class name for testing purposes
     // eslint-disable-next-line tailwindcss/no-custom-classname
     render(<ToggleField className="custom-class" />);

--- a/packages/design-system/src/scalars/components/toggle/toggle-field.test.tsx
+++ b/packages/design-system/src/scalars/components/toggle/toggle-field.test.tsx
@@ -2,11 +2,8 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, vi } from "vitest";
 import { ToggleField } from "./toggle-field";
 
-describe("Toggle Component", () => {
+describe("ToggleField Component", () => {
   const mockOnChange = vi.fn();
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
 
   it("should match snapshot", () => {
     const { asFragment } = render(<ToggleField />);

--- a/packages/design-system/src/scalars/components/toggle/toggle-field.tsx
+++ b/packages/design-system/src/scalars/components/toggle/toggle-field.tsx
@@ -33,16 +33,6 @@ const ToggleField: React.FC<ToggleFieldProps> = ({
       data-testid="custom-class"
     >
       <div className="flex items-center">
-        {label && (
-          <FormLabel
-            htmlFor={id}
-            className="mr-2"
-            disabled={disabled}
-            id={`${id}-label`}
-          >
-            {label}
-          </FormLabel>
-        )}
         <Toggle
           aria-labelledby={`${id}-label`}
           required={required}
@@ -52,6 +42,16 @@ const ToggleField: React.FC<ToggleFieldProps> = ({
           checked={checked}
           onCheckedChange={onCheckedChange}
         />
+        {label && (
+          <FormLabel
+            htmlFor={id}
+            className="ml-2"
+            disabled={disabled}
+            id={`${id}-label`}
+          >
+            {label}
+          </FormLabel>
+        )}
       </div>
       {errors.length !== 0 && (
         <FormMessageList messages={errors} type="error" />

--- a/packages/design-system/src/scalars/components/toggle/toggle.stories.tsx
+++ b/packages/design-system/src/scalars/components/toggle/toggle.stories.tsx
@@ -70,6 +70,7 @@ export const CheckedWithLabel: Story = {
   args: {
     checked: true,
     label: "Active",
+    errors: [],
   },
 };
 
@@ -77,6 +78,7 @@ export const Unchecked: Story = {
   name: "Unchecked without label",
   args: {
     checked: false,
+    errors: [],
   },
 };
 
@@ -85,6 +87,7 @@ export const UncheckedWithLabel: Story = {
   args: {
     checked: false,
     label: "Active",
+    errors: [],
   },
 };
 
@@ -93,6 +96,7 @@ export const DisabledChecked: Story = {
   args: {
     checked: true,
     disabled: true,
+    errors: [],
   },
 };
 
@@ -102,6 +106,7 @@ export const DisabledCheckedWithLabel: Story = {
     disabled: true,
     checked: true,
     label: "Active",
+    errors: [],
   },
 };
 
@@ -110,6 +115,7 @@ export const DisabledUncheckedWithoutLabel: Story = {
   args: {
     checked: false,
     disabled: true,
+    errors: [],
   },
 };
 
@@ -119,5 +125,6 @@ export const DisabledUncheckedWithLabel: Story = {
     disabled: true,
     checked: false,
     label: "Active",
+    errors: [],
   },
 };

--- a/packages/design-system/src/scalars/components/toggle/toggle.test.tsx
+++ b/packages/design-system/src/scalars/components/toggle/toggle.test.tsx
@@ -11,11 +11,7 @@ describe("Toggle Component", () => {
     required: false,
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  describe("Functionality", () => {
+  describe("Testing the interactive behavior of the Toggle component", () => {
     it("should call onChange with correct value when clicked", () => {
       const handleChange = vi.fn();
       render(<Toggle {...defaultProps} onChange={handleChange} />);
@@ -58,7 +54,7 @@ describe("Toggle Component", () => {
     });
   });
 
-  describe("Rendering", () => {
+  describe("Testing rendering characteristics of the Toggle component", () => {
     it("should render with correct initial checked state", () => {
       render(<Toggle {...defaultProps} checked={true} />);
       const toggle = screen.getByRole("switch");

--- a/packages/design-system/src/scalars/components/toggle/toggle.test.tsx
+++ b/packages/design-system/src/scalars/components/toggle/toggle.test.tsx
@@ -1,75 +1,97 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, vi } from "vitest";
-import { ToggleField } from "./toggle-field";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { Toggle } from "./toggle";
+import { vi } from "vitest";
 
 describe("Toggle Component", () => {
-  const mockOnChange = vi.fn();
+  const defaultProps = {
+    onChange: vi.fn(),
+    disabled: false,
+    checked: false,
+    required: false,
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("should match snapshot", () => {
-    const { asFragment } = render(<ToggleField />);
-    expect(asFragment()).toMatchSnapshot();
+  describe("Functionality", () => {
+    it("should call onChange with correct value when clicked", () => {
+      const handleChange = vi.fn();
+      render(<Toggle {...defaultProps} onChange={handleChange} />);
+
+      const toggle = screen.getByRole("switch");
+      fireEvent.click(toggle);
+
+      expect(handleChange).toHaveBeenCalledTimes(1);
+      expect(handleChange).toHaveBeenCalledWith(true);
+    });
+
+    it("should not call onChange when disabled", () => {
+      const handleChange = vi.fn();
+      render(
+        <Toggle {...defaultProps} disabled={true} onChange={handleChange} />,
+      );
+
+      const toggle = screen.getByRole("switch");
+      fireEvent.click(toggle);
+
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+
+    it("should toggle between checked and unchecked states", () => {
+      const handleChange = vi.fn();
+      const { rerender } = render(
+        <Toggle {...defaultProps} checked={false} onChange={handleChange} />,
+      );
+
+      const toggle = screen.getByRole("switch");
+
+      expect(toggle).toHaveAttribute("data-state", "unchecked");
+
+      fireEvent.click(toggle);
+      rerender(
+        <Toggle {...defaultProps} checked={true} onChange={handleChange} />,
+      );
+
+      expect(toggle).toHaveAttribute("data-state", "checked");
+    });
   });
 
-  it("renders default status without a label at the left", () => {
-    render(<ToggleField />);
-    expect(screen.queryByText("Test Label")).not.toBeInTheDocument();
-  });
+  describe("Rendering", () => {
+    it("should render with correct initial checked state", () => {
+      render(<Toggle {...defaultProps} checked={true} />);
+      const toggle = screen.getByRole("switch");
+      expect(toggle).toHaveAttribute("data-state", "checked");
+    });
 
-  it("renders default status without a label at the left", () => {
-    render(<ToggleField label="Test Label" />);
-    expect(screen.getByText("Test Label")).toBeInTheDocument();
-  });
+    it("should render as unchecked when checked prop is false", () => {
+      render(<Toggle {...defaultProps} checked={false} />);
+      const toggle = screen.getByRole("switch");
+      expect(toggle).toHaveAttribute("data-state", "unchecked");
+    });
 
-  it("renders checked status without label", () => {
-    render(<ToggleField checked={true} />);
-    expect(screen.queryByText("Test Label")).not.toBeInTheDocument();
-  });
+    it("should apply disabled styles when disabled", () => {
+      render(<Toggle {...defaultProps} disabled={true} checked={true} />);
+      const toggle = screen.getByRole("switch");
 
-  it("renders defaultd status with a label at the left", () => {
-    render(<ToggleField label="Test Label" checked={true} />);
-    expect(screen.getByText("Test Label")).toBeInTheDocument();
-  });
+      expect(toggle).toHaveClass("cursor-not-allowed");
+      expect(toggle).toHaveClass("data-[state=checked]:bg-[#C5C7C7]");
+    });
 
-  it("does not render the label when not provided", () => {
-    render(<ToggleField />);
-    expect(screen.queryByText("Test Label")).not.toBeInTheDocument();
-  });
+    it("should mark as required when required prop is true", () => {
+      render(<Toggle {...defaultProps} disabled={true} />);
+      const toggle = screen.getByRole("switch");
 
-  it("displays an error message when hasMessage is true", () => {
-    render(<ToggleField label="Test Label" errors={["Error message"]} />);
-    expect(screen.getByText("Error message")).toBeInTheDocument();
-  });
+      expect(toggle).toHaveAttribute("disabled");
+    });
 
-  it("calls onCheckedChange when clicked", () => {
-    render(<ToggleField label="Test Label" onCheckedChange={mockOnChange} />);
-    const toggleInput = screen.getByRole("switch");
+    it("should apply custom className when provided", () => {
+      const customClass = "custom-class";
+      render(<Toggle {...defaultProps} className={customClass} />);
+      const toggle = screen.getByRole("switch");
 
-    fireEvent.click(toggleInput);
-    expect(mockOnChange).toHaveBeenCalledTimes(1);
-    expect(toggleInput).toBeInTheDocument();
-  });
-
-  it("disables the toggle when disabled prop is true", () => {
-    render(
-      <ToggleField
-        label="Test Label"
-        disabled
-        onCheckedChange={mockOnChange}
-      />,
-    );
-    const toggleInput = screen.getByRole("switch");
-    expect(toggleInput).toBeDisabled();
-  });
-
-  it("renders with custom className", () => {
-    // this is a custom class name for testing purposes
-    // eslint-disable-next-line tailwindcss/no-custom-classname
-    render(<ToggleField className="custom-class" />);
-    const toggle = screen.getByTestId("custom-class");
-    expect(toggle).toHaveClass("custom-class");
+      expect(toggle).toHaveClass(customClass);
+    });
   });
 });

--- a/packages/design-system/src/scalars/components/toggle/toggle.test.tsx
+++ b/packages/design-system/src/scalars/components/toggle/toggle.test.tsx
@@ -79,7 +79,7 @@ describe("Toggle Component", () => {
       expect(toggle).toHaveClass("data-[state=checked]:bg-[#C5C7C7]");
     });
 
-    it("should mark as required when required prop is true", () => {
+    it("should mark as required when disabled prop is true", () => {
       render(<Toggle {...defaultProps} disabled={true} />);
       const toggle = screen.getByRole("switch");
 

--- a/packages/design-system/src/scalars/components/toggle/toggle.tsx
+++ b/packages/design-system/src/scalars/components/toggle/toggle.tsx
@@ -31,9 +31,9 @@ const Toggle = React.forwardRef<
       disabled={disabled}
       onCheckedChange={onChange}
       className={cn(
-        "peer inline-flex h-4 w-8 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=checked]:bg-[#0084FF] data-[state=unchecked]:bg-[#9EA0A1]",
+        "peer inline-flex h-4 w-8 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=checked]:bg-[#343839] data-[state=unchecked]:bg-[#D7D8D9] dark:data-[state=checked]:bg-[#3BBE5F] dark:data-[state=unchecked]:bg-[#404446]",
         disabled &&
-          "cursor-not-allowed data-[state=checked]:bg-[#E5F3FF] data-[state=unchecked]:bg-[#EFEFEF]",
+          "cursor-not-allowed data-[state=checked]:bg-[#C5C7C7] data-[state=unchecked]:bg-[#EFEFEF] dark:data-[state=checked]:bg-[#404446] dark:data-[state=unchecked]:bg-[#343839]",
         className,
       )}
       {...props}
@@ -42,7 +42,8 @@ const Toggle = React.forwardRef<
       <SwitchPrimitives.Thumb
         className={cn(
           "peer pointer-events-none block h-3.5 w-3.5 rounded-full bg-[#FCFCFC] shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-3.5 data-[state=unchecked]:translate-x-0",
-          disabled && "disabled:cursor-not-allowed bg-[#FCFCFC]",
+          disabled &&
+            "disabled:cursor-not-allowed bg-[#FCFCFC] dark:bg-[#6C7275]",
         )}
       />
     </SwitchPrimitives.Root>

--- a/packages/design-system/tailwind.config.ts
+++ b/packages/design-system/tailwind.config.ts
@@ -2,6 +2,7 @@ import type { Config } from "tailwindcss";
 import { designSystemPreset } from "./src/shared-tailwind.config";
 
 const config = {
+  darkMode: ["class", '[data-mode="dark"]'],
   content: ["./src/**/*.{html,js,ts,tsx}", ".storybook/**/*.{html,js,ts,tsx}"],
   theme: designSystemPreset.theme,
   plugins: designSystemPreset.plugins,


### PR DESCRIPTION
## Ticket
https://trello.com/c/uY0oAAr1/713-2-boolean-toggle-component

## What solved
- [X] Default status without a label at the right.
- [X] Default status with a label at the right. 
- [X] Off status without a label. 
- [X] Off status with a label.
- [X] Off status with a label. 
- [X] Read only On status without a label.
- [X] Read only On status with a label at the right.
- [X] Read only On status with a label at the right. 
- [X] Read only Off status with a label at the right. 
- [X] Read only Off status without a label. 
