### PR TITLE
fix(scalars): allow trailingZeros in the ui

### DIFF
--- a/packages/design-system/src/scalars/components/number-field/number-field-validations.ts
+++ b/packages/design-system/src/scalars/components/number-field/number-field-validations.ts
@@ -30,7 +30,7 @@ export const validateNumericType =
     const isPositive = Number(value) > 0;
     const isNegative = Number(value) < 0;
     const isInt = isInteger(value);
-
+    if (value === "") return true;
     switch (numericType) {
       case "PositiveInt": {
         if (!isInt) return "Value must be a positive integer";


### PR DESCRIPTION
## Ticket

## Description
- NumberField. Submitting the value and clearing up the field.  If the field is not required, non-error message should be displayed. An error message is shown. 

- NumberField. precision = 2, trailingZeros = false. Inserting a number with two zeros (e.g. 34.00)**Expected Output:** The zeros should not be preserved, 34 should be displayed. The full number and the zeros are displayed with trailing zeros in true or false. The same result is displayed.