### PR TITLE
feat(scalars): add TextareaField with all props and base for styles, stories, tests and behavior

### DIFF
--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group-field.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { RadioGroupField } from "./radio-group-field";
@@ -8,53 +8,115 @@ const meta: Meta<typeof RadioGroupField> = {
     className: {
       control: "text",
       description: "Additional CSS classes to apply to the Radio Group",
+      table: {
+        type: { summary: "string" },
+        category: "Styling",
+      },
     },
     defaultValue: {
       control: "text",
-      description: "Default selected value for the Radio Group",
+      description: "Default selected value for uncontrolled Radio Group",
+      table: {
+        type: { summary: "string" },
+        category: "State",
+      },
     },
     description: {
       control: "text",
       description: "Description for the Radio Group",
-    },
-    warnings: {
-      control: "object",
-      description: "Array of warning messages to display",
-      table: { defaultValue: { summary: "[]" } },
+      table: {
+        type: { summary: "string" },
+        category: "Content",
+      },
     },
     errors: {
       control: "object",
-      description: "Array of error messages to display",
-      table: { defaultValue: { summary: "[]" } },
+      description: "Array of error messages to display below the Radio Group",
+      table: {
+        type: { summary: "string[]" },
+        defaultValue: { summary: "[]" },
+        category: "Validation",
+      },
+    },
+    id: {
+      control: "text",
+      description: "Unique identifier for the Radio Group",
+      table: {
+        type: { summary: "string" },
+        category: "Technical",
+      },
     },
     label: {
       control: "text",
       description: "Label for the Radio Group",
+      table: {
+        type: { summary: "string" },
+        category: "Content",
+      },
+    },
+    name: {
+      control: "text",
+      description: "Name attribute for the Radio Group form field",
+      table: {
+        type: { summary: "string" },
+        category: "Technical",
+      },
     },
     onChange: {
       action: "onChange",
-      description: "Callback fired when the value changes",
+      description: "Callback fired when a radio option is selected",
+      table: {
+        type: { summary: "(value: string) => void" },
+        category: "Events",
+      },
     },
     radioOptions: {
       control: "object",
       description:
-        "Array of radio options with label, value and optional description",
-      table: { defaultValue: { summary: "[]" } },
+        "Array of radio options with label, value, description, and disabled state",
+      table: {
+        type: {
+          summary:
+            "Array<{ label: string; value: string; description?: string; disabled?: boolean; }>",
+        },
+        defaultValue: { summary: "[]" },
+        category: "Content",
+      },
     },
     required: {
       control: "boolean",
-      description:
-        "Indicates if selecting an option in the Radio Group is required",
-      table: { defaultValue: { summary: "false" } },
+      description: "Whether selecting an option is required",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "Validation",
+      },
     },
     value: {
       control: "text",
-      description: "Currently selected value in the Radio Group",
+      description: "Currently selected value (for controlled component)",
+      table: {
+        type: { summary: "string" },
+        category: "State",
+      },
+    },
+    warnings: {
+      control: "object",
+      description: "Array of warning messages to display below the Radio Group",
+      table: {
+        type: { summary: "string[]" },
+        defaultValue: { summary: "[]" },
+        category: "Validation",
+      },
     },
   },
   component: RadioGroupField,
   parameters: {
-    controls: { sort: "requiredFirst" },
+    layout: "centered",
+    controls: {
+      sort: "requiredFirst",
+      expanded: true,
+    },
   },
   tags: ["autodocs"],
   title: "Document Engineering/Fragments/Radio Group Field",
@@ -133,7 +195,7 @@ export const WithOptionSelectedByDefault: Story = {
 };
 
 const ControlledRadioGroup = () => {
-  const [value, setValue] = React.useState("1");
+  const [value, setValue] = useState("1");
   const handleChange = (newValue: string) => {
     setValue(newValue);
     action("onChange")(newValue);
@@ -156,7 +218,7 @@ export const Controlled: Story = {
       source: {
         code: `
 const ControlledRadioGroup = () => {
-  const [value, setValue] = React.useState("1");
+  const [value, setValue] = useState("1");
   const handleChange = (newValue: string) => {
     setValue(newValue);
   };

--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group-field.stories.tsx
@@ -1,6 +1,4 @@
-import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import { action } from "@storybook/addon-actions";
 import { RadioGroupField } from "./radio-group-field";
 
 const meta: Meta<typeof RadioGroupField> = {
@@ -191,54 +189,6 @@ export const WithOptionSelectedByDefault: Story = {
     defaultValue: "2",
     label: "Radio Group with option selected by default",
     radioOptions: defaultRadioOptions,
-  },
-};
-
-const ControlledRadioGroup = () => {
-  const [value, setValue] = useState("1");
-  const handleChange = (newValue: string) => {
-    setValue(newValue);
-    action("onChange")(newValue);
-  };
-
-  return (
-    <RadioGroupField
-      label="Controlled Radio Group"
-      onChange={handleChange}
-      radioOptions={defaultRadioOptions}
-      value={value}
-    />
-  );
-};
-
-export const Controlled: Story = {
-  render: () => <ControlledRadioGroup />,
-  parameters: {
-    docs: {
-      source: {
-        code: `
-const ControlledRadioGroup = () => {
-  const [value, setValue] = useState("1");
-  const handleChange = (newValue: string) => {
-    setValue(newValue);
-  };
-
-  return (
-    <RadioGroupField
-      label="Controlled Radio Group"
-      onChange={handleChange}
-      radioOptions={[
-        { label: "Option 1", value: "1" },
-        { label: "Option 2", value: "2" },
-        { label: "Option 3", value: "3" },
-      ]}
-      value={value}
-    />
-  );
-};
-        `,
-      },
-    },
   },
 };
 

--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group-field.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group-field.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import { RadioGroupField } from "./radio-group-field";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { RadioGroupField } from "./radio-group-field";
 
 describe("RadioGroupField Component", () => {
   it("should match snapshot", () => {

--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group-field.tsx
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group-field.tsx
@@ -26,22 +26,20 @@ export interface RadioGroupFieldProps {
   value?: string;
 }
 
-export const RadioGroupField: React.FC<RadioGroupFieldProps> = (props) => {
-  const {
-    className,
-    defaultValue,
-    description,
-    warnings = [],
-    errors = [],
-    id,
-    label,
-    name,
-    onChange,
-    radioOptions = [],
-    required = false,
-    value,
-  } = props;
-
+export const RadioGroupField: React.FC<RadioGroupFieldProps> = ({
+  className,
+  defaultValue,
+  description,
+  warnings = [],
+  errors = [],
+  id,
+  label,
+  name,
+  onChange,
+  radioOptions = [],
+  required = false,
+  value,
+}) => {
   const hasLabel = label !== undefined;
   const hasError = errors.length > 0;
   const prefix = useId();

--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group.test.tsx
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { Radio } from "./radio";
-import { RadioGroup } from "./radio-group";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Radio } from "./radio";
+import { RadioGroup } from "./radio-group";
 
 describe("RadioGroup Component", () => {
   it("should match snapshot", () => {

--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group.tsx
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group.tsx
@@ -13,10 +13,9 @@ export interface RadioGroupProps
 export const RadioGroup = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Root>,
   RadioGroupProps
->(({ children, className, id: propId, name: propName, ...props }, ref) => {
+>(({ children, className, id: propId, name, ...props }, ref) => {
   const prefix = useId();
   const id = propId ?? `${prefix}-radio-group`;
-  const name = propName ?? `${prefix}-radio-group`;
 
   return (
     <RadioGroupPrimitive.Root

--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group.tsx
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group.tsx
@@ -20,11 +20,11 @@ export const RadioGroup = React.forwardRef<
 
   return (
     <RadioGroupPrimitive.Root
-      {...props}
       className={cn("flex flex-col gap-2.5", className)}
       id={id}
       name={name}
       ref={ref}
+      {...props}
     >
       {children}
     </RadioGroupPrimitive.Root>

--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/radio/radio.stories.tsx
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/radio/radio.stories.tsx
@@ -81,6 +81,42 @@ export const DefaultWithDescriptionChecked: Story = {
   },
 };
 
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    label: "Disabled",
+    value: "disabled",
+  },
+};
+
+export const DisabledChecked: Story = {
+  args: {
+    checked: true,
+    disabled: true,
+    label: "Disabled checked",
+    value: "disabled-checked",
+  },
+};
+
+export const DisabledWithDescription: Story = {
+  args: {
+    description: "This is a disabled Radio with description",
+    disabled: true,
+    label: "Disabled with description",
+    value: "disabled-with-description",
+  },
+};
+
+export const DisabledWithDescriptionChecked: Story = {
+  args: {
+    checked: true,
+    description: "This is a disabled Radio with description and checked",
+    disabled: true,
+    label: "Disabled with description and checked",
+    value: "disabled-with-description-checked",
+  },
+};
+
 export const Focus: Story = {
   args: {
     label: "Focus",
@@ -166,41 +202,5 @@ export const HoverWithDescriptionChecked: Story = {
   },
   parameters: {
     pseudo: { hover: true },
-  },
-};
-
-export const Disabled: Story = {
-  args: {
-    disabled: true,
-    label: "Disabled",
-    value: "disabled",
-  },
-};
-
-export const DisabledChecked: Story = {
-  args: {
-    checked: true,
-    disabled: true,
-    label: "Disabled checked",
-    value: "disabled-checked",
-  },
-};
-
-export const DisabledWithDescription: Story = {
-  args: {
-    description: "This is a disabled Radio with description",
-    disabled: true,
-    label: "Disabled with description",
-    value: "disabled-with-description",
-  },
-};
-
-export const DisabledWithDescriptionChecked: Story = {
-  args: {
-    checked: true,
-    description: "This is a disabled Radio with description and checked",
-    disabled: true,
-    label: "Disabled with description and checked",
-    value: "disabled-with-description-checked",
   },
 };

--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/radio/radio.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/radio/radio.test.tsx
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { Radio } from "./radio";
-import { RadioGroup } from "../radio-group";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Radio } from "./radio";
+import { RadioGroup } from "../radio-group";
 
 describe("Radio Component", () => {
   it("should match snapshot", () => {

--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/radio/radio.tsx
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/radio/radio.tsx
@@ -37,7 +37,6 @@ export const Radio = React.forwardRef<
     return (
       <>
         <RadioGroupPrimitive.Item
-          {...props}
           aria-disabled={disabled}
           aria-invalid={hasError}
           className={cn(
@@ -63,6 +62,7 @@ export const Radio = React.forwardRef<
           id={id}
           ref={ref}
           value={value}
+          {...props}
         >
           <RadioGroupPrimitive.Indicator
             className={cn(

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/__snapshots__/textarea-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/__snapshots__/textarea-field.test.tsx.snap
@@ -1,0 +1,141 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`TextareaField Component > should match snapshot with full props 1`] = `
+<DocumentFragment>
+  <div
+    class="flex flex-col gap-2"
+  >
+    <label
+      class="inline-flex items-center text-sm leading-[22px] dark:text-gray-400 dark:group-hover:text-slate-50 group-hover:text-red-900 mb-1.5 font-normal text-gray-900"
+      for=":r0:-textarea"
+      role="label"
+    >
+      Default Label
+      <span
+        class="ml-1 text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50"
+      >
+        *
+      </span>
+    </label>
+    <div
+      class="relative"
+    >
+      <textarea
+        aria-invalid="true"
+        aria-required="true"
+        autocomplete="off"
+        class="flex w-full rounded-lg text-base leading-normal transition-all duration-200 font-normal font-sans text-gray-900 dark:text-gray-100 border placeholder:text-gray-500 dark:placeholder:text-gray-600 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-offset-0 active:border-gray-400 dark:active:border-gray-600 disabled:cursor-not-allowed disabled:border-gray-100 disabled:bg-gray-50 disabled:text-gray-400 dark:disabled:border-gray-800 dark:disabled:bg-gray-900/50 dark:disabled:text-gray-600 border-red-700 bg-red-50/50 dark:border-red-400 dark:bg-red-900/5 hover:border-red-800 dark:hover:border-red-300 focus:border-red-900 focus:ring-red-100 dark:focus:border-red-300 dark:focus:ring-red-900/30 focus:hover:border-red-900 focus:hover:ring-red-200 dark:focus:hover:border-red-300 dark:focus:hover:ring-red-900/40 min-h-[120px] resize-y scrollbar scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent dark:scrollbar-thumb-gray-600"
+        id=":r0:-textarea"
+        name=":r0:-textarea"
+        rows="3"
+        spellcheck="false"
+      />
+      <div
+        class="mt-1.5 flex justify-end"
+      >
+        <div
+          class="flex items-center text-[10px]"
+        >
+          <span
+            class="text-gray-500"
+          >
+            0
+          </span>
+          <span
+            class="text-gray-300"
+          >
+            /100
+          </span>
+        </div>
+      </div>
+    </div>
+    <p
+      class="font-inter font-normal mt-1.5 text-sm text-gray-500 dark:text-gray-400"
+    >
+      Default description
+    </p>
+    <p
+      class="mb-0 inline-flex items-center text-xs font-medium text-orange-900 dark:text-orange-900"
+      data-type="warning"
+    >
+      Warning
+    </p>
+    <p
+      class="mb-0 inline-flex items-center text-xs font-medium text-red-900 dark:text-red-700"
+      data-type="error"
+    >
+      Error
+    </p>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`TextareaField Component > should match snapshot with props 1`] = `
+<DocumentFragment>
+  <div
+    class="flex flex-col gap-2"
+  >
+    <label
+      class="inline-flex items-center text-sm leading-[22px] dark:text-gray-400 dark:group-hover:text-slate-50 group-hover:text-red-900 mb-1.5 font-normal text-gray-900"
+      for=":r0:-textarea"
+      role="label"
+    >
+      Default Label
+      <span
+        class="ml-1 text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50"
+      >
+        *
+      </span>
+    </label>
+    <div
+      class="relative"
+    >
+      <textarea
+        aria-invalid="true"
+        aria-required="true"
+        autocomplete="off"
+        class="flex w-full rounded-lg text-base leading-normal transition-all duration-200 font-normal font-sans text-gray-900 dark:text-gray-100 border placeholder:text-gray-500 dark:placeholder:text-gray-600 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-offset-0 active:border-gray-400 dark:active:border-gray-600 disabled:cursor-not-allowed disabled:border-gray-100 disabled:bg-gray-50 disabled:text-gray-400 dark:disabled:border-gray-800 dark:disabled:bg-gray-900/50 dark:disabled:text-gray-600 border-red-700 bg-red-50/50 dark:border-red-400 dark:bg-red-900/5 hover:border-red-800 dark:hover:border-red-300 focus:border-red-900 focus:ring-red-100 dark:focus:border-red-300 dark:focus:ring-red-900/30 focus:hover:border-red-900 focus:hover:ring-red-200 dark:focus:hover:border-red-300 dark:focus:hover:ring-red-900/40 min-h-[120px] resize-y scrollbar scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent dark:scrollbar-thumb-gray-600"
+        id=":r0:-textarea"
+        name=":r0:-textarea"
+        rows="3"
+        spellcheck="false"
+      />
+      <div
+        class="mt-1.5 flex justify-end"
+      >
+        <div
+          class="flex items-center text-[10px]"
+        >
+          <span
+            class="text-gray-500"
+          >
+            0
+          </span>
+          <span
+            class="text-gray-300"
+          >
+            /100
+          </span>
+        </div>
+      </div>
+    </div>
+    <p
+      class="font-inter font-normal mt-1.5 text-sm text-gray-500 dark:text-gray-400"
+    >
+      Default description
+    </p>
+    <p
+      class="mb-0 inline-flex items-center text-xs font-medium text-orange-900 dark:text-orange-900"
+      data-type="warning"
+    >
+      Warning
+    </p>
+    <p
+      class="mb-0 inline-flex items-center text-xs font-medium text-red-900 dark:text-red-700"
+      data-type="error"
+    >
+      Error
+    </p>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/__snapshots__/textarea-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/__snapshots__/textarea-field.test.tsx.snap
@@ -1,75 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`TextareaField Component > should match snapshot with full props 1`] = `
-<DocumentFragment>
-  <div
-    class="flex flex-col gap-2"
-  >
-    <label
-      class="inline-flex items-center text-sm leading-[22px] dark:text-gray-400 dark:group-hover:text-slate-50 group-hover:text-red-900 mb-1.5 font-normal text-gray-900"
-      for=":r0:-textarea"
-      role="label"
-    >
-      Default Label
-      <span
-        class="ml-1 text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50"
-      >
-        *
-      </span>
-    </label>
-    <div
-      class="relative"
-    >
-      <textarea
-        aria-invalid="true"
-        aria-required="true"
-        autocomplete="off"
-        class="flex w-full rounded-lg text-base leading-normal transition-all duration-200 font-normal font-sans text-gray-900 dark:text-gray-100 border placeholder:text-gray-500 dark:placeholder:text-gray-600 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-offset-0 active:border-gray-400 dark:active:border-gray-600 disabled:cursor-not-allowed disabled:border-gray-100 disabled:bg-gray-50 disabled:text-gray-400 dark:disabled:border-gray-800 dark:disabled:bg-gray-900/50 dark:disabled:text-gray-600 border-red-700 bg-red-50/50 dark:border-red-400 dark:bg-red-900/5 hover:border-red-800 dark:hover:border-red-300 focus:border-red-900 focus:ring-red-100 dark:focus:border-red-300 dark:focus:ring-red-900/30 focus:hover:border-red-900 focus:hover:ring-red-200 dark:focus:hover:border-red-300 dark:focus:hover:ring-red-900/40 min-h-[120px] resize-y scrollbar scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent dark:scrollbar-thumb-gray-600"
-        id=":r0:-textarea"
-        name=":r0:-textarea"
-        rows="3"
-        spellcheck="false"
-      />
-      <div
-        class="mt-1.5 flex justify-end"
-      >
-        <div
-          class="flex items-center text-[10px]"
-        >
-          <span
-            class="text-gray-500"
-          >
-            0
-          </span>
-          <span
-            class="text-gray-300"
-          >
-            /100
-          </span>
-        </div>
-      </div>
-    </div>
-    <p
-      class="font-inter font-normal mt-1.5 text-sm text-gray-500 dark:text-gray-400"
-    >
-      Default description
-    </p>
-    <p
-      class="mb-0 inline-flex items-center text-xs font-medium text-orange-900 dark:text-orange-900"
-      data-type="warning"
-    >
-      Warning
-    </p>
-    <p
-      class="mb-0 inline-flex items-center text-xs font-medium text-red-900 dark:text-red-700"
-      data-type="error"
-    >
-      Error
-    </p>
-  </div>
-</DocumentFragment>
-`;
-
 exports[`TextareaField Component > should match snapshot with props 1`] = `
 <DocumentFragment>
   <div
@@ -96,7 +26,7 @@ exports[`TextareaField Component > should match snapshot with props 1`] = `
         autocomplete="off"
         class="flex w-full rounded-lg text-base leading-normal transition-all duration-200 font-normal font-sans text-gray-900 dark:text-gray-100 border placeholder:text-gray-500 dark:placeholder:text-gray-600 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-offset-0 active:border-gray-400 dark:active:border-gray-600 disabled:cursor-not-allowed disabled:border-gray-100 disabled:bg-gray-50 disabled:text-gray-400 dark:disabled:border-gray-800 dark:disabled:bg-gray-900/50 dark:disabled:text-gray-600 border-red-700 bg-red-50/50 dark:border-red-400 dark:bg-red-900/5 hover:border-red-800 dark:hover:border-red-300 focus:border-red-900 focus:ring-red-100 dark:focus:border-red-300 dark:focus:ring-red-900/30 focus:hover:border-red-900 focus:hover:ring-red-200 dark:focus:hover:border-red-300 dark:focus:hover:ring-red-900/40 min-h-[120px] resize-y scrollbar scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent dark:scrollbar-thumb-gray-600"
         id=":r0:-textarea"
-        name=":r0:-textarea"
+        name="textarea"
         rows="3"
         spellcheck="false"
       />

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.stories.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import { action } from "@storybook/addon-actions";
 import { TextareaField } from "./textarea-field";
 
 const meta = {
@@ -266,14 +265,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 // Basic Examples
-export const Default: Story = {
-  args: {
-    placeholder: "Enter your text here...",
-  },
-};
-
 export const WithLabel: Story = {
   args: {
+    name: "textarea",
     label: "Message",
     placeholder: "Enter your message",
   },
@@ -281,6 +275,7 @@ export const WithLabel: Story = {
 
 export const WithLabelAndDescription: Story = {
   args: {
+    name: "textarea",
     label: "Bio",
     description: "Tell us about yourself in a few sentences",
     placeholder: "I am...",
@@ -290,6 +285,7 @@ export const WithLabelAndDescription: Story = {
 // Validation States
 export const Required: Story = {
   args: {
+    name: "textarea",
     label: "Comments",
     required: true,
     placeholder: "This field is required",
@@ -298,6 +294,7 @@ export const Required: Story = {
 
 export const WithSingleWarning: Story = {
   args: {
+    name: "textarea",
     label: "Feedback",
     value: "OK",
     warnings: ["Your feedback seems quite short"],
@@ -306,8 +303,9 @@ export const WithSingleWarning: Story = {
 
 export const WithMultipleWarnings: Story = {
   args: {
+    name: "textarea",
     label: "Feedback",
-    value: "test",
+    value: "warnings",
     warnings: [
       "Consider providing more detailed feedback",
       "Your response may be too brief for proper evaluation",
@@ -317,8 +315,9 @@ export const WithMultipleWarnings: Story = {
 
 export const WithSingleError: Story = {
   args: {
+    name: "textarea",
     label: "Comments",
-    value: "ab",
+    value: "error",
     errors: ["Comments must be at least 10 characters long"],
     minLength: 10,
   },
@@ -326,8 +325,9 @@ export const WithSingleError: Story = {
 
 export const WithMultipleErrors: Story = {
   args: {
+    name: "textarea",
     label: "Comments",
-    value: "ab",
+    value: "errors",
     errors: [
       "Comments must be at least 10 characters long",
       "Comments must include a specific example",
@@ -338,8 +338,9 @@ export const WithMultipleErrors: Story = {
 
 export const WithWarningsAndErrors: Story = {
   args: {
+    name: "textarea",
     label: "Feedback",
-    value: "test",
+    value: "warnings and errors",
     warnings: [
       "Consider providing more detailed feedback",
       "Your response may be too brief",
@@ -354,6 +355,7 @@ export const WithWarningsAndErrors: Story = {
 // Length Constraints
 export const WithMinLength: Story = {
   args: {
+    name: "textarea",
     label: "Short answer",
     minLength: 20,
     placeholder: "Must be at least 20 characters",
@@ -363,26 +365,51 @@ export const WithMinLength: Story = {
 
 export const WithMaxLength: Story = {
   args: {
+    name: "textarea",
     label: "Brief response",
     maxLength: 50,
     placeholder: "Maximum 50 characters allowed",
     description: "Maximum length: 50 characters",
+    value: "", // Initial value
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value || "");
+    return (
+      <TextareaField
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
   },
 };
 
 export const WithMinAndMaxLength: Story = {
   args: {
+    name: "textarea",
     label: "Constrained response",
     minLength: 20,
     maxLength: 100,
     placeholder: "Between 20 and 100 characters",
     description: "Please provide between 20 and 100 characters",
+    value: "", // Initial value
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value || "");
+    return (
+      <TextareaField
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
   },
 };
 
 // Visual States
 export const Disabled: Story = {
   args: {
+    name: "textarea",
     label: "Disabled content",
     value: "This content cannot be edited",
     disabled: true,
@@ -391,6 +418,7 @@ export const Disabled: Story = {
 
 export const Focused: Story = {
   args: {
+    name: "textarea",
     label: "Focused textarea",
     placeholder: "This field is focused",
     autoFocus: true,
@@ -401,8 +429,19 @@ export const Focused: Story = {
 };
 
 // Special Features
+export const WithAutoComplete: Story = {
+  args: {
+    name: "textarea",
+    label: "Auto-complete enabled textarea",
+    autoComplete: true,
+    placeholder: "Browser auto-complete is enabled...",
+    description: "This field will show browser auto-complete suggestions",
+  },
+};
+
 export const WithSpellCheck: Story = {
   args: {
+    name: "textarea",
     label: "Spell-checked textarea",
     spellCheck: true,
     placeholder: "Spell checking is enabled...",
@@ -412,23 +451,16 @@ export const WithSpellCheck: Story = {
 
 export const WithCustomRows: Story = {
   args: {
+    name: "textarea",
     label: "Custom height textarea",
     rows: 10,
     placeholder: "This textarea shows 10 rows...",
   },
 };
 
-export const WithCharacterCounter: Story = {
-  args: {
-    label: "Limited text",
-    maxLength: 100,
-    value: "This text shows the character counter in action",
-    placeholder: "Start typing... (max 100 characters)",
-  },
-};
-
 export const AutoExpanding: Story = {
   args: {
+    name: "textarea",
     label: "Auto-expanding textarea",
     autoExpand: true,
     placeholder: "This will grow as you type...",
@@ -440,69 +472,81 @@ export const AutoExpanding: Story = {
 // Text Transformations
 export const WithTrimTransformation: Story = {
   args: {
+    name: "textarea",
     label: "Trimmed text",
     value: "  This text will have whitespace trimmed  ",
     trim: true,
     description: "Leading and trailing whitespace will be removed",
   },
+  render: (args) => {
+    const [value, setValue] = useState(args.value || "");
+    return (
+      <TextareaField
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
+  },
 };
 
 export const WithUppercaseTransformation: Story = {
   args: {
+    name: "textarea",
     label: "Uppercase text",
     value: "This text will be uppercase",
     uppercase: true,
     description: "Text will be converted to uppercase",
   },
+  render: (args) => {
+    const [value, setValue] = useState(args.value || "");
+    return (
+      <TextareaField
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
+  },
 };
 
-export const WithBothTransformations: Story = {
+export const WithLowercaseTransformation: Story = {
   args: {
+    name: "textarea",
+    label: "Lowercase text",
+    value: "THIS TEXT WILL BE LOWERCASE",
+    lowercase: true,
+    description: "Text will be converted to lowercase",
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value || "");
+    return (
+      <TextareaField
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
+  },
+};
+
+export const WithTrimAndUppercaseTransformations: Story = {
+  args: {
+    name: "textarea",
     label: "Transformed text",
     value: "  this will be trimmed and uppercase  ",
     trim: true,
     uppercase: true,
     description: "Text will be trimmed and converted to uppercase",
   },
-};
-
-// Controlled
-const ControlledTextarea = () => {
-  const [value, setValue] = useState("");
-  return (
-    <TextareaField
-      label="Controlled textarea"
-      value={value}
-      onChange={(e) => {
-        setValue(e.target.value);
-        action("onChange")(e);
-      }}
-      placeholder="Type something..."
-      description="This is a controlled component example"
-    />
-  );
-};
-
-export const Controlled: Story = {
-  render: () => <ControlledTextarea />,
-  parameters: {
-    docs: {
-      source: {
-        code: `
-const ControlledTextarea = () => {
-  const [value, setValue] = useState("");
-  return (
-    <TextareaField
-      label="Controlled textarea"
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      placeholder="Type something..."
-      description="This is a controlled component example"
-    />
-  );
-};
-`,
-      },
-    },
+  render: (args) => {
+    const [value, setValue] = useState(args.value || "");
+    return (
+      <TextareaField
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
   },
 };

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.stories.tsx
@@ -1,0 +1,508 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { TextareaField } from "./textarea-field";
+
+const meta = {
+  title: "Document Engineering/Fragments/TextareaField",
+  component: TextareaField,
+  parameters: {
+    layout: "centered",
+    controls: {
+      sort: "requiredFirst",
+      expanded: true,
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    autoComplete: {
+      control: "boolean",
+      description:
+        "Whether to enable browser autocompletion for the textarea field",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "Behavior",
+      },
+    },
+    autoExpand: {
+      control: "boolean",
+      description:
+        "Whether the textarea should automatically expand with content",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "Behavior",
+      },
+    },
+    autoFocus: {
+      control: "boolean",
+      description:
+        "Whether the textarea should automatically receive focus on mount",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "Behavior",
+      },
+    },
+    className: {
+      control: "text",
+      description: "Additional CSS classes to apply to the textarea",
+      table: {
+        type: { summary: "string" },
+        category: "Styling",
+      },
+    },
+    customValidator: {
+      description:
+        "Custom validation function that returns error message or null",
+      table: {
+        type: { summary: "(value: string) => string | null" },
+        category: "Validation",
+      },
+    },
+    defaultValue: {
+      control: "text",
+      description: "Initial value for uncontrolled component usage",
+      table: {
+        type: { summary: "string" },
+        category: "State",
+      },
+    },
+    description: {
+      control: "text",
+      description: "Helper text displayed below the textarea field",
+      table: {
+        type: { summary: "string" },
+        category: "Content",
+      },
+    },
+    disabled: {
+      control: "boolean",
+      description: "Whether the textarea field is disabled",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "State",
+      },
+    },
+    errors: {
+      control: "object",
+      description:
+        "Array of error messages to display below the textarea field",
+      table: {
+        type: { summary: "string[]" },
+        defaultValue: { summary: "[]" },
+        category: "Validation",
+      },
+    },
+    id: {
+      control: "text",
+      description:
+        "Unique identifier for the textarea field. Auto-generated if not provided",
+      table: {
+        type: { summary: "string" },
+        category: "Technical",
+      },
+    },
+    label: {
+      control: "text",
+      description:
+        "Label text displayed above the textarea field for accessibility and UX",
+      table: {
+        type: { summary: "string" },
+        category: "Content",
+      },
+    },
+    lowercase: {
+      control: "boolean",
+      description:
+        "Transforms input text to lowercase. Cannot be used with uppercase",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "Text Transformation",
+      },
+    },
+    maxLength: {
+      control: "number",
+      description: "Maximum number of characters allowed in the textarea",
+      table: {
+        type: { summary: "number" },
+        category: "Validation",
+      },
+    },
+    minLength: {
+      control: "number",
+      description: "Minimum number of characters required in the textarea",
+      table: {
+        type: { summary: "number" },
+        category: "Validation",
+      },
+    },
+    name: {
+      control: "text",
+      description:
+        "Name attribute for the textarea field. Auto-generated if not provided",
+      table: {
+        type: { summary: "string" },
+        category: "Technical",
+      },
+    },
+    onChange: {
+      action: "onChange",
+      description: "Callback fired when the textarea value changes",
+      table: {
+        type: {
+          summary: "(event: React.ChangeEvent<HTMLTextAreaElement>) => void",
+        },
+        category: "Events",
+      },
+    },
+    pattern: {
+      control: "text",
+      description: "Regular expression pattern for input validation",
+      table: {
+        type: { summary: "string" },
+        category: "Validation",
+      },
+    },
+    placeholder: {
+      control: "text",
+      description: "Placeholder text displayed when the textarea is empty",
+      table: {
+        type: { summary: "string" },
+        category: "Content",
+      },
+    },
+    required: {
+      control: "boolean",
+      description: "Whether the textarea input is required",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "Validation",
+      },
+    },
+    rows: {
+      control: "number",
+      description: "Number of visible text lines in the textarea",
+      table: {
+        type: { summary: "number" },
+        defaultValue: { summary: "3" },
+        category: "Appearance",
+      },
+    },
+    showErrorOnBlur: {
+      control: "boolean",
+      description:
+        "Whether to display validation errors when the field loses focus",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "Validation",
+      },
+    },
+    showErrorOnChange: {
+      control: "boolean",
+      description: "Whether to display validation errors as the user types",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "Validation",
+      },
+    },
+    spellCheck: {
+      control: "boolean",
+      description: "Whether to enable browser spell checking on the textarea",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "Behavior",
+      },
+    },
+    trim: {
+      control: "boolean",
+      description:
+        "Whether to remove leading and trailing whitespace from the value",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "Text Transformation",
+      },
+    },
+    uppercase: {
+      control: "boolean",
+      description:
+        "Transforms input text to uppercase. Cannot be used with lowercase",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: "Text Transformation",
+      },
+    },
+    value: {
+      control: "text",
+      description:
+        "Controlled value of the textarea field. Use with onChange handler",
+      table: {
+        type: { summary: "string" },
+        category: "State",
+      },
+    },
+    warnings: {
+      control: "object",
+      description: "Array of warning messages to display below the textarea",
+      table: {
+        type: { summary: "string[]" },
+        defaultValue: { summary: "[]" },
+        category: "Validation",
+      },
+    },
+  },
+} satisfies Meta<typeof TextareaField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Basic Examples
+export const Default: Story = {
+  args: {
+    placeholder: "Enter your text here...",
+  },
+};
+
+export const WithLabel: Story = {
+  args: {
+    label: "Message",
+    placeholder: "Enter your message",
+  },
+};
+
+export const WithLabelAndDescription: Story = {
+  args: {
+    label: "Bio",
+    description: "Tell us about yourself in a few sentences",
+    placeholder: "I am...",
+  },
+};
+
+// Validation States
+export const Required: Story = {
+  args: {
+    label: "Comments",
+    required: true,
+    placeholder: "This field is required",
+  },
+};
+
+export const WithSingleWarning: Story = {
+  args: {
+    label: "Feedback",
+    value: "OK",
+    warnings: ["Your feedback seems quite short"],
+  },
+};
+
+export const WithMultipleWarnings: Story = {
+  args: {
+    label: "Feedback",
+    value: "test",
+    warnings: [
+      "Consider providing more detailed feedback",
+      "Your response may be too brief for proper evaluation",
+    ],
+  },
+};
+
+export const WithSingleError: Story = {
+  args: {
+    label: "Comments",
+    value: "ab",
+    errors: ["Comments must be at least 10 characters long"],
+    minLength: 10,
+  },
+};
+
+export const WithMultipleErrors: Story = {
+  args: {
+    label: "Comments",
+    value: "ab",
+    errors: [
+      "Comments must be at least 10 characters long",
+      "Comments must include a specific example",
+    ],
+    minLength: 10,
+  },
+};
+
+export const WithWarningsAndErrors: Story = {
+  args: {
+    label: "Feedback",
+    value: "test",
+    warnings: [
+      "Consider providing more detailed feedback",
+      "Your response may be too brief",
+    ],
+    errors: [
+      "Feedback must be at least 10 characters long",
+      "Feedback must include specific examples",
+    ],
+  },
+};
+
+// Length Constraints
+export const WithMinLength: Story = {
+  args: {
+    label: "Short answer",
+    minLength: 20,
+    placeholder: "Must be at least 20 characters",
+    description: "Minimum length: 20 characters",
+  },
+};
+
+export const WithMaxLength: Story = {
+  args: {
+    label: "Brief response",
+    maxLength: 50,
+    placeholder: "Maximum 50 characters allowed",
+    description: "Maximum length: 50 characters",
+  },
+};
+
+export const WithMinAndMaxLength: Story = {
+  args: {
+    label: "Constrained response",
+    minLength: 20,
+    maxLength: 100,
+    placeholder: "Between 20 and 100 characters",
+    description: "Please provide between 20 and 100 characters",
+  },
+};
+
+// Visual States
+export const Disabled: Story = {
+  args: {
+    label: "Disabled content",
+    value: "This content cannot be edited",
+    disabled: true,
+  },
+};
+
+export const Focused: Story = {
+  args: {
+    label: "Focused textarea",
+    placeholder: "This field is focused",
+    autoFocus: true,
+  },
+  parameters: {
+    pseudo: { focus: true },
+  },
+};
+
+// Special Features
+export const WithSpellCheck: Story = {
+  args: {
+    label: "Spell-checked textarea",
+    spellCheck: true,
+    placeholder: "Spell checking is enabled...",
+    description: "This field will check your spelling",
+  },
+};
+
+export const WithCustomRows: Story = {
+  args: {
+    label: "Custom height textarea",
+    rows: 10,
+    placeholder: "This textarea shows 10 rows...",
+  },
+};
+
+export const WithCharacterCounter: Story = {
+  args: {
+    label: "Limited text",
+    maxLength: 100,
+    value: "This text shows the character counter in action",
+    placeholder: "Start typing... (max 100 characters)",
+  },
+};
+
+export const AutoExpanding: Story = {
+  args: {
+    label: "Auto-expanding textarea",
+    autoExpand: true,
+    placeholder: "This will grow as you type...",
+    description:
+      "The textarea will automatically expand as you type more content",
+  },
+};
+
+// Text Transformations
+export const WithTrimTransformation: Story = {
+  args: {
+    label: "Trimmed text",
+    value: "  This text will have whitespace trimmed  ",
+    trim: true,
+    description: "Leading and trailing whitespace will be removed",
+  },
+};
+
+export const WithUppercaseTransformation: Story = {
+  args: {
+    label: "Uppercase text",
+    value: "This text will be uppercase",
+    uppercase: true,
+    description: "Text will be converted to uppercase",
+  },
+};
+
+export const WithBothTransformations: Story = {
+  args: {
+    label: "Transformed text",
+    value: "  this will be trimmed and uppercase  ",
+    trim: true,
+    uppercase: true,
+    description: "Text will be trimmed and converted to uppercase",
+  },
+};
+
+// Controlled
+const ControlledTextarea = () => {
+  const [value, setValue] = useState("");
+  return (
+    <TextareaField
+      label="Controlled textarea"
+      value={value}
+      onChange={(e) => {
+        setValue(e.target.value);
+        action("onChange")(e);
+      }}
+      placeholder="Type something..."
+      description="This is a controlled component example"
+    />
+  );
+};
+
+export const Controlled: Story = {
+  render: () => <ControlledTextarea />,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+const ControlledTextarea = () => {
+  const [value, setValue] = useState("");
+  return (
+    <TextareaField
+      label="Controlled textarea"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      placeholder="Type something..."
+      description="This is a controlled component example"
+    />
+  );
+};
+`,
+      },
+    },
+  },
+};

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.test.tsx
@@ -1,4 +1,3 @@
-// Commented tests are WIP
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -8,6 +7,7 @@ describe("TextareaField Component", () => {
   it("should match snapshot with props", () => {
     const { asFragment } = render(
       <TextareaField
+        name="textarea"
         label="Default Label"
         description="Default description"
         required
@@ -22,6 +22,7 @@ describe("TextareaField Component", () => {
   it("should handle basic props and attributes", () => {
     render(
       <TextareaField
+        name="textarea"
         label="Test Label"
         required
         disabled
@@ -40,11 +41,11 @@ describe("TextareaField Component", () => {
   });
 
   it("should handle resize behavior", () => {
-    const { rerender } = render(<TextareaField />);
+    const { rerender } = render(<TextareaField name="textarea" />);
     let textarea = screen.getByRole("textbox");
     expect(textarea).toHaveClass("resize-y");
 
-    rerender(<TextareaField autoExpand />);
+    rerender(<TextareaField name="textarea" autoExpand />);
     textarea = screen.getByRole("textbox");
     expect(textarea).toHaveClass("resize-none", "overflow-hidden");
   });
@@ -52,7 +53,7 @@ describe("TextareaField Component", () => {
   describe("Styling and Visual States", () => {
     it("should apply correct styles for different states", async () => {
       const user = userEvent.setup();
-      const { rerender } = render(<TextareaField />);
+      const { rerender } = render(<TextareaField name="textarea" />);
       const textarea = screen.getByRole("textbox");
 
       // Default state
@@ -75,7 +76,7 @@ describe("TextareaField Component", () => {
       );
 
       // Error state
-      rerender(<TextareaField errors={["Error"]} />);
+      rerender(<TextareaField name="textarea" errors={["Error"]} />);
       expect(textarea).toHaveClass(
         "border-red-700",
         "bg-red-50/50",
@@ -86,6 +87,7 @@ describe("TextareaField Component", () => {
       // Custom class
       rerender(
         <TextareaField
+          name="textarea"
           // eslint-disable-next-line tailwindcss/no-custom-classname
           className="custom-class"
         />,
@@ -98,6 +100,7 @@ describe("TextareaField Component", () => {
     it("should handle warnings and errors", () => {
       render(
         <TextareaField
+          name="textarea"
           description="Help text"
           warnings={["Warning 1", "Warning 2"]}
           errors={["Error 1", "Error 2"]}
@@ -112,70 +115,6 @@ describe("TextareaField Component", () => {
     });
   });
 
-  /* describe("Input Handling", () => {
-    it("should handle various input methods and transformations", async () => {
-      const user = userEvent.setup();
-      const onChange = vi.fn();
-
-      render(
-        <TextareaField
-          value="Initial"
-          onChange={onChange}
-          maxLength={20}
-          trim
-          uppercase
-        />,
-      );
-
-      const textarea = screen.getByRole("textbox");
-
-      // Regular typing
-      await user.type(textarea, " text");
-      // Check the actual textarea value
-      expect(textarea).toHaveValue("INITIAL TEXT");
-
-      // Emoji input
-      await user.clear(textarea);
-      await user.type(textarea, "👋🏻");
-      expect(textarea).toHaveValue("👋🏻");
-      expect(screen.getByText("2/10")).toBeInTheDocument();
-
-      // Paste handling
-      const pasteData = "Pasted";
-      const pasteEvent = new ClipboardEvent("paste", {
-        clipboardData: new DataTransfer(),
-      });
-      pasteEvent.clipboardData?.setData("text/plain", pasteData);
-      textarea.dispatchEvent(pasteEvent);
-
-      // RTL text handling
-      await user.clear(textarea);
-      const rtlText = "مرحبا";
-      await user.type(textarea, rtlText);
-      expect(textarea).toHaveValue(rtlText);
-      expect(textarea).toHaveStyle({ direction: "rtl" });
-    });
-  }); */
-
-  /* describe("Accessibility", () => {
-    it("should handle all accessibility attributes and announcements", () => {
-      render(
-        <TextareaField
-          errors={["Error message"]}
-          maxLength={10}
-          value="Test"
-        />,
-      );
-
-      const textarea = screen.getByRole("textbox");
-      const counter = screen.getByText("4/10");
-
-      expect(textarea).toHaveAttribute("aria-label", "Text area");
-      expect(textarea).toHaveAttribute("aria-invalid", "true");
-      expect(counter).toBeInTheDocument();
-    });
-  }); */
-
   describe("Form Integration", () => {
     it("should handle form operations", async () => {
       const user = userEvent.setup();
@@ -183,7 +122,7 @@ describe("TextareaField Component", () => {
 
       render(
         <form onSubmit={handleSubmit}>
-          <TextareaField defaultValue="Initial" name="test" />
+          <TextareaField defaultValue="Initial" name="textarea" />
           <button type="submit">Submit</button>
           <button type="reset">Reset</button>
         </form>,
@@ -201,32 +140,4 @@ describe("TextareaField Component", () => {
       expect(textarea).toHaveValue("Initial");
     });
   });
-
-  /* describe("Performance", () => {
-    it("should handle auto-expansion and long content efficiently", async () => {
-      vi.useFakeTimers();
-      const user = userEvent.setup({ delay: null });
-      const onChange = vi.fn();
-
-      render(<TextareaField onChange={onChange} autoExpand />);
-      const textarea = screen.getByRole("textbox");
-      const initialHeight = textarea.clientHeight;
-
-      // Test long content
-      const longText = "a".repeat(1000);
-      await user.type(textarea, longText);
-      expect(onChange).toHaveBeenCalledTimes(1000);
-
-      // Test auto-expansion
-      await user.clear(textarea);
-      await user.type(textarea, "Line 1\nLine 2\nLine 3");
-
-      // Check debounced resize
-      expect(textarea.clientHeight).toBe(initialHeight);
-      vi.runAllTimers();
-      expect(textarea.clientHeight).toBeGreaterThan(initialHeight);
-
-      vi.useRealTimers();
-    });
-  }); */
 });

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.test.tsx
@@ -1,0 +1,232 @@
+// Commented tests are WIP
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TextareaField } from "./textarea-field";
+
+describe("TextareaField Component", () => {
+  it("should match snapshot with props", () => {
+    const { asFragment } = render(
+      <TextareaField
+        label="Default Label"
+        description="Default description"
+        required
+        maxLength={100}
+        warnings={["Warning"]}
+        errors={["Error"]}
+      />,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("should handle basic props and attributes", () => {
+    render(
+      <TextareaField
+        label="Test Label"
+        required
+        disabled
+        rows={5}
+        spellCheck={true}
+      />,
+    );
+
+    const textarea = screen.getByRole("textbox");
+    const label = screen.getByText("Test Label");
+
+    expect(label.parentElement).toHaveTextContent("*");
+    expect(textarea).toBeDisabled();
+    expect(textarea).toHaveAttribute("rows", "5");
+    expect(textarea).toHaveAttribute("spellcheck", "true");
+  });
+
+  it("should handle resize behavior", () => {
+    const { rerender } = render(<TextareaField />);
+    let textarea = screen.getByRole("textbox");
+    expect(textarea).toHaveClass("resize-y");
+
+    rerender(<TextareaField autoExpand />);
+    textarea = screen.getByRole("textbox");
+    expect(textarea).toHaveClass("resize-none", "overflow-hidden");
+  });
+
+  describe("Styling and Visual States", () => {
+    it("should apply correct styles for different states", async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(<TextareaField />);
+      const textarea = screen.getByRole("textbox");
+
+      // Default state
+      expect(textarea).toHaveClass("resize-y");
+
+      // Hover state
+      await user.hover(textarea);
+      expect(textarea).toHaveClass(
+        "hover:border-gray-300",
+        "dark:hover:border-gray-700",
+      );
+
+      // Focus state
+      await user.tab();
+      expect(textarea).toHaveClass(
+        "focus:border-gray-900",
+        "focus:ring-2",
+        "focus:ring-gray-100",
+        "focus:ring-offset-0",
+      );
+
+      // Error state
+      rerender(<TextareaField errors={["Error"]} />);
+      expect(textarea).toHaveClass(
+        "border-red-700",
+        "bg-red-50/50",
+        "dark:border-red-400",
+        "dark:bg-red-900/5",
+      );
+
+      // Custom class
+      rerender(
+        <TextareaField
+          // eslint-disable-next-line tailwindcss/no-custom-classname
+          className="custom-class"
+        />,
+      );
+      expect(textarea).toHaveClass("custom-class");
+    });
+  });
+
+  describe("Messages and Feedback", () => {
+    it("should handle warnings and errors", () => {
+      render(
+        <TextareaField
+          description="Help text"
+          warnings={["Warning 1", "Warning 2"]}
+          errors={["Error 1", "Error 2"]}
+        />,
+      );
+
+      expect(screen.getByText("Help text")).toBeInTheDocument();
+      expect(screen.getByText("Warning 1")).toBeInTheDocument();
+      expect(screen.getByText("Warning 2")).toBeInTheDocument();
+      expect(screen.getByText("Error 1")).toBeInTheDocument();
+      expect(screen.getByText("Error 2")).toBeInTheDocument();
+    });
+  });
+
+  /* describe("Input Handling", () => {
+    it("should handle various input methods and transformations", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(
+        <TextareaField
+          value="Initial"
+          onChange={onChange}
+          maxLength={20}
+          trim
+          uppercase
+        />,
+      );
+
+      const textarea = screen.getByRole("textbox");
+
+      // Regular typing
+      await user.type(textarea, " text");
+      // Check the actual textarea value
+      expect(textarea).toHaveValue("INITIAL TEXT");
+
+      // Emoji input
+      await user.clear(textarea);
+      await user.type(textarea, "👋🏻");
+      expect(textarea).toHaveValue("👋🏻");
+      expect(screen.getByText("2/10")).toBeInTheDocument();
+
+      // Paste handling
+      const pasteData = "Pasted";
+      const pasteEvent = new ClipboardEvent("paste", {
+        clipboardData: new DataTransfer(),
+      });
+      pasteEvent.clipboardData?.setData("text/plain", pasteData);
+      textarea.dispatchEvent(pasteEvent);
+
+      // RTL text handling
+      await user.clear(textarea);
+      const rtlText = "مرحبا";
+      await user.type(textarea, rtlText);
+      expect(textarea).toHaveValue(rtlText);
+      expect(textarea).toHaveStyle({ direction: "rtl" });
+    });
+  }); */
+
+  /* describe("Accessibility", () => {
+    it("should handle all accessibility attributes and announcements", () => {
+      render(
+        <TextareaField
+          errors={["Error message"]}
+          maxLength={10}
+          value="Test"
+        />,
+      );
+
+      const textarea = screen.getByRole("textbox");
+      const counter = screen.getByText("4/10");
+
+      expect(textarea).toHaveAttribute("aria-label", "Text area");
+      expect(textarea).toHaveAttribute("aria-invalid", "true");
+      expect(counter).toBeInTheDocument();
+    });
+  }); */
+
+  describe("Form Integration", () => {
+    it("should handle form operations", async () => {
+      const user = userEvent.setup();
+      const handleSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+
+      render(
+        <form onSubmit={handleSubmit}>
+          <TextareaField defaultValue="Initial" name="test" />
+          <button type="submit">Submit</button>
+          <button type="reset">Reset</button>
+        </form>,
+      );
+
+      const textarea = screen.getByRole("textbox");
+
+      // Submit
+      await user.click(screen.getByRole("button", { name: "Submit" }));
+      expect(handleSubmit).toHaveBeenCalled();
+
+      // Reset
+      await user.type(textarea, " modified");
+      await user.click(screen.getByRole("button", { name: "Reset" }));
+      expect(textarea).toHaveValue("Initial");
+    });
+  });
+
+  /* describe("Performance", () => {
+    it("should handle auto-expansion and long content efficiently", async () => {
+      vi.useFakeTimers();
+      const user = userEvent.setup({ delay: null });
+      const onChange = vi.fn();
+
+      render(<TextareaField onChange={onChange} autoExpand />);
+      const textarea = screen.getByRole("textbox");
+      const initialHeight = textarea.clientHeight;
+
+      // Test long content
+      const longText = "a".repeat(1000);
+      await user.type(textarea, longText);
+      expect(onChange).toHaveBeenCalledTimes(1000);
+
+      // Test auto-expansion
+      await user.clear(textarea);
+      await user.type(textarea, "Line 1\nLine 2\nLine 3");
+
+      // Check debounced resize
+      expect(textarea.clientHeight).toBe(initialHeight);
+      vi.runAllTimers();
+      expect(textarea.clientHeight).toBeGreaterThan(initialHeight);
+
+      vi.useRealTimers();
+    });
+  }); */
+});

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.tsx
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.tsx
@@ -44,7 +44,7 @@ export const TextareaField = React.forwardRef<
       lowercase = false,
       maxLength,
       minLength,
-      name: propName,
+      name,
       onChange,
       pattern,
       placeholder,
@@ -62,12 +62,10 @@ export const TextareaField = React.forwardRef<
     ref,
   ) => {
     const autoCompleteValue = autoComplete ? "on" : "off";
-    const spellCheckValue = spellCheck ? "true" : "false";
     const hasError = errors.length > 0;
 
     const prefix = useId();
     const id = propId ?? `${prefix}-textarea`;
-    const name = propName ?? `${prefix}-textarea`;
 
     const transformedValue = applyTransformers(value, {
       lowercase,
@@ -85,8 +83,9 @@ export const TextareaField = React.forwardRef<
     };
 
     useEffect(() => {
-      if (ref && "current" in ref && ref.current && autoExpand) {
-        adjustHeight(ref.current);
+      const textareaRef = ref && (ref as React.RefObject<HTMLTextAreaElement>);
+      if (textareaRef?.current && autoExpand) {
+        adjustHeight(textareaRef.current);
       }
     }, [value, autoExpand]);
 
@@ -197,7 +196,7 @@ export const TextareaField = React.forwardRef<
             placeholder={placeholder}
             ref={ref}
             rows={rows}
-            spellCheck={spellCheckValue}
+            spellCheck={spellCheck}
             value={transformedValue}
             {...props}
           />

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.tsx
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.tsx
@@ -1,17 +1,228 @@
-import type { FieldCommonProps, TextProps, ErrorHandling } from "../../types";
+import React, { useId, useEffect } from "react";
+import { FormLabel } from "@/scalars/components/fragments/form-label";
+import { FormMessageList } from "@/scalars/components/fragments/form-message";
+import { FormGroup } from "@/scalars/components/fragments/form-group";
+import { FormDescription } from "@/scalars/components/fragments/form-description";
+import { applyTransformers } from "@/scalars/lib/transformers";
+import { CharacterCounter } from "@/scalars/components/fragments/character-counter";
+import { cn } from "@/scalars/lib/utils";
+import {
+  ErrorHandling,
+  FieldCommonProps,
+  TextProps,
+} from "@/scalars/components/types";
+
+type TextareaBaseProps = Omit<
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+  keyof FieldCommonProps<string> | keyof TextProps | keyof ErrorHandling
+>;
 
 export interface TextareaProps
-  extends Omit<
-    FieldCommonProps<string> &
-      TextProps &
-      ErrorHandling &
-      React.TextareaHTMLAttributes<HTMLTextAreaElement>,
-    "value" | "spellCheck"
-  > {
-  value?: string;
-  spellCheck?: boolean;
+  extends TextareaBaseProps,
+    FieldCommonProps<string>,
+    TextProps,
+    ErrorHandling {
+  autoExpand?: boolean;
 }
 
-export const TextareaField: React.FC<TextareaProps> = ({ ...props }) => {
-  return <textarea {...props} />;
-};
+export const TextareaField = React.forwardRef<
+  HTMLTextAreaElement,
+  TextareaProps
+>(
+  (
+    {
+      autoComplete = false,
+      autoExpand = false,
+      className,
+      customValidator,
+      defaultValue,
+      description,
+      disabled = false,
+      errors = [],
+      id: propId,
+      label,
+      lowercase = false,
+      maxLength,
+      minLength,
+      name: propName,
+      onChange,
+      pattern,
+      placeholder,
+      required = false,
+      rows = 3,
+      showErrorOnBlur = false,
+      showErrorOnChange = false,
+      spellCheck = false,
+      trim = false,
+      uppercase = false,
+      value,
+      warnings = [],
+      ...props
+    },
+    ref,
+  ) => {
+    const autoCompleteValue = autoComplete ? "on" : "off";
+    const spellCheckValue = spellCheck ? "true" : "false";
+    const hasError = errors.length > 0;
+
+    const prefix = useId();
+    const id = propId ?? `${prefix}-textarea`;
+    const name = propName ?? `${prefix}-textarea`;
+
+    const transformedValue = applyTransformers(value, {
+      lowercase,
+      trim,
+      uppercase,
+    });
+
+    const adjustHeight = (element: HTMLTextAreaElement) => {
+      if (autoExpand) {
+        // Reset height to allow shrinking
+        element.style.height = "auto";
+        // Set to scrollHeight to expand based on content
+        element.style.height = `${element.scrollHeight}px`;
+      }
+    };
+
+    useEffect(() => {
+      if (ref && "current" in ref && ref.current && autoExpand) {
+        adjustHeight(ref.current);
+      }
+    }, [value, autoExpand]);
+
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      if (autoExpand) {
+        adjustHeight(e.currentTarget);
+      }
+      // Preserve existing onChange handler
+      onChange?.(e);
+    };
+
+    return (
+      <FormGroup>
+        {label && (
+          <FormLabel
+            className="mb-1.5 font-normal text-gray-900"
+            disabled={disabled}
+            hasError={hasError}
+            htmlFor={id}
+            required={required}
+          >
+            {label}
+          </FormLabel>
+        )}
+        <div className="relative">
+          <textarea
+            aria-invalid={hasError}
+            aria-label={label ? undefined : "Text area"}
+            aria-required={required}
+            autoComplete={autoCompleteValue}
+            className={cn(
+              // Base styles
+              "flex w-full rounded-lg text-base leading-normal transition-all duration-200",
+              "font-normal font-sans",
+
+              // Colors & Background
+              "text-gray-900 bg-white",
+              "dark:text-gray-100 dark:bg-gray-900",
+
+              // Border styles
+              "border border-gray-200",
+              "dark:border-gray-800",
+
+              // Placeholder
+              "placeholder:text-gray-500",
+              "dark:placeholder:text-gray-600",
+
+              // Padding & Spacing
+              "px-4 py-3",
+
+              // Focus state
+              "focus:border-gray-900 focus:outline-none",
+              "focus:ring-2 focus:ring-gray-100 focus:ring-offset-0",
+              "dark:focus:border-gray-400 dark:focus:ring-gray-900/30",
+
+              // Hover state
+              "hover:border-gray-300",
+              "dark:hover:border-gray-700",
+
+              // Focus + Hover combined state
+              "focus:hover:border-gray-900 focus:hover:ring-gray-200",
+              "dark:focus:hover:border-gray-400 dark:focus:hover:ring-gray-900/40",
+
+              // Active state
+              "active:border-gray-400",
+              "dark:active:border-gray-600",
+
+              // Disabled state
+              "disabled:cursor-not-allowed",
+              "disabled:border-gray-100 disabled:bg-gray-50 disabled:text-gray-400",
+              "dark:disabled:border-gray-800 dark:disabled:bg-gray-900/50 dark:disabled:text-gray-600",
+
+              // Error states
+              hasError && [
+                // Base error
+                "border-red-700 bg-red-50/50",
+                "dark:border-red-400 dark:bg-red-900/5",
+
+                // Error hover
+                "hover:border-red-800",
+                "dark:hover:border-red-300",
+
+                // Error focus
+                "focus:border-red-900 focus:ring-red-100",
+                "dark:focus:border-red-300 dark:focus:ring-red-900/30",
+
+                // Error focus + hover
+                "focus:hover:border-red-900 focus:hover:ring-red-200",
+                "dark:focus:hover:border-red-300 dark:focus:hover:ring-red-900/40",
+              ],
+
+              // Resize behavior
+              autoExpand && "resize-none overflow-hidden",
+              !autoExpand && [
+                "min-h-[120px] resize-y",
+                "scrollbar scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent",
+                "dark:scrollbar-thumb-gray-600",
+              ],
+
+              className,
+            )}
+            defaultValue={defaultValue}
+            disabled={disabled}
+            id={id}
+            minLength={minLength}
+            name={name}
+            onChange={handleChange}
+            placeholder={placeholder}
+            ref={ref}
+            rows={rows}
+            spellCheck={spellCheckValue}
+            value={transformedValue}
+            {...props}
+          />
+          {maxLength && (
+            <div className="mt-1.5 flex justify-end">
+              <CharacterCounter maxLength={maxLength} value={value ?? ""} />
+            </div>
+          )}
+        </div>
+        {description && (
+          <FormDescription className="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
+            {description}
+          </FormDescription>
+        )}
+        {warnings.length > 0 && (
+          <FormMessageList
+            className="mt-1.5"
+            messages={warnings}
+            type="warning"
+          />
+        )}
+        {hasError && (
+          <FormMessageList className="mt-1.5" messages={errors} type="error" />
+        )}
+      </FormGroup>
+    );
+  },
+);

--- a/packages/design-system/src/scalars/components/string-field/__snapshots__/string-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/string-field/__snapshots__/string-field.test.tsx.snap
@@ -5,9 +5,25 @@ exports[`StringField > should match snapshot when multiline is true (textarea) 1
   <form
     novalidate=""
   >
-    <textarea
-      name="test"
-    />
+    <div
+      class="flex flex-col gap-2"
+    >
+      <div
+        class="relative"
+      >
+        <textarea
+          aria-invalid="false"
+          aria-label="Text area"
+          aria-required="false"
+          autocomplete="off"
+          class="flex w-full rounded-lg text-base leading-normal transition-all duration-200 font-normal font-sans text-gray-900 bg-white dark:text-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 placeholder:text-gray-500 dark:placeholder:text-gray-600 px-4 py-3 focus:border-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-100 focus:ring-offset-0 dark:focus:border-gray-400 dark:focus:ring-gray-900/30 hover:border-gray-300 dark:hover:border-gray-700 focus:hover:border-gray-900 focus:hover:ring-gray-200 dark:focus:hover:border-gray-400 dark:focus:hover:ring-gray-900/40 active:border-gray-400 dark:active:border-gray-600 disabled:cursor-not-allowed disabled:border-gray-100 disabled:bg-gray-50 disabled:text-gray-400 dark:disabled:border-gray-800 dark:disabled:bg-gray-900/50 dark:disabled:text-gray-600 min-h-[120px] resize-y scrollbar scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent dark:scrollbar-thumb-gray-600"
+          id=":r0:-textarea"
+          name="test"
+          rows="3"
+          spellcheck="false"
+        />
+      </div>
+    </div>
   </form>
 </div>
 `;

--- a/packages/design-system/src/scalars/components/string-field/__snapshots__/string-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/string-field/__snapshots__/string-field.test.tsx.snap
@@ -2,7 +2,25 @@
 
 exports[`StringField > should match snapshot when multiline is true (textarea) 1`] = `
 <div>
-  <textarea />
+  <div
+    class="flex flex-col gap-2"
+  >
+    <div
+      class="relative"
+    >
+      <textarea
+        aria-invalid="false"
+        aria-label="Text area"
+        aria-required="false"
+        autocomplete="off"
+        class="flex w-full rounded-lg text-base leading-normal transition-all duration-200 font-normal font-sans text-gray-900 bg-white dark:text-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 placeholder:text-gray-500 dark:placeholder:text-gray-600 px-4 py-3 focus:border-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-100 focus:ring-offset-0 dark:focus:border-gray-400 dark:focus:ring-gray-900/30 hover:border-gray-300 dark:hover:border-gray-700 focus:hover:border-gray-900 focus:hover:ring-gray-200 dark:focus:hover:border-gray-400 dark:focus:hover:ring-gray-900/40 active:border-gray-400 dark:active:border-gray-600 disabled:cursor-not-allowed disabled:border-gray-100 disabled:bg-gray-50 disabled:text-gray-400 dark:disabled:border-gray-800 dark:disabled:bg-gray-900/50 dark:disabled:text-gray-600 min-h-[120px] resize-y scrollbar scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent dark:scrollbar-thumb-gray-600"
+        id=":r0:-textarea"
+        name=":r0:-textarea"
+        rows="3"
+        spellcheck="false"
+      />
+    </div>
+  </div>
 </div>
 `;
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/uUwA1jHm/715-1-string-multi-line-component

## Description
Add TextareaField with all props and base for styles, stories, tests and behavior.

## What solved
- [X] Add TextareaField with all props.
- [X] Add base styles, stories and tests.
- [X] Add autoExpand behavior.
- [X] Add support for trim, uppercase and lowercase the text.
- [X] Code improvements.