### PR TITLE
fix(scalars): avoid that SelectField save the "hover, selected and search states"

### DIFF
--- a/packages/design-system/src/scalars/components/country-code-field/__snapshots__/country-code-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/country-code-field/__snapshots__/country-code-field.test.tsx.snap
@@ -15,39 +15,27 @@ exports[`CountryCodeField Component > should match snapshot 1`] = `
       >
         Select Country
       </label>
-      <div
-        class="flex size-full flex-col rounded"
-        cmdk-root=""
-        tabindex="-1"
+      <button
+        aria-controls="radix-:r2:"
+        aria-expanded="false"
+        aria-haspopup="dialog"
+        aria-invalid="false"
+        class="gap-2 whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 flex h-9 w-full items-center justify-between px-3 py-2 dark:border-charcoal-700 dark:bg-charcoal-900 rounded-md border border-gray-300 bg-white hover:border-gray-300 hover:bg-gray-100 dark:hover:border-charcoal-700 dark:hover:bg-charcoal-800 dark:focus:ring-charcoal-300 focus:outline-none focus:ring-1 focus:ring-gray-900 focus:ring-offset-0 dark:focus-visible:ring-charcoal-300 focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0"
+        data-state="closed"
+        id=":r1:-select"
+        name="country"
+        role="combobox"
+        type="button"
       >
-        <label
-          cmdk-label=""
-          for="radix-:r5:"
-          id="radix-:r4:"
-          style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
-        />
-        <button
-          aria-controls="radix-:r2:"
-          aria-expanded="false"
-          aria-haspopup="dialog"
-          aria-invalid="false"
-          class="gap-2 whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 flex h-9 w-full items-center justify-between px-3 py-2 dark:border-charcoal-700 dark:bg-charcoal-900 rounded-md border border-gray-300 bg-white hover:border-gray-300 hover:bg-gray-100 dark:hover:border-charcoal-700 dark:hover:bg-charcoal-800 dark:focus:ring-charcoal-300 focus:outline-none focus:ring-1 focus:ring-gray-900 focus:ring-offset-0 dark:focus-visible:ring-charcoal-300 focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0"
-          data-state="closed"
-          id=":r1:-select"
-          name="country"
-          role="combobox"
-          type="button"
+        <div
+          class="mx-auto flex w-full items-center justify-end"
         >
           <div
-            class="mx-auto flex w-full items-center justify-end"
-          >
-            <div
-              data-testid="icon-fallback"
-              style="width: 16px; height: 16px;"
-            />
-          </div>
-        </button>
-      </div>
+            data-testid="icon-fallback"
+            style="width: 16px; height: 16px;"
+          />
+        </div>
+      </button>
     </div>
   </form>
 </DocumentFragment>

--- a/packages/design-system/src/scalars/components/enum-field/__snapshots__/enum-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/enum-field/__snapshots__/enum-field.test.tsx.snap
@@ -126,40 +126,28 @@ exports[`EnumField Component > should match snapshot with Select variant 1`] = `
     <div
       class="flex flex-col gap-2"
     >
-      <div
-        class="flex size-full flex-col rounded"
-        cmdk-root=""
-        tabindex="-1"
+      <button
+        aria-controls="radix-:rb:"
+        aria-expanded="false"
+        aria-haspopup="dialog"
+        aria-invalid="false"
+        aria-label="Select"
+        class="gap-2 whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 flex h-9 w-full items-center justify-between px-3 py-2 dark:border-charcoal-700 dark:bg-charcoal-900 rounded-md border border-gray-300 bg-white hover:border-gray-300 hover:bg-gray-100 dark:hover:border-charcoal-700 dark:hover:bg-charcoal-800 dark:focus:ring-charcoal-300 focus:outline-none focus:ring-1 focus:ring-gray-900 focus:ring-offset-0 dark:focus-visible:ring-charcoal-300 focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0"
+        data-state="closed"
+        id=":ra:-select"
+        name="enum"
+        role="combobox"
+        type="button"
       >
-        <label
-          cmdk-label=""
-          for="radix-:re:"
-          id="radix-:rd:"
-          style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
-        />
-        <button
-          aria-controls="radix-:rb:"
-          aria-expanded="false"
-          aria-haspopup="dialog"
-          aria-invalid="false"
-          aria-label="Select"
-          class="gap-2 whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 flex h-9 w-full items-center justify-between px-3 py-2 dark:border-charcoal-700 dark:bg-charcoal-900 rounded-md border border-gray-300 bg-white hover:border-gray-300 hover:bg-gray-100 dark:hover:border-charcoal-700 dark:hover:bg-charcoal-800 dark:focus:ring-charcoal-300 focus:outline-none focus:ring-1 focus:ring-gray-900 focus:ring-offset-0 dark:focus-visible:ring-charcoal-300 focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0"
-          data-state="closed"
-          id=":ra:-select"
-          name="enum"
-          role="combobox"
-          type="button"
+        <div
+          class="mx-auto flex w-full items-center justify-end"
         >
           <div
-            class="mx-auto flex w-full items-center justify-end"
-          >
-            <div
-              data-testid="icon-fallback"
-              style="width: 16px; height: 16px;"
-            />
-          </div>
-        </button>
-      </div>
+            data-testid="icon-fallback"
+            style="width: 16px; height: 16px;"
+          />
+        </div>
+      </button>
     </div>
   </form>
 </DocumentFragment>

--- a/packages/design-system/src/scalars/components/enum-field/enum-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/enum-field/enum-field.stories.tsx
@@ -90,6 +90,7 @@ const meta: Meta<typeof EnumField> = {
         defaultValue: { summary: '"Left"' },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
+      if: { arg: "optionsCheckmark", eq: "Checkmark" },
     },
 
     searchable: {

--- a/packages/design-system/src/scalars/components/fragments/command/command.tsx
+++ b/packages/design-system/src/scalars/components/fragments/command/command.tsx
@@ -64,7 +64,11 @@ const CommandList = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.List
     ref={ref}
-    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+    className={cn(
+      "max-h-[300px] overflow-y-auto overflow-x-hidden",
+      "focus:outline-none",
+      className,
+    )}
     {...props}
   />
 ));

--- a/packages/design-system/src/scalars/components/fragments/select-field/__snapshots__/select-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/select-field/__snapshots__/select-field.test.tsx.snap
@@ -9,40 +9,28 @@ exports[`SelectField Component > should match snapshot 1`] = `
     <div
       class="flex flex-col gap-2"
     >
-      <div
-        class="flex size-full flex-col rounded"
-        cmdk-root=""
-        tabindex="-1"
+      <button
+        aria-controls="radix-:r2:"
+        aria-expanded="false"
+        aria-haspopup="dialog"
+        aria-invalid="false"
+        aria-label="Select"
+        class="gap-2 whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 flex h-9 w-full items-center justify-between px-3 py-2 dark:border-charcoal-700 dark:bg-charcoal-900 rounded-md border border-gray-300 bg-white hover:border-gray-300 hover:bg-gray-100 dark:hover:border-charcoal-700 dark:hover:bg-charcoal-800 dark:focus:ring-charcoal-300 focus:outline-none focus:ring-1 focus:ring-gray-900 focus:ring-offset-0 dark:focus-visible:ring-charcoal-300 focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0"
+        data-state="closed"
+        id=":r1:-select"
+        name="select"
+        role="combobox"
+        type="button"
       >
-        <label
-          cmdk-label=""
-          for="radix-:r5:"
-          id="radix-:r4:"
-          style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
-        />
-        <button
-          aria-controls="radix-:r2:"
-          aria-expanded="false"
-          aria-haspopup="dialog"
-          aria-invalid="false"
-          aria-label="Select"
-          class="gap-2 whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 flex h-9 w-full items-center justify-between px-3 py-2 dark:border-charcoal-700 dark:bg-charcoal-900 rounded-md border border-gray-300 bg-white hover:border-gray-300 hover:bg-gray-100 dark:hover:border-charcoal-700 dark:hover:bg-charcoal-800 dark:focus:ring-charcoal-300 focus:outline-none focus:ring-1 focus:ring-gray-900 focus:ring-offset-0 dark:focus-visible:ring-charcoal-300 focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0"
-          data-state="closed"
-          id=":r1:-select"
-          name="select"
-          role="combobox"
-          type="button"
+        <div
+          class="mx-auto flex w-full items-center justify-end"
         >
           <div
-            class="mx-auto flex w-full items-center justify-end"
-          >
-            <div
-              data-testid="icon-fallback"
-              style="width: 16px; height: 16px;"
-            />
-          </div>
-        </button>
-      </div>
+            data-testid="icon-fallback"
+            style="width: 16px; height: 16px;"
+          />
+        </div>
+      </button>
     </div>
   </form>
 </DocumentFragment>

--- a/packages/design-system/src/scalars/components/fragments/select-field/content.tsx
+++ b/packages/design-system/src/scalars/components/fragments/select-field/content.tsx
@@ -83,10 +83,9 @@ export const Content: React.FC<ContentProps> = ({
           placeholder="Search..."
           wrapperClassName="rounded-t"
           className="text-gray-900 dark:text-gray-50"
-          autoFocus
         />
       )}
-      <CommandList ref={commandListRef}>
+      <CommandList ref={commandListRef} tabIndex={!searchable ? 0 : undefined}>
         <CommandEmpty className="p-4 text-center text-[14px] font-normal leading-5 text-gray-700 dark:text-gray-400">
           No results found.
         </CommandEmpty>

--- a/packages/design-system/src/scalars/components/fragments/select-field/select-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/fragments/select-field/select-field.stories.tsx
@@ -74,6 +74,7 @@ const meta: Meta<typeof SelectField> = {
         defaultValue: { summary: '"Left"' },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
+      if: { arg: "optionsCheckmark", eq: "Checkmark" },
     },
 
     searchable: {

--- a/packages/design-system/src/scalars/components/fragments/select-field/select-field.tsx
+++ b/packages/design-system/src/scalars/components/fragments/select-field/select-field.tsx
@@ -117,61 +117,56 @@ export const SelectFieldRaw = React.forwardRef<
           </FormLabel>
         )}
         <Popover open={isPopoverOpen} onOpenChange={handleOpenChange}>
-          <Command>
-            <PopoverTrigger asChild={true}>
-              {/* TODO: create a trigger component */}
-              <Button
-                id={id}
-                name={name}
-                type="button"
-                role="combobox"
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    handleOpenChange(true);
-                  }
-                }}
-                onBlur={onTriggerBlur}
-                disabled={disabled}
-                aria-invalid={errors.length > 0}
-                aria-label={
-                  label ? undefined : multiple ? "Multi select" : "Select"
-                }
-                aria-required={required}
-                aria-expanded={isPopoverOpen}
-                className={cn(
-                  "flex h-9 w-full items-center justify-between px-3 py-2",
-                  "dark:border-charcoal-700 dark:bg-charcoal-900 rounded-md border border-gray-300 bg-white",
-                  "hover:border-gray-300 hover:bg-gray-100",
-                  "dark:hover:border-charcoal-700 dark:hover:bg-charcoal-800",
-                  "dark:focus:ring-charcoal-300 focus:outline-none focus:ring-1 focus:ring-gray-900 focus:ring-offset-0",
-                  "dark:focus-visible:ring-charcoal-300 focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0",
-                  disabled && [
-                    "!pointer-events-auto cursor-not-allowed",
-                    "dark:hover:border-charcoal-700 dark:hover:bg-charcoal-900 hover:border-gray-300 hover:bg-white",
-                  ],
-                  className,
-                )}
-                {...props}
-                ref={ref}
-              >
-                <SelectedContent
-                  selectedValues={selectedValues}
-                  options={options}
-                  multiple={multiple}
-                  searchable={searchable}
-                  placeholder={placeholder}
-                  handleClear={handleClear}
-                />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent
-              align="start"
+          <PopoverTrigger asChild={true}>
+            {/* TODO: create a trigger component */}
+            <Button
+              id={id}
+              name={name}
+              type="button"
+              role="combobox"
+              onBlur={onTriggerBlur}
+              disabled={disabled}
+              aria-invalid={errors.length > 0}
+              aria-label={
+                label ? undefined : multiple ? "Multi select" : "Select"
+              }
+              aria-required={required}
+              aria-expanded={isPopoverOpen}
               className={cn(
-                "w-[--radix-popover-trigger-width] p-0",
-                "border-gray-300 bg-white dark:border-slate-500 dark:bg-slate-700",
-                "rounded shadow-[1px_4px_15px_0px_rgba(74,88,115,0.25)] dark:shadow-[1px_4px_15.3px_0px_#141921]",
+                "flex h-9 w-full items-center justify-between px-3 py-2",
+                "dark:border-charcoal-700 dark:bg-charcoal-900 rounded-md border border-gray-300 bg-white",
+                "hover:border-gray-300 hover:bg-gray-100",
+                "dark:hover:border-charcoal-700 dark:hover:bg-charcoal-800",
+                "dark:focus:ring-charcoal-300 focus:outline-none focus:ring-1 focus:ring-gray-900 focus:ring-offset-0",
+                "dark:focus-visible:ring-charcoal-300 focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0",
+                disabled && [
+                  "!pointer-events-auto cursor-not-allowed",
+                  "dark:hover:border-charcoal-700 dark:hover:bg-charcoal-900 hover:border-gray-300 hover:bg-white",
+                ],
+                className,
               )}
+              {...props}
+              ref={ref}
             >
+              <SelectedContent
+                selectedValues={selectedValues}
+                options={options}
+                multiple={multiple}
+                searchable={searchable}
+                placeholder={placeholder}
+                handleClear={handleClear}
+              />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            className={cn(
+              "w-[--radix-popover-trigger-width] p-0",
+              "border-gray-300 bg-white dark:border-slate-500 dark:bg-slate-700",
+              "rounded shadow-[1px_4px_15px_0px_rgba(74,88,115,0.25)] dark:shadow-[1px_4px_15.3px_0px_#141921]",
+            )}
+          >
+            <Command>
               <Content
                 searchable={searchable}
                 commandListRef={commandListRef}
@@ -183,8 +178,8 @@ export const SelectFieldRaw = React.forwardRef<
                 toggleAll={toggleAll}
                 toggleOption={toggleOption}
               />
-            </PopoverContent>
-          </Command>
+            </Command>
+          </PopoverContent>
         </Popover>
         {description && <FormDescription>{description}</FormDescription>}
         {warnings.length > 0 && (


### PR DESCRIPTION
## Ticket
https://trello.com/c/zZlPyvEY/754-final-design-4-enum

## Description
- The hover should appears by default in the first element (avoid that SelectField save the "hover, selected and search states")
- The "optionsCheckmarkPosition" control should appear only if "Checkmark" is selected