### PR TITLE
feat(document-model-libs): use document toolbar in document-editor-v2

### DIFF
--- a/packages/document-model-libs/editors/document-model-2/index.ts
+++ b/packages/document-model-libs/editors/document-model-2/index.ts
@@ -15,7 +15,8 @@ export const module: ExtendedEditor<
   documentTypes: ["powerhouse/document-model"],
   config: {
     id: "document-model-editor-v2",
-    disableExternalControls: false,
+    disableExternalControls: true,
+    documentToolbarEnabled: true,
   },
 };
 


### PR DESCRIPTION
## Description:

- Enable document toolbar for document-editor-v2

<img width="1728" alt="Screenshot 2024-11-06 at 11 23 17 AM" src="https://github.com/user-attachments/assets/2b2ff629-3400-463b-864b-b137e2d05294">
