### PR TITLE
feat(document model libs): use separate build schema

### DIFF
--- a/packages/document-model-libs/editors/document-model-2/components/errors.tsx
+++ b/packages/document-model-libs/editors/document-model-2/components/errors.tsx
@@ -4,8 +4,8 @@ type Props = {
 
 export function Errors({ errors }: Props) {
   return (
-    <div>
-      {errors.split("\n").map((error) => (
+    <div className="mt-1">
+      {Array.from(new Set(errors.split("\n"))).map((error) => (
         <p className="text-red-900" key={error}>
           {error}
         </p>

--- a/packages/document-model-libs/editors/document-model-2/components/graphql-editor.tsx
+++ b/packages/document-model-libs/editors/document-model-2/components/graphql-editor.tsx
@@ -83,7 +83,7 @@ export function GraphqlEditor(props: Props) {
         viewRef.current = null;
       }
     };
-  }, [readonly]);
+  }, [readonly, sharedSchema]);
 
   useEffect(() => {
     const view = viewRef.current;

--- a/packages/document-model-libs/editors/document-model-2/components/json-editor.tsx
+++ b/packages/document-model-libs/editors/document-model-2/components/json-editor.tsx
@@ -4,11 +4,9 @@ import { useEffect, useRef } from "react";
 import { basicSetup } from "codemirror";
 import { json, jsonParseLinter } from "@codemirror/lang-json";
 import { linter } from "@codemirror/lint";
-import { GraphQLSchema } from "graphql";
 import { ayuLight } from "thememirror";
 
 type Props = {
-  schema: GraphQLSchema;
   doc: string;
   readonly?: boolean;
   updateDoc: (newDoc: string) => void;

--- a/packages/document-model-libs/editors/document-model-2/components/model-metadata-form.tsx
+++ b/packages/document-model-libs/editors/document-model-2/components/model-metadata-form.tsx
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { DocumentActionHandlers } from "../types";
-import { GraphQLSchema } from "graphql";
 import { TextField } from "./text-field";
 import { useCallback } from "react";
 import { makeInitialSchemaDoc, renameSchemaType } from "../utils";
@@ -20,7 +19,6 @@ type Props = MetadataFormValues & {
   handlers: DocumentActionHandlers;
   globalStateSchema: string;
   localStateSchema: string;
-  schema: GraphQLSchema;
 };
 
 export function ModelMetadata(props: Props) {
@@ -41,7 +39,7 @@ export function ModelMetadata(props: Props) {
 }
 
 export function ModelNameForm(props: Props) {
-  const { name, handlers, globalStateSchema, localStateSchema, schema } = props;
+  const { name, handlers, globalStateSchema, localStateSchema } = props;
 
   const onSubmit = useCallback(
     (newName: string) => {
@@ -75,7 +73,7 @@ export function ModelNameForm(props: Props) {
         handlers.setStateSchema(newLocalStateSchema, "local");
       }
     },
-    [name, globalStateSchema, localStateSchema, handlers, schema],
+    [name, globalStateSchema, localStateSchema, handlers],
   );
 
   return (

--- a/packages/document-model-libs/editors/document-model-2/components/modules.tsx
+++ b/packages/document-model-libs/editors/document-model-2/components/modules.tsx
@@ -7,12 +7,11 @@ import { useId, useState, useRef } from "react";
 import { Divider } from "./divider";
 
 type Props = {
-  schema: GraphQLSchema;
   modules: Module[];
   allOperations: Operation[];
   handlers: DocumentActionHandlers;
 };
-export function Modules({ schema, modules, allOperations, handlers }: Props) {
+export function Modules({ modules, allOperations, handlers }: Props) {
   const [lastCreatedModuleId, setLastCreatedModuleId] = useState<string | null>(
     null,
   );
@@ -44,7 +43,6 @@ export function Modules({ schema, modules, allOperations, handlers }: Props) {
             <Divider />
           </div>
           <Operations
-            schema={schema}
             module={module}
             handlers={wrappedHandlers}
             allOperations={allOperations}

--- a/packages/document-model-libs/editors/document-model-2/components/operation.tsx
+++ b/packages/document-model-libs/editors/document-model-2/components/operation.tsx
@@ -45,6 +45,7 @@ export function Operation(props: Props) {
           </div>
         </div>
         <GraphqlEditor
+          doc={operation.schema ?? ""}
           id={operation.id}
           updateDocumentInModel={(newDoc) =>
             wrappedHandlers.updateOperationSchema(operation.id, newDoc)

--- a/packages/document-model-libs/editors/document-model-2/components/operation.tsx
+++ b/packages/document-model-libs/editors/document-model-2/components/operation.tsx
@@ -4,7 +4,7 @@ import { OperationDescriptionForm } from "./operation-description-form";
 import { OperationErrors } from "./operation-errors";
 import { OperationForm } from "./operation-form";
 import { DocumentActionHandlers } from "../types";
-import { GraphQLSchema } from "graphql";
+
 export type WrappedHandlers = DocumentActionHandlers & {
   addOperationAndInitialSchema: (
     moduleId: string,
@@ -12,7 +12,6 @@ export type WrappedHandlers = DocumentActionHandlers & {
   ) => Promise<string | undefined>;
 };
 type Props = {
-  schema: GraphQLSchema;
   lastCreatedOperationId: string | null;
   operation: Operation;
   module: Module;
@@ -26,7 +25,6 @@ export function Operation(props: Props) {
     wrappedHandlers,
     allOperationNames,
     lastCreatedOperationId,
-    schema,
   } = props;
   return (
     <div key={operation.id}>
@@ -47,9 +45,8 @@ export function Operation(props: Props) {
           </div>
         </div>
         <GraphqlEditor
-          schema={schema}
-          doc={operation.schema ?? ""}
-          updateDoc={(newDoc) =>
+          id={operation.id}
+          updateDocumentInModel={(newDoc) =>
             wrappedHandlers.updateOperationSchema(operation.id, newDoc)
           }
         />

--- a/packages/document-model-libs/editors/document-model-2/components/operations.tsx
+++ b/packages/document-model-libs/editors/document-model-2/components/operations.tsx
@@ -7,14 +7,12 @@ import { Operation, WrappedHandlers } from "./operation";
 import { Divider } from "./divider";
 
 type Props = {
-  schema: GraphQLSchema;
   module: Module;
   allOperations: TOperation[];
   handlers: DocumentActionHandlers;
   shouldFocusNewOperation: boolean;
 };
 export function Operations({
-  schema,
   module,
   handlers,
   allOperations,
@@ -48,7 +46,6 @@ export function Operations({
             operation={operation}
             module={module}
             wrappedHandlers={wrappedHandlers}
-            schema={schema}
             lastCreatedOperationId={lastCreatedOperationId}
             allOperationNames={allOperationNames}
           />

--- a/packages/document-model-libs/editors/document-model-2/components/state-schemas.tsx
+++ b/packages/document-model-libs/editors/document-model-2/components/state-schemas.tsx
@@ -1,4 +1,3 @@
-import { typeDefs } from "@powerhousedao/scalars";
 import { makeMinimalObjectFromSDL, makeInitialSchemaDoc } from "../utils";
 import { GraphqlEditor } from "./graphql-editor";
 import { JSONEditor } from "./json-editor";
@@ -6,14 +5,14 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "./tabs";
 import { DocumentActionHandlers } from "../types";
 import { useState } from "react";
 import { capitalCase } from "change-case";
-import { schema } from "@powerhousedao/scalars/AmountTokens";
 import { useSchemaContext } from "../context/schema-context";
+import { hiddenQueryTypeDefDoc } from "../constants";
 
 type Props = {
   modelName: string;
   globalStateSchema: string;
-  globalStateInitialValue: string;
   localStateSchema: string;
+  globalStateInitialValue: string;
   localStateInitialValue: string;
   handlers: DocumentActionHandlers;
 };
@@ -41,6 +40,7 @@ function StateEditor({
         <div>
           {showStandardLib && (
             <GraphqlEditor
+              doc={hiddenQueryTypeDefDoc}
               id="standard-lib"
               readonly
               updateDocumentInModel={() => {}}
@@ -54,6 +54,7 @@ function StateEditor({
           </button>
           <div className="pt-2">
             <GraphqlEditor
+              doc={stateSchema}
               id={scope}
               updateDocumentInModel={(newDoc) =>
                 handlers.setStateSchema(newDoc, scope)

--- a/packages/document-model-libs/editors/document-model-2/components/state-schemas.tsx
+++ b/packages/document-model-libs/editors/document-model-2/components/state-schemas.tsx
@@ -5,12 +5,12 @@ import { JSONEditor } from "./json-editor";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "./tabs";
 import { DocumentActionHandlers } from "../types";
 import { useState } from "react";
-import { GraphQLSchema } from "graphql";
 import { capitalCase } from "change-case";
+import { schema } from "@powerhousedao/scalars/AmountTokens";
+import { useSchemaContext } from "../context/schema-context";
 
 type Props = {
   modelName: string;
-  schema: GraphQLSchema;
   globalStateSchema: string;
   globalStateInitialValue: string;
   localStateSchema: string;
@@ -19,7 +19,6 @@ type Props = {
 };
 
 type StateEditorProps = {
-  schema: GraphQLSchema;
   stateSchema: string;
   initialValue: string;
   handlers: DocumentActionHandlers;
@@ -27,12 +26,12 @@ type StateEditorProps = {
 };
 
 function StateEditor({
-  schema,
   stateSchema,
   initialValue,
   handlers,
   scope,
 }: StateEditorProps) {
+  const { sharedSchema } = useSchemaContext();
   const [showStandardLib, setShowStandardLib] = useState(false);
 
   return (
@@ -42,10 +41,9 @@ function StateEditor({
         <div>
           {showStandardLib && (
             <GraphqlEditor
-              doc={typeDefs.join("\n")}
-              schema={schema}
+              id="standard-lib"
               readonly
-              updateDoc={() => {}}
+              updateDocumentInModel={() => {}}
             />
           )}
           <button
@@ -56,9 +54,10 @@ function StateEditor({
           </button>
           <div className="pt-2">
             <GraphqlEditor
-              doc={stateSchema}
-              schema={schema}
-              updateDoc={(newDoc) => handlers.setStateSchema(newDoc, scope)}
+              id={scope}
+              updateDocumentInModel={(newDoc) =>
+                handlers.setStateSchema(newDoc, scope)
+              }
             />
           </div>
         </div>
@@ -69,7 +68,7 @@ function StateEditor({
               className="rounded border border-slate-800 bg-white px-2 py-1 text-slate-800"
               onClick={() => {
                 const updatedStateDoc = makeMinimalObjectFromSDL(
-                  schema,
+                  sharedSchema,
                   stateSchema,
                   initialValue ? JSON.parse(initialValue) : {},
                 );
@@ -81,7 +80,6 @@ function StateEditor({
           </div>
           <div className="pt-2">
             <JSONEditor
-              schema={schema}
               doc={initialValue}
               updateDoc={(newDoc) => handlers.setInitialState(newDoc, scope)}
             />
@@ -94,7 +92,6 @@ function StateEditor({
 
 export function StateSchemas(props: Props) {
   const {
-    schema,
     modelName,
     globalStateSchema,
     localStateSchema,
@@ -116,7 +113,6 @@ export function StateSchemas(props: Props) {
 
       <TabsContent value="global" tabIndex={-1}>
         <StateEditor
-          schema={schema}
           stateSchema={globalStateSchema}
           initialValue={globalStateInitialValue}
           handlers={handlers}
@@ -142,7 +138,6 @@ export function StateSchemas(props: Props) {
           </button>
         ) : (
           <StateEditor
-            schema={schema}
             stateSchema={localStateSchema}
             initialValue={localStateInitialValue}
             handlers={handlers}

--- a/packages/document-model-libs/editors/document-model-2/constants/documents.ts
+++ b/packages/document-model-libs/editors/document-model-2/constants/documents.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
+import { buildSchema } from "graphql";
 import { typeDefs } from "@powerhousedao/scalars";
 
 export const hiddenQueryTypeDefDoc = `type Query {
@@ -7,15 +7,4 @@ export const hiddenQueryTypeDefDoc = `type Query {
 ${typeDefs.join("\n")}
 `;
 
-export const query = new GraphQLObjectType({
-  name: "Query",
-  fields: {
-    _hidden: {
-      type: GraphQLString,
-    },
-  },
-});
-
-export const initialSchema = new GraphQLSchema({
-  query,
-});
+export const initialSchema = buildSchema(hiddenQueryTypeDefDoc);

--- a/packages/document-model-libs/editors/document-model-2/context/schema-context.tsx
+++ b/packages/document-model-libs/editors/document-model-2/context/schema-context.tsx
@@ -1,0 +1,127 @@
+import { Operation } from "document-model/document-model";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { hiddenQueryTypeDefDoc, initialSchema } from "../constants/documents";
+import { buildSchema, GraphQLSchema } from "graphql";
+import { isDocumentString } from "@graphql-tools/utils";
+
+type TSchemaContext = {
+  sharedSchema: GraphQLSchema;
+  getDocument: (id: string) => string;
+  updateSharedSchema: (
+    id: string,
+    newDoc: string,
+  ) =>
+    | {
+        success: true;
+      }
+    | {
+        success: false;
+        errors: string;
+      };
+  handleSchemaErrors: (
+    id: string,
+    newDoc: string,
+  ) =>
+    | {
+        success: true;
+        schema: GraphQLSchema;
+      }
+    | {
+        success: false;
+        errors: string;
+      };
+};
+
+type TSchemaContextProps = {
+  globalStateSchema: string;
+  localStateSchema: string;
+  operations: Operation[];
+  children: React.ReactNode;
+};
+
+export const SchemaContext = createContext<TSchemaContext>({
+  sharedSchema: initialSchema,
+  getDocument: () => "",
+  updateSharedSchema: () => ({ success: true }),
+  handleSchemaErrors: () => ({ success: true, schema: initialSchema }),
+});
+export function SchemaContextProvider(props: TSchemaContextProps) {
+  const { children, globalStateSchema, localStateSchema, operations } = props;
+  const [sharedSchema, setSharedSchema] = useState(initialSchema);
+  const [documents, setDocuments] = useState(new Map<string, string>());
+
+  useEffect(() => {
+    setDocuments((prev) => {
+      const newDocuments = new Map<string, string>(prev);
+      newDocuments.set("standard-lib", hiddenQueryTypeDefDoc);
+      newDocuments.set("global", globalStateSchema);
+      newDocuments.set("local", localStateSchema);
+      for (const operation of operations) {
+        if (operation.schema) {
+          newDocuments.set(operation.id, operation.schema);
+        }
+      }
+      return newDocuments;
+    });
+  }, [globalStateSchema, localStateSchema, operations]);
+
+  const handleSchemaErrors: TSchemaContext["handleSchemaErrors"] = useCallback(
+    (id: string, newDoc: string) => {
+      if (!isDocumentString(newDoc)) return { success: false, errors: "" };
+      const newDocuments = new Map(documents);
+      newDocuments.set(id, newDoc);
+      try {
+        const newSchemaString = Array.from(newDocuments.values()).join("\n");
+        const newSharedSchema = buildSchema(newSchemaString);
+        return {
+          success: true,
+          schema: newSharedSchema,
+        };
+      } catch (e) {
+        return {
+          success: false,
+          errors: (e as Error).message,
+        };
+      }
+    },
+    [documents],
+  );
+
+  const updateSharedSchema: TSchemaContext["updateSharedSchema"] = useCallback(
+    (id: string, newDoc: string) => {
+      const result = handleSchemaErrors(id, newDoc);
+
+      if (result.success) {
+        setSharedSchema(result.schema);
+      }
+      return result;
+    },
+    [handleSchemaErrors],
+  );
+
+  const value = useMemo(
+    () => ({
+      sharedSchema,
+      documents,
+      getDocument: (id: string) => documents.get(id) ?? "",
+      handleSchemaErrors,
+      updateSharedSchema,
+    }),
+    [sharedSchema, documents, handleSchemaErrors],
+  );
+
+  return (
+    <SchemaContext.Provider value={value}>{children}</SchemaContext.Provider>
+  );
+}
+
+export function useSchemaContext() {
+  return useContext(SchemaContext);
+}

--- a/packages/document-model-libs/editors/document-model-2/context/schema-context.tsx
+++ b/packages/document-model-libs/editors/document-model-2/context/schema-context.tsx
@@ -55,7 +55,18 @@ export const SchemaContext = createContext<TSchemaContext>({
 export function SchemaContextProvider(props: TSchemaContextProps) {
   const { children, globalStateSchema, localStateSchema, operations } = props;
   const [sharedSchema, setSharedSchema] = useState(initialSchema);
-  const [documents, setDocuments] = useState(new Map<string, string>());
+  const [documents, setDocuments] = useState(() => {
+    const newDocuments = new Map<string, string>();
+    newDocuments.set("standard-lib", hiddenQueryTypeDefDoc);
+    newDocuments.set("global", globalStateSchema);
+    newDocuments.set("local", localStateSchema);
+    for (const operation of operations) {
+      if (operation.schema) {
+        newDocuments.set(operation.id, operation.schema);
+      }
+    }
+    return newDocuments;
+  });
 
   useEffect(() => {
     setDocuments((prev) => {

--- a/packages/document-model-libs/editors/document-model-2/document-model-2.stories.tsx
+++ b/packages/document-model-libs/editors/document-model-2/document-model-2.stories.tsx
@@ -29,7 +29,7 @@ const mockDocument = {
           state: {
             global: {
               schema:
-                'type TestState {\n  "Add your global state fields here"\n  _placeholder: String\n}',
+                'type TestState {\n  "Add your global state fields here"\n  _placeholder: Date\n}',
               initialValue: '{\n  "_placeholder": ""\n}',
               examples: [],
             },

--- a/packages/document-model-libs/editors/document-model-2/document-model-editor.tsx
+++ b/packages/document-model-libs/editors/document-model-2/document-model-editor.tsx
@@ -1,15 +1,12 @@
 import { memo } from "react";
-import { GraphQLSchema } from "graphql";
 import { Modules } from "./components/modules";
 import { Divider } from "./components/divider";
-import { Errors } from "./components/errors";
 import { StateSchemas } from "./components/state-schemas";
 import { DocumentActionHandlers } from "./types";
 import { Module, Operation } from "document-model/document-model";
 
 type Props = {
   modelName: string;
-  schema: GraphQLSchema;
   globalStateSchema: string;
   globalStateInitialValue: string;
   localStateSchema: string;
@@ -17,12 +14,10 @@ type Props = {
   handlers: DocumentActionHandlers;
   modules: Module[];
   operations: Operation[];
-  errors: string;
 };
 export function _DocumentModelEditor(props: Props) {
   const {
     modelName,
-    schema,
     globalStateSchema,
     globalStateInitialValue,
     localStateSchema,
@@ -30,7 +25,6 @@ export function _DocumentModelEditor(props: Props) {
     modules,
     operations,
     handlers,
-    errors,
   } = props;
 
   if (!globalStateSchema) return null;
@@ -39,18 +33,15 @@ export function _DocumentModelEditor(props: Props) {
     <div>
       <StateSchemas
         modelName={modelName}
-        schema={schema}
         globalStateSchema={globalStateSchema}
         globalStateInitialValue={globalStateInitialValue}
         localStateSchema={localStateSchema}
         localStateInitialValue={localStateInitialValue}
         handlers={handlers}
       />
-      <Errors errors={errors} />
       <Divider />
       <h3 className="mb-6 text-lg">Global Operations</h3>
       <Modules
-        schema={schema}
         modules={modules}
         allOperations={operations}
         handlers={handlers}


### PR DESCRIPTION
We want to be able to see the errors for a given graphql editor such that they are displayed under their specific editor.
Currently we are showing them all under the state editors.

We must understand that there are two types of errors that we are dealing with:

document errors — this is when what you have typed is not a valid document at all, for example with wrong syntax. This is already handled by the built-in linting.

schema build errors — these are thrown when passing a string to `buildSchema`. This includes things like "there can only be one type 'OID'" etc.

To determine errors of the second type, we need to build the _whole_ schema with all of the various documents. Previously we were doing this in the parent editor component.

In this PR, I have moved the shared schema into a context. This context maintains a map of the IDs of the various documents and their contents, and ships functions for updating the shared schema locally from the component. These functions know about the whole list of documents and can therefore do the second type of error handling locally in the component.

I have also added debounce logic for the graphql editor, since we are now dispatching without waiting for the document to be valid.

Doing this also ensures that the standard library types are immediately available on render.