### PR TITLE
feat(scalars): allow to submit changes only

### DIFF
--- a/packages/design-system/src/scalars/components/form/form.test.tsx
+++ b/packages/design-system/src/scalars/components/form/form.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { Form } from "./form";
+import { StringField } from "../string-field";
+import userEvent from "@testing-library/user-event";
+
+describe("Form", () => {
+  it("should render children as React nodes", () => {
+    render(
+      <Form onSubmit={() => {}}>
+        <div data-testid="child">Test Child</div>
+      </Form>,
+    );
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  it("should render children as function with form methods", () => {
+    render(
+      <Form onSubmit={() => {}}>
+        {(methods) => (
+          <div data-testid="child">
+            {methods.formState.isSubmitting ? "Submitting" : "Not Submitting"}
+          </div>
+        )}
+      </Form>,
+    );
+    expect(screen.getByTestId("child")).toHaveTextContent("Not Submitting");
+  });
+
+  it("should call onSubmit with form data", async () => {
+    const handleSubmit = vi.fn();
+    render(
+      <Form onSubmit={handleSubmit}>
+        <StringField name="test" defaultValue="test-value" />
+        <button type="submit">Submit</button>
+      </Form>,
+    );
+
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({
+        test: "test-value",
+      });
+    });
+  });
+
+  it("should reset form after successful submit when resetOnSuccessfulSubmit is true", async () => {
+    const user = userEvent.setup();
+    const handleSubmit = vi.fn();
+    render(
+      <Form
+        onSubmit={handleSubmit}
+        resetOnSuccessfulSubmit
+        defaultValues={{ test: "hello" }}
+      >
+        <StringField name="test" />
+        <button type="submit">Submit</button>
+      </Form>,
+    );
+
+    // type something in the input
+    const stringField = screen.getByRole("textbox");
+    await user.type(stringField, " world");
+
+    expect(stringField).toHaveValue("hello world");
+
+    const input = screen.getByRole("textbox");
+    fireEvent.click(screen.getByText("Submit"));
+
+    await waitFor(() => {
+      expect(input).toHaveValue("hello");
+    });
+  });
+
+  it("should submit only changed values when submitChangesOnly is true", async () => {
+    const handleSubmit = vi.fn();
+    const user = userEvent.setup();
+    const defaultValues = { unchanged: "default", changed: "old" };
+
+    render(
+      <Form
+        onSubmit={handleSubmit}
+        defaultValues={defaultValues}
+        submitChangesOnly
+      >
+        <StringField name="unchanged" />
+        <StringField name="changed" />
+        <button type="submit">Submit</button>
+      </Form>,
+    );
+
+    const changedInput = screen.getByDisplayValue("old");
+    await user.clear(changedInput);
+    await user.type(changedInput, "new");
+    fireEvent.click(screen.getByText("Submit"));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({
+        changed: "new",
+      });
+    });
+  });
+
+  it("should submit null for empty values", async () => {
+    const handleSubmit = vi.fn();
+    render(
+      <Form onSubmit={handleSubmit}>
+        <StringField name="empty" />
+        <button type="submit">Submit</button>
+      </Form>,
+    );
+
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({
+        empty: null,
+      });
+    });
+  });
+
+  it("should apply className to form element", () => {
+    render(
+      // disable tailwind custom classname rule for this test
+      // eslint-disable-next-line tailwindcss/no-custom-classname
+      <Form onSubmit={() => {}} className="test-class">
+        Test
+      </Form>,
+    );
+    expect(screen.getByText("Test")).toHaveClass("test-class");
+  });
+});

--- a/packages/design-system/src/scalars/docs/examples/reset-on-successful-submit/reset-on-successful-submit.tsx
+++ b/packages/design-system/src/scalars/docs/examples/reset-on-successful-submit/reset-on-successful-submit.tsx
@@ -19,7 +19,6 @@ const FormWithResetOnSuccessfulSubmit = () => {
           placeholder="Type something"
           label="Field example"
           required
-          autoFocus
         />
         <NumberField name="number" label="Number" required />
 

--- a/packages/design-system/src/scalars/docs/examples/submit-changes-only/submit-changes-only.stories.tsx
+++ b/packages/design-system/src/scalars/docs/examples/submit-changes-only/submit-changes-only.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import SubmitChangesOnly, { DOCS_CODE } from "./submit-changes-only";
+
+const meta = {
+  title: "Document Engineering/Docs/Examples/Submit Changes Only",
+  component: SubmitChangesOnly,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      source: {
+        language: "tsx",
+        format: true,
+        code: DOCS_CODE,
+      },
+    },
+  },
+} satisfies Meta<typeof SubmitChangesOnly>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/packages/design-system/src/scalars/docs/examples/submit-changes-only/submit-changes-only.tsx
+++ b/packages/design-system/src/scalars/docs/examples/submit-changes-only/submit-changes-only.tsx
@@ -1,0 +1,124 @@
+import { Button } from "@/powerhouse/components/button";
+import { Form, StringField } from "../../../components";
+
+const SubmitChangesOnly = () => {
+  return (
+    <Form
+      onSubmit={(data: FormData) => {
+        alert(JSON.stringify(data, null, 2));
+      }}
+      submitChangesOnly
+      defaultValues={{
+        firstName: "Jhon",
+        lastName: "Doe",
+        bio: "I'm a software engineer",
+      }}
+    >
+      {({ reset }) => (
+        <div className="flex w-full flex-col gap-2 md:w-96">
+          <StringField
+            name="firstName"
+            placeholder="Jhon"
+            label="First name"
+            required
+          />
+          <StringField
+            name="lastName"
+            placeholder="Doe"
+            label="Last name"
+            required
+          />
+          <StringField
+            name="bio"
+            placeholder="I'm a software engineer"
+            label="Bio"
+            description="If you leave this field empty, it will be submitted as null"
+            multiline
+          />
+
+          <div className="text-sm text-gray-500">
+            After submitting the form, all form fields will be reset to their
+            initial values
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              className="w-full"
+              color="light"
+              type="reset"
+              onClick={() => reset()}
+            >
+              Reset
+            </Button>
+            <Button className="w-full" type="submit">
+              Submit
+            </Button>
+          </div>
+        </div>
+      )}
+    </Form>
+  );
+};
+
+export default SubmitChangesOnly;
+
+export const DOCS_CODE = `
+const SubmitChangesOnly = () => {
+  return (
+    <Form
+      onSubmit={(data: FormData) => {
+        alert(JSON.stringify(data, null, 2));
+      }}
+      submitChangesOnly
+      defaultValues={{
+        firstName: "Jhon",
+        lastName: "Doe",
+        bio: "I'm a software engineer",
+      }}
+    >
+      {({ reset }) => (
+        <div className="flex w-full flex-col gap-2 md:w-96">
+          <StringField
+            name="firstName"
+            placeholder="Jhon"
+            label="First name"
+            required
+          />
+          <StringField
+            name="lastName"
+            placeholder="Doe"
+            label="Last name"
+            required
+          />
+          <StringField
+            name="bio"
+            placeholder="I'm a software engineer"
+            label="Bio"
+            description="If you leave this field empty, it will be submitted as null"
+            multiline
+          />
+
+          <div className="text-sm text-gray-500">
+            After submitting the form, all form fields will be reset to their
+            initial values
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              className="w-full"
+              color="light"
+              type="reset"
+              onClick={() => reset()}
+            >
+              Reset
+            </Button>
+            <Button className="w-full" type="submit">
+              Submit
+            </Button>
+          </div>
+        </div>
+      )}
+    </Form>
+  );
+};
+`;

--- a/packages/design-system/src/scalars/docs/forms.mdx
+++ b/packages/design-system/src/scalars/docs/forms.mdx
@@ -2,6 +2,7 @@ import { Meta, Source, Canvas, Controls } from "@storybook/blocks";
 
 import * as ResetButtonStories from "./examples/reset-button/reset-button.stories";
 import * as ResetOnSuccessfulSubmitStories from "./examples/reset-on-successful-submit/reset-on-successful-submit.stories";
+import * as SubmitChangesOnly from "./examples/submit-changes-only/submit-changes-only.stories";
 
 <Meta title="Document Engineering/Docs/Forms" />
 
@@ -42,6 +43,26 @@ import { Form } from "@powerhousedao/design-system/scalars"
 
 </Form>
 `}/>
+
+### Submissions
+
+The `Form` component requires an `onSubmit` prop, which is a callback function that executes when the form is successfully submitted and passes validation. This callback receives the form data and is typed as follows:
+
+```ts
+function onSubmit(data: Record<string, any>): void
+```
+
+Each key of the the `data` parameter record is going to be the name of each field registered in the `Form`.
+
+> **Important**: For non-required fields, empty values are automatically converted to `null` in the submitted form data. This standardizes the handling of unset fields in the `onSubmit` callback's `data` parameter, making it easier to process form submissions consistently.
+
+#### Submit changes only
+
+The `submitChangesOnly` prop enables selective form submission, where only modified fields are included in the submission data. When enabled, the form automatically compares the current values against the initial `defaultValues` and includes only the changed fields in the `data` parameter passed to the `onSubmit` callback.
+
+Example usage:
+
+<Canvas of={SubmitChangesOnly.Default} withToolbar />
 
 ### Form reset
 
@@ -91,14 +112,14 @@ import { useRef } from "react";
 import { UseFormReturn } from "react-hook-form";
 
 function FormExample() {
-const formRef = useRef<UseFormReturn>(null);
+   const formRef = useRef<UseFormReturn>(null);
 
-console.log(ref.current?.formState?.submitCount)
+   console.log(ref.current?.formState?.submitCount)
 
-return (
-<Form ref={formRef} onSubmit={/* your submit function */}>
-{/* your fields */}
-</Form>
-)
+   return (
+      <Form ref={formRef} onSubmit={/* your submit function */}>
+         {/* your fields */}
+      </Form>
+   )
 }
 `}/>

--- a/packages/design-system/src/scalars/lib/deep-equal.test.ts
+++ b/packages/design-system/src/scalars/lib/deep-equal.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { deepEqual } from "./deep-equal";
+
+describe("deepEqual", () => {
+  it("should return true for identical primitive values", () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual("test", "test")).toBe(true);
+    expect(deepEqual(true, true)).toBe(true);
+    expect(deepEqual(null, null)).toBe(true);
+    expect(deepEqual(undefined, undefined)).toBe(true);
+  });
+
+  it("should return false for different primitive values", () => {
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual("test", "test2")).toBe(false);
+    expect(deepEqual(true, false)).toBe(false);
+    expect(deepEqual(null, undefined)).toBe(false);
+  });
+
+  it("should return false for values of different types", () => {
+    expect(deepEqual(1, "1")).toBe(false);
+    expect(deepEqual(0, false)).toBe(false);
+    expect(deepEqual("", false)).toBe(false);
+    expect(deepEqual([], {})).toBe(false);
+  });
+
+  it("should handle arrays correctly", () => {
+    expect(deepEqual([], [])).toBe(true);
+    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(deepEqual([1, 2, 3], [1, 2, 4])).toBe(false);
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+    expect(deepEqual([1, 2], [2, 1])).toBe(false);
+    expect(deepEqual([1, [2, 3]], [1, [2, 3]])).toBe(true);
+    expect(deepEqual([1, [2, 3]], [1, [2, 4]])).toBe(false);
+    expect(deepEqual([1, { a: 1 }], [1, { a: 1 }])).toBe(true);
+  });
+
+  it("should handle objects correctly", () => {
+    expect(deepEqual({}, {})).toBe(true);
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true);
+    expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1, b: 3 })).toBe(false);
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+  });
+
+  it("should handle nested objects correctly", () => {
+    expect(deepEqual({ a: { b: 1 } }, { a: { b: 1 } })).toBe(true);
+    expect(deepEqual({ a: { b: 1 } }, { a: { b: 2 } })).toBe(false);
+    expect(deepEqual({ a: { b: { c: 3 } } }, { a: { b: { c: 3 } } })).toBe(
+      true,
+    );
+  });
+
+  it("should handle mixed nested structures correctly", () => {
+    expect(deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 2 }] })).toBe(true);
+    expect(deepEqual([{ a: 1 }, [2, 3]], [{ a: 1 }, [2, 3]])).toBe(true);
+    expect(deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 3 }] })).toBe(false);
+  });
+
+  it("should handle edge cases correctly", () => {
+    expect(deepEqual(NaN, NaN)).toBe(false);
+    expect(deepEqual(-0, +0)).toBe(true);
+    expect(deepEqual(Infinity, Infinity)).toBe(true);
+    expect(deepEqual(-Infinity, -Infinity)).toBe(true);
+    expect(deepEqual(-Infinity, Infinity)).toBe(false);
+  });
+
+  it("should handle circular references", () => {
+    const obj1: Record<string, unknown> = { a: 1 };
+    const obj2: Record<string, unknown> = { a: 1 };
+    obj1.self = obj1;
+    obj2.self = obj2;
+    expect(deepEqual(obj1, obj2)).toBe(true);
+
+    const arr1: any[] = [1];
+    const arr2: any[] = [1];
+    arr1.push(arr1);
+    arr2.push(arr2);
+    expect(deepEqual(arr1, arr2)).toBe(true);
+  });
+});

--- a/packages/design-system/src/scalars/lib/deep-equal.ts
+++ b/packages/design-system/src/scalars/lib/deep-equal.ts
@@ -1,0 +1,57 @@
+export function deepEqual(
+  a: unknown,
+  b: unknown,
+  visited = new Map(),
+): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  if (a === null || b === null || a === undefined || b === undefined) {
+    return false;
+  }
+
+  if (typeof a !== typeof b) {
+    return false;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (visited.get(a) === b) {
+      return true; // Same circular reference detected
+    }
+    visited.set(a, b);
+    return (
+      a.length === b.length &&
+      a.every((value, index) => deepEqual(value, b[index], visited))
+    );
+  }
+
+  if (
+    typeof a === "object" &&
+    typeof b === "object" &&
+    !Array.isArray(a) &&
+    !Array.isArray(b)
+  ) {
+    if (visited.get(a) === b) {
+      return true; // Same circular reference detected
+    }
+    visited.set(a, b);
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    return (
+      aKeys.length === bKeys.length &&
+      aKeys.every((key) => {
+        return (
+          key in b &&
+          deepEqual(
+            (a as Record<string, unknown>)[key],
+            (b as Record<string, unknown>)[key],
+            visited,
+          )
+        );
+      })
+    );
+  }
+
+  return false;
+}

--- a/packages/design-system/src/scalars/lib/is-empty.test.ts
+++ b/packages/design-system/src/scalars/lib/is-empty.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { isEmpty } from "./is-empty";
+
+describe("isEmpty", () => {
+  // Null/undefined cases
+  it("should return true for null", () => {
+    expect(isEmpty(null)).toBe(true);
+  });
+
+  it("should return true for undefined", () => {
+    expect(isEmpty(undefined)).toBe(true);
+  });
+
+  // Boolean cases
+  it("should return false for true", () => {
+    expect(isEmpty(true)).toBe(false);
+  });
+
+  it("should return false for false", () => {
+    expect(isEmpty(false)).toBe(false);
+  });
+
+  // Number cases
+  it("should return false for non-zero numbers", () => {
+    expect(isEmpty(42)).toBe(false);
+  });
+
+  it("should return false for zero", () => {
+    expect(isEmpty(0)).toBe(false);
+  });
+
+  it("should return true for NaN", () => {
+    expect(isEmpty(NaN)).toBe(true);
+  });
+
+  // String cases
+  it("should return true for empty string", () => {
+    expect(isEmpty("")).toBe(true);
+  });
+
+  it("should return false for non-empty string", () => {
+    expect(isEmpty("hello")).toBe(false);
+  });
+
+  it("should return false for string with spaces", () => {
+    expect(isEmpty("   ")).toBe(false);
+  });
+
+  // Array cases
+  it("should return true for empty array", () => {
+    expect(isEmpty([])).toBe(true);
+  });
+
+  it("should return false for non-empty array", () => {
+    expect(isEmpty([1, 2, 3])).toBe(false);
+  });
+
+  it("should return false for array with undefined values", () => {
+    expect(isEmpty([undefined])).toBe(false);
+  });
+
+  // Object cases
+  it("should return true for empty object", () => {
+    expect(isEmpty({})).toBe(true);
+  });
+
+  it("should return false for non-empty object", () => {
+    expect(isEmpty({ key: "value" })).toBe(false);
+  });
+
+  it("should return false for object with null values", () => {
+    expect(isEmpty({ key: null })).toBe(false);
+  });
+
+  // Map cases
+  it("should return true for empty Map", () => {
+    expect(isEmpty(new Map())).toBe(true);
+  });
+
+  it("should return false for non-empty Map", () => {
+    const map = new Map();
+    map.set("key", "value");
+    expect(isEmpty(map)).toBe(false);
+  });
+
+  // Set cases
+  it("should return true for empty Set", () => {
+    expect(isEmpty(new Set())).toBe(true);
+  });
+
+  it("should return false for non-empty Set", () => {
+    const set = new Set();
+    set.add("value");
+    expect(isEmpty(set)).toBe(false);
+  });
+
+  // Edge cases
+  it("should return false for Date object", () => {
+    expect(isEmpty(new Date())).toBe(false);
+  });
+
+  it("should return false for RegExp", () => {
+    expect(isEmpty(/test/)).toBe(false);
+  });
+
+  it("should return false for functions", () => {
+    expect(isEmpty(() => {})).toBe(false);
+  });
+});

--- a/packages/design-system/src/scalars/lib/is-empty.ts
+++ b/packages/design-system/src/scalars/lib/is-empty.ts
@@ -1,0 +1,31 @@
+export function isEmpty(value: unknown): boolean {
+  if (
+    value === null ||
+    value === undefined ||
+    (typeof value === "number" && isNaN(value))
+  ) {
+    return true;
+  }
+
+  if (typeof value === "boolean" || typeof value === "number") {
+    return false;
+  }
+
+  if (value instanceof RegExp || value instanceof Date) {
+    return false; // Regex and Date are not considered empty
+  }
+
+  if (typeof value === "string" || Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  if (value instanceof Map || value instanceof Set) {
+    return value.size === 0;
+  }
+
+  if (typeof value === "object") {
+    return Object.keys(value).length === 0;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Ticket
https://trello.com/c/Z1QZdy5Z

## Description
- Add `submitChangesOnly` prop to the form to allow to submit the fields that changed its values only
- Transform empty fields to `null` on submit
- Improve `Form` documentation