### PR TITLE
feat(scalars): allow to use predefined icons in SelectField options

### DIFF
--- a/packages/design-system/src/scalars/components/enum-field/enum-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/enum-field/enum-field.stories.tsx
@@ -44,11 +44,12 @@ const meta: Meta<typeof EnumField> = {
 
     options: {
       control: "object",
-      description: "Array of options with label, value, icon, and description",
+      description:
+        "Array of options with label, value, icon, description and disabled",
       table: {
         type: {
           summary:
-            "Array<{ label: string; value: string; icon?: IconComponent; description?: string; disabled?: boolean; }>",
+            "Array<{ label: string; value: string; icon?: IconName | React.ComponentType<{ className?: string }>; description?: string; disabled?: boolean; }>",
         },
         defaultValue: { summary: "[]" },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,

--- a/packages/design-system/src/scalars/components/fragments/select-field/content.tsx
+++ b/packages/design-system/src/scalars/components/fragments/select-field/content.tsx
@@ -11,6 +11,7 @@ import {
 import { Separator } from "@/scalars/components/fragments/separator";
 import { cn } from "@/scalars/lib/utils";
 import { SelectProps } from "@/scalars/components/types";
+import { Icon, type IconName } from "@/powerhouse/components/icon";
 
 interface ContentProps {
   selectedValues: string[];
@@ -31,6 +32,37 @@ export const Content: React.FC<ContentProps> = ({
   toggleOption,
   toggleAll,
 }) => {
+  const renderIcon = (
+    IconComponent:
+      | IconName
+      | React.ComponentType<{ className?: string }>
+      | undefined,
+    disabled: boolean | undefined,
+  ) => {
+    if (typeof IconComponent === "string") {
+      return (
+        <Icon
+          name={IconComponent}
+          size={16}
+          className={cn(
+            "mr-2 text-gray-500 dark:text-gray-400",
+            disabled && "opacity-75",
+          )}
+        />
+      );
+    }
+    return (
+      IconComponent && (
+        <IconComponent
+          className={cn(
+            "mr-2 size-4 text-gray-500 dark:text-gray-400",
+            disabled && "opacity-75",
+          )}
+        />
+      )
+    );
+  };
+
   return (
     <Command
       className={cn(
@@ -89,7 +121,6 @@ export const Content: React.FC<ContentProps> = ({
           )}
           {options.map((option) => {
             const isSelected = selectedValues.includes(option.value);
-            const IconComponent = option.icon;
 
             return (
               <CommandItem
@@ -137,14 +168,7 @@ export const Content: React.FC<ContentProps> = ({
                     )}
                   </>
                 )}
-                {IconComponent && (
-                  <IconComponent
-                    className={cn(
-                      "mr-2 size-4 text-gray-500 dark:text-gray-400",
-                      option.disabled && "opacity-75",
-                    )}
-                  />
-                )}
+                {renderIcon(option.icon, option.disabled)}
                 <span
                   className={cn(
                     "text-gray-900 dark:text-gray-100",

--- a/packages/design-system/src/scalars/components/fragments/select-field/select-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/fragments/select-field/select-field.stories.tsx
@@ -38,7 +38,7 @@ const meta: Meta<typeof SelectField> = {
       table: {
         type: {
           summary:
-            "Array<{ value: string; label: string; icon?: IconComponent; disabled?: boolean }>",
+            "Array<{ value: string; label: string; icon?: IconName | React.ComponentType<{ className?: string }>; disabled?: boolean }>",
         },
         defaultValue: { summary: "[]" },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
@@ -219,5 +219,25 @@ export const WithoutCheckmarks: Story = {
     options: defaultOptions,
     optionsCheckmark: "None",
     placeholder: "Select icons",
+  },
+};
+
+export const WithPredefinedIcons: Story = {
+  args: {
+    label: "Options with predefined icon",
+    description: "Choose your favorite predefined icon",
+    options: [
+      { value: "CircleInfo", label: "CircleInfo", icon: "CircleInfo" },
+      { value: "Calendar", label: "Calendar", icon: "Calendar" },
+      {
+        value: "Settings",
+        label: "Settings",
+        icon: "Settings",
+        disabled: true,
+      },
+      { value: "Trash", label: "Trash", icon: "Trash" },
+      { value: "None", label: "None" },
+    ],
+    placeholder: "Select an icon",
   },
 };

--- a/packages/design-system/src/scalars/components/fragments/select-field/selected-content.tsx
+++ b/packages/design-system/src/scalars/components/fragments/select-field/selected-content.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/scalars/components/fragments/button";
 import { Separator } from "@/scalars/components/fragments/separator";
 import { cn } from "@/scalars/lib/utils";
 import { SelectProps } from "@/scalars/components/types";
+import { Icon, type IconName } from "@/powerhouse/components/icon";
 
 interface SelectedContentProps {
   selectedValues: string[];
@@ -27,6 +28,18 @@ export const SelectedContent: React.FC<SelectedContentProps> = ({
   disabled,
   handleClear,
 }) => {
+  const renderIcon = (
+    IconComponent:
+      | IconName
+      | React.ComponentType<{ className?: string }>
+      | undefined,
+  ) => {
+    if (typeof IconComponent === "string") {
+      return <Icon name={IconComponent} size={16} className="mr-2" />;
+    }
+    return IconComponent && <IconComponent className="mr-2 size-4" />;
+  };
+
   if (selectedValues.length === 0) {
     return (
       <div className="mx-auto flex w-full items-center justify-between">
@@ -49,7 +62,6 @@ export const SelectedContent: React.FC<SelectedContentProps> = ({
       <div className={cn("flex flex-wrap items-center", !multiple && "w-full")}>
         {selectedValues.slice(0, maxSelectedOptionsToShow).map((value) => {
           const option = options.find((o) => o.value === value);
-          const IconComponent = option?.icon;
           return (
             <Badge
               key={value}
@@ -73,7 +85,7 @@ export const SelectedContent: React.FC<SelectedContentProps> = ({
                 "rounded-md",
               )}
             >
-              {IconComponent && <IconComponent className="mr-2 size-4" />}
+              {renderIcon(option?.icon)}
               {option?.label}
             </Badge>
           );

--- a/packages/design-system/src/scalars/components/types.ts
+++ b/packages/design-system/src/scalars/components/types.ts
@@ -1,4 +1,5 @@
 import { currencies } from "../lib/currency-list";
+import type { IconName } from "@/powerhouse/components/icon";
 
 export type ErrorMessage = string;
 
@@ -80,7 +81,7 @@ export interface RadioGroupProps {
 
 export interface SelectProps {
   options?: {
-    icon?: React.ComponentType<{ className?: string }>;
+    icon?: IconName | React.ComponentType<{ className?: string }>;
     value: string;
     label: string;
     disabled?: boolean;


### PR DESCRIPTION
## Ticket
https://trello.com/c/zZlPyvEY/754-final-design-4-enum

## Description
- Should allow predefined icons or react components