### PR TITLE
feat(scalars): add support for custom validators

### DIFF
--- a/packages/design-system/src/scalars/components/fragments/with-field-validation/with-field-validation.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/with-field-validation/with-field-validation.test.tsx
@@ -165,4 +165,46 @@ describe("withFieldValidation", () => {
     expect(handleSubmit).not.toHaveBeenCalled();
     expect(await screen.findByTestId("error-message")).toBeInTheDocument();
   });
+
+  it("should validate custom validators", async () => {
+    const WrappedComponentWithCustomValidator =
+      withFieldValidation<TextFieldProps>(TextFieldTesting, {
+        validations: {
+          _isPrime: () => (value: string) => {
+            return Number(value) % 2 === 0 || "Custom error message";
+          },
+        },
+      });
+    renderWithForm(<WrappedComponentWithCustomValidator name="test" />);
+
+    const input = screen.getByTestId("test-input");
+    await userEvent.type(input, "3");
+    await userEvent.keyboard("{Enter}");
+
+    expect(await screen.findByTestId("error-message")).toBeInTheDocument();
+  });
+
+  it("should validate custom validators using parent props", async () => {
+    const WrappedComponentWithCustomValidator =
+      withFieldValidation<TextFieldProps>(TextFieldTesting, {
+        validations: {
+          _autoCompleteRequireLength3: (props) => (value: string) => {
+            return props.autoComplete
+              ? value.length > 3
+                ? true
+                : "Error"
+              : true;
+          },
+        },
+      });
+    renderWithForm(
+      <WrappedComponentWithCustomValidator name="test" autoComplete />,
+    );
+
+    const input = screen.getByTestId("test-input");
+    await userEvent.type(input, "12");
+    await userEvent.keyboard("{Enter}");
+
+    expect(await screen.findByTestId("error-message")).toBeInTheDocument();
+  });
 });

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -128,5 +128,17 @@ const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
   },
 );
 
-export const NumberField =
-  withFieldValidation<NumberFieldProps>(NumberFieldRaw);
+export const NumberField = withFieldValidation<NumberFieldProps>(
+  NumberFieldRaw,
+  {
+    validations: {
+      _positive: (props) => (value) => {
+        return props.allowNegative
+          ? true
+          : Number(value) > 0
+            ? true
+            : "Value must be positive";
+      },
+    },
+  },
+);


### PR DESCRIPTION
## Ticket
https://trello.com/c/S2RNIMLT/685-1-numbers-int-float-bigint-negativeint-positiveint-nonnegativeint-1nonpositiveint-negativefloat-positivefloat-nonnegativefloat-n

## Description
Allow custom validators to be added to the `withFieldValidation` HOC. Usage:

```tsx
export const NumberField = withFieldValidation<NumberFieldProps>(
  NumberFieldRaw,
  {
    validations: {
      _positive: (props) => (value) => {
        return props.allowNegative
          ? true
          : Number(value) > 0
            ? true
            : "Value must be positive";
      },
      _isPrime: () => (value) => {
        return Number(value) % 2 === 0 ? true : `${value} is not a prime number`;
      },
    },
  },
);
```