### PR TITLE
chore(scalars): use auto EOL prettier config in eslint to prevent issues on windows

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -84,6 +84,14 @@ export default tseslint.config(
   ...tailwind.configs["flat/recommended"],
   eslintPluginPrettierRecommended,
   {
+    rules: {
+      "prettier/prettier": [
+        "error",
+        {
+          endOfLine: "auto",
+        },
+      ],
+    },
     ignores: [
       "node_modules/",
       "dist/",


### PR DESCRIPTION
Auto EOL config of prettier to prevent EOL issues on windows