### PR TITLE
fix(scalars): fix the colors and remove the autoFocus in the docs

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/design-system",
-  "version": "1.9.1-canary.28",
+  "version": "1.9.1-canary.29",
   "description": "",
   "files": [
     "/dist"

--- a/packages/design-system/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`AmountField Component > should match snapshot 1`] = `
           >
             <input
               aria-invalid="false"
-              class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-50 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 flex-1 pr-6 outline-none"
+              class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 flex-1 pr-6 outline-none"
               id=":r0:"
               name="amount"
               type="number"

--- a/packages/design-system/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`AmountField Component > should match snapshot 1`] = `
       class="flex flex-col gap-2"
     >
       <label
-        class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50"
+        class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 mb-[3px]"
         for=":r0:"
       >
         Amount Label

--- a/packages/design-system/src/scalars/components/boolean-field/__snapshots__/boolean-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/boolean-field/__snapshots__/boolean-field.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`BooleanField > should render checkbox field when isToggle is false 1`] 
           aria-checked="true"
           aria-invalid="true"
           aria-required="true"
-          class="peer size-4 shrink-0 rounded border-input border shadow-sm shadow-black/[.04] ring-offset-background transition-shadow focus-visible:border-ring focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:data-[invalid=false]:data-[state=checked]:bg-gray-700 dark:disabled:data-[invalid=false]:data-[state=checked]:bg-gray-500 data-[state]:border-gray-700 dark:data-[state]:border-gray-400 data-[state=checked]:bg-gray-900 data-[state=indeterminate]:bg-gray-900 dark:data-[state=checked]:bg-gray-400 dark:data-[state=indeterminate]:bg-gray-400 data-[state=checked]:text-slate-50 data-[state=indeterminate]:text-slate-50 dark:data-[state=checked]:text-gray-900 dark:data-[state=indeterminate]:text-gray-900 data-[invalid=true]:data-[state]:border-red-800 data-[invalid=true]:data-[state=checked]:bg-red-800 data-[invalid=true]:data-[state=indeterminate]:bg-red-800"
+          class="peer size-4 shrink-0 rounded border-input border shadow-sm shadow-black/[.04] ring-offset-background transition-shadow focus-visible:border-ring focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:data-[invalid=false]:data-[state=checked]:bg-gray-700 dark:disabled:data-[invalid=false]:data-[state=checked]:bg-gray-500 data-[state]:border-gray-700 dark:data-[state]:border-gray-400 data-[state=checked]:bg-gray-900 data-[state=indeterminate]:bg-gray-900 dark:data-[state=checked]:bg-gray-400 dark:data-[state=indeterminate]:bg-gray-400 data-[state=checked]:text-slate-50 data-[state=indeterminate]:text-slate-50 dark:data-[state=checked]:text-gray-900 dark:data-[state=indeterminate]:text-gray-900 group-hover:border-gray-900 data-[state=checked]:group-hover:bg-gray-900 data-[state=indeterminate]:group-hover:bg-gray-900 dark:group-hover:border-slate-50 dark:data-[state=checked]:group-hover:bg-slate-50 dark:data-[state=indeterminate]:group-hover:bg-slate-50 data-[invalid=true]:data-[state]:!border-red-800 data-[invalid=true]:data-[state=checked]:!bg-red-800 data-[invalid=true]:data-[state=indeterminate]:!bg-red-800 dark:data-[invalid=true]:data-[state]:!border-red-800 dark:data-[invalid=true]:data-[state=checked]:!bg-red-800 dark:data-[invalid=true]:data-[state=indeterminate]:!bg-red-800 data-[invalid=true]:group-hover:!border-red-900 data-[invalid=true]:data-[state=checked]:group-hover:!bg-red-900 data-[invalid=true]:data-[state=indeterminate]:group-hover:!bg-red-900"
           data-invalid="true"
           data-state="checked"
           id=":r2:"
@@ -59,7 +59,7 @@ exports[`BooleanField > should render checkbox field when isToggle is false 1`] 
         >
           Test Field
           <span
-            class="ml-1 text-blue-900 group-hover:text-gray-900 dark:group-hover:text-slate-50"
+            class="ml-1 text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 !text-red-800 group-hover:!text-red-900"
           >
             *
           </span>
@@ -129,13 +129,13 @@ exports[`BooleanField > should render toggle field when isToggle is true 1`] = `
           value="on"
         />
         <label
-          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50 ml-2"
+          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 ml-2"
           for=":r0:"
           id=":r0:-label"
         >
           Test Field
           <span
-            class="ml-1 text-blue-900 group-hover:text-gray-900 dark:group-hover:text-slate-50"
+            class="ml-1 text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50"
           >
             *
           </span>

--- a/packages/design-system/src/scalars/components/enum-field/__snapshots__/enum-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/enum-field/__snapshots__/enum-field.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`EnumField Component > should match snapshot 1`] = `
           value="option1"
         />
         <label
-          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
+          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
           for=":r0:-radio-0-option1"
         >
           Option 1
@@ -74,7 +74,7 @@ exports[`EnumField Component > should match snapshot 1`] = `
           value="option2"
         />
         <label
-          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
+          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
           for=":r0:-radio-1-option2"
         >
           Option 2
@@ -106,7 +106,7 @@ exports[`EnumField Component > should match snapshot 1`] = `
           value="option3"
         />
         <label
-          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
+          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
           for=":r0:-radio-2-option3"
         >
           Option 3

--- a/packages/design-system/src/scalars/components/fragments/checkbox-field/__snapshots__/checkbox-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/checkbox-field/__snapshots__/checkbox-field.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`CheckboxField > should match snapshot 1`] = `
         <button
           aria-checked="false"
           aria-invalid="false"
-          class="peer size-4 shrink-0 rounded border-input border shadow-sm shadow-black/[.04] ring-offset-background transition-shadow focus-visible:border-ring focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:data-[invalid=false]:data-[state=checked]:bg-gray-700 dark:disabled:data-[invalid=false]:data-[state=checked]:bg-gray-500 data-[state]:border-gray-700 dark:data-[state]:border-gray-400 data-[state=checked]:bg-gray-900 data-[state=indeterminate]:bg-gray-900 dark:data-[state=checked]:bg-gray-400 dark:data-[state=indeterminate]:bg-gray-400 data-[state=checked]:text-slate-50 data-[state=indeterminate]:text-slate-50 dark:data-[state=checked]:text-gray-900 dark:data-[state=indeterminate]:text-gray-900 data-[invalid=true]:data-[state]:border-red-800 data-[invalid=true]:data-[state=checked]:bg-red-800 data-[invalid=true]:data-[state=indeterminate]:bg-red-800"
+          class="peer size-4 shrink-0 rounded border-input border shadow-sm shadow-black/[.04] ring-offset-background transition-shadow focus-visible:border-ring focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:data-[invalid=false]:data-[state=checked]:bg-gray-700 dark:disabled:data-[invalid=false]:data-[state=checked]:bg-gray-500 data-[state]:border-gray-700 dark:data-[state]:border-gray-400 data-[state=checked]:bg-gray-900 data-[state=indeterminate]:bg-gray-900 dark:data-[state=checked]:bg-gray-400 dark:data-[state=indeterminate]:bg-gray-400 data-[state=checked]:text-slate-50 data-[state=indeterminate]:text-slate-50 dark:data-[state=checked]:text-gray-900 dark:data-[state=indeterminate]:text-gray-900 group-hover:border-gray-900 data-[state=checked]:group-hover:bg-gray-900 data-[state=indeterminate]:group-hover:bg-gray-900 dark:group-hover:border-slate-50 dark:data-[state=checked]:group-hover:bg-slate-50 dark:data-[state=indeterminate]:group-hover:bg-slate-50 data-[invalid=true]:data-[state]:!border-red-800 data-[invalid=true]:data-[state=checked]:!bg-red-800 data-[invalid=true]:data-[state=indeterminate]:!bg-red-800 dark:data-[invalid=true]:data-[state]:!border-red-800 dark:data-[invalid=true]:data-[state=checked]:!bg-red-800 dark:data-[invalid=true]:data-[state=indeterminate]:!bg-red-800 data-[invalid=true]:group-hover:!border-red-900 data-[invalid=true]:data-[state=checked]:group-hover:!bg-red-900 data-[invalid=true]:data-[state=indeterminate]:group-hover:!bg-red-900"
           data-invalid="false"
           data-state="unchecked"
           id=":r0:"
@@ -31,7 +31,7 @@ exports[`CheckboxField > should match snapshot 1`] = `
           value="on"
         />
         <label
-          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50 group-hover:cursor-pointer"
+          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 group-hover:cursor-pointer"
           for=":r0:"
         >
           Test Label

--- a/packages/design-system/src/scalars/components/fragments/checkbox-field/checkbox-field.tsx
+++ b/packages/design-system/src/scalars/components/fragments/checkbox-field/checkbox-field.tsx
@@ -56,6 +56,7 @@ const CheckboxRaw: React.FC<CheckboxFieldProps> = ({
           hasError={hasError}
           description={description}
           className={cn(!disabled && "group-hover:cursor-pointer")}
+          inline
         >
           {label}
         </FormLabel>

--- a/packages/design-system/src/scalars/components/fragments/checkbox-field/checkbox.tsx
+++ b/packages/design-system/src/scalars/components/fragments/checkbox-field/checkbox.tsx
@@ -18,6 +18,7 @@ const Checkbox = React.forwardRef<
 >(({ className, checked, invalid, ...props }, ref) => (
   <CheckboxPrimitive.Root
     ref={ref}
+    // eslint-disable-next-line tailwindcss/no-custom-classname
     className={cn(
       // Base styles
       "peer size-4 shrink-0 rounded",
@@ -33,8 +34,14 @@ const Checkbox = React.forwardRef<
       "data-[state]:border-gray-700 dark:data-[state]:border-gray-400",
       "data-[state=checked]:bg-gray-900 data-[state=indeterminate]:bg-gray-900 dark:data-[state=checked]:bg-gray-400 dark:data-[state=indeterminate]:bg-gray-400",
       "data-[state=checked]:text-slate-50 data-[state=indeterminate]:text-slate-50 dark:data-[state=checked]:text-gray-900 dark:data-[state=indeterminate]:text-gray-900",
+      // hover states
+      "group-hover:border-gray-900 data-[state=checked]:group-hover:bg-gray-900 data-[state=indeterminate]:group-hover:bg-gray-900",
+      "dark:group-hover:border-slate-50 dark:data-[state=checked]:group-hover:bg-slate-50 dark:data-[state=indeterminate]:group-hover:bg-slate-50",
       // Error state
-      "data-[invalid=true]:data-[state]:border-red-800 data-[invalid=true]:data-[state=checked]:bg-red-800 data-[invalid=true]:data-[state=indeterminate]:bg-red-800",
+      "data-[invalid=true]:data-[state]:!border-red-800 data-[invalid=true]:data-[state=checked]:!bg-red-800 data-[invalid=true]:data-[state=indeterminate]:!bg-red-800",
+      "dark:data-[invalid=true]:data-[state]:!border-red-800 dark:data-[invalid=true]:data-[state=checked]:!bg-red-800 dark:data-[invalid=true]:data-[state=indeterminate]:!bg-red-800",
+      // error hover states
+      "data-[invalid=true]:group-hover:!border-red-900 data-[invalid=true]:data-[state=checked]:group-hover:!bg-red-900 data-[invalid=true]:data-[state=indeterminate]:group-hover:!bg-red-900",
       className,
     )}
     checked={checked}

--- a/packages/design-system/src/scalars/components/fragments/form-description/__snapshots__/form-description.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/form-description/__snapshots__/form-description.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FormDescription > should render correctly 1`] = `
 <div>
   <p
-    class="font-sans text-sm font-normal leading-5 text-gray-600"
+    class="font-sans text-sm font-normal leading-5 text-gray-600 dark:text-gray-500"
   >
     Test description
   </p>

--- a/packages/design-system/src/scalars/components/fragments/form-description/form-description.tsx
+++ b/packages/design-system/src/scalars/components/fragments/form-description/form-description.tsx
@@ -16,7 +16,7 @@ const FormDescription: React.FC<FormDescriptionProps> = ({
   return (
     <Component
       className={cn(
-        "font-sans text-sm font-normal leading-5 text-gray-600",
+        "font-sans text-sm font-normal leading-5 text-gray-600 dark:text-gray-500",
         className,
       )}
     >

--- a/packages/design-system/src/scalars/components/fragments/form-label/__snapshots__/form-label.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/form-label/__snapshots__/form-label.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FormLabel Component > should match snapshot 1`] = `
 <DocumentFragment>
   <label
-    class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50"
+    class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 mb-[3px]"
     data-testid="form-label"
   >
     label

--- a/packages/design-system/src/scalars/components/fragments/form-label/form-label.tsx
+++ b/packages/design-system/src/scalars/components/fragments/form-label/form-label.tsx
@@ -10,6 +10,7 @@ export interface FormLabelProps
   disabled?: boolean;
   description?: string;
   hasError?: boolean;
+  inline?: boolean;
   className?: string;
 }
 
@@ -19,14 +20,17 @@ export const FormLabel: React.FC<FormLabelProps> = ({
   disabled,
   description,
   hasError,
+  inline,
   className,
   ...htmlLabelProps
 }) => {
   const classes = cn(
-    "inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50",
+    "inline-flex items-center text-sm font-medium leading-[22px]",
+    "text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50",
     hasError &&
       "text-red-700 group-hover:text-red-900 dark:text-red-700 dark:group-hover:text-red-900",
     disabled && "cursor-not-allowed text-gray-600 dark:text-gray-600",
+    !inline && "mb-[3px]",
     className,
   );
 
@@ -43,7 +47,12 @@ export const FormLabel: React.FC<FormLabelProps> = ({
     <label className={classes} {...extraProps}>
       {children}
       {required && (
-        <span className="ml-1 text-blue-900 group-hover:text-gray-900 dark:group-hover:text-slate-50">
+        <span
+          className={cn(
+            "ml-1 text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50",
+            hasError && "!text-red-800 group-hover:!text-red-900",
+          )}
+        >
           *
         </span>
       )}

--- a/packages/design-system/src/scalars/components/fragments/input/__snapshots__/input.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/input/__snapshots__/input.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Input > should match snapshot 1`] = `
 <div>
   <input
-    class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-50 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
+    class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
     placeholder="Test placeholder"
   />
 </div>

--- a/packages/design-system/src/scalars/components/fragments/input/input.tsx
+++ b/packages/design-system/src/scalars/components/fragments/input/input.tsx
@@ -5,7 +5,7 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const inputBaseStyles = cn(
   // Base styles
-  "flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-50",
+  "flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-700",
   // Border & Background
   "border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900",
   // Padding

--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/__snapshots__/radio-group-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/__snapshots__/radio-group-field.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`RadioGroupField Component > should match snapshot 1`] = `
           value="1"
         />
         <label
-          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
+          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
           for=":r0:-radio-0-1"
         >
           Option 1
@@ -74,7 +74,7 @@ exports[`RadioGroupField Component > should match snapshot 1`] = `
           value="2"
         />
         <label
-          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
+          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
           for=":r0:-radio-1-2"
         >
           Option 2

--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/__snapshots__/radio-group.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/__snapshots__/radio-group.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`RadioGroup Component > should match snapshot 1`] = `
       value="1"
     />
     <label
-      class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
+      class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
       for=":r1:-radio"
     >
       Option 1
@@ -44,7 +44,7 @@ exports[`RadioGroup Component > should match snapshot 1`] = `
       value="2"
     />
     <label
-      class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
+      class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
       for=":r3:-radio"
     >
       Option 2

--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/__snapshots__/radio.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/__snapshots__/radio.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`Radio Component > should match snapshot 1`] = `
       value="test"
     />
     <label
-      class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
+      class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 cursor-pointer peer-hover:text-gray-900 dark:peer-hover:text-gray-50"
       for=":r1:-radio"
     >
       Test Label

--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/radio.tsx
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/radio.tsx
@@ -87,6 +87,7 @@ export const Radio = React.forwardRef<
           hasError={hasError}
           htmlFor={id}
           required={props.required}
+          inline
         >
           {label}
         </FormLabel>

--- a/packages/design-system/src/scalars/components/fragments/text-field/__snapshots__/text-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/text-field/__snapshots__/text-field.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TextField > should match snapshot 1`] = `
       class="flex flex-col gap-2"
     >
       <label
-        class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50"
+        class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 mb-[3px]"
         for=":r0:"
       >
         Test Label

--- a/packages/design-system/src/scalars/components/fragments/text-field/__snapshots__/text-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/text-field/__snapshots__/text-field.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`TextField > should match snapshot 1`] = `
         Test Label
       </label>
       <input
-        class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-50 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
+        class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
         id=":r0:"
         name="test"
         value=""

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/__snapshots__/textarea-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/__snapshots__/textarea-field.test.tsx.snap
@@ -9,12 +9,12 @@ exports[`TextareaField Component > should match snapshot with props 1`] = `
       class="flex flex-col gap-2"
     >
       <label
-        class="inline-flex items-center text-sm font-medium leading-[22px] text-red-700 group-hover:text-red-900 dark:text-red-700 dark:group-hover:text-red-900"
+        class="inline-flex items-center text-sm font-medium leading-[22px] text-red-700 group-hover:text-red-900 dark:text-red-700 dark:group-hover:text-red-900 mb-[3px]"
         for=":r0:-textarea"
       >
         Default Label
         <span
-          class="ml-1 text-blue-900 group-hover:text-gray-900 dark:group-hover:text-slate-50"
+          class="ml-1 text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 !text-red-800 group-hover:!text-red-900"
         >
           *
         </span>
@@ -26,7 +26,7 @@ exports[`TextareaField Component > should match snapshot with props 1`] = `
           aria-invalid="true"
           aria-required="true"
           autocomplete="off"
-          class="flex w-full rounded-md text-sm leading-normal dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 px-3 py-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 min-h-[120px] resize-y scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-300 dark:scrollbar-track-gray-900 dark:scrollbar-thumb-gray-600"
+          class="flex w-full rounded-md text-sm leading-normal border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 px-3 py-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 min-h-[120px] resize-y scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-300 dark:scrollbar-track-gray-900 dark:scrollbar-thumb-gray-600"
           id=":r0:-textarea"
           name="textarea"
           rows="3"

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/__snapshots__/textarea-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/__snapshots__/textarea-field.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`TextareaField Component > should match snapshot with props 1`] = `
         </div>
       </div>
       <p
-        class="font-sans text-sm font-normal leading-5 text-gray-600"
+        class="font-sans text-sm font-normal leading-5 text-gray-600 dark:text-gray-500"
       >
         Default description
       </p>

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.tsx
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.tsx
@@ -31,7 +31,7 @@ const textareaBaseStyles = cn(
   // Base styles
   "flex w-full rounded-md text-sm leading-normal",
   // Colors & Background
-  "dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white",
+  "border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900",
   // Placeholder
   "font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500",
   // Padding & Spacing

--- a/packages/design-system/src/scalars/components/fragments/toggle-field/toggle-field.tsx
+++ b/packages/design-system/src/scalars/components/fragments/toggle-field/toggle-field.tsx
@@ -49,6 +49,7 @@ const ToggleRaw: React.FC<ToggleFieldProps> = ({
             disabled={disabled}
             required={required}
             description={description}
+            inline
             id={`${id}-label`}
           >
             {label}

--- a/packages/design-system/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`NumberField Component > should match snapshot 1`] = `
       class="flex flex-col gap-2"
     >
       <label
-        class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50 mb-[3px]"
+        class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 mb-[3px]"
         for=":r0:"
       >
         Test Label

--- a/packages/design-system/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
@@ -9,14 +9,14 @@ exports[`NumberField Component > should match snapshot 1`] = `
       class="flex flex-col gap-2"
     >
       <label
-        class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50"
+        class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 group-hover:text-gray-900 dark:text-gray-50 dark:group-hover:text-slate-50 mb-[3px]"
         for=":r0:"
       >
         Test Label
       </label>
       <input
         aria-invalid="false"
-        class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-50 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
+        class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
         id=":r0:"
         name="Label"
         type="number"

--- a/packages/design-system/src/scalars/components/number-field/number-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.stories.tsx
@@ -38,6 +38,11 @@ const meta = {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
+    autoFocus: {
+      table: {
+        disable: true, // Esto ocultará autoFocus de la documentación
+      },
+    },
     numericType: {
       control: "text",
       description:

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -24,7 +24,7 @@ export interface NumberFieldProps extends InputNumberProps {
   value?: number | string;
 }
 
-const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
+export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
   (
     {
       label,
@@ -81,6 +81,7 @@ const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
             required={props.required}
             disabled={props.disabled}
             hasError={!!errors?.length}
+            className="mb-[3px]"
           >
             {label}
           </FormLabel>
@@ -106,8 +107,8 @@ const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
           defaultValue={defaultValue}
           onChange={onChange}
           onPaste={blockInvalidPaste}
-          {...props}
           ref={ref}
+          {...props}
         />
         {description && <FormDescription>{description}</FormDescription>}
         {warnings && <FormMessageList messages={warnings} type="warning" />}
@@ -117,15 +118,15 @@ const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
   },
 );
 
-export const NumberField = withFieldValidation<NumberFieldProps>(
-  NumberFieldRaw,
-  {
-    validations: {
-      _positive: validatePositive,
-      _isBigInt: validateIsBigInt,
-      _precision: validatePrecision,
-      _trailingZeros: validateTrailingZeros,
-      _decimalRequired: validateDecimalRequired,
-    },
+const NumberField = withFieldValidation<NumberFieldProps>(NumberFieldRaw, {
+  validations: {
+    _positive: validatePositive,
+    _isBigInt: validateIsBigInt,
+    _precision: validatePrecision,
+    _trailingZeros: validateTrailingZeros,
+    _decimalRequired: validateDecimalRequired,
   },
-);
+});
+NumberField.displayName = "NumberField";
+
+export { NumberField };

--- a/packages/design-system/src/scalars/components/string-field/__snapshots__/string-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/string-field/__snapshots__/string-field.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`StringField > should match snapshot with minimal props 1`] = `
       class="flex flex-col gap-2"
     >
       <input
-        class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-50 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
+        class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
         id=":r0:"
         name="test"
         value=""

--- a/packages/design-system/src/scalars/components/string-field/__snapshots__/string-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/string-field/__snapshots__/string-field.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`StringField > should match snapshot when multiline is true (textarea) 1
         <textarea
           aria-invalid="false"
           autocomplete="off"
-          class="flex w-full rounded-md text-sm leading-normal dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 px-3 py-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 min-h-[120px] resize-y scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-300 dark:scrollbar-track-gray-900 dark:scrollbar-thumb-gray-600"
+          class="flex w-full rounded-md text-sm leading-normal border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 px-3 py-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 min-h-[120px] resize-y scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-300 dark:scrollbar-track-gray-900 dark:scrollbar-thumb-gray-600"
           id=":r1:-textarea"
           name="test"
           rows="3"

--- a/packages/design-system/src/scalars/components/url-field/__snapshots__/url-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/url-field/__snapshots__/url-field.test.tsx.snap
@@ -23,13 +23,13 @@ exports[`UrlField > should match snapshot 1`] = `
         class="flex items-center"
       >
         <input
-          class="flex h-10 rounded-md text-sm text-gray-900 dark:text-gray-50 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 w-auto rounded-r-none border-r-0 focus:z-10"
+          class="flex h-10 rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 w-auto rounded-r-none border-r-0 focus:z-10"
           readonly=""
           style="width: 64px;"
           value="http://"
         />
         <input
-          class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-50 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 focus:z-10 rounded-l-none"
+          class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 focus:z-10 rounded-l-none"
           id=":r0:"
           name="test-url"
           placeholder="https://example.com"
@@ -39,7 +39,7 @@ exports[`UrlField > should match snapshot 1`] = `
         />
       </div>
       <p
-        class="font-sans text-sm font-normal leading-5 text-gray-600"
+        class="font-sans text-sm font-normal leading-5 text-gray-600 dark:text-gray-500"
       >
         Enter your website URL
       </p>

--- a/packages/design-system/src/scalars/components/url-field/__snapshots__/url-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/url-field/__snapshots__/url-field.test.tsx.snap
@@ -9,12 +9,12 @@ exports[`UrlField > should match snapshot 1`] = `
       class="flex flex-col gap-2"
     >
       <label
-        class="inline-flex items-center text-sm font-medium leading-[22px] text-red-700 group-hover:text-red-900 dark:text-red-700 dark:group-hover:text-red-900"
+        class="inline-flex items-center text-sm font-medium leading-[22px] text-red-700 group-hover:text-red-900 dark:text-red-700 dark:group-hover:text-red-900 mb-[3px]"
         for=":r0:"
       >
         Website URL
         <span
-          class="ml-1 text-blue-900 group-hover:text-gray-900 dark:group-hover:text-slate-50"
+          class="ml-1 text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 !text-red-800 group-hover:!text-red-900"
         >
           *
         </span>

--- a/packages/design-system/src/scalars/lib/decorators.tsx
+++ b/packages/design-system/src/scalars/lib/decorators.tsx
@@ -52,7 +52,10 @@ export const withForm: Decorator = (Story, context) => {
                 setShowFormButtons(checked as boolean)
               }
             />
-            <label className="cursor-pointer" htmlFor={checkboxId}>
+            <label
+              className="cursor-pointer dark:text-gray-400"
+              htmlFor={checkboxId}
+            >
               Show form buttons
             </label>
           </div>

--- a/packages/scalars/package.json
+++ b/packages/scalars/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/scalars",
-  "version": "1.9.1-canary.28",
+  "version": "1.9.1-canary.29",
   "license": "AGPL-3.0-only",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Ticket
https://trello.com/c/dcRznxfV/752-final-design-1-number

## Description
 - The gap between the field and the label should be 11px. **Current Output:** The gap is 8px (.5rem). 
 - The autoFocus prop should not be visible in the component. **Current Output:** The prop is visible as the first element.
 - NumberField. Dark mode. The description should have the color Gray/500. The description is displayed with color Gray/600 
