### PR TITLE
fix(scalars): add correct validations in bigInt and validate per type

### DIFF
--- a/packages/design-system/src/scalars/components/number-field/number-field-validations.ts
+++ b/packages/design-system/src/scalars/components/number-field/number-field-validations.ts
@@ -11,7 +11,62 @@ export const validatePositive =
   };
 
 export const validateIsBigInt =
-  ({ isBigInt }: NumberFieldProps) =>
+  ({ isBigInt, numericType }: NumberFieldProps) =>
   (value: unknown) => {
-    return isBigInt || isBigIntNumber(value);
+    return isBigInt || numericType === "BigInt" || isBigIntNumber(value);
+  };
+
+export const isInteger = (value: unknown): boolean =>
+  Number.isInteger(Number(value));
+
+export const isFloat = (value: unknown): boolean =>
+  !Number.isInteger(Number(value));
+
+export const validateNumericType =
+  ({
+    allowNegative = false,
+    isBigInt = false,
+    numericType = "PositiveInt",
+  }: NumberFieldProps) =>
+  (value: unknown) => {
+    switch (numericType) {
+      case "PositiveInt":
+        return (isInteger(value) && Number(value) > 0) || allowNegative
+          ? true
+          : "Value must be a positive integer";
+      case "NegativeInt": {
+        return isInteger(value) && Number(value) < 0
+          ? true
+          : "Value must be a negative integer";
+      }
+
+      case "NonNegativeInt":
+        return (isInteger(value) && Number(value) >= 0) || allowNegative
+          ? true
+          : "Value must be a non-negative integer";
+      case "NonPositiveInt":
+        return isInteger(value) && Number(value) <= 0
+          ? true
+          : "Value must be a non-positive integer";
+      case "PositiveFloat":
+        return (isFloat(value) && parseFloat(value as string) > 0) ||
+          allowNegative
+          ? true
+          : "Value must be a positive float";
+      case "NegativeFloat":
+        return isFloat(value) && parseFloat(value as string) < 0
+          ? true
+          : "Value must be a negative float";
+      case "NonNegativeFloat":
+        return isFloat(value) && parseFloat(value as string) >= 0
+          ? true
+          : "Value must be a non-negative float";
+      case "NonPositiveFloat":
+        return isFloat(value) && parseFloat(value as string) <= 0
+          ? true
+          : "Value must be a non-positive float";
+      case "BigInt": {
+        return isBigInt || !isFloat(value) ? true : "This is not a vaid BigInt";
+      }
+    }
   };

--- a/packages/design-system/src/scalars/components/number-field/number-field-validations.ts
+++ b/packages/design-system/src/scalars/components/number-field/number-field-validations.ts
@@ -23,50 +23,79 @@ export const isFloat = (value: unknown): boolean =>
   !Number.isInteger(Number(value));
 
 export const validateNumericType =
-  ({
-    allowNegative = false,
-    isBigInt = false,
-    numericType = "PositiveInt",
-  }: NumberFieldProps) =>
+  ({ allowNegative = false, numericType = "PositiveInt" }: NumberFieldProps) =>
   (value: unknown) => {
+    const isPositive = Number(value) > 0;
+    const isInt = isInteger(value);
+
     switch (numericType) {
-      case "PositiveInt":
-        return (isInteger(value) && Number(value) > 0) || allowNegative
-          ? true
-          : "Value must be a positive integer";
-      case "NegativeInt": {
-        return isInteger(value) && Number(value) < 0
-          ? true
-          : "Value must be a negative integer";
+      case "PositiveInt": {
+        if (!isInt) return "Value must be a integer";
+        if (allowNegative) return true;
+        // Si llegue hasta aqui no permito negative
+        if (isPositive) return true;
+        return "Value must be a positive integer";
       }
 
-      case "NonNegativeInt":
-        return (isInteger(value) && Number(value) >= 0) || allowNegative
-          ? true
-          : "Value must be a non-negative integer";
-      case "NonPositiveInt":
-        return isInteger(value) && Number(value) <= 0
-          ? true
-          : "Value must be a non-positive integer";
-      case "PositiveFloat":
-        return (isFloat(value) && parseFloat(value as string) > 0) ||
-          allowNegative
-          ? true
-          : "Value must be a positive float";
-      case "NegativeFloat":
-        return isFloat(value) && parseFloat(value as string) < 0
-          ? true
-          : "Value must be a negative float";
-      case "NonNegativeFloat":
-        return isFloat(value) && parseFloat(value as string) >= 0
-          ? true
-          : "Value must be a non-negative float";
-      case "NonPositiveFloat":
-        return isFloat(value) && parseFloat(value as string) <= 0
-          ? true
-          : "Value must be a non-positive float";
+      case "NegativeInt": {
+        if (!isInt) return "Value must be an integer";
+        if (!allowNegative && Number(value) >= 0)
+          return "Value must be a negative integer";
+        if (Number(value) < 0) return true;
+        return "Value must be a negative integer";
+      }
+
+      case "NonNegativeInt": {
+        if (!isInt) return "Value must be an integer";
+        if (!allowNegative && Number(value) < 0)
+          return "Value must be a non-negative integer";
+        if (Number(value) >= 0) return true;
+        return "Value must be a non-negative integer";
+      }
+
+      case "NonPositiveInt": {
+        if (!isInt) return "Value must be an integer";
+        if (!allowNegative && Number(value) > 0)
+          return "Value must be a non-positive integer";
+        if (Number(value) <= 0) return true;
+        return "Value must be a non-positive integer";
+      }
+
+      case "PositiveFloat": {
+        if (!isFloat(value)) return "Value must be a float";
+        if (!allowNegative && parseFloat(value as string) <= 0)
+          return "Value must be a positive float";
+        if (parseFloat(value as string) > 0) return true;
+        return "Value must be a positive float";
+      }
+
+      case "NegativeFloat": {
+        if (!isFloat(value)) return "Value must be a float";
+        if (!allowNegative && parseFloat(value as string) >= 0)
+          return "Value must be a negative float";
+        if (parseFloat(value as string) < 0) return true;
+        return "Value must be a negative float";
+      }
+
+      case "NonNegativeFloat": {
+        if (!isFloat(value)) return "Value must be a float";
+        if (!allowNegative && parseFloat(value as string) < 0)
+          return "Value must be a non-negative float";
+        if (parseFloat(value as string) >= 0) return true;
+        return "Value must be a non-negative float";
+      }
+
+      case "NonPositiveFloat": {
+        if (!isFloat(value)) return "Value must be a float";
+        if (!allowNegative && parseFloat(value as string) > 0)
+          return "Value must be a non-positive float";
+        if (parseFloat(value as string) <= 0) return true;
+        return "Value must be a non-positive float";
+      }
+
       case "BigInt": {
-        return isBigInt || !isFloat(value) ? true : "This is not a vaid BigInt";
+        if (!isFloat(value)) return true;
+        return "This is not a valid BigInt";
       }
     }
   };

--- a/packages/design-system/src/scalars/components/number-field/number-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.stories.tsx
@@ -100,7 +100,6 @@ export const Default: Story = {
     name: "Label",
     label: "Label",
     placeholder: "0",
-    showErrorOnBlur: true,
     step: 0,
     value: 1234,
   },
@@ -203,8 +202,9 @@ export const WithBigInt: Story = {
   args: {
     name: "Label",
     label: "Label",
-    value: "9999999999999999999",
+    value: 999999,
     isBigInt: true,
+    step: 0,
   },
 };
 

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -7,13 +7,17 @@ import { InputNumberProps } from "../types";
 import { FormDescription } from "../fragments/form-description";
 import { cn } from "@/scalars/lib";
 import { withFieldValidation } from "../fragments/with-field-validation";
-import { validateIsBigInt, validatePositive } from "./number-field-validations";
+import {
+  validateIsBigInt,
+  validateNumericType,
+  validatePositive,
+} from "./number-field-validations";
 import { Icon } from "@/powerhouse/components/icon";
 import { getDisplayValue, regex } from "./utils";
 
 export interface NumberFieldProps extends InputNumberProps {
   name: string;
-  value?: string | number;
+  value?: number;
   defaultValue?: string | number;
   className?: string;
   pattern?: RegExp;
@@ -52,7 +56,6 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
 
     // Determines the HTML input type based on `isBigInt`: sets to "text" for BigInt values to avoid numeric input constraints,
     // Otherwise sets to "number" for standard numeric input.
-    const inputType = isBigInt ? "text" : "number";
     const showSteps = step !== 0;
 
     // Prevent to write invalid characters
@@ -141,7 +144,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
             name={name}
             className={cn(className, showSteps && "pr-8")}
             pattern={isBigInt ? regex.toString() : pattern?.toString()}
-            type={inputType}
+            type="number"
             min={minValue}
             max={maxValue}
             aria-valuemin={minValue}
@@ -203,6 +206,7 @@ export const NumberField = withFieldValidation<NumberFieldProps>(
     validations: {
       _positive: validatePositive,
       _isBigInt: validateIsBigInt,
+      _numericType: validateNumericType,
     },
   },
 );

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -10,7 +10,6 @@ import { withFieldValidation } from "../fragments/with-field-validation";
 import {
   validateIsBigInt,
   validateNumericType,
-  validatePositive,
 } from "./number-field-validations";
 import { Icon } from "@/powerhouse/components/icon";
 import { getDisplayValue, regex } from "./utils";
@@ -204,7 +203,6 @@ export const NumberField = withFieldValidation<NumberFieldProps>(
   NumberFieldRaw,
   {
     validations: {
-      _positive: validatePositive,
       _isBigInt: validateIsBigInt,
       _numericType: validateNumericType,
     },

--- a/packages/design-system/src/scalars/components/number-field/utils.ts
+++ b/packages/design-system/src/scalars/components/number-field/utils.ts
@@ -1,11 +1,3 @@
-import {
-  applyBigInt,
-  applyMaxSafeInteger,
-  applyPrecision,
-  applyTransformations,
-  Transformation,
-} from "./transformations";
-
 export const regex = /^-?\d*\.?\d*$/;
 
 type TransformProps = {
@@ -13,6 +5,7 @@ type TransformProps = {
   trailingZeros?: boolean;
   precision?: number;
 };
+const validNumber = /^-?\d+$/;
 export function getDisplayValue(
   value = "",
   transformProps?: TransformProps,
@@ -23,21 +16,39 @@ export function getDisplayValue(
     trailingZeros = false,
   } = transformProps || {};
 
+  // Return an empty string if value is empty
   if (value === "") {
     return "";
   }
 
-  const transformations: Transformation[] = [];
-
+  // Handle the case when isBigInt is true
   if (isBigInt) {
-    transformations.push(applyBigInt);
+    const newValue = value.toString().replace(/[^-\d.]/g, "");
+    // Remove the decimal part if it exists and keep only the integer part
+    const integerPart = newValue.split(".")[0];
+
+    if (!validNumber.test(integerPart)) {
+      return "";
+    }
+    return BigInt(integerPart).toString();
   }
 
-  transformations.push(applyMaxSafeInteger);
+  // Check if the value exceeds MAX_SAFE_INTEGER  or MIN_SAFE_INTEGER  and is not BigInt
+  const numericValue = parseFloat(value);
+  if (
+    numericValue > Number.MAX_SAFE_INTEGER ||
+    numericValue < Number.MIN_SAFE_INTEGER
+  ) {
+    const newValue = value.toString().replace(/[^-\d.]/g, "");
+    return newValue; // Return the value as a string without conversion
+  }
 
+  // Handle precision and trailing zeros if specified
   if (precision !== undefined) {
-    transformations.push(applyPrecision(precision, trailingZeros));
+    const formattedValue = numericValue.toFixed(precision);
+    return trailingZeros
+      ? formattedValue
+      : parseFloat(formattedValue).toString();
   }
-
-  return applyTransformations(value, transformations);
+  return numericValue.toString();
 }


### PR DESCRIPTION
## Ticket
https://trello.com/c/dcRznxfV/752-final-design-1-number


## Description
- Selecting the NegativeInt type and inserting the number 9.  The field should allow only values less than 0. 

- NumberField. isBigInt = true. Inserting text. **Expected Output:** An error message should be displayed. **Current Output:** The error message is displayed but when click out the field, the text becomes NaN. 