### PR TITLE
feat(scalars): generate nanoids by default in id fields

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -112,6 +112,7 @@
     "date-fns-tz": "^3.2.0",
     "document-model": "workspace:*",
     "mathjs": "^13.1.1",
+    "nanoid": "^5.0.9",
     "natural-orderby": "^4.0.0",
     "react-circle-flags": "^0.0.22",
     "react-hook-form": "^7.53.0",

--- a/packages/design-system/src/scalars/components/id-field/id-field.test.tsx
+++ b/packages/design-system/src/scalars/components/id-field/id-field.test.tsx
@@ -50,9 +50,10 @@ describe("IdField", () => {
     expect(input).toHaveValue("static-id");
   });
 
-  it("should use UUID generator by default", () => {
-    const mockUUID = "00000000-0000-0000-0000-000000000000";
-    vi.spyOn(crypto, "randomUUID").mockReturnValue(mockUUID);
+  it("should use nanoid generator by default", () => {
+    vi.mock("nanoid", () => ({
+      nanoid: () => "aaa",
+    }));
 
     render(
       <Form onSubmit={() => {}}>
@@ -61,7 +62,7 @@ describe("IdField", () => {
     );
 
     const input = screen.getByTestId("id-field");
-    expect(input).toHaveValue(mockUUID);
+    expect(input).toHaveValue("aaa");
   });
 
   it("should use custom generator function when provided", () => {
@@ -90,7 +91,7 @@ describe("IdField", () => {
 
     render(
       <Form onSubmit={handleSubmit}>
-        <IdField data-testid="id-field" />
+        <IdField data-testid="id-field" generator="uuid" />
         <button type="submit">Submit</button>
       </Form>,
     );

--- a/packages/design-system/src/scalars/components/id-field/id-field.tsx
+++ b/packages/design-system/src/scalars/components/id-field/id-field.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from "react";
 import { useFormContext } from "react-hook-form";
+import { nanoid } from "nanoid";
 
 export type GeneratorFn = () => string;
 
-export type BuiltInGenerator = "UUID";
+export type BuiltInGenerator = "uuid" | "nanoid";
 
 export interface IdFieldProps {
   name?: string;
@@ -14,7 +15,7 @@ export interface IdFieldProps {
 export const IdField: React.FC<IdFieldProps> = ({
   name = "id",
   value,
-  generator = "UUID",
+  generator = "nanoid",
   ...rest
 }) => {
   const {
@@ -22,12 +23,18 @@ export const IdField: React.FC<IdFieldProps> = ({
     formState: { submitCount },
   } = useFormContext();
   const actualValue = useMemo(
-    () =>
-      value !== undefined
-        ? value
-        : typeof generator === "function"
-          ? generator()
-          : crypto.randomUUID(),
+    () => {
+      if (value !== undefined) return value;
+
+      if (typeof generator === "function") return generator();
+
+      switch (generator) {
+        case "nanoid":
+          return nanoid();
+        case "uuid":
+          return crypto.randomUUID();
+      }
+    },
     // We want to re-generate the ID on every submit
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [value, generator, submitCount],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,6 +505,9 @@ importers:
       mathjs:
         specifier: ^13.1.1
         version: 13.2.3
+      nanoid:
+        specifier: ^5.0.9
+        version: 5.0.9
       natural-orderby:
         specifier: ^4.0.0
         version: 4.0.0
@@ -997,7 +1000,7 @@ importers:
         version: link:../codegen
       '@powerhousedao/connect':
         specifier: develop
-        version: 1.0.0-dev.174(@powerhousedao/design-system@packages+design-system)(@powerhousedao/scalars@packages+scalars)(@types/node@22.10.1)(document-model-libs@packages+document-model-libs)(lightningcss@1.28.2)
+        version: 1.0.0-dev.179(@powerhousedao/design-system@packages+design-system)(@powerhousedao/scalars@packages+scalars)(@types/node@22.10.1)(document-model-libs@packages+document-model-libs)(lightningcss@1.28.2)
       '@powerhousedao/design-system':
         specifier: workspace:*
         version: link:../design-system
@@ -4394,8 +4397,8 @@ packages:
   '@powerhousedao/analytics-engine-pg@0.3.0':
     resolution: {integrity: sha512-0N90CJzgrjZONA7VzEQKq5ne0DuzGpjTj3ZeZyjoaOq4gKopVdX+6j7zHmbfFKx15bkY6/T/+VoIKt9WN+We0Q==}
 
-  '@powerhousedao/connect@1.0.0-dev.174':
-    resolution: {integrity: sha512-1oaW+5YWuqC6VhsEgtDAufoA40dQEuoyPXw7laeJWUg+jhlsCzmeXfeJjEJ27fNRMm6Z+NWZuCang5jivUvreA==}
+  '@powerhousedao/connect@1.0.0-dev.179':
+    resolution: {integrity: sha512-fZworcjJHo608/68vpvvUfOkZl9jzWvRGNc0aQAUO9kI7HTkeyNwuwFQtlAYELIpLPesdGPArYZq8XgIryNSGQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
@@ -9936,6 +9939,7 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lie@3.1.1:
@@ -10555,6 +10559,11 @@ packages:
   nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.0.9:
+    resolution: {integrity: sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   napi-build-utils@1.0.2:
@@ -17781,7 +17790,7 @@ snapshots:
       - supports-color
       - tedious
 
-  '@powerhousedao/connect@1.0.0-dev.174(@powerhousedao/design-system@packages+design-system)(@powerhousedao/scalars@packages+scalars)(@types/node@22.10.1)(document-model-libs@packages+document-model-libs)(lightningcss@1.28.2)':
+  '@powerhousedao/connect@1.0.0-dev.179(@powerhousedao/design-system@packages+design-system)(@powerhousedao/scalars@packages+scalars)(@types/node@22.10.1)(document-model-libs@packages+document-model-libs)(lightningcss@1.28.2)':
     dependencies:
       '@powerhousedao/design-system': link:packages/design-system
       '@powerhousedao/scalars': link:packages/scalars
@@ -25481,6 +25490,8 @@ snapshots:
   nanoevents@9.1.0: {}
 
   nanoid@3.3.8: {}
+
+  nanoid@5.0.9: {}
 
   napi-build-utils@1.0.2:
     optional: true


### PR DESCRIPTION
## Ticket
https://trello.com/c/9PSFnLlU/688-5-urlfield-url-urlyoutube-urlgithub-urldiscord-urldiscourse

## Description
Add support for NanoIDs in the IdField and use them by default if any other generator is provided