### PR TITLE
fix(scalars): fix the color in the input and add setp default value i…

### DIFF
--- a/packages/design-system/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`AmountField Component > should match snapshot 1`] = `
             >
               <input
                 aria-invalid="false"
-                class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 flex-1 outline-none pr-8"
+                class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 flex-1 outline-none pr-8"
                 id=":r0:"
                 name=""
                 type="number"

--- a/packages/design-system/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`AmountField Component > should match snapshot 1`] = `
             >
               <input
                 aria-invalid="false"
-                class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 flex-1 outline-none pr-8"
+                class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-50 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 flex-1 outline-none pr-8"
                 id=":r0:"
                 name=""
                 type="number"

--- a/packages/design-system/src/scalars/components/fragments/input/__snapshots__/input.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/input/__snapshots__/input.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Input > should match snapshot 1`] = `
 <div>
   <input
-    class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
+    class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-50 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
     placeholder="Test placeholder"
   />
 </div>

--- a/packages/design-system/src/scalars/components/fragments/input/__snapshots__/input.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/input/__snapshots__/input.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Input > should match snapshot 1`] = `
 <div>
   <input
-    class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
+    class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
     placeholder="Test placeholder"
   />
 </div>

--- a/packages/design-system/src/scalars/components/fragments/input/input.tsx
+++ b/packages/design-system/src/scalars/components/fragments/input/input.tsx
@@ -5,7 +5,7 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const inputBaseStyles = cn(
   // Base styles
-  "flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-50",
+  "flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-50",
   // Border & Background
   "border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900",
   // Padding

--- a/packages/design-system/src/scalars/components/fragments/input/input.tsx
+++ b/packages/design-system/src/scalars/components/fragments/input/input.tsx
@@ -5,7 +5,7 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const inputBaseStyles = cn(
   // Base styles
-  "flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-700",
+  "flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-50",
   // Border & Background
   "border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900",
   // Padding

--- a/packages/design-system/src/scalars/components/fragments/text-field/__snapshots__/text-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/text-field/__snapshots__/text-field.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`TextField > should match snapshot 1`] = `
         Test Label
       </label>
       <input
-        class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
+        class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
         id=":r0:"
         name="test"
         value=""

--- a/packages/design-system/src/scalars/components/fragments/text-field/__snapshots__/text-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/text-field/__snapshots__/text-field.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`TextField > should match snapshot 1`] = `
         Test Label
       </label>
       <input
-        class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
+        class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-50 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
         id=":r0:"
         name="test"
         value=""

--- a/packages/design-system/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`NumberField Component > should match snapshot 1`] = `
       >
         <input
           aria-invalid="false"
-          class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 pr-8"
+          class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 pr-8"
           id=":r0:"
           name="Label"
           type="number"

--- a/packages/design-system/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`NumberField Component > should match snapshot 1`] = `
       >
         <input
           aria-invalid="false"
-          class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 pr-8"
+          class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-50 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 pr-8"
           id=":r0:"
           name="Label"
           type="number"

--- a/packages/design-system/src/scalars/components/number-field/number-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.stories.tsx
@@ -26,6 +26,7 @@ const meta = {
       description: "Step value for the input field",
       table: {
         type: { summary: "number" },
+        defaultValue: { summary: "1" },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -167,7 +167,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
                   size={10}
                   name="ChevronDown"
                   className={cn(
-                    "rotate-180 text-gray-700",
+                    "rotate-180 text-gray-700 dark:text-gray-300",
                     isIncrementDisabled && "cursor-not-allowed",
                   )}
                 />
@@ -181,7 +181,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
                   size={10}
                   name="ChevronDown"
                   className={cn(
-                    " items-center justify-center text-gray-700",
+                    " items-center justify-center text-gray-700 dark:text-gray-300",
                     isDecrementDisabled && "cursor-not-allowed",
                   )}
                 />

--- a/packages/design-system/src/scalars/components/string-field/__snapshots__/string-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/string-field/__snapshots__/string-field.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`StringField > should match snapshot with minimal props 1`] = `
       class="flex flex-col gap-2"
     >
       <input
-        class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
+        class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
         id=":r0:"
         name="test"
         value=""

--- a/packages/design-system/src/scalars/components/string-field/__snapshots__/string-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/string-field/__snapshots__/string-field.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`StringField > should match snapshot with minimal props 1`] = `
       class="flex flex-col gap-2"
     >
       <input
-        class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
+        class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-50 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
         id=":r0:"
         name="test"
         value=""

--- a/packages/design-system/src/scalars/components/url-field/__snapshots__/url-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/url-field/__snapshots__/url-field.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`UrlField > should match snapshot 1`] = `
         class="relative"
       >
         <input
-          class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
+          class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-50 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
           id=":r0:"
           name="test-url"
           placeholder="https://example.com"

--- a/packages/design-system/src/scalars/components/url-field/__snapshots__/url-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/url-field/__snapshots__/url-field.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`UrlField > should match snapshot 1`] = `
         class="relative"
       >
         <input
-          class="flex h-10 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
+          class="flex h-9 w-full rounded-md text-sm text-gray-900 dark:text-gray-700 border border-gray-300 bg-white dark:border-charcoal-700 dark:bg-charcoal-900 px-3 py-2 font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500"
           id=":r0:"
           name="test-url"
           placeholder="https://example.com"


### PR DESCRIPTION
## Ticket
https://trello.com/c/dcRznxfV/752-final-design-1-number

## Description
- NumberField. Dark Mode, Filled status.  The values should have Gray/50.  The values are barely visible, the values are displayed with font color

- NumberField. Dark Mode, Steps representation.  The carets should have color =  Gray/300.  The carets are barely visible with color = Gray/700. 