### PR TITLE
fix(scalars): rename and add stories to the amount

### DIFF
--- a/packages/design-system/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`AmountField Component > should match snapshot 1`] = `
             >
               <input
                 aria-invalid="false"
-                class="flex h-9 w-full text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-white disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 border border-r-[0.5px] border-gray-300 focus:border-r-0 rounded-md pr-8"
+                class="flex h-9 w-full text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-white disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 border border-r-[0.5px] border-gray-300 focus:border-r-0 rounded-md"
                 data-cast="Number"
                 id=":r1:"
                 inputmode="numeric"
@@ -43,26 +43,6 @@ exports[`AmountField Component > should match snapshot 1`] = `
                 type="text"
                 value="345"
               />
-              <div
-                class="absolute inset-y-2 right-3 flex flex-col justify-center"
-              >
-                <button
-                  type="button"
-                >
-                  <div
-                    data-testid="icon-fallback"
-                    style="width: 10px; height: 10px;"
-                  />
-                </button>
-                <button
-                  type="button"
-                >
-                  <div
-                    data-testid="icon-fallback"
-                    style="width: 10px; height: 10px;"
-                  />
-                </button>
-              </div>
             </div>
           </div>
         </div>

--- a/packages/design-system/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`AmountField Component > should match snapshot 1`] = `
             >
               <input
                 aria-invalid="false"
-                class="flex h-9 w-full text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-white disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 border border-r-[0.5px] border-gray-300 focus:border-r-0 rounded-md"
+                class="flex h-9 w-full text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-white disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-8 border border-r-[0.5px] border-gray-300 focus:border-r-0 rounded-md"
                 data-cast="Number"
                 id=":r1:"
                 inputmode="numeric"

--- a/packages/design-system/src/scalars/components/amount-field/amount-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/amount-field/amount-field.stories.tsx
@@ -177,6 +177,22 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
+    placeholder: "0",
+    label: "Enter Amount and Select Currency",
+    name: "amount",
+    step: 0,
+    type: "AmountCurrencyFiat",
+    allowedCurrencies: ["USD", "EUR"],
+    currencyPosition: "right",
+    value: {
+      amount: undefined,
+      currency: "USD",
+    },
+  },
+};
+
+export const WithValue: Story = {
+  args: {
     placeholder: "Enter Amount",
     label: "Enter Amount and Select Currency",
     name: "amount",
@@ -185,13 +201,23 @@ export const Default: Story = {
     allowedCurrencies: ["USD", "EUR"],
     currencyPosition: "right",
     value: {
-      amount: 345,
       currency: "USD",
+      amount: 100,
     },
   },
 };
-export const TokenIcon: Story = {
-  name: "Token Icon",
+export const WithAmount: Story = {
+  args: {
+    placeholder: "Enter Amount",
+    label: "EnterAmout ",
+    name: "amount",
+    type: "Amount",
+    value: 345,
+    step: 0,
+  },
+};
+export const CurrencyIcon: Story = {
+  name: "Currency Icon",
   args: {
     placeholder: "Enter Amount",
     label: "Enter Amount and Select Currency",
@@ -210,7 +236,7 @@ export const TokenIcon: Story = {
   },
 };
 
-export const Token: Story = {
+export const WithToken: Story = {
   args: {
     placeholder: "Enter Amount",
     label: "Enter Amount and Select Currency",
@@ -225,17 +251,8 @@ export const Token: Story = {
     },
   },
 };
-export const Amount: Story = {
-  args: {
-    placeholder: "Enter Amount",
-    label: "Enter Amount ",
-    name: "amount",
-    type: "Amount",
-    value: 345,
-    step: 0,
-  },
-};
-export const Percent: Story = {
+
+export const WithValuePercent: Story = {
   args: {
     label: "Enter Percentage ",
     placeholder: "Enter Amount",
@@ -245,8 +262,23 @@ export const Percent: Story = {
     step: 0,
   },
 };
+export const Disable: Story = {
+  args: {
+    label: "Enter Amount ",
+    placeholder: "Enter Amount",
+    name: "amount",
+    type: "AmountCurrencyFiat",
+    allowedCurrencies: ["USD", "EUR"],
+    disabled: true,
+    value: {
+      amount: 9,
+      currency: "USD",
+    },
+    step: 0,
+  },
+};
 
-export const UniversalAmountCurrency: Story = {
+export const WithValueUniversalAmountCurrency: Story = {
   args: {
     name: "amount",
     label: "Label",

--- a/packages/design-system/src/scalars/components/amount-field/amount-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/amount-field/amount-field.stories.tsx
@@ -160,10 +160,6 @@ const meta = {
   },
 
   args: {
-    errors: [],
-    warnings: [],
-    allowedTokens: [],
-    allowedCurrencies: [],
     name: "amount-field",
   },
 } satisfies Meta<typeof AmountField>;
@@ -180,10 +176,8 @@ export const Default: Story = {
     placeholder: "0",
     label: "Enter Amount and Select Currency",
     name: "amount",
-    step: 0,
     type: "AmountCurrencyFiat",
     allowedCurrencies: ["USD", "EUR"],
-    currencyPosition: "right",
     value: {
       amount: undefined,
       currency: "USD",
@@ -196,10 +190,8 @@ export const WithValue: Story = {
     placeholder: "Enter Amount",
     label: "Enter Amount and Select Currency",
     name: "amount",
-    step: 0,
     type: "AmountCurrencyFiat",
     allowedCurrencies: ["USD", "EUR"],
-    currencyPosition: "right",
     value: {
       currency: "USD",
       amount: 100,
@@ -213,7 +205,6 @@ export const WithAmount: Story = {
     name: "amount",
     type: "Amount",
     value: 345,
-    step: 0,
   },
 };
 export const CurrencyIcon: Story = {
@@ -228,7 +219,6 @@ export const CurrencyIcon: Story = {
       BTC: IconComponent("Briefcase"),
       ETH: IconComponent("Briefcase"),
     },
-    currencyPosition: "right",
     value: {
       amount: 3454564564 as unknown as bigint,
       currency: "BTC",
@@ -241,10 +231,9 @@ export const WithToken: Story = {
     placeholder: "Enter Amount",
     label: "Enter Amount and Select Currency",
     name: "amount",
-    step: 0,
+
     type: "AmountCurrencyCrypto",
     allowedTokens: ["BTC", "ETH", "USDT"],
-    currencyPosition: "right",
     value: {
       amount: 12321312 as unknown as bigint,
       currency: "BTC",
@@ -259,7 +248,6 @@ export const WithValuePercent: Story = {
     name: "amount",
     type: "AmountPercentage",
     value: 9,
-    step: 0,
   },
 };
 export const Disable: Story = {
@@ -274,7 +262,6 @@ export const Disable: Story = {
       amount: 9,
       currency: "USD",
     },
-    step: 0,
   },
 };
 
@@ -284,13 +271,11 @@ export const WithValueUniversalAmountCurrency: Story = {
     label: "Label",
     placeholder: "Enter Amount",
     type: "AmountCurrencyUniversal",
-    currencyPosition: "right",
     allowedCurrencies: ["USD", "EUR"],
 
     value: {
       amount: 2324234,
       currency: "USD",
     },
-    step: 0,
   },
 };

--- a/packages/design-system/src/scalars/components/amount-field/amount-field.tsx
+++ b/packages/design-system/src/scalars/components/amount-field/amount-field.tsx
@@ -88,6 +88,7 @@ export const AmountFieldRaw = forwardRef<HTMLInputElement, AmountFieldProps>(
       isBigInt,
       handleIsInputFocused,
       isAmount,
+      inputFocused,
     } = useAmountField({
       value,
       defaultValue,
@@ -174,7 +175,7 @@ export const AmountFieldRaw = forwardRef<HTMLInputElement, AmountFieldProps>(
               ref={ref}
               {...(numberProps || {})}
             />
-            {isPercent && step === 0 && (
+            {isPercent && !inputFocused && (
               <span
                 className={cn(
                   "pointer-events-none absolute inset-y-0 right-2 ml-2 flex items-center",

--- a/packages/design-system/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`NumberField > should match snapshot 1`] = `
       >
         <input
           aria-invalid="false"
-          class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-white disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300"
+          class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-white disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-8"
           data-cast="Number"
           id=":r1:"
           inputmode="numeric"

--- a/packages/design-system/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`NumberField > should match snapshot 1`] = `
       >
         <input
           aria-invalid="false"
-          class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-white disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-8"
+          class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-white disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300"
           data-cast="Number"
           id=":r1:"
           inputmode="numeric"
@@ -29,26 +29,6 @@ exports[`NumberField > should match snapshot 1`] = `
           type="text"
           value="345"
         />
-        <div
-          class="absolute inset-y-2 right-3 flex flex-col justify-center"
-        >
-          <button
-            type="button"
-          >
-            <div
-              data-testid="icon-fallback"
-              style="width: 10px; height: 10px;"
-            />
-          </button>
-          <button
-            type="button"
-          >
-            <div
-              data-testid="icon-fallback"
-              style="width: 10px; height: 10px;"
-            />
-          </button>
-        </div>
       </div>
     </div>
   </form>

--- a/packages/design-system/src/scalars/components/number-field/number-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.stories.tsx
@@ -96,7 +96,6 @@ export const Default: Story = {
     name: "Label",
     label: "Label",
     placeholder: "Enter a number",
-    step: 0,
     value: 1234,
   },
 };
@@ -106,7 +105,6 @@ export const Active: Story = {
     label: "Label",
     autoFocus: true,
     value: 45,
-    step: 0,
     placeholder: "Enter a number",
   },
   parameters: {
@@ -119,7 +117,6 @@ export const Disable: Story = {
     label: "Label",
     value: 1234,
     disabled: true,
-    step: 0,
   },
 };
 export const Required: Story = {
@@ -128,7 +125,6 @@ export const Required: Story = {
     label: "Label",
     value: 345,
     required: true,
-    step: 0,
     placeholder: "A number is required",
   },
 };
@@ -137,7 +133,6 @@ export const WithWarning: Story = {
     name: "Label",
     label: "Label",
     value: 23,
-    step: 0,
     warnings: ["Warning message"],
     placeholder: "Enter  number",
   },
@@ -147,7 +142,6 @@ export const WithError: Story = {
     name: "Label",
     label: "Label",
     value: 23,
-    step: 0,
     errors: ["Error message"],
     placeholder: "Enter a number",
   },
@@ -157,7 +151,6 @@ export const WithMultipleErrors: Story = {
     name: "Label",
     label: "Label",
     value: 23,
-    step: 0,
     errors: [
       "Error message number 1",
       "Error message number 2",
@@ -170,7 +163,6 @@ export const WithMultipleErrors: Story = {
 
 export const WithValue: Story = {
   args: {
-    step: 0,
     name: "Label",
     label: "Label",
     value: 23,
@@ -180,7 +172,6 @@ export const WithValue: Story = {
 
 export const WithDescription: Story = {
   args: {
-    step: 0,
     name: "Label",
     label: "Label",
     value: 0,
@@ -192,7 +183,6 @@ export const WithDescription: Story = {
 // Float Stories
 export const WithFloatNumber: Story = {
   args: {
-    step: 0,
     label: "Label",
     name: "Label",
     value: 0.0,
@@ -208,7 +198,7 @@ export const WithBigInt: Story = {
     label: "Label",
     value: 99992342343299,
     numericType: "BigInt",
-    step: 0,
+
     placeholder: "Enter a large number",
   },
 };

--- a/packages/design-system/src/scalars/components/number-field/number-field.test.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.test.tsx
@@ -208,10 +208,10 @@ describe("NumberField", () => {
 
     expect(input).toHaveValue("5");
   });
-
   // Test for step
   it("should increment the value when increment arrow button is clicked", async () => {
     const user = userEvent.setup();
+
     renderWithForm(
       <NumberField
         label="Test Label"
@@ -222,15 +222,20 @@ describe("NumberField", () => {
       />,
     );
 
-    const decrementButton = screen.getAllByRole("button")[0];
-    await user.click(decrementButton);
+    const input = screen.getByRole("spinbutton");
+    await user.click(input); // Simula el clic en el input
 
+    // Ensure that the input has focus
+    expect(input).toHaveFocus();
+
+    const incrementButton = screen.getByRole("button", { name: /Increment/i });
+    await user.click(incrementButton);
+
+    // Verify that `mockOnChange` was called and that the input remains focused
     expect(mockOnChange).toHaveBeenCalledTimes(1);
-
+    expect(input).toHaveFocus();
     const eventArg = mockOnChange.mock
       .calls[0][0] as React.ChangeEvent<HTMLInputElement>;
-
-    expect(eventArg).toBeInstanceOf(Event);
 
     expect(eventArg.target).toMatchObject({
       value: 6,
@@ -248,9 +253,16 @@ describe("NumberField", () => {
         onChange={mockOnChange}
       />,
     );
+    const input = screen.getByRole("spinbutton");
+    await user.click(input); // Simulate click on the input
+    // Ensure that the input has focus
+    expect(input).toHaveFocus();
 
-    const decrementButton = screen.getAllByRole("button")[1];
+    const decrementButton = screen.getByRole("button", { name: /Decrement/i });
     await user.click(decrementButton);
+    // Ensure that the input has focus
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+
     const eventArg = mockOnChange.mock
       .calls[0][0] as React.ChangeEvent<HTMLInputElement>;
 
@@ -259,7 +271,7 @@ describe("NumberField", () => {
     });
   });
 
-  it("should not exceed maxValue when increment button is clicked, and should not invoke onChange if the value does not change", async () => {
+  it("should not exceed maxValue when increment button is clicked", async () => {
     const user = userEvent.setup();
     renderWithForm(
       <NumberField
@@ -271,32 +283,23 @@ describe("NumberField", () => {
         onChange={mockOnChange}
       />,
     );
+    const input = screen.getByRole("spinbutton");
+    await user.click(input); // Simulate click on the input
+    // Ensure that the input has focus
+    expect(input).toHaveFocus();
 
-    const incrementButton = screen.getAllByRole("button")[0];
+    const incrementButton = screen.getByRole("button", { name: /Increment/i });
     await user.click(incrementButton);
+    // // Asegúrate de que el input tiene foco
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
 
-    expect(mockOnChange).not.toHaveBeenCalled();
+    const eventArg = mockOnChange.mock
+      .calls[0][0] as React.ChangeEvent<HTMLInputElement>;
+
+    expect(eventArg.target.value).toBe("10");
   });
 
-  it("should not go up of  maxValue when increment button is clicked and should not invoke onChange if the value does not change", async () => {
-    const user = userEvent.setup();
-    renderWithForm(
-      <NumberField
-        label="Test Label"
-        name="Label"
-        value={30}
-        maxValue={30}
-        step={1}
-        onChange={mockOnChange}
-      />,
-    );
-
-    const decrementButton = screen.getAllByRole("button")[0];
-    await user.click(decrementButton);
-
-    expect(mockOnChange).not.toHaveBeenCalled();
-  });
-  it("should not go below minValue when decrement button is clicked and should not invoke onChange if the value does not change", async () => {
+  it("should not go below minValue when decrement button is clicked", async () => {
     const user = userEvent.setup();
     renderWithForm(
       <NumberField
@@ -308,11 +311,18 @@ describe("NumberField", () => {
         onChange={mockOnChange}
       />,
     );
+    const input = screen.getByRole("spinbutton");
+    await user.click(input); // Simulate click on the input
+    // Ensure that the input has focus
+    expect(input).toHaveFocus();
 
-    const decrementButton = screen.getAllByRole("button")[1];
+    const decrementButton = screen.getByRole("button", { name: /Decrement/i });
     await user.click(decrementButton);
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    const eventArg = mockOnChange.mock
+      .calls[0][0] as React.ChangeEvent<HTMLInputElement>;
 
-    expect(mockOnChange).not.toHaveBeenCalled();
+    expect(eventArg.target.value).toBe("1");
   });
 
   //New test for the issues

--- a/packages/design-system/src/scalars/components/number-field/number-field.test.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.test.tsx
@@ -254,7 +254,7 @@ describe("NumberField", () => {
       />,
     );
     const input = screen.getByRole("spinbutton");
-    await user.click(input); // Simulate click on the input
+    await user.click(input);
     // Ensure that the input has focus
     expect(input).toHaveFocus();
 
@@ -284,7 +284,7 @@ describe("NumberField", () => {
       />,
     );
     const input = screen.getByRole("spinbutton");
-    await user.click(input); // Simulate click on the input
+    await user.click(input);
     // Ensure that the input has focus
     expect(input).toHaveFocus();
 
@@ -312,7 +312,7 @@ describe("NumberField", () => {
       />,
     );
     const input = screen.getByRole("spinbutton");
-    await user.click(input); // Simulate click on the input
+    await user.click(input);
     // Ensure that the input has focus
     expect(input).toHaveFocus();
 

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -18,6 +18,7 @@ export interface NumberFieldProps extends InputNumberProps {
   defaultValue?: number | bigint;
   className?: string;
   pattern?: RegExp;
+  onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
 }
 export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
   (
@@ -40,6 +41,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
       trailingZeros = false,
       numericType = "Float",
       precision = 0,
+      onFocus,
       ...props
     },
     ref,
@@ -69,6 +71,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
       onBlur,
       trailingZeros,
       precision,
+      onFocus,
     });
 
     return (
@@ -89,8 +92,7 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
             id={id}
             onFocus={handleFocus}
             name={name}
-            // className={cn(className, showSteps && "pr-8")}
-            className={cn(className)}
+            className={cn("pr-8", className)}
             pattern={isBigInt ? regex.toString() : pattern?.toString()}
             type="text"
             inputMode="numeric"
@@ -121,7 +123,6 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
                 onMouseDown={(e) => e.preventDefault()}
                 type="button"
                 onClick={(e) => {
-                  console.log("buttonRef", buttonRef.current);
                   stepValueHandler(e, "increment");
                   if (buttonRef.current) {
                     buttonRef.current.focus();

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -56,6 +56,9 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
       preventLetterInput,
       isBigInt,
       handleBlur,
+
+      handleFocus,
+      buttonRef,
     } = useNumberField({
       value,
       maxValue,
@@ -84,8 +87,10 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
         <div className="relative flex items-center">
           <Input
             id={id}
+            onFocus={handleFocus}
             name={name}
-            className={cn(className, showSteps && "pr-8")}
+            // className={cn(className, showSteps && "pr-8")}
+            className={cn(className)}
             pattern={isBigInt ? regex.toString() : pattern?.toString()}
             type="text"
             inputMode="numeric"
@@ -111,9 +116,17 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
           {showSteps && (
             <div className="absolute inset-y-2 right-3 flex flex-col justify-center">
               <button
+                aria-label="Increment"
                 disabled={canIncrement}
+                onMouseDown={(e) => e.preventDefault()}
                 type="button"
-                onClick={(e) => stepValueHandler(e, "increment")}
+                onClick={(e) => {
+                  console.log("buttonRef", buttonRef.current);
+                  stepValueHandler(e, "increment");
+                  if (buttonRef.current) {
+                    buttonRef.current.focus();
+                  }
+                }}
               >
                 <Icon
                   size={10}
@@ -125,9 +138,16 @@ export const NumberFieldRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
                 />
               </button>
               <button
+                aria-label="Decrement"
+                onMouseDown={(e) => e.preventDefault()}
                 disabled={canDecrement}
                 type="button"
-                onClick={(e) => stepValueHandler(e, "decrement")}
+                onClick={(e) => {
+                  stepValueHandler(e, "decrement");
+                  if (buttonRef.current) {
+                    buttonRef.current.focus();
+                  }
+                }}
               >
                 <Icon
                   size={10}

--- a/packages/design-system/src/scalars/components/number-field/use-number-field.ts
+++ b/packages/design-system/src/scalars/components/number-field/use-number-field.ts
@@ -13,6 +13,7 @@ interface UseNumberFieldProps {
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   trailingZeros?: boolean;
   precision?: number;
+  onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
 }
 
 export const useNumberField = ({
@@ -25,6 +26,7 @@ export const useNumberField = ({
   onBlur,
   trailingZeros = false,
   precision = 0,
+  onFocus,
 }: UseNumberFieldProps) => {
   const [isFocus, setIsFocus] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -88,6 +90,7 @@ export const useNumberField = ({
     e: React.MouseEvent<HTMLButtonElement>,
     operation: "increment" | "decrement",
   ) => {
+    e.preventDefault();
     let newValue: number | bigint;
 
     if (isBigInt) {
@@ -176,6 +179,7 @@ export const useNumberField = ({
   const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
     e.preventDefault();
     setIsFocus(true);
+    onFocus?.(e);
   };
 
   return {

--- a/packages/design-system/src/scalars/components/number-field/use-number-field.ts
+++ b/packages/design-system/src/scalars/components/number-field/use-number-field.ts
@@ -1,3 +1,4 @@
+import { useRef, useState } from "react";
 import { isNotSafeValue } from "../amount-field/utils";
 import { NumericType } from "./types";
 import { getDisplayValue } from "./utils";
@@ -25,6 +26,8 @@ export const useNumberField = ({
   trailingZeros = false,
   precision = 0,
 }: UseNumberFieldProps) => {
+  const [isFocus, setIsFocus] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const canIncrement =
     maxValue !== undefined &&
     (typeof value === "bigint"
@@ -37,7 +40,7 @@ export const useNumberField = ({
       ? value <= BigInt(minValue)
       : Number(value) <= minValue);
 
-  const showSteps = step !== 0;
+  const showSteps = isFocus;
 
   // Boolean to no convert float values to BigInt
   const isBigInt = numericType && numericType === "BigInt";
@@ -85,8 +88,6 @@ export const useNumberField = ({
     e: React.MouseEvent<HTMLButtonElement>,
     operation: "increment" | "decrement",
   ) => {
-    e.preventDefault();
-
     let newValue: number | bigint;
 
     if (isBigInt) {
@@ -120,6 +121,7 @@ export const useNumberField = ({
   };
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    setIsFocus(false);
     const inputValue = e.target.value;
 
     // If the value is not a number, not an empty string, or is empty, show the error message or keep it empty
@@ -171,6 +173,11 @@ export const useNumberField = ({
     onBlur?.(e);
   };
 
+  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    setIsFocus(true);
+  };
+
   return {
     canIncrement,
     canDecrement,
@@ -181,5 +188,8 @@ export const useNumberField = ({
     preventLetterInput,
     isBigInt,
     handleBlur,
+    handleFocus,
+    isFocus,
+    buttonRef,
   };
 };

--- a/packages/design-system/src/scalars/lib/value-cast.ts
+++ b/packages/design-system/src/scalars/lib/value-cast.ts
@@ -25,7 +25,7 @@ export const castFunctions: Record<ValueCast, (value: any) => any> = {
     if (typeof value === "object" && "currency" in value) {
       return {
         ...value,
-        amount: value.amount !== undefined ? BigInt(value.amount) : undefined,
+        amount: value.amount !== undefined ? BigInt(value.amount) : null,
       };
     }
   },


### PR DESCRIPTION
## Ticket
https://trello.com/c/iV03PjGR/757-9-amountfield

## Description
- The default state should represent the field without value in both sections. In the currency section should be an option when there is no option selected.

- Remove the unnecessaries stories 
- Add disabled variant 
- Add With Value variant (currently is the variant represented as Default) 
- Storybook: Update the Variants name with the names specified in the user story. 

## Notes:
- This pr will be affect to the number field behavior too