### PR TITLE
fix(scalars): add the placeholders and show bigInt in the alert

### DIFF
--- a/packages/design-system/src/scalars/components/number-field/number-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.stories.tsx
@@ -99,7 +99,7 @@ export const Default: Story = {
   args: {
     name: "Label",
     label: "Label",
-    placeholder: "0",
+    placeholder: "Enter a number",
     step: 0,
     value: 1234,
   },
@@ -111,6 +111,7 @@ export const Active: Story = {
     autoFocus: true,
     defaultValue: 45,
     step: 0,
+    placeholder: "Enter a number",
   },
   parameters: {
     pseudo: { focus: true },
@@ -132,6 +133,7 @@ export const Required: Story = {
     value: 345,
     required: true,
     step: 0,
+    placeholder: "A number is required",
   },
 };
 export const WithWarning: Story = {
@@ -141,6 +143,7 @@ export const WithWarning: Story = {
     value: 23,
     step: 0,
     warnings: ["Warning message"],
+    placeholder: "Enter  number",
   },
 };
 export const WithError: Story = {
@@ -150,6 +153,7 @@ export const WithError: Story = {
     value: 23,
     step: 0,
     errors: ["Error message"],
+    placeholder: "Enter a number",
   },
 };
 export const WithMultipleErrors: Story = {
@@ -164,6 +168,7 @@ export const WithMultipleErrors: Story = {
       "Error message number 3",
       "Error message number 4",
     ],
+    placeholder: "Enter a number",
   },
 };
 
@@ -173,6 +178,7 @@ export const WithValue: Story = {
     name: "Label",
     label: "Label",
     value: 23,
+    placeholder: "Enter a number",
   },
 };
 
@@ -183,6 +189,7 @@ export const WithDescription: Story = {
     label: "Label",
     value: 0,
     description: "This is the field description",
+    placeholder: "Enter a number",
   },
 };
 
@@ -195,6 +202,7 @@ export const WithFloatNumber: Story = {
     value: 0.0,
     precision: 2,
     trailingZeros: true,
+    placeholder: "Enter a decimal number",
   },
 };
 // BigInt Stories
@@ -205,6 +213,7 @@ export const WithBigInt: Story = {
     value: 999999,
     isBigInt: true,
     step: 0,
+    placeholder: "Enter a large number",
   },
 };
 
@@ -216,5 +225,6 @@ export const WithStep: Story = {
     value: 456,
     step: 10,
     minValue: 20,
+    placeholder: "Enter a number",
   },
 };

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -47,7 +47,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
       precision = 0,
       ...props
     },
-    ref
+    ref,
   ) => {
     const generatedId = useId();
     const id = propId ?? generatedId;
@@ -79,7 +79,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
         // Call the handleChangeSteps function
         handleChangeSteps(
           e as unknown as React.MouseEvent<HTMLButtonElement>,
-          operation
+          operation,
         );
       }
     };
@@ -93,7 +93,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
     };
     const handleChangeSteps = (
       e: React.MouseEvent<HTMLButtonElement>,
-      operation: "increment" | "decrement"
+      operation: "increment" | "decrement",
     ) => {
       e.preventDefault();
 
@@ -164,7 +164,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
           writable: false,
         });
         onChange?.(
-          nativeEvent as unknown as React.ChangeEvent<HTMLInputElement>
+          nativeEvent as unknown as React.ChangeEvent<HTMLInputElement>,
         );
         onBlur?.(e);
         // Add return to avoid the conversion after
@@ -231,7 +231,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
                   name="ChevronDown"
                   className={cn(
                     "rotate-180 text-gray-700 dark:text-gray-300",
-                    isIncrementDisabled && "cursor-not-allowed"
+                    isIncrementDisabled && "cursor-not-allowed",
                   )}
                 />
               </button>
@@ -245,7 +245,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
                   name="ChevronDown"
                   className={cn(
                     " items-center justify-center text-gray-700 dark:text-gray-300",
-                    isDecrementDisabled && "cursor-not-allowed"
+                    isDecrementDisabled && "cursor-not-allowed",
                   )}
                 />
               </button>
@@ -257,7 +257,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
         {errors && <FormMessageList messages={errors} type="error" />}
       </FormGroup>
     );
-  }
+  },
 );
 
 export const NumberField = withFieldValidation<NumberFieldProps>(
@@ -267,6 +267,6 @@ export const NumberField = withFieldValidation<NumberFieldProps>(
       _isBigInt: validateIsBigInt,
       _numericType: validateNumericType,
     },
-  }
+  },
 );
 NumberField.displayName = "NumberField";

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -47,7 +47,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
       precision = 0,
       ...props
     },
-    ref,
+    ref
   ) => {
     const generatedId = useId();
     const id = propId ?? generatedId;
@@ -79,7 +79,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
         // Call the handleChangeSteps function
         handleChangeSteps(
           e as unknown as React.MouseEvent<HTMLButtonElement>,
-          operation,
+          operation
         );
       }
     };
@@ -93,7 +93,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
     };
     const handleChangeSteps = (
       e: React.MouseEvent<HTMLButtonElement>,
-      operation: "increment" | "decrement",
+      operation: "increment" | "decrement"
     ) => {
       e.preventDefault();
 
@@ -164,7 +164,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
           writable: false,
         });
         onChange?.(
-          nativeEvent as unknown as React.ChangeEvent<HTMLInputElement>,
+          nativeEvent as unknown as React.ChangeEvent<HTMLInputElement>
         );
         onBlur?.(e);
         // Add return to avoid the conversion after
@@ -231,7 +231,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
                   name="ChevronDown"
                   className={cn(
                     "rotate-180 text-gray-700 dark:text-gray-300",
-                    isIncrementDisabled && "cursor-not-allowed",
+                    isIncrementDisabled && "cursor-not-allowed"
                   )}
                 />
               </button>
@@ -245,7 +245,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
                   name="ChevronDown"
                   className={cn(
                     " items-center justify-center text-gray-700 dark:text-gray-300",
-                    isDecrementDisabled && "cursor-not-allowed",
+                    isDecrementDisabled && "cursor-not-allowed"
                   )}
                 />
               </button>
@@ -257,7 +257,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
         {errors && <FormMessageList messages={errors} type="error" />}
       </FormGroup>
     );
-  },
+  }
 );
 
 export const NumberField = withFieldValidation<NumberFieldProps>(
@@ -267,6 +267,6 @@ export const NumberField = withFieldValidation<NumberFieldProps>(
       _isBigInt: validateIsBigInt,
       _numericType: validateNumericType,
     },
-  },
+  }
 );
 NumberField.displayName = "NumberField";

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -185,6 +185,22 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
       onChange?.(nativeEvent as unknown as React.ChangeEvent<HTMLInputElement>);
       onBlur?.(e);
     };
+
+    // Avoid to write letters directly in safari
+    const handleInput = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      const char = event.key;
+      // Allow numbers, decimal point, hyphen (for negatives) and control keys
+      if (
+        !/^[0-9.-]$/.test(char) && // Numbers, decimal point and hyphen
+        !["Backspace", "Delete", "ArrowLeft", "ArrowRight", "Tab"].includes(
+          char,
+        ) &&
+        !(event.ctrlKey || event.metaKey)
+      ) {
+        event.preventDefault();
+      }
+    };
+
     return (
       <FormGroup>
         {label && (
@@ -210,7 +226,10 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
             aria-valuemin={minValue}
             aria-valuemax={maxValue}
             aria-invalid={!!errors?.length}
-            onKeyDown={blockInvalidChar}
+            onKeyDown={(e) => {
+              handleInput(e);
+              blockInvalidChar(e);
+            }}
             value={value === undefined ? "" : value.toString()}
             onBlur={handleBlur}
             defaultValue={defaultValue?.toString()}

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -189,14 +189,8 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
     // Avoid to write letters directly in safari
     const handleInput = (event: React.KeyboardEvent<HTMLInputElement>) => {
       const char = event.key;
-      // Allow numbers, decimal point, hyphen (for negatives) and control keys
-      if (
-        !/^[0-9.-]$/.test(char) && // Numbers, decimal point and hyphen
-        !["Backspace", "Delete", "ArrowLeft", "ArrowRight", "Tab"].includes(
-          char,
-        ) &&
-        !(event.ctrlKey || event.metaKey)
-      ) {
+      // Only prevent letters, allow all other characters
+      if (/^[a-zA-Z]$/.test(char) && !(event.ctrlKey || event.metaKey)) {
         event.preventDefault();
       }
     };

--- a/packages/design-system/src/scalars/lib/decorators.tsx
+++ b/packages/design-system/src/scalars/lib/decorators.tsx
@@ -23,7 +23,14 @@ export const withForm: Decorator = (Story, context) => {
   const { viewMode } = context;
 
   const onSubmit = useCallback((data: any) => {
-    alert(JSON.stringify(data, null, 2));
+    // Allow to show bigInt values in the alert
+    const serializedData = JSON.stringify(
+      data,
+      (key, value): any =>
+        typeof value === "bigint" ? value.toString() : value,
+      2,
+    );
+    alert(serializedData);
   }, []);
 
   const onReset = useCallback(() => {


### PR DESCRIPTION
## Ticket
https://trello.com/c/dcRznxfV/752-final-design-1-number

## Description
- Deleting the values.  The placeholder should be set by default like the label is to avoid showing the field empty. **Current Output:** The field is empty without value or placeholder. 


- NumberField. numericType = NonNegativeInt. Inserting e.g - 76 and submit. **Expected Output:** The value should be submitted. **Current Output:** Nothing happens, the values is not submitted.