### PR TITLE
fix(scalars): character counter when maxLenght <= 0

### DIFF
--- a/packages/design-system/src/scalars/components/fragments/text-field/text-field.tsx
+++ b/packages/design-system/src/scalars/components/fragments/text-field/text-field.tsx
@@ -78,7 +78,7 @@ const TextFieldRaw = forwardRef<HTMLInputElement, TextFieldProps>(
             ref={ref}
           />
         </ValueTransformer>
-        {maxLength && (
+        {typeof maxLength === "number" && maxLength > 0 && (
           <div className="flex justify-end">
             <CharacterCounter maxLength={maxLength} value={value ?? ""} />
           </div>

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.tsx
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.tsx
@@ -162,7 +162,7 @@ const TextareaFieldRaw = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
               {...props}
             />
           </ValueTransformer>
-          {maxLength && (
+          {typeof maxLength === "number" && maxLength > 0 && (
             <div className="mt-0.5 flex justify-end">
               <CharacterCounter maxLength={maxLength} value={value ?? ""} />
             </div>


### PR DESCRIPTION
## Ticket
https://trello.com/c/TDN5P8Vi/750-final-design-1-string

## Description
The character counter was showing up when the `maxLenght` is 0 or negative