### PR TITLE
feat(scalars): add the validations for int and bigInt

### DIFF
--- a/packages/design-system/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`NumberField Component > should match snapshot 1`] = `
       </label>
       <input
         aria-invalid="false"
-        class="flex h-10 w-full rounded-md text-sm border border-gray-300 bg-background px-3 py-2 ring-offset-background focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed show-arrows text-gray-900 dark:text-gray-50 dark:bg-[#252A34] dark:border-[#485265] focus:text-gray-300 dark:focus:text-gray-700 placeholder:focus:text-gray-300 dark:placeholder:focus:text-gray-700 focus-visible:ring-[#9DA6B9] focus-visible:ring-offset-1 dark:ring-offset-[#252A34] placeholder:focus:ml-0.5 placeholder:text-gray-300 dark:placeholder:text-gray-700 disabled:border-gray-300 dark:disabled:border-[#373E4D] disabled:bg-[#FFFFFF]dark:disabled:bg-[#252A34] disabled:text-gray-500 dark:disabled:text-gray-700"
+        class="flex h-10 w-full rounded-md text-sm border border-gray-300 bg-background px-3 py-2 ring-offset-background focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed text-gray-900 dark:text-gray-50 dark:bg-[#252A34] dark:border-[#485265] focus:text-gray-300 dark:focus:text-gray-700 placeholder:focus:text-gray-300 dark:placeholder:focus:text-gray-700 focus-visible:ring-[#9DA6B9] focus-visible:ring-offset-1 dark:ring-offset-[#252A34] placeholder:focus:ml-0.5 placeholder:text-gray-300 dark:placeholder:text-gray-700 disabled:border-gray-300 dark:disabled:border-[#373E4D] disabled:bg-[#FFFFFF]dark:disabled:bg-[#252A34] disabled:text-gray-500 dark:disabled:text-gray-700"
         id=":r0:"
         name="Label"
         type="number"

--- a/packages/design-system/src/scalars/components/number-field/number-field.test.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.test.tsx
@@ -123,20 +123,6 @@ describe("NumberField Component", () => {
     );
   });
 
-  it("should renders input with provided className", () => {
-    renderWithForm(
-      <NumberField
-        label="Test Label"
-        // This a custom class for testing no a class for tailwindcss
-        // eslint-disable-next-line tailwindcss/no-custom-classname
-        className="custom-class"
-        onChange={mockOnChange}
-        name="Label"
-      />,
-    );
-    expect(screen.getByLabelText("Test Label")).toHaveClass("custom-class");
-  });
-
   it("should supports a defaultValue prop", () => {
     renderWithForm(
       <NumberField

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -8,6 +8,13 @@ import { FormDescription } from "../fragments/form-description";
 import { cn } from "@/scalars/lib";
 import { getDisplayValue, regex } from "@/scalars/utils/utils";
 import { withFieldValidation } from "../fragments/with-field-validation";
+import {
+  validateDecimalRequired,
+  validateIsBigInt,
+  validatePositive,
+  validatePrecision,
+  validateTrailingZeros,
+} from "./numberFieldValidations";
 
 export interface NumberFieldProps
   extends Omit<
@@ -132,19 +139,11 @@ export const NumberField = withFieldValidation<NumberFieldProps>(
   NumberFieldRaw,
   {
     validations: {
-      _positive: (props) => (value) => {
-        return props.allowNegative
-          ? true
-          : Number(value) > 0
-            ? true
-            : ` ${props.label} be a positive value`;
-      },
-      _isBigInt: (props) => (value: string) => {
-        const isLargeNumber = Math.abs(Number(value)) > Number.MAX_SAFE_INTEGER;
-        return isLargeNumber && !props.isBigInt
-          ? "Value is too large for standard integer, set isBigInt to true"
-          : true;
-      },
+      _positive: validatePositive,
+      _isBigInt: validateIsBigInt,
+      _precision: validatePrecision,
+      _trailingZeros: validateTrailingZeros,
+      _decimalRequired: validateDecimalRequired,
     },
   },
 );

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -99,7 +99,7 @@ const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
           name={name}
           className={cn(
             // Allow the arrows step
-            "show-arrows",
+            step && "show-arrows",
             // text and background style
             "text-gray-900 dark:text-gray-50 dark:bg-[#252A34]  dark:border-[#485265]",
             //Focus state text and placeholder

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -137,7 +137,13 @@ export const NumberField = withFieldValidation<NumberFieldProps>(
           ? true
           : Number(value) > 0
             ? true
-            : "Value must be positive";
+            : ` ${props.label} be a positive value`;
+      },
+      _isBigInt: (props) => (value: string) => {
+        const isLargeNumber = Math.abs(Number(value)) > Number.MAX_SAFE_INTEGER;
+        return isLargeNumber && !props.isBigInt
+          ? "Value is too large for standard integer, set isBigInt to true"
+          : true;
       },
     },
   },

--- a/packages/design-system/src/scalars/components/number-field/numberFieldValidations.ts
+++ b/packages/design-system/src/scalars/components/number-field/numberFieldValidations.ts
@@ -13,18 +13,22 @@ export const validateIsBigInt =
   (props: NumberFieldProps) => (value: string) => {
     const isLargeNumber = Math.abs(Number(value)) > Number.MAX_SAFE_INTEGER;
     return isLargeNumber && !props.isBigInt
-      ? "Value is too large for standard integer, set isBigInt to true"
+      ? "Value is too large for standard integer"
       : true;
   };
 
 export const validatePrecision =
   (props: NumberFieldProps) => (value: string) => {
-    if (props.precision === 0) return true;
     if (props.precision === undefined) return true;
+
     const decimalPart = value.toString().split(".")[1];
-    return decimalPart && decimalPart.length <= (props.precision ?? 0)
+    if (props.precision === 0) {
+      return !decimalPart ? true : "Value must be an integer";
+    }
+
+    return decimalPart && decimalPart.length <= props.precision
       ? true
-      : `Value must have ${props.precision} decimal places`;
+      : `Value must have ${props.precision} decimal places or fewer`;
   };
 
 export const validateTrailingZeros =

--- a/packages/design-system/src/scalars/components/number-field/numberFieldValidations.ts
+++ b/packages/design-system/src/scalars/components/number-field/numberFieldValidations.ts
@@ -1,0 +1,45 @@
+import { NumberFieldProps } from "./number-field";
+
+export const validatePositive =
+  (props: NumberFieldProps) => (value: string) => {
+    return props.allowNegative
+      ? true
+      : Number(value) > 0
+        ? true
+        : "Value must be a positive value";
+  };
+
+export const validateIsBigInt =
+  (props: NumberFieldProps) => (value: string) => {
+    const isLargeNumber = Math.abs(Number(value)) > Number.MAX_SAFE_INTEGER;
+    return isLargeNumber && !props.isBigInt
+      ? "Value is too large for standard integer, set isBigInt to true"
+      : true;
+  };
+
+export const validatePrecision =
+  (props: NumberFieldProps) => (value: string) => {
+    if (props.precision === 0) return true;
+    if (props.precision === undefined) return true;
+    const decimalPart = value.toString().split(".")[1];
+    return decimalPart && decimalPart.length <= (props.precision ?? 0)
+      ? true
+      : `Value must have ${props.precision} decimal places`;
+  };
+
+export const validateTrailingZeros =
+  (props: NumberFieldProps) => (value: string) => {
+    if (!props.trailingZeros) return true;
+    const hasTrailingZeros =
+      value.toString().split(".")[1]?.length === props.precision;
+    return hasTrailingZeros
+      ? true
+      : `Value must have exactly ${props.precision} decimal places with trailing zeros if needed`;
+  };
+
+export const validateDecimalRequired =
+  (props: NumberFieldProps) => (value: string) => {
+    return props.decimalRequired && !value.includes(".")
+      ? "Value must include a decimal point"
+      : true;
+  };

--- a/packages/design-system/src/scalars/components/types.ts
+++ b/packages/design-system/src/scalars/components/types.ts
@@ -50,7 +50,8 @@ export type NumericType =
   | "NegativeFloat" // Negative float values
   | "PositiveFloat" // Positive float values
   | "NonNegativeFloat" // Non-negative float values (>= 0.0)
-  | "NonPositiveFloat"; // Non-positive float values (<= 0.0)
+  | "NonPositiveFloat" // Non-positive float values (<= 0.0)
+  | "BigInt";
 
 export interface NumberProps {
   numericType?: NumericType;

--- a/packages/design-system/src/scalars/docs/form-example.tsx
+++ b/packages/design-system/src/scalars/docs/form-example.tsx
@@ -39,9 +39,20 @@ const FormExample = () => {
               label="Age"
               placeholder="25"
               required
-              minValue={18}
+              allowNegative={false}
             />
-
+            <NumberField
+              showErrorOnBlur
+              name="height"
+              label="Height (cm)"
+              placeholder="180"
+              required
+              allowNegative={false}
+              isBigInt={false}
+              precision={2}
+              trailingZeros
+              decimalRequired
+            />
             <StringField
               name="email"
               label="Email"

--- a/packages/design-system/src/scalars/docs/form-example.tsx
+++ b/packages/design-system/src/scalars/docs/form-example.tsx
@@ -40,6 +40,7 @@ const FormExample = () => {
               placeholder="25"
               required
               allowNegative={false}
+              precision={0}
             />
             <NumberField
               showErrorOnBlur


### PR DESCRIPTION
## Ticket
https://trello.com/c/S2RNIMLT/685-1-numbers-int-float-bigint-negativeint-positiveint-nonnegativeint-1nonpositiveint-negativefloat-positivefloat-nonnegativefloat-n

## Description
- Should allow setting **minValue:** number as a minimum allowed value.
- Should show the proper message when the minValue is not met.
- Should allow setting **maxValue:** number as a maximum allowed value.
- Should show the proper message when the maxValue has been exceeded.
-  Should allow setting **allowNegative:** Boolean.
- Should allow negative numbers if the allowNegative config is true.
- Should allow setting **isBigInt:** Boolean — Whether large numbers beyond Int are allowed.