### PR TITLE
fix(scalars): handle custom errors as form field errors

### DIFF
--- a/packages/design-system/src/scalars/components/amount-field/amount-field.test.tsx
+++ b/packages/design-system/src/scalars/components/amount-field/amount-field.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { AmountField } from "./amount-field";
 import { renderWithForm } from "@/scalars/lib/testing";
 
@@ -29,7 +29,7 @@ describe("AmountField Component", () => {
     expect(screen.getByLabelText("Amount Label")).toBeInTheDocument();
   });
 
-  it("should render error messages when provided", () => {
+  it("should render error messages when provided", async () => {
     renderWithForm(
       <AmountField
         selectName="currency"
@@ -40,8 +40,10 @@ describe("AmountField Component", () => {
         errors={["Error 1", "Error 2"]}
       />,
     );
-    expect(screen.getByText("Error 1")).toBeInTheDocument();
-    expect(screen.getByText("Error 2")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Error 1")).toBeInTheDocument();
+      expect(screen.getByText("Error 2")).toBeInTheDocument();
+    });
   });
 
   it("should render the percentage sign if the type is percent", () => {

--- a/packages/design-system/src/scalars/components/boolean-field/__snapshots__/boolean-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/boolean-field/__snapshots__/boolean-field.test.tsx.snap
@@ -13,10 +13,10 @@ exports[`BooleanField > should render checkbox field when isToggle is false 1`] 
       >
         <button
           aria-checked="true"
-          aria-invalid="true"
+          aria-invalid="false"
           aria-required="true"
           class="peer size-4 shrink-0 rounded border-input border shadow-sm shadow-black/[.04] ring-offset-background transition-shadow focus-visible:border-ring focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:border-gray-700 disabled:data-[invalid=false]:data-[state=checked]:bg-gray-700 disabled:data-[invalid=false]:data-[state=indeterminate]:bg-gray-700 dark:disabled:data-[invalid=false]:data-[state=checked]:bg-gray-500 dark:disabled:data-[invalid=false]:data-[state=indeterminate]:bg-gray-500 data-[state]:border-gray-700 dark:data-[state]:border-gray-500 data-[state=checked]:bg-gray-900 data-[state=indeterminate]:bg-gray-900 dark:data-[state=checked]:bg-gray-400 dark:data-[state=indeterminate]:bg-gray-400 data-[state=checked]:text-slate-50 data-[state=indeterminate]:text-slate-50 dark:data-[state=checked]:text-gray-900 dark:data-[state=indeterminate]:text-gray-900 group-hover:border-gray-900 data-[state=checked]:group-hover:bg-gray-900 data-[state=indeterminate]:group-hover:bg-gray-900 dark:group-hover:border-slate-50 dark:data-[state=checked]:group-hover:bg-slate-50 dark:data-[state=indeterminate]:group-hover:bg-slate-50 data-[invalid=true]:data-[state]:!border-red-800 data-[invalid=true]:data-[state=checked]:!bg-red-800 data-[invalid=true]:data-[state=indeterminate]:!bg-red-800 dark:data-[invalid=true]:data-[state]:!border-red-800 dark:data-[invalid=true]:data-[state=checked]:!bg-red-800 dark:data-[invalid=true]:data-[state=indeterminate]:!bg-red-800 data-[invalid=true]:group-hover:!border-red-900 data-[invalid=true]:data-[state=checked]:group-hover:!bg-red-900 data-[invalid=true]:data-[state=indeterminate]:group-hover:!bg-red-900"
-          data-invalid="true"
+          data-invalid="false"
           data-state="checked"
           id=":r2:"
           role="checkbox"
@@ -54,12 +54,12 @@ exports[`BooleanField > should render checkbox field when isToggle is false 1`] 
           value="on"
         />
         <label
-          class="inline-flex items-center text-sm font-medium leading-[22px] text-red-800 group-hover:!text-red-900 dark:text-red-800 dark:group-hover:!text-red-900 group-hover:text-gray-900 dark:group-hover:text-slate-50 group-hover:cursor-pointer"
+          class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-slate-50 group-hover:cursor-pointer"
           for=":r2:"
         >
           Test Field
           <span
-            class="ml-1 text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 !text-red-800 group-hover:!text-red-900"
+            class="ml-1 text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50"
           >
             *
           </span>
@@ -78,12 +78,6 @@ exports[`BooleanField > should render checkbox field when isToggle is false 1`] 
         data-type="warning"
       >
         Test warning
-      </p>
-      <p
-        class="mb-0 inline-flex items-center text-xs font-medium text-red-900 dark:text-red-900"
-        data-type="error"
-      >
-        Test error
       </p>
     </div>
   </form>
@@ -154,12 +148,6 @@ exports[`BooleanField > should render toggle field when isToggle is true 1`] = `
         data-type="warning"
       >
         Test warning
-      </p>
-      <p
-        class="mb-0 inline-flex items-center text-xs font-medium text-red-900 dark:text-red-900"
-        data-type="error"
-      >
-        Test error
       </p>
     </div>
   </form>

--- a/packages/design-system/src/scalars/components/enum-field/enum-field.test.tsx
+++ b/packages/design-system/src/scalars/components/enum-field/enum-field.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithForm } from "@/scalars/lib/testing";
 import { EnumField } from "./enum-field";
@@ -51,9 +51,11 @@ describe("EnumField Component", () => {
     expect(screen.getByText("Warning message")).toBeInTheDocument();
   });
 
-  it("should render error messages when provided", () => {
+  it("should render error messages when provided", async () => {
     renderWithForm(<EnumField {...defaultProps} errors={["Error message"]} />);
-    expect(screen.getByText("Error message")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("Error message")).toBeInTheDocument(),
+    );
   });
 
   it("should handle value changes in RadioGroup variant", async () => {

--- a/packages/design-system/src/scalars/components/fragments/checkbox-field/checkbox-field.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/checkbox-field/checkbox-field.test.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { CheckboxField } from "./checkbox-field";
 import { renderWithForm } from "@/scalars/lib/testing";
@@ -61,7 +61,7 @@ describe("CheckboxField", () => {
     expect(checkbox).toBeRequired();
   });
 
-  it("should render with errors", () => {
+  it("should render with errors", async () => {
     renderWithForm(
       <CheckboxField
         name="test"
@@ -69,10 +69,12 @@ describe("CheckboxField", () => {
         errors={["This is an error"]}
       />,
     );
-    expect(screen.getByText("This is an error")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("This is an error")).toBeInTheDocument(),
+    );
   });
 
-  it("should render with warnings and errors", () => {
+  it("should render with warnings and errors", async () => {
     renderWithForm(
       <CheckboxField
         name="test"
@@ -82,6 +84,8 @@ describe("CheckboxField", () => {
       />,
     );
     expect(screen.getByText("This is a warning")).toBeInTheDocument();
-    expect(screen.getByText("This is an error")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("This is an error")).toBeInTheDocument(),
+    );
   });
 });

--- a/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group-field.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/radio-group-field/radio-group-field.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithForm } from "@/scalars/lib/testing";
 import { RadioGroupField } from "./radio-group-field";
@@ -100,7 +100,7 @@ describe("RadioGroupField Component", () => {
     expect(screen.getByText("Warning message")).toBeInTheDocument();
   });
 
-  it("should show an error when provided", () => {
+  it("should show an error when provided", async () => {
     renderWithForm(
       <RadioGroupField
         name="radio-group"
@@ -110,8 +110,12 @@ describe("RadioGroupField Component", () => {
       />,
     );
     const radioGroup = screen.getByRole("radiogroup");
-    expect(radioGroup).toHaveAttribute("aria-invalid", "true");
-    expect(screen.getByText("Error message")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(radioGroup).toHaveAttribute("aria-invalid", "true"),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Error message")).toBeInTheDocument(),
+    );
   });
 
   it("should have aria-label when no label is provided", () => {
@@ -218,7 +222,7 @@ describe("RadioGroupField Component", () => {
     expect(screen.getByText("Warning 2")).toBeInTheDocument();
   });
 
-  it("should handle multiple errors", () => {
+  it("should handle multiple errors", async () => {
     renderWithForm(
       <RadioGroupField
         name="radio-group"
@@ -227,11 +231,13 @@ describe("RadioGroupField Component", () => {
         options={[{ label: "Option 1", value: "1" }]}
       />,
     );
-    expect(screen.getByText("Error 1")).toBeInTheDocument();
-    expect(screen.getByText("Error 2")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Error 1")).toBeInTheDocument();
+      expect(screen.getByText("Error 2")).toBeInTheDocument();
+    });
   });
 
-  it("should show both warnings and errors when provided", () => {
+  it("should show both warnings and errors when provided", async () => {
     renderWithForm(
       <RadioGroupField
         name="radio-group"
@@ -242,6 +248,8 @@ describe("RadioGroupField Component", () => {
       />,
     );
     expect(screen.getByText("Warning message")).toBeInTheDocument();
-    expect(screen.getByText("Error message")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("Error message")).toBeInTheDocument(),
+    );
   });
 });

--- a/packages/design-system/src/scalars/components/fragments/select-field/select-field.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/select-field/select-field.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithForm } from "@/scalars/lib/testing";
 import { SelectField } from "./select-field";
@@ -115,7 +115,7 @@ describe("SelectField Component", () => {
   });
 
   // Validation and Error Handling Tests
-  it("should display error messages", () => {
+  it("should display error messages", async () => {
     renderWithForm(
       <SelectField
         name="select"
@@ -123,7 +123,9 @@ describe("SelectField Component", () => {
         errors={["This field is required"]}
       />,
     );
-    expect(screen.getByText("This field is required")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("This field is required")).toBeInTheDocument(),
+    );
   });
 
   it("should display warning messages", () => {
@@ -167,7 +169,7 @@ describe("SelectField Component", () => {
   });
 
   // Accessibility Tests
-  it("should have correct ARIA attributes", () => {
+  it("should have correct ARIA attributes", async () => {
     renderWithForm(
       <SelectField
         name="select"
@@ -180,7 +182,7 @@ describe("SelectField Component", () => {
 
     const select = screen.getByRole("combobox");
     expect(select).toHaveAttribute("aria-required", "true");
-    expect(select).toHaveAttribute("aria-invalid", "true");
+    await waitFor(() => expect(select).toHaveAttribute("aria-invalid", "true"));
     expect(select).toHaveAttribute("aria-expanded", "false");
   });
 

--- a/packages/design-system/src/scalars/components/fragments/text-field/text-field.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/text-field/text-field.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TextField } from "./text-field";
 import { renderWithForm } from "../../../lib/testing";
@@ -45,11 +45,13 @@ describe("TextField", () => {
     expect(screen.getByRole("textbox")).toBeDisabled();
   });
 
-  it("should display error messages", () => {
+  it("should display error messages", async () => {
     renderWithForm(
       <TextField name="name" label="Name" errors={["Name is required"]} />,
     );
-    expect(screen.getByText("Name is required")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("Name is required")).toBeInTheDocument(),
+    );
   });
 
   it("should display warning messages", () => {

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/__snapshots__/textarea-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/__snapshots__/textarea-field.test.tsx.snap
@@ -9,12 +9,12 @@ exports[`TextareaField Component > should match snapshot with props 1`] = `
       class="flex flex-col gap-2"
     >
       <label
-        class="inline-flex items-center text-sm font-medium leading-[22px] text-red-800 group-hover:!text-red-900 dark:text-red-800 dark:group-hover:!text-red-900 mb-[3px]"
+        class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 dark:text-gray-400 mb-[3px]"
         for=":r0:-textarea"
       >
         Default Label
         <span
-          class="ml-1 text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 !text-red-800 group-hover:!text-red-900"
+          class="ml-1 text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50"
         >
           *
         </span>
@@ -23,7 +23,7 @@ exports[`TextareaField Component > should match snapshot with props 1`] = `
         class="relative"
       >
         <textarea
-          aria-invalid="true"
+          aria-invalid="false"
           aria-required="true"
           autocomplete="off"
           class="flex w-full rounded-md text-[14px] font-normal leading-5 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white font-sans placeholder:text-gray-600 dark:placeholder:text-gray-500 px-3 py-[7.2px] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-500 resize-y scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-300 dark:scrollbar-track-gray-900 dark:scrollbar-thumb-gray-600"
@@ -60,12 +60,6 @@ exports[`TextareaField Component > should match snapshot with props 1`] = `
         data-type="warning"
       >
         Warning
-      </p>
-      <p
-        class="mb-0 inline-flex items-center text-xs font-medium text-red-900 dark:text-red-900"
-        data-type="error"
-      >
-        Error
       </p>
     </div>
   </form>

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithForm } from "@/scalars/lib/testing";
 import { TextareaField } from "./textarea-field";
@@ -52,7 +52,7 @@ describe("TextareaField Component", () => {
   });
 
   describe("Messages and Feedback", () => {
-    it("should handle warnings and errors", () => {
+    it("should handle warnings and errors", async () => {
       renderWithForm(
         <TextareaField
           name="textarea"
@@ -65,8 +65,12 @@ describe("TextareaField Component", () => {
       expect(screen.getByText("Help text")).toBeInTheDocument();
       expect(screen.getByText("Warning 1")).toBeInTheDocument();
       expect(screen.getByText("Warning 2")).toBeInTheDocument();
-      expect(screen.getByText("Error 1")).toBeInTheDocument();
-      expect(screen.getByText("Error 2")).toBeInTheDocument();
+      await waitFor(() =>
+        expect(screen.getByText("Error 1")).toBeInTheDocument(),
+      );
+      await waitFor(() =>
+        expect(screen.getByText("Error 2")).toBeInTheDocument(),
+      );
     });
   });
 

--- a/packages/design-system/src/scalars/components/fragments/toggle-field/toggle-field.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/toggle-field/toggle-field.test.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, vi } from "vitest";
 import { ToggleField } from "./toggle-field";
 import { renderWithForm } from "@/scalars/lib/testing";
@@ -36,11 +36,13 @@ describe("ToggleField Component", () => {
     expect(screen.queryByText("Test Label")).not.toBeInTheDocument();
   });
 
-  it("should display an error message when hasMessage is true", () => {
+  it("should display an error message when hasMessage is true", async () => {
     renderWithForm(
       <ToggleField name="test" label="Test Label" errors={["Error message"]} />,
     );
-    expect(screen.getByText("Error message")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("Error message")).toBeInTheDocument(),
+    );
   });
 
   it("should call onChange when clicked", () => {

--- a/packages/design-system/src/scalars/components/fragments/with-field-validation/with-field-validation.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/with-field-validation/with-field-validation.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { withFieldValidation } from "./with-field-validation";
 import { Form } from "../../form";
@@ -132,8 +132,12 @@ describe("withFieldValidation", () => {
     expect(await screen.findByTestId("error-message")).toBeInTheDocument();
   });
 
-  it("should pass through custom error messages", () => {
-    renderWithForm(<WrappedComponent name="test" errors={["Custom error"]} />);
+  it("should pass through custom error messages", async () => {
+    await act(() =>
+      renderWithForm(
+        <WrappedComponent name="test" errors={["Custom error"]} />,
+      ),
+    );
 
     expect(screen.getByTestId("error-message")).toHaveTextContent(
       "Custom error",

--- a/packages/design-system/src/scalars/components/number-field/number-field.test.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { NumberField } from "./number-field";
 import { renderWithForm } from "@/scalars/lib/testing";
@@ -37,7 +37,7 @@ describe("NumberField Component", () => {
     expect(screen.getByText("This is a description")).toBeInTheDocument();
   });
 
-  it("should render error messages when provided", () => {
+  it("should render error messages when provided", async () => {
     renderWithForm(
       <NumberField
         label="Test Label"
@@ -46,8 +46,10 @@ describe("NumberField Component", () => {
         name="Label"
       />,
     );
-    expect(screen.getByText("Error 1")).toBeInTheDocument();
-    expect(screen.getByText("Error 2")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Error 1")).toBeInTheDocument();
+      expect(screen.getByText("Error 2")).toBeInTheDocument();
+    });
   });
 
   it("should render warning messages when provided", () => {

--- a/packages/design-system/src/scalars/components/string-field/string-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/string-field/string-field.stories.tsx
@@ -102,10 +102,10 @@ export const Disabled: Story = {
 
 export const WithError: Story = {
   args: {
-    label: "Password",
+    label: "Username",
     value: "123",
     required: true,
-    errors: ["Password must be at least 8 characters long"],
+    errors: ["Username must be at least 8 characters long"],
   },
 };
 

--- a/packages/design-system/src/scalars/components/string-field/string-field.test.tsx
+++ b/packages/design-system/src/scalars/components/string-field/string-field.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { StringField } from "./string-field";
 import { renderWithForm } from "@/scalars/lib/testing";
@@ -25,9 +25,11 @@ describe("StringField", () => {
     expect(screen.getByText("Test description")).toBeInTheDocument();
   });
 
-  it("should render error messages when provided", () => {
+  it("should render error messages when provided", async () => {
     renderWithForm(<StringField name="test" errors={["Error message"]} />);
-    expect(screen.getByText("Error message")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("Error message")).toBeInTheDocument(),
+    );
   });
 
   it("should render warning messages when provided", () => {

--- a/packages/design-system/src/scalars/components/url-field/__snapshots__/url-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/url-field/__snapshots__/url-field.test.tsx.snap
@@ -9,12 +9,12 @@ exports[`UrlField > should match snapshot 1`] = `
       class="flex flex-col gap-2"
     >
       <label
-        class="inline-flex items-center text-sm font-medium leading-[22px] text-red-800 group-hover:!text-red-900 dark:text-red-800 dark:group-hover:!text-red-900 mb-[3px]"
+        class="inline-flex items-center text-sm font-medium leading-[22px] text-gray-900 dark:text-gray-400 mb-[3px]"
         for=":r0:"
       >
         Website URL
         <span
-          class="ml-1 text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50 !text-red-800 group-hover:!text-red-900"
+          class="ml-1 text-gray-800 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-slate-50"
         >
           *
         </span>
@@ -42,12 +42,6 @@ exports[`UrlField > should match snapshot 1`] = `
         data-type="warning"
       >
         URL may be unreachable
-      </p>
-      <p
-        class="mb-0 inline-flex items-center text-xs font-medium text-red-900 dark:text-red-900"
-        data-type="error"
-      >
-        Invalid URL format
       </p>
     </div>
   </form>

--- a/packages/design-system/src/scalars/components/url-field/url-field.test.tsx
+++ b/packages/design-system/src/scalars/components/url-field/url-field.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { UrlField } from "./url-field";
 import { renderWithForm } from "@/scalars/lib/testing";
@@ -63,7 +63,7 @@ describe("UrlField", () => {
     expect(screen.getByText("Enter your website URL")).toBeInTheDocument();
   });
 
-  it("should show error message when provided", () => {
+  it("should show error message when provided", async () => {
     renderWithForm(
       <UrlField
         name="test-url"
@@ -72,7 +72,9 @@ describe("UrlField", () => {
       />,
     );
 
-    expect(screen.getByText("Invalid URL format")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("Invalid URL format")).toBeInTheDocument(),
+    );
   });
 
   it("should show warning message when provided", () => {


### PR DESCRIPTION
## Ticket
https://trello.com/c/TDN5P8Vi/750-final-design-1-string

## Description
Handle internally custom errors passed as props to the components as `react-hooks-form` errors avoiding allowing the form to be submitted with custom errors