### PR TITLE
fix(scalars): add more especific type in typescript and delete unnces…

### DIFF
--- a/packages/design-system/src/scalars/components/amount-field/amount-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/amount-field/amount-field.stories.tsx
@@ -162,6 +162,8 @@ const meta = {
   args: {
     errors: [],
     warnings: [],
+    allowedTokens: [],
+    allowedCurrencies: [],
     name: "amount-field",
   },
 } satisfies Meta<typeof AmountField>;

--- a/packages/design-system/src/scalars/components/amount-field/types.ts
+++ b/packages/design-system/src/scalars/components/amount-field/types.ts
@@ -1,3 +1,5 @@
+import { TokenIcons } from "./amount-field";
+
 export type Amount = number | undefined;
 export type AmountPercentage = number | undefined;
 export interface AmountCurrencyFiat {
@@ -18,26 +20,47 @@ export type AmountFieldPropsGeneric =
       type: "Amount";
       value?: Amount;
       trailingZeros?: boolean;
+      allowedCurrencies?: never;
+      currencySymbol?: never;
+      allowedTokens?: never;
+      tokenIcons?: never;
     }
   | {
       type: "AmountCurrencyFiat";
       value?: AmountCurrencyFiat;
       trailingZeros?: boolean;
+      allowedCurrencies: string[];
+      // Disable currencySymbol for AmountCurrencyFiat
+      currencySymbol?: never;
+      allowedTokens?: never;
+      tokenIcons?: never;
     }
   | {
       type: "AmountPercentage";
       value?: AmountPercentage;
       trailingZeros?: boolean;
+      allowedCurrencies?: never;
+      currencySymbol?: never;
+      allowedTokens?: never;
+      tokenIcons?: never;
     }
   | {
       type: "AmountCurrencyCrypto";
       value?: AmountCurrencyCrypto;
       trailingZeros?: never;
+      allowedTokens?: string[];
+      tokenIcons?: TokenIcons;
+      allowedCurrencies?: never;
+      currencySymbol?: never;
     }
   | {
       type: "AmountCurrencyUniversal";
       value?: AmountCurrencyUniversal;
-      trailingZeros?: never;
+      trailingZeros?: boolean;
+      allowedCurrencies?: string[];
+      currencySymbol?: string;
+      allowedTokens?: string[];
+      tokenIcons?: TokenIcons;
     };
 
 export type AmountValue =

--- a/packages/design-system/src/scalars/components/amount-field/use-amount-field.tsx
+++ b/packages/design-system/src/scalars/components/amount-field/use-amount-field.tsx
@@ -42,8 +42,6 @@ export const useAmountField = ({
   viewPrecision,
   trailingZeros,
 }: UseAmountFieldProps) => {
-  // Boolean to no convert float values to BigInt
-
   const currentValue = value ?? defaultValue;
 
   const baseValue =


### PR DESCRIPTION
## Ticket
https://trello.com/c/iV03PjGR/757-9-amountfield

## Description
Type prop. The type prop should allow you to select the type in a list.  It is impossible to see the field with the different types in one variant. Navigate for all variants it's needed. 