### PR TITLE
fix(scalars): improve naming & behavior of some props in SelectField

### DIFF
--- a/packages/design-system/src/scalars/components/amount-field/amount-field.tsx
+++ b/packages/design-system/src/scalars/components/amount-field/amount-field.tsx
@@ -26,7 +26,7 @@ export type AmountFieldProps = AmountFieldPropsGeneric &
     name: string;
     pattern?: RegExp;
     numberProps?: Omit<NumberFieldProps, "name">;
-    selectProps?: Omit<SelectFieldProps, "name">;
+    selectProps?: SelectFieldProps;
     allowedCurrencies?: string[];
     allowedTokens?: string[];
     selectName: string;
@@ -94,7 +94,7 @@ const AmountFieldRaw: FC<AmountFieldProps> = ({
           required={required}
           disabled={disabled}
           hasError={!!errors?.length}
-          className={cn(disabled && "text-gray-400 mb-[3px]")}
+          className={cn(disabled && "mb-[3px] text-gray-400")}
         >
           {label}
         </FormLabel>
@@ -103,20 +103,19 @@ const AmountFieldRaw: FC<AmountFieldProps> = ({
         <div className={cn("relative flex items-center")}>
           {isShowSelect && currencyPosition === "left" && (
             <SelectFieldRaw
-              optionsCheckmark="Checkmark"
+              selectionIcon="checkmark"
               value={valueSelect}
-              name=""
               required={required}
               options={options}
               disabled={disabled}
               onChange={handleOnChangeSelect}
               className={cn(
-                "border border-gray-300 rounded-l-md rounded-r-none",
-                "border-r-[0.5px] focus:border-r-[1px] focus:ring-1 focus:ring-gray-900",
+                "rounded-l-md rounded-r-none border border-gray-300",
+                "border-r-[0.5px] focus:border-r focus:ring-1 focus:ring-gray-900",
                 "focus:outline-none",
                 selectProps?.className,
               )}
-              {...(selectProps || {})}
+              {...(selectProps ?? { name: "" })}
             />
           )}
           <NumberFieldRaw
@@ -134,9 +133,9 @@ const AmountFieldRaw: FC<AmountFieldProps> = ({
             onChange={handleOnChangeInput}
             className={cn(
               currencyPosition === "left" &&
-                "border border-gray-300 rounded-l-none border-l-[0.5px]",
+                "rounded-l-none border border-l-[0.5px] border-gray-300",
               currencyPosition === "right" &&
-                "border border-gray-300 rounded-r-none border-r-[0.5px]",
+                "rounded-r-none border border-r-[0.5px] border-gray-300",
               isPercent && "pr-7",
               className,
             )}
@@ -157,19 +156,18 @@ const AmountFieldRaw: FC<AmountFieldProps> = ({
         {isShowSelect && currencyPosition === "right" && (
           <div>
             <SelectFieldRaw
-              optionsCheckmark="Checkmark"
+              selectionIcon="checkmark"
               value={valueSelect}
-              name=""
               required={required}
               disabled={disabled}
               onChange={handleOnChangeSelect}
               options={options}
               className={cn(
                 "rounded-l-none rounded-r-md border border-gray-300",
-                "border-l-[0.5px] focus:border-l-[1px] focus:ring-1 focus:ring-gray-900 focus:ring-offset-0",
+                "border-l-[0.5px] focus:border-l focus:ring-1 focus:ring-gray-900 focus:ring-offset-0",
                 "focus:outline-none",
               )}
-              {...(selectProps || {})}
+              {...(selectProps ?? { name: "" })}
             />
           </div>
         )}

--- a/packages/design-system/src/scalars/components/country-code-field/country-code-field.tsx
+++ b/packages/design-system/src/scalars/components/country-code-field/country-code-field.tsx
@@ -67,8 +67,8 @@ const CountryCodeFieldRaw: React.FC<CountryCodeFieldProps> = React.forwardRef<
       <SelectFieldRaw
         ref={ref}
         options={options}
-        optionsCheckmark="Checkmark"
-        optionsCheckmarkPosition="Right"
+        selectionIcon="checkmark"
+        selectionIconPosition="right"
         searchable={enableSearch}
         onChange={onChange}
         placeholder={placeholder}

--- a/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.tsx
+++ b/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.tsx
@@ -99,7 +99,7 @@ const CurrencyCodeFieldRaw = React.forwardRef<
       <SelectFieldRaw
         ref={ref}
         options={options}
-        optionsCheckmark="Checkmark"
+        selectionIcon="checkmark"
         searchable
         multiple={multiple}
         placeholder={placeholder}

--- a/packages/design-system/src/scalars/components/enum-field/enum-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/enum-field/enum-field.stories.tsx
@@ -29,16 +29,16 @@ const meta: Meta<typeof EnumField> = {
 
     variant: {
       control: "radio",
-      options: ["Auto", "RadioGroup", "Select"],
+      options: ["auto", "RadioGroup", "Select"],
       description:
         "Enum field variant. " +
-        "Auto: uses the most appropriate variant based on the number of options " +
+        "auto: uses the most appropriate variant based on the number of options " +
         "(less than 6 options -> RadioGroup, 6 options or more -> Select). " +
         "RadioGroup: displays options in a group of radio buttons. " +
         "Select: displays options in a dropdown menu.",
       table: {
-        type: { summary: '"Auto" | "RadioGroup" | "Select"' },
-        defaultValue: { summary: "Auto" },
+        type: { summary: '"auto" | "RadioGroup" | "Select"' },
+        defaultValue: { summary: "auto" },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
@@ -66,31 +66,31 @@ const meta: Meta<typeof EnumField> = {
       },
     },
 
-    optionsCheckmark: {
+    selectionIcon: {
       control: "radio",
-      options: ["Auto", "Checkmark"],
+      options: ["auto", "checkmark"],
       description:
-        "Type of checkmark to show in the options. " +
-        "Auto: Show a Radio for Single Select and a Checkbox for Multi Select. " +
-        "Checkmark: Show a Checkmark for Single and Multi Select. ",
+        "Selection icon to show in the options. " +
+        "auto: Show a Radio for Single Select and a Checkbox for Multi Select. " +
+        "checkmark: Show a checkmark icon for Single and Multi Select. ",
       table: {
-        type: { summary: '"Auto" | "Checkmark"' },
-        defaultValue: { summary: '"Auto"' },
+        type: { summary: '"auto" | "checkmark"' },
+        defaultValue: { summary: '"auto"' },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
 
-    optionsCheckmarkPosition: {
+    selectionIconPosition: {
       control: "radio",
-      options: ["Left", "Right"],
+      options: ["left", "right"],
       description:
-        'Checkmark position in options. Only apply if optionsCheckmark is "Checkmark".',
+        'Selection icon position in options. Only apply if "selectionIcon" is "checkmark".',
       table: {
-        type: { summary: '"Left" | "Right"' },
-        defaultValue: { summary: '"Left"' },
+        type: { summary: '"left" | "right"' },
+        defaultValue: { summary: '"left"' },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
-      if: { arg: "optionsCheckmark", eq: "Checkmark" },
+      if: { arg: "selectionIcon", eq: "checkmark" },
     },
 
     searchable: {
@@ -128,13 +128,13 @@ type EnumFieldArgs = {
     description?: string;
     disabled?: boolean;
   }[];
-  optionsCheckmark?: "Auto" | "Checkmark";
-  optionsCheckmarkPosition?: "Left" | "Right";
+  selectionIcon?: "auto" | "checkmark";
+  selectionIconPosition?: "left" | "right";
   placeholder?: string;
   required?: boolean;
   searchable?: boolean;
   value?: string | string[];
-  variant: "Auto" | "RadioGroup" | "Select";
+  variant: "auto" | "RadioGroup" | "Select";
   warnings?: string[];
 };
 
@@ -300,7 +300,7 @@ export const SelectWithCheckmark: Story = {
     description: "Shows a checkmark for selected options",
     variant: "Select",
     options: defaultOptions,
-    optionsCheckmark: "Checkmark",
+    selectionIcon: "checkmark",
     placeholder: "Select an icon name",
   },
 };
@@ -311,8 +311,8 @@ export const SelectWithIcon: Story = {
     description: "Choose your favorite icon",
     variant: "Select",
     options: defaultOptionsWithIcon,
-    optionsCheckmark: "Checkmark",
-    optionsCheckmarkPosition: "Right",
+    selectionIcon: "checkmark",
+    selectionIconPosition: "right",
     placeholder: "Select an icon",
   },
 };

--- a/packages/design-system/src/scalars/components/enum-field/enum-field.tsx
+++ b/packages/design-system/src/scalars/components/enum-field/enum-field.tsx
@@ -27,7 +27,7 @@ type SelectVariant = Omit<
 };
 
 export const EnumField: React.FC<EnumFieldProps> = ({
-  variant = "Auto",
+  variant = "auto",
   options = [],
   ...props
 }) => {
@@ -43,7 +43,7 @@ export const EnumField: React.FC<EnumFieldProps> = ({
       return radio;
     case "Select":
       return select;
-    case "Auto":
+    case "auto":
       return options.length < 6 ? radio : select;
   }
 };

--- a/packages/design-system/src/scalars/components/enum-field/types.ts
+++ b/packages/design-system/src/scalars/components/enum-field/types.ts
@@ -17,19 +17,27 @@ export interface SelectOption {
   disabled?: boolean;
 }
 
-export interface SelectProps {
+export interface SelectBaseProps {
   options?: SelectOption[];
-  optionsCheckmark?: "Auto" | "Checkmark";
-  optionsCheckmarkPosition?: "Left" | "Right";
   placeholder?: string;
   multiple?: boolean;
   searchable?: boolean;
   onChange?: (value: string | string[]) => void;
 }
 
+export type SelectProps =
+  | (SelectBaseProps & {
+      selectionIcon?: "auto";
+      selectionIconPosition?: "left";
+    })
+  | (SelectBaseProps & {
+      selectionIcon: "checkmark";
+      selectionIconPosition?: "left" | "right";
+    });
+
 export type EnumProps =
   | ({
-      variant?: "Auto";
+      variant?: "auto";
     } & (RadioGroupProps | SelectProps))
   | ({
       variant: "RadioGroup";

--- a/packages/design-system/src/scalars/components/fragments/select-field/content.tsx
+++ b/packages/design-system/src/scalars/components/fragments/select-field/content.tsx
@@ -17,8 +17,8 @@ interface ContentProps {
   commandListRef: React.RefObject<HTMLDivElement>;
   multiple?: boolean;
   selectedValues: string[];
-  optionsCheckmark: "Auto" | "Checkmark";
-  optionsCheckmarkPosition: "Left" | "Right";
+  selectionIcon: "auto" | "checkmark";
+  selectionIconPosition: "left" | "right";
   options: SelectProps["options"];
   toggleAll: () => void;
   toggleOption: (value: string) => void;
@@ -61,8 +61,8 @@ export const Content: React.FC<ContentProps> = ({
   commandListRef,
   multiple,
   selectedValues,
-  optionsCheckmark,
-  optionsCheckmarkPosition,
+  selectionIcon,
+  selectionIconPosition,
   options = [],
   toggleAll,
   toggleOption,
@@ -73,7 +73,7 @@ export const Content: React.FC<ContentProps> = ({
   const cmdkSearch = useCommandState((state) => state.search) as string;
   // scroll to top when search change
   useEffect(() => {
-    commandListRef.current?.scrollTo?.({ top: 0, behavior: "instant" });
+    commandListRef.current?.scrollTo({ top: 0, behavior: "instant" });
   }, [commandListRef, cmdkSearch]);
 
   return (
@@ -105,7 +105,7 @@ export const Content: React.FC<ContentProps> = ({
               aria-selected={selectedValues.length === enabledOptions.length}
             >
               <div className="flex w-full items-center gap-2">
-                {optionsCheckmark === "Auto" && (
+                {selectionIcon === "auto" && (
                   <div
                     className={cn(
                       "flex size-4 items-center justify-center rounded border",
@@ -119,10 +119,10 @@ export const Content: React.FC<ContentProps> = ({
                     )}
                   </div>
                 )}
-                {optionsCheckmark === "Checkmark" &&
-                  !(optionsCheckmarkPosition === "Right" && hasAnyIcon) && (
+                {selectionIcon === "checkmark" &&
+                  !(selectionIconPosition === "right" && hasAnyIcon) && (
                     <div className="size-4">
-                      {optionsCheckmarkPosition === "Left" &&
+                      {selectionIconPosition === "left" &&
                         selectedValues.length === enabledOptions.length && (
                           <Icon
                             name="Checkmark"
@@ -137,8 +137,8 @@ export const Content: React.FC<ContentProps> = ({
                     ? "Deselect All"
                     : "Select All"}
                 </span>
-                {optionsCheckmark === "Checkmark" &&
-                  optionsCheckmarkPosition === "Right" && (
+                {selectionIcon === "checkmark" &&
+                  selectionIconPosition === "right" && (
                     <div className="ml-auto size-4">
                       {selectedValues.length === enabledOptions.length && (
                         <Icon
@@ -176,7 +176,7 @@ export const Content: React.FC<ContentProps> = ({
                 role="option"
                 aria-selected={isSelected}
               >
-                {optionsCheckmark === "Auto" &&
+                {selectionIcon === "auto" &&
                   (multiple ? (
                     <div
                       className={cn(
@@ -205,10 +205,10 @@ export const Content: React.FC<ContentProps> = ({
                       )}
                     </div>
                   ))}
-                {optionsCheckmark === "Checkmark" &&
-                  !(optionsCheckmarkPosition === "Right" && hasAnyIcon) && (
+                {selectionIcon === "checkmark" &&
+                  !(selectionIconPosition === "right" && hasAnyIcon) && (
                     <div className="size-4">
-                      {optionsCheckmarkPosition === "Left" && isSelected && (
+                      {selectionIconPosition === "left" && isSelected && (
                         <Icon
                           name="Checkmark"
                           size={16}
@@ -227,8 +227,8 @@ export const Content: React.FC<ContentProps> = ({
                 >
                   {opt.label}
                 </span>
-                {optionsCheckmark === "Checkmark" &&
-                  optionsCheckmarkPosition === "Right" && (
+                {selectionIcon === "checkmark" &&
+                  selectionIconPosition === "right" && (
                     <div className="size-4">
                       {isSelected && (
                         <Icon

--- a/packages/design-system/src/scalars/components/fragments/select-field/select-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/fragments/select-field/select-field.stories.tsx
@@ -50,31 +50,31 @@ const meta: Meta<typeof SelectField> = {
       },
     },
 
-    optionsCheckmark: {
+    selectionIcon: {
       control: "radio",
-      options: ["Auto", "Checkmark"],
+      options: ["auto", "checkmark"],
       description:
-        "Type of checkmark to show in the options. " +
-        "Auto: Show a Radio for Single Select and a Checkbox for Multi Select. " +
-        "Checkmark: Show a Checkmark for Single and Multi Select. ",
+        "Selection icon to show in the options. " +
+        "auto: Show a Radio for Single Select and a Checkbox for Multi Select. " +
+        "checkmark: Show a checkmark icon for Single and Multi Select. ",
       table: {
-        type: { summary: '"Auto" | "Checkmark"' },
-        defaultValue: { summary: '"Auto"' },
+        type: { summary: '"auto" | "checkmark"' },
+        defaultValue: { summary: '"auto"' },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
 
-    optionsCheckmarkPosition: {
+    selectionIconPosition: {
       control: "radio",
-      options: ["Left", "Right"],
+      options: ["left", "right"],
       description:
-        'Checkmark position in options. Only apply if optionsCheckmark is "Checkmark".',
+        'Selection icon position in options. Only apply if "selectionIcon" is "checkmark".',
       table: {
-        type: { summary: '"Left" | "Right"' },
-        defaultValue: { summary: '"Left"' },
+        type: { summary: '"left" | "right"' },
+        defaultValue: { summary: '"left"' },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
-      if: { arg: "optionsCheckmark", eq: "Checkmark" },
+      if: { arg: "selectionIcon", eq: "checkmark" },
     },
 
     searchable: {
@@ -96,7 +96,7 @@ const meta: Meta<typeof SelectField> = {
 } satisfies Meta<typeof SelectField>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof SelectField>;
 
 const IconComponent = (
   name: IconName,
@@ -240,9 +240,9 @@ export const Multiple: Story = {
 export const WithCheckmark: Story = {
   args: {
     label: "With checkmark",
-    description: "This select field shows a checkmark for selected options",
+    description: "This select field shows a checkmark icon for selected option",
     options: defaultOptions,
-    optionsCheckmark: "Checkmark",
+    selectionIcon: "checkmark",
     placeholder: "Select an icon name",
   },
 };
@@ -252,8 +252,8 @@ export const WithIcon: Story = {
     label: "Favorite icon",
     description: "Choose your favorite icon",
     options: defaultOptionsWithIcon,
-    optionsCheckmark: "Checkmark",
-    optionsCheckmarkPosition: "Right",
+    selectionIcon: "checkmark",
+    selectionIconPosition: "right",
     placeholder: "Select an icon",
   },
 };

--- a/packages/design-system/src/scalars/components/fragments/select-field/select-field.tsx
+++ b/packages/design-system/src/scalars/components/fragments/select-field/select-field.tsx
@@ -27,11 +27,10 @@ type SelectFieldBaseProps = Omit<
   | keyof SelectProps
 >;
 
-export interface SelectFieldProps
-  extends SelectFieldBaseProps,
-    FieldCommonProps<string | string[]>,
-    ErrorHandling,
-    SelectProps {}
+export type SelectFieldProps = SelectFieldBaseProps &
+  FieldCommonProps<string | string[]> &
+  ErrorHandling &
+  SelectProps;
 
 export const SelectFieldRaw = React.forwardRef<
   HTMLButtonElement,
@@ -59,8 +58,8 @@ export const SelectFieldRaw = React.forwardRef<
 
       // behavior props
       multiple,
-      optionsCheckmark = "Auto",
-      optionsCheckmarkPosition = "Left",
+      selectionIcon = "auto",
+      selectionIconPosition = "left",
       searchable,
 
       // display props
@@ -176,8 +175,8 @@ export const SelectFieldRaw = React.forwardRef<
                 commandListRef={commandListRef}
                 multiple={multiple}
                 selectedValues={selectedValues}
-                optionsCheckmark={optionsCheckmark}
-                optionsCheckmarkPosition={optionsCheckmarkPosition}
+                selectionIcon={selectionIcon}
+                selectionIconPosition={selectionIconPosition}
                 options={options}
                 toggleAll={toggleAll}
                 toggleOption={toggleOption}


### PR DESCRIPTION
## Ticket
https://trello.com/c/zZlPyvEY/754-final-design-4-enum

## Description
- improve naming & behavior of some props in SelectField
- now selectionIconPosition="right" can only be specified if selectionIcon prop is "checkmark"