### PR TITLE
feat: design system/date picker fixes

### DIFF
--- a/packages/design-system/src/rwa/components/inputs/entry-time-label.tsx
+++ b/packages/design-system/src/rwa/components/inputs/entry-time-label.tsx
@@ -1,0 +1,12 @@
+import { GroupTransactionFormInputs } from "@/rwa/types";
+import { formatDateForDisplay } from "@/rwa/utils";
+import { Control, useWatch } from "react-hook-form";
+
+export function EntryTimeLabel({
+  control,
+}: {
+  control: Control<GroupTransactionFormInputs>;
+}) {
+  const value = useWatch({ control, name: "entryTime" });
+  return value ? formatDateForDisplay(new Date(value), true, true) : null;
+}

--- a/packages/design-system/src/rwa/hooks/useFormInputs.tsx
+++ b/packages/design-system/src/rwa/hooks/useFormInputs.tsx
@@ -21,7 +21,7 @@ import {
   useEditorContext,
   useModal,
 } from "@/rwa";
-import { ReactElement, useCallback, useMemo } from "react";
+import { ReactElement, ReactNode, useCallback, useMemo } from "react";
 import {
   Control,
   FormState,
@@ -29,11 +29,12 @@ import {
   UseFormWatch,
 } from "react-hook-form";
 import { CashBalanceChange } from "../components/table/transactions/cash-balance-change";
+import { EntryTimeLabel } from "../components/inputs/entry-time-label";
 
 type Input = {
   label: string;
   Input: () => string | React.JSX.Element;
-  inputLabel?: string | null;
+  inputLabel?: ReactNode | null;
 };
 
 type Props = {
@@ -72,7 +73,6 @@ export function useFormInputs(props: Props): {
     },
     [showModal],
   );
-
   return useMemo(() => {
     switch (tableName) {
       case tableNames.ASSET: {
@@ -251,8 +251,6 @@ export function useFormInputs(props: Props): {
         const { errors } = _formState as FormState<Payload>;
         const control = _control as Control<Payload>;
         const type = watch("type");
-        const entryTimeInputValue =
-          watch("entryTime") ?? new Date().toISOString();
         const isFeesTransaction = !!type && feesTransactions.includes(type);
         const isAssetTransaction =
           !!type && assetGroupTransactions.includes(type);
@@ -302,9 +300,7 @@ export function useFormInputs(props: Props): {
                 })}
               />
             ),
-            inputLabel: entryTimeInputValue
-              ? formatDateForDisplay(new Date(entryTimeInputValue))
-              : null,
+            inputLabel: <EntryTimeLabel control={control} />,
           },
           isFeesTransaction
             ? {

--- a/packages/design-system/src/rwa/utils/date.ts
+++ b/packages/design-system/src/rwa/utils/date.ts
@@ -1,8 +1,13 @@
 import { formatInTimeZone } from "date-fns-tz/formatInTimeZone";
 
-export function formatDateForDisplay(date: Date | string, displayTime = true) {
+export function formatDateForDisplay(
+  date: Date | string,
+  displayTime = true,
+  isUTC = false,
+) {
   const formatString = displayTime ? "yyyy/MM/dd, HH:mm:ss zzz" : "yyyy/MM/dd";
-  return formatInTimeZone(date, getTimeZone(), formatString);
+  const timeZone = isUTC ? "UTC" : getTimeZone();
+  return formatInTimeZone(date, timeZone, formatString);
 }
 
 export function isISODate(str: string) {
@@ -19,7 +24,7 @@ export function isoDateStringToDateInput(
   isoDateString: string,
   withTime = false,
 ) {
-  const format = withTime ? "yyyy-MM-dd'T'HH:mm:ss.SSS" : "yyyy-MM-dd";
+  const format = withTime ? "yyyy-MM-dd'T'HH:mm:ss" : "yyyy-MM-dd";
   const timeZone = getTimeZone();
   return formatInTimeZone(isoDateString, timeZone, format);
 }

--- a/packages/document-model-libs/document-models/real-world-assets/mock-data/initial-state.ts
+++ b/packages/document-model-libs/document-models/real-world-assets/mock-data/initial-state.ts
@@ -130,7 +130,7 @@ export const initialState: RealWorldAssetsState = {
     {
       id: "lHExR6QgOChLhp1hLpMgwp6DSb8=",
       type: "AssetPurchase",
-      entryTime: "2021-03-10T08:00:00.000Z",
+      entryTime: "2021-03-10T08:00:00.123Z",
       cashBalanceChange: -1,
       unitPrice: 1,
       serviceProviderFeeTypeId: null,

--- a/packages/document-model-libs/package.json
+++ b/packages/document-model-libs/package.json
@@ -90,7 +90,7 @@
     "@monaco-editor/react": "^4.6.0",
     "@mui/material": "^5.15.5",
     "@powerhousedao/codegen": "0.14.1",
-    "@powerhousedao/design-system": "1.8.0",
+    "@powerhousedao/design-system": "workspace:*",
     "@powerhousedao/scalars": "^1.9.0",
     "@prettier/sync": "^0.5.2",
     "@radix-ui/react-checkbox": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -782,7 +782,7 @@ importers:
         specifier: 0.14.1
         version: link:../codegen
       '@powerhousedao/design-system':
-        specifier: 1.8.0
+        specifier: workspace:*
         version: link:../design-system
       '@powerhousedao/scalars':
         specifier: ^1.9.0


### PR DESCRIPTION
- remove milliseconds from date input
- extract entry time label to component

there was a bug because of how the entry time label was getting its value from the form — using `watch` in the function that returns the component causes the whole component to rerender on any change of the value. this caused the input to lose focus and the date picker to close immediately on input.

to solve this we move this label component to its own component, which can then use the `useWatch` hook instead of `watch`. This means that the rendering is contained in the label component itself, and therefore the value is not changing and rerendering the component.