### PR TITLE
feat(ph-cli): added connect command

### DIFF
--- a/packages/ph-cli/package.json
+++ b/packages/ph-cli/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@powerhousedao/codegen": "workspace:*",
     "@powerhousedao/config": "workspace:*",
-    "@powerhousedao/connect": "develop",
+    "@powerhousedao/connect": "1.0.0-dev.181",
     "@powerhousedao/design-system": "workspace:*",
     "@powerhousedao/reactor-local": "workspace:*",
     "@powerhousedao/scalars": "workspace:*",

--- a/packages/ph-cli/src/commands/connect.ts
+++ b/packages/ph-cli/src/commands/connect.ts
@@ -1,0 +1,45 @@
+import {
+  startConnectStudio,
+  ConnectStudioOptions,
+} from "@powerhousedao/connect";
+import { getConfig } from "@powerhousedao/config/powerhouse";
+import { Command } from "commander";
+
+export type ConnectOptions = ConnectStudioOptions;
+
+export async function startConnect(connectOptions: ConnectOptions) {
+  const { documentModelsDir, editorsDir } = getConfig();
+  const options = { documentModelsDir, editorsDir, ...connectOptions };
+  return await startConnectStudio(options);
+}
+
+export function connectCommand(program: Command) {
+  program
+    .name("connect")
+    .description("Starts Connect Studio")
+    .option("-p, --port <port>", "Port to run the server on", "3000")
+    .option("-h, --host", "Expose the server to the network")
+    .option(
+      "--config-file <configFile>",
+      "Path to the powerhouse.config.js file",
+    )
+    .option(
+      "-le, --local-editors <localEditors>",
+      "Link local document editors path",
+    )
+    .option(
+      "-ld, --local-documents <localDocuments>",
+      "Link local documents path",
+    )
+    .action(async (...args: [ConnectOptions]) => {
+      await startConnectStudio(...args);
+    });
+}
+
+if (process.argv.at(2) === "spawn") {
+  const optionsArg = process.argv.at(3);
+  const options = optionsArg ? (JSON.parse(optionsArg) as ConnectOptions) : {};
+  startConnect(options).catch((e: unknown) => {
+    throw e;
+  });
+}

--- a/packages/ph-cli/src/commands/generate.ts
+++ b/packages/ph-cli/src/commands/generate.ts
@@ -85,8 +85,8 @@ export const generate: CommandActionType<
     return;
   }
 
-  if (command.subgraph) {
-    await generateSubgraph(command.subgraphName!, config);
+  if (command.subgraph && command.subgraphName) {
+    await generateSubgraph(command.subgraphName, config);
     return;
   }
 

--- a/packages/ph-cli/src/commands/index.ts
+++ b/packages/ph-cli/src/commands/index.ts
@@ -2,12 +2,14 @@ import { Command } from "commander";
 import { devCommand } from "./dev.js";
 import { helpCommand } from "./help.js";
 import { initCommand } from "./init.js";
-import { generateCommand } from "./generate.js";
+import { connectCommand } from "./connect.js";
 import { reactorCommand } from "./reactor.js";
+import { generateCommand } from "./generate.js";
 
 export const commands = [
   initCommand,
   devCommand,
+  connectCommand,
   generateCommand,
   reactorCommand,
   helpCommand,

--- a/packages/reactor-local/src/server.ts
+++ b/packages/reactor-local/src/server.ts
@@ -21,7 +21,15 @@ import { DocumentModel } from "document-model/document";
 import { module as DocumentModelLib } from "document-model/document-model";
 import dotenv from "dotenv";
 import path from "node:path";
+import { access } from "node:fs/promises";
 import { createServer as createViteServer, ViteDevServer } from "vite";
+
+type FSError = {
+  errno: number;
+  code: string;
+  syscall: string;
+  path: string;
+};
 
 const dirname = process.cwd();
 
@@ -184,6 +192,7 @@ async function loadDocumentModels(
 ) {
   try {
     console.log("> Loading document models from", path);
+    await access(path);
     const localDMs = (await vite.ssrLoadModule(path)) as Record<
       string,
       DocumentModel
@@ -193,7 +202,11 @@ async function loadDocumentModels(
       ...Object.values(localDMs),
     ]);
   } catch (e) {
-    console.error("Error loading document models", e);
+    if ((e as FSError).code === "ENOENT") {
+      console.warn("No local document models found");
+    } else {
+      console.error("Error loading document models", e);
+    }
   }
 }
 
@@ -204,6 +217,7 @@ async function loadProcessors(
 ) {
   try {
     console.log("> Loading processors from", path);
+    await access(path);
     const localProcessors = await vite.ssrLoadModule(path);
     for (const [name, processor] of Object.entries(localProcessors)) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
@@ -213,7 +227,11 @@ async function loadProcessors(
       }
     }
   } catch (e) {
-    console.error("Error loading processors", e);
+    if ((e as FSError).code === "ENOENT") {
+      console.warn("No local document models found");
+    } else {
+      console.error("Error loading processors", e);
+    }
   }
 }
 
@@ -224,6 +242,7 @@ async function loadSubgraphs(
 ) {
   try {
     console.log("> Loading subgraphs from", path);
+    await access(path);
     const localSubgraphs = await vite.ssrLoadModule(path);
     for (const [name, subgraph] of Object.entries(localSubgraphs)) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -233,7 +252,11 @@ async function loadSubgraphs(
       }
     }
   } catch (e) {
-    console.error("Error loading subgraphs", e);
+    if ((e as FSError).code === "ENOENT") {
+      console.warn("No local document models found");
+    } else {
+      console.error("Error loading subgraphs", e);
+    }
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -988,8 +988,8 @@ importers:
         specifier: workspace:*
         version: link:../config
       '@powerhousedao/connect':
-        specifier: develop
-        version: 1.0.0-dev.184(@powerhousedao/design-system@packages+design-system)(@powerhousedao/scalars@packages+scalars)(@types/node@22.10.3)(document-model-libs@packages+document-model-libs)
+        specifier: 1.0.0-dev.181
+        version: 1.0.0-dev.181(@powerhousedao/design-system@packages+design-system)(@powerhousedao/scalars@packages+scalars)(@types/node@22.10.3)(document-model-libs@packages+document-model-libs)
       '@powerhousedao/design-system':
         specifier: workspace:*
         version: link:../design-system
@@ -4490,8 +4490,8 @@ packages:
   '@powerhousedao/analytics-engine-pg@0.3.0':
     resolution: {integrity: sha512-0N90CJzgrjZONA7VzEQKq5ne0DuzGpjTj3ZeZyjoaOq4gKopVdX+6j7zHmbfFKx15bkY6/T/+VoIKt9WN+We0Q==}
 
-  '@powerhousedao/connect@1.0.0-dev.184':
-    resolution: {integrity: sha512-br684JvhFWV0PQtuum4/vbw1RA5UycSt4TIRm3An9bzCTL028IuEQBZT+UAXqs5RKaW1s50+k7QMbQZSH7Xp4g==}
+  '@powerhousedao/connect@1.0.0-dev.181':
+    resolution: {integrity: sha512-UVNdViymnJsx6Xaf9bE8c/EPrYsYybmXRARijTGDF9VxJza5BlS7JlSFaPN/InFVHl4RBWPiUlZe/+q6Wh5E0g==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
@@ -10008,7 +10008,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lie@3.1.1:
@@ -18040,7 +18039,7 @@ snapshots:
       - supports-color
       - tedious
 
-  '@powerhousedao/connect@1.0.0-dev.184(@powerhousedao/design-system@packages+design-system)(@powerhousedao/scalars@packages+scalars)(@types/node@22.10.3)(document-model-libs@packages+document-model-libs)':
+  '@powerhousedao/connect@1.0.0-dev.181(@powerhousedao/design-system@packages+design-system)(@powerhousedao/scalars@packages+scalars)(@types/node@22.10.3)(document-model-libs@packages+document-model-libs)':
     dependencies:
       '@powerhousedao/design-system': link:packages/design-system
       '@powerhousedao/scalars': link:packages/scalars


### PR DESCRIPTION
Adds `ph connect` to launch Connect. The same method is used in `ph dev` to spawn connect programmatically instead of looking for connect in the node_modules folder.