### PR TITLE
feat(scalars): adds support for all different values ​​of "viewMode" and related story variants

### DIFF
--- a/packages/design-system/src/scalars/components/country-code-field/country-code-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/country-code-field/country-code-field.stories.tsx
@@ -133,9 +133,7 @@ export const Required: Story = {
   args: {
     label: "Country",
     placeholder: "Select a country",
-    description: "This field is required",
     required: true,
-    showErrorOnBlur: true,
   },
 };
 
@@ -169,5 +167,31 @@ export const WithoutFlags: Story = {
     label: "Country",
     placeholder: "Select a country",
     showFlagIcons: false,
+  },
+};
+
+export const WithShowErrorOnBlur: Story = {
+  args: {
+    label: "Country",
+    description: 'This field shows errors "on blur"',
+    placeholder: "Select a country",
+    required: true,
+    showErrorOnBlur: true,
+  },
+};
+
+export const WithCodesOnly: Story = {
+  args: {
+    label: "Country",
+    placeholder: "Select a country",
+    viewMode: "CodesOnly",
+  },
+};
+
+export const WithNamesAndCodes: Story = {
+  args: {
+    label: "Country",
+    placeholder: "Select a country",
+    viewMode: "NamesAndCodes",
   },
 };

--- a/packages/design-system/src/scalars/components/country-code-field/country-code-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/country-code-field/country-code-field.stories.tsx
@@ -170,16 +170,6 @@ export const WithoutFlags: Story = {
   },
 };
 
-export const WithShowErrorOnBlur: Story = {
-  args: {
-    label: "Country",
-    description: 'This field shows errors "on blur"',
-    placeholder: "Select a country",
-    required: true,
-    showErrorOnBlur: true,
-  },
-};
-
 export const WithCodesOnly: Story = {
   args: {
     label: "Country",

--- a/packages/design-system/src/scalars/components/country-code-field/country-code-field.tsx
+++ b/packages/design-system/src/scalars/components/country-code-field/country-code-field.tsx
@@ -28,7 +28,12 @@ const CountryCodeFieldRaw: React.FC<CountryCodeFieldProps> = ({
     )
     .map((country) => ({
       value: country.alpha2,
-      label: country.name,
+      label:
+        viewMode === "CodesOnly"
+          ? country.alpha2
+          : viewMode === "NamesAndCodes"
+            ? `${country.name} (${country.alpha2})`
+            : country.name,
       icon: showFlagIcons
         ? () => (
             <CircleFlag
@@ -69,9 +74,9 @@ export const CountryCodeField = withFieldValidation<CountryCodeFieldProps>(
     validations: {
       _validOption:
         ({ allowedCountries, excludedCountries }) =>
-        (value: string) => {
-          if (!value) {
-            return "Please select a valid country";
+        (value: string | undefined) => {
+          if (value === "" || value === undefined) {
+            return true; // show only the required message
           }
 
           const validCountries = countries.all

--- a/packages/design-system/src/scalars/components/index.ts
+++ b/packages/design-system/src/scalars/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./boolean-field";
+export * from "./country-code-field";
 export * from "./enum-field";
 export * from "./form";
 export * from "./fragments";


### PR DESCRIPTION
## Ticket
https://trello.com/c/FpOHFVJ0/760-11-countrycodefield

## Description
- Should viewMode allow CodesOnly, NamesOnly, NamesAndCodes. NamesOnly by default
- add story variants: WithCodesOnly and WithNamesAndCodes
- Dropdown open with variants with iconFlag