### PR TITLE
feat(scalars): match server errors with fields after submission

### DIFF
--- a/packages/design-system/src/scalars/components/form/form.tsx
+++ b/packages/design-system/src/scalars/components/form/form.tsx
@@ -9,6 +9,8 @@ import {
   useImperativeHandle,
 } from "react";
 import { FormProvider, useForm, UseFormReturn } from "react-hook-form";
+import { FormServerErrorMessage } from "../fragments/form-message/form-server-error-message";
+import { defaultOnError } from "./utils";
 
 interface FormProps {
   /**
@@ -24,7 +26,7 @@ interface FormProps {
    *
    * @param data - An object containing the form values, keyed by field names
    */
-  onSubmit: (data: any) => void;
+  onSubmit: (data: any) => void | Promise<void>;
 
   /**
    * Whether to reset the form after a successful submit.
@@ -48,6 +50,30 @@ interface FormProps {
    * Useful for editing existing data or setting initial state.
    */
   defaultValues?: Record<string, any>;
+
+  /**
+   * Whether to handle errors that happen during the submit process manually instead of showing
+   * them automatically.
+   *
+   * @default false The errors will be rendered automatically on top of the form.
+   */
+  renderSubmitErrorsManually?: boolean;
+
+  /**
+   * Callback to match a submission error with one or more form fields or form level errors.
+   *
+   * @default defaultOnError The form tries to match the error with a field name by default and if it
+   * doesn't match any field name, then an generic error or the error message will be shown as a form
+   * level error.
+   *
+   * @returns An object where each key should be a field name or "root.serverError" for form level errors.
+   * If the keys doesn't match any field name, then the UI error should be handled manually using the form
+   * error state to get the message.
+   */
+  submissionErrorMatcher?: (
+    error: Error,
+    fieldNames: string[],
+  ) => Record<string, string>;
 
   /**
    * Additional CSS class name to apply to the form element.
@@ -98,6 +124,8 @@ export const Form = forwardRef<UseFormReturn, FormProps>(
       resetOnSuccessfulSubmit = false,
       submitChangesOnly = false,
       defaultValues,
+      renderSubmitErrorsManually = false,
+      submissionErrorMatcher = defaultOnError,
       className,
     },
     ref,
@@ -121,63 +149,97 @@ export const Form = forwardRef<UseFormReturn, FormProps>(
     ]);
 
     const wrappedOnSubmit = useCallback(
-      (rawData: Record<string, any>) => {
-        let data = rawData;
-        // we should make sure that empty fields are submitted as `null`
-        // react-hook-form doesn't submit fields with `undefined` values
-        // so we need to add them to the data as `null`
-        Object.keys(methods.control._fields).forEach((fieldName) => {
-          if (!Object.keys(data).includes(fieldName)) {
-            data[fieldName] = null;
-          }
-        });
-
-        if (submitChangesOnly && !!defaultValues) {
-          // remove fields that didn't change it's value
-          data = Object.fromEntries(
-            Object.entries(rawData).filter(
-              ([fieldName, value]) =>
-                !deepEqual(value, defaultValues[fieldName]),
-            ),
-          );
-        }
-
-        // at this point all the fields that need to be submitted are in the data
-        // we just need to make sure that "empty" values are submitted as `null`
-        data = Object.fromEntries(
-          Object.entries(data).map(([fieldName, value]) => [
-            fieldName,
-            isEmpty(value) ? null : value,
-          ]),
-        );
-
-        // cast data if needed to prevent submitting wrong data type
-        const form = document.getElementById(formId);
-        Object.keys(data).map((key) => {
-          try {
-            const value: unknown = data[key];
-            if (value !== null) {
-              const field = form?.querySelector(`[name="${key}"]`);
-              const dataCast = field?.getAttribute("data-cast");
-              if (dataCast) {
-                data[key] = castValue(value, dataCast as ValueCast) as unknown;
-              }
+      async (rawData: Record<string, any>) => {
+        try {
+          let data = rawData;
+          // we should make sure that empty fields are submitted as `null`
+          // react-hook-form doesn't submit fields with `undefined` values
+          // so we need to add them to the data as `null`
+          Object.keys(methods.control._fields).forEach((fieldName) => {
+            if (!Object.keys(data).includes(fieldName)) {
+              data[fieldName] = null;
             }
-          } catch (error) {
-            // print out the error but continue the execution
-            console.error(error);
-          }
-        });
+          });
 
-        // we need to return the promise from the onSubmit callback if there is one
-        // so react-hook-form can wait for it to resolve and update the form state correctly
-        return onSubmit(data);
+          if (submitChangesOnly && !!defaultValues) {
+            // remove fields that didn't change it's value
+            data = Object.fromEntries(
+              Object.entries(rawData).filter(
+                ([fieldName, value]) =>
+                  !deepEqual(value, defaultValues[fieldName]),
+              ),
+            );
+          }
+
+          // at this point all the fields that need to be submitted are in the data
+          // we just need to make sure that "empty" values are submitted as `null`
+          data = Object.fromEntries(
+            Object.entries(data).map(([fieldName, value]) => [
+              fieldName,
+              isEmpty(value) ? null : value,
+            ]),
+          );
+
+          // cast data if needed to prevent submitting wrong data type
+          const form = document.getElementById(formId);
+          Object.keys(data).map((key) => {
+            try {
+              const value: unknown = data[key];
+              if (value !== null) {
+                const field = form?.querySelector(`[name="${key}"]`);
+                const dataCast = field?.getAttribute("data-cast");
+                if (dataCast) {
+                  data[key] = castValue(
+                    value,
+                    dataCast as ValueCast,
+                  ) as unknown;
+                }
+              }
+            } catch (error) {
+              // print out the error but continue the execution
+              console.error(error);
+            }
+          });
+
+          // we need to return the promise from the onSubmit callback if there is one
+          // so react-hook-form can wait for it to resolve and update the form state correctly
+          return await onSubmit(data);
+        } catch (error: any) {
+          const errors = submissionErrorMatcher(
+            error as Error,
+            Object.keys(methods.control._fields),
+          );
+
+          Object.entries(errors).forEach(([key, value]) => {
+            methods.setError(key, {
+              type: "serverError",
+              message: value,
+              types: {
+                serverError: value,
+              },
+            });
+          });
+        }
       },
-      [methods.control, submitChangesOnly, defaultValues, formId, onSubmit],
+      [
+        methods,
+        submitChangesOnly,
+        defaultValues,
+        formId,
+        onSubmit,
+        submissionErrorMatcher,
+      ],
     );
 
     return (
       <FormProvider {...methods}>
+        {!renderSubmitErrorsManually &&
+          methods.formState.errors.root?.serverError.message && (
+            <div className="mb-2">
+              <FormServerErrorMessage />
+            </div>
+          )}
+
         <form
           id={formId}
           onSubmit={methods.handleSubmit(wrappedOnSubmit)}

--- a/packages/design-system/src/scalars/components/form/utils.ts
+++ b/packages/design-system/src/scalars/components/form/utils.ts
@@ -1,0 +1,41 @@
+export interface SupportedErrorObject extends Error {
+  data: {
+    path?: string;
+    message?: string;
+  }[];
+}
+
+export const isSupportedErrorObject = (
+  error: object,
+): error is SupportedErrorObject => {
+  return (
+    typeof error === "object" &&
+    Object.hasOwn(error, "data") &&
+    Array.isArray((error as { data?: unknown }).data)
+  );
+};
+
+export const defaultOnError = (
+  error: Error,
+  fieldNames: string[],
+): Record<string, string> => {
+  let message = "An error occurred while submitting the data";
+  let formErrorPath = "root.serverError"; // form level error by default
+
+  if (typeof error === "object" && isSupportedErrorObject(error)) {
+    const path = error.data[0]?.path;
+    if (error.data[0]?.message) {
+      message = error.data[0].message;
+    }
+    if (Array.isArray(path)) {
+      // maybe we can reconciliate this error with a form field
+      if (path.length === 1 && fieldNames.includes(path[0])) {
+        formErrorPath = path[0];
+      }
+    }
+  }
+
+  return {
+    [formErrorPath]: message,
+  };
+};

--- a/packages/design-system/src/scalars/components/fragments/form-message/form-server-error-message.tsx
+++ b/packages/design-system/src/scalars/components/fragments/form-message/form-server-error-message.tsx
@@ -1,0 +1,17 @@
+import { useFormContext } from "react-hook-form";
+import { FormMessageList } from "./message-list";
+
+export const FormServerErrorMessage = () => {
+  const { formState } = useFormContext();
+
+  if (!formState.errors.root?.serverError.message) {
+    return null;
+  }
+
+  return (
+    <FormMessageList
+      messages={[formState.errors.root.serverError.message]}
+      type="error"
+    />
+  );
+};

--- a/packages/design-system/src/scalars/components/fragments/form-message/index.ts
+++ b/packages/design-system/src/scalars/components/fragments/form-message/index.ts
@@ -1,2 +1,3 @@
 export * from "./form-message";
+export * from "./form-server-error-message";
 export * from "./message-list";

--- a/packages/design-system/src/scalars/components/url-field/url-field.test.tsx
+++ b/packages/design-system/src/scalars/components/url-field/url-field.test.tsx
@@ -230,7 +230,7 @@ describe("UrlField", () => {
   it("should hide warnings when the form is reset", async () => {
     const user = userEvent.setup();
     render(
-      <Form onSubmit={() => null} defaultValues={{ "test-url": "" }}>
+      <Form onSubmit={() => undefined} defaultValues={{ "test-url": "" }}>
         {({ reset }) => (
           <>
             <UrlField

--- a/packages/design-system/src/scalars/docs/examples/multiple-fields-with-complex-layout/multiple-fields-with-complex-layout.tsx
+++ b/packages/design-system/src/scalars/docs/examples/multiple-fields-with-complex-layout/multiple-fields-with-complex-layout.tsx
@@ -17,7 +17,7 @@ const MultipleFieldsWithComplexLayout = () => {
         email: "",
         bio: "",
         phone: "",
-        age: NaN,
+        age: 0,
         notifications: true,
         gender: "",
         subscribe: true,


### PR DESCRIPTION
## Ticket
https://trello.com/c/X30k6NmB/769-fix-existing-component-issues

## Description
- Reconciliation of server errors with their corresponding field or show errors as form-level errors
- Added form prop to add custom matcher function which allows the dev to handle the error reconciliation