### PR TITLE
fix(scalars): add allowNegative and add validations along with number…

### DIFF
--- a/packages/design-system/src/scalars/components/amount-field/amount-field-validations.ts
+++ b/packages/design-system/src/scalars/components/amount-field/amount-field-validations.ts
@@ -31,7 +31,14 @@ const getAmount = (
 };
 
 export const validateAmount =
-  ({ type, required }: AmountFieldProps) =>
+  ({
+    type,
+    required,
+    minValue,
+    maxValue,
+    allowNegative,
+    pattern,
+  }: AmountFieldProps) =>
   (value: unknown): ValidatorResult => {
     const amount = getAmount(value as AmountValue, type);
     if (value === "") return true;
@@ -44,11 +51,29 @@ export const validateAmount =
     if (!isValidNumber(amount) && type !== "AmountToken") {
       return "Value is not a valid number";
     }
+    if (!allowNegative && amount < 0) {
+      return "Value must be positive";
+    }
     if (type === "AmountToken") {
       if (!isInteger(amount)) {
         return "Value is not an bigint";
       }
       return true;
+    }
+    if (maxValue) {
+      if (amount > maxValue) {
+        return `This field must be less than ${maxValue}`;
+      }
+    }
+    if (minValue) {
+      if (amount < minValue) {
+        return `This field must be more than ${minValue}`;
+      }
+    }
+    if (pattern) {
+      if (!new RegExp(pattern).test(amount as unknown as string)) {
+        return `This field must match the pattern ${pattern}`;
+      }
     }
 
     if (Math.abs(Number(amount)) > Number.MAX_SAFE_INTEGER) {

--- a/packages/design-system/src/scalars/components/amount-field/amount-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/amount-field/amount-field.stories.tsx
@@ -59,7 +59,15 @@ const meta = {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
-
+    allowNegative: {
+      control: "boolean",
+      description: "Whether negative values are allowed (true or false).",
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "boolean" },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+    },
     selectName: {
       control: "object",
       description: "Add the label for the select",

--- a/packages/design-system/src/scalars/components/amount-field/amount-field.tsx
+++ b/packages/design-system/src/scalars/components/amount-field/amount-field.tsx
@@ -16,7 +16,7 @@ import { AmountValue } from "./types";
 import { AmountFieldPropsGeneric } from "./types";
 import { IconName } from "@/powerhouse";
 import { validateAmount } from "./amount-field-validations";
-import { isValidNumber } from "../number-field/number-field-validations";
+import { ValidatorHandler } from "../types";
 
 export interface TokenIcons {
   [key: string]: IconName | (() => React.JSX.Element);
@@ -38,6 +38,7 @@ export type AmountFieldProps = AmountFieldPropsGeneric &
     onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
     currencyPosition?: "left" | "right";
     tokenIcons?: TokenIcons;
+    allowNegative?: boolean;
     // handle precision
     viewPrecision?: number;
     precision?: number;
@@ -70,6 +71,7 @@ export const AmountFieldRaw: FC<AmountFieldProps> = ({
   trailingZeros,
   viewPrecision,
   precision,
+  // customValidators,
 }) => {
   const generatedId = useId();
   const id = propId ?? generatedId;


### PR DESCRIPTION
## Ticket
https://trello.com/c/iV03PjGR/757-9-amountfield

##Description
- Should the field show the decimals places set in viewPrecision, when the control is not focused.
- Should the field allow the numbers of decimals to be set in number precision.
