### PR TITLE
fix(scalars): remove maxLength from Url component

### DIFF
--- a/packages/design-system/src/scalars/components/url-field/url-field.tsx
+++ b/packages/design-system/src/scalars/components/url-field/url-field.tsx
@@ -15,7 +15,6 @@ import { useURLWarnings } from "./useURLWarnings";
 import UrlFavicon from "./url-favicon";
 import ValueTransformer from "../fragments/value-transformer";
 import { sharedValueTransformers } from "@/scalars/lib/shared-value-transformers";
-import { url } from "node:inspector";
 
 export type PlatformIcon = IconName | React.ReactElement;
 
@@ -24,7 +23,7 @@ interface UrlFieldProps
     ErrorHandling,
     Omit<
       React.InputHTMLAttributes<HTMLInputElement>,
-      "pattern" | "value" | "defaultValue" | "name"
+      "pattern" | "value" | "defaultValue" | "name" | "maxLength"
     > {
   allowedProtocols?: string[];
   maxURLLength?: number;


### PR DESCRIPTION
## Ticket
https://trello.com/c/9PSFnLlU/688-5-urlfield-url-urlyoutube-urlgithub-urldiscord-urldiscourse

## Description
Remove `maxLength` form URL as the props is names `maxURLLength`