### PR TITLE
fix(design-system): revert changes not related to scalars components

### DIFF
--- a/packages/design-system/src/connect/components/revision-history/revision/address.stories.tsx
+++ b/packages/design-system/src/connect/components/revision-history/revision/address.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { Address } from "./address";
-import { TooltipProvider } from "@/connect";
 
 const meta = {
   title: "Connect/Components/Revision History/Revision/Address",
@@ -16,9 +15,4 @@ export const Default: Story = {
     address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
     chainId: 1,
   },
-  render: (props) => (
-    <TooltipProvider>
-      <Address {...props} />
-    </TooltipProvider>
-  ),
 };

--- a/packages/design-system/src/connect/components/revision-history/revision/errors.stories.tsx
+++ b/packages/design-system/src/connect/components/revision-history/revision/errors.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { TooltipProvider } from "@/connect";
 import { Errors } from "./errors";
 
 const meta = {
@@ -23,11 +22,6 @@ export const WithOneError: Story = {
       "Data mismatch detected in this signature which needs to be resolved.",
     ],
   },
-  render: (props) => (
-    <TooltipProvider>
-      <Errors {...props} />,
-    </TooltipProvider>
-  ),
 };
 
 export const WithMultipleErrors: Story = {
@@ -38,9 +32,4 @@ export const WithMultipleErrors: Story = {
       "Data mismatch detected in this signature which needs to be resolved.",
     ],
   },
-  render: (props) => (
-    <TooltipProvider>
-      <Errors {...props} />,
-    </TooltipProvider>
-  ),
 };

--- a/packages/design-system/src/connect/components/revision-history/revision/operation.stories.tsx
+++ b/packages/design-system/src/connect/components/revision-history/revision/operation.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { Operation } from "./operation";
-import { TooltipProvider } from "@/connect";
 
 const meta = {
   title: "Connect/Components/Revision History/Revision/Operation",
@@ -23,9 +22,4 @@ export const Default: Story = {
       },
     },
   },
-  render: (props) => (
-    <TooltipProvider>
-      <Operation {...props} />,
-    </TooltipProvider>
-  ),
 };

--- a/packages/design-system/src/connect/components/revision-history/revision/revision.stories.tsx
+++ b/packages/design-system/src/connect/components/revision-history/revision/revision.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { Revision } from "./revision";
-import { TooltipProvider } from "@/connect";
 
 const meta = {
   title: "Connect/Components/Revision History/Revision",
@@ -48,11 +47,6 @@ export const Verified: Story = {
     ],
     errors: [],
   },
-  render: (props) => (
-    <TooltipProvider>
-      <Revision {...props} />
-    </TooltipProvider>
-  ),
 };
 
 export const PartiallyVerified: Story = {
@@ -92,11 +86,6 @@ export const PartiallyVerified: Story = {
     ],
     errors: ["Data mismatch detected"],
   },
-  render: (props) => (
-    <TooltipProvider>
-      <Revision {...props} />
-    </TooltipProvider>
-  ),
 };
 
 export const NotVerified: Story = {
@@ -136,9 +125,4 @@ export const NotVerified: Story = {
     ],
     errors: ["Data mismatch detected"],
   },
-  render: (props) => (
-    <TooltipProvider>
-      <Revision {...props} />
-    </TooltipProvider>
-  ),
 };

--- a/packages/design-system/src/connect/components/revision-history/revision/signature.stories.tsx
+++ b/packages/design-system/src/connect/components/revision-history/revision/signature.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { Signature } from "./signature";
-import { TooltipProvider } from "@/connect";
 
 const meta = {
   title: "Connect/Components/Revision History/Revision/Signature",
@@ -30,11 +29,6 @@ export const NotVerified: Story = {
       },
     ],
   },
-  render: (props) => (
-    <TooltipProvider>
-      <Signature {...props} />
-    </TooltipProvider>
-  ),
 };
 
 export const PartiallyVerified: Story = {
@@ -56,11 +50,6 @@ export const PartiallyVerified: Story = {
       },
     ],
   },
-  render: (props) => (
-    <TooltipProvider>
-      <Signature {...props} />
-    </TooltipProvider>
-  ),
 };
 
 export const Verified: Story = {
@@ -82,9 +71,4 @@ export const Verified: Story = {
       },
     ],
   },
-  render: (props) => (
-    <TooltipProvider>
-      <Signature {...props} />
-    </TooltipProvider>
-  ),
 };

--- a/packages/design-system/src/connect/components/revision-history/revision/timestamp.stories.tsx
+++ b/packages/design-system/src/connect/components/revision-history/revision/timestamp.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { Timestamp } from "./timestamp";
-import { TooltipProvider } from "@/connect";
 
 const meta = {
   title: "Connect/Components/Revision History/Revision/Timestamp",
@@ -15,9 +14,4 @@ export const Default: Story = {
   args: {
     timestamp: 1719232415114,
   },
-  render: (props) => (
-    <TooltipProvider>
-      <Timestamp {...props} />
-    </TooltipProvider>
-  ),
 };

--- a/packages/design-system/src/connect/components/revision-history/revision/timestamp.tsx
+++ b/packages/design-system/src/connect/components/revision-history/revision/timestamp.tsx
@@ -7,11 +7,7 @@ export type TimestampProps = {
 
 export function Timestamp(props: TimestampProps) {
   const { timestamp } = props;
-
-  const timestampNumber =
-    typeof timestamp === "string" ? parseInt(timestamp) : timestamp;
-
-  const date = new Date(timestampNumber);
+  const date = new Date(timestamp);
   const shortDate = format(date, "HH:mm 'UTC'");
   const longDate = format(date, "eee, dd MMM yyyy HH:mm:ss 'UTC'");
   const tooltipContent = <div>{longDate}</div>;


### PR DESCRIPTION
## Description:

- revert changes not related to scalars from dspot-branch merge (this fixes the issue with the revision history timestamp)