### PR TITLE
feat(scalars): ensure no render label if empty

### DIFF
--- a/packages/design-system/src/scalars/components/fragments/form-label/form-label.tsx
+++ b/packages/design-system/src/scalars/components/fragments/form-label/form-label.tsx
@@ -30,6 +30,11 @@ export const FormLabel: React.FC<FormLabelProps> = ({
     className,
   );
 
+  if (!children) {
+    // no label provided
+    return null;
+  }
+
   const extraProps = {
     ...htmlLabelProps,
   };


### PR DESCRIPTION
## Ticket
https://trello.com/c/9PSFnLlU/688-5-urlfield-url-urlyoutube-urlgithub-urldiscord-urldiscourse

## Description
Ensure that no label is rendered if the label is empty or not provided