### PR TITLE
feat(monorepo): remove problematic peer deps

### DIFF
--- a/packages/document-drive/package.json
+++ b/packages/document-drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "document-drive",
-  "version": "1.13.5",
+  "version": "1.13.2",
   "license": "AGPL-3.0-only",
   "type": "module",
   "module": "./src/index.ts",
@@ -35,18 +35,6 @@
     "test:watch": "vitest watch",
     "clean": "rimraf dist",
     "clean:node_modules": "rimraf node_modules"
-  },
-  "peerDependencies": {
-    "@powerhousedao/scalars": "workspace:*",
-    "change-case": "^5.4.4",
-    "document-model": "workspace:*",
-    "document-model-libs": "workspace:*",
-    "graphql": "^16.9.0",
-    "graphql-request": "^6.1.0",
-    "json-stringify-deterministic": "^1.0.12",
-    "nanoevents": "^9.0.0",
-    "prisma": "^5.18.0",
-    "sanitize-filename": "^1.6.3"
   },
   "optionalDependencies": {
     "@powerhousedao/scalars": "workspace:*",

--- a/packages/document-drive/package.json
+++ b/packages/document-drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "document-drive",
-  "version": "1.13.2",
+  "version": "1.13.5",
   "license": "AGPL-3.0-only",
   "type": "module",
   "module": "./src/index.ts",

--- a/packages/reactor-browser/package.json
+++ b/packages/reactor-browser/package.json
@@ -29,26 +29,20 @@
     "@powerhousedao/config": "workspace:*",
     "@powerhousedao/design-system": "workspace:*",
     "@powerhousedao/scalars": "workspace:*",
-    "document-drive": "workspace:*",
-    "document-model": "workspace:*",
-    "document-model-libs": "workspace:*",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "peerDependencies": {
-    "@powerhousedao/config": "workspace:*",
-    "@powerhousedao/design-system": "workspace:*",
-    "@powerhousedao/scalars": "workspace:*",
-    "document-drive": "workspace:*",
-    "document-model": "workspace:*",
-    "document-model-libs": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "dependencies": {
     "did-key-creator": "^1.2.0",
-    "jotai": "^2.10.3"
+    "jotai": "^2.10.3",
+    "document-model": "workspace:*",
+    "document-model-libs": "workspace:*",
+    "document-drive": "workspace:*"
   }
 }

--- a/packages/reactor-browser/vite.config.ts
+++ b/packages/reactor-browser/vite.config.ts
@@ -11,7 +11,7 @@ const dependenciesRegex = dependencies.map(
   (dep) => new RegExp(`^${dep}(?:/.+)?$`),
 );
 const devDependencies = Object.keys(pkg.devDependencies);
-const devDependenciessRegex = devDependencies.map(
+const devDependenciesRegex = devDependencies.map(
   (dep) => new RegExp(`^${dep}(?:/.+)?$`),
 );
 
@@ -62,10 +62,10 @@ export default defineConfig(() => {
           // throw error if dev dependency is included in the bundle
           if (
             devDependencies.includes(id) ||
-            devDependenciessRegex.some((depMatcher) => depMatcher.test(id))
+            devDependenciesRegex.some((depMatcher) => depMatcher.test(id))
           ) {
             console.error(
-              `\x1b[31m\n\nDev dependency is being added to the bundle: ${id}\nMove it to dependencies or peerDependecies\n\n`,
+              `\x1b[31m\n\nDev dependency is being added to the bundle: ${id}\nMove it to dependencies.\n\n`,
             );
             process.exit(1);
           }

--- a/packages/renown/package.json
+++ b/packages/renown/package.json
@@ -37,9 +37,6 @@
     "clean": "rimraf dist/",
     "clean:node_modules": "rimraf node_modules"
   },
-  "peerDependencies": {
-    "document-model": "workspace:*"
-  },
   "devDependencies": {
     "document-model": "workspace:*"
   }

--- a/packages/scalars/package.json
+++ b/packages/scalars/package.json
@@ -28,10 +28,6 @@
     "graphql": "^16.9.0",
     "zod": "^3.23.8"
   },
-  "peerDependencies": {
-    "graphql": "^16.9.0",
-    "zod": "^3.23.8"
-  },
   "exports": {
     ".": {
       "types": "./dist/types/src/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -914,7 +914,7 @@ importers:
         version: 1.0.1(document-model@packages+document-model)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@5.0.10))
       dspot-powerhouse-components:
         specifier: ^1.1.0
-        version: 1.1.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@mui/material@5.16.13(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(document-model-libs@1.125.3(@codemirror/language@6.10.8)(@codemirror/state@6.5.0)(@codemirror/view@6.36.1)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.1.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@mui/material@5.16.13(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(document-model-libs@1.125.5(@codemirror/language@6.10.8)(@codemirror/state@6.5.0)(@codemirror/view@6.36.1)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphql:
         specifier: ^16.9.0
         version: 16.10.0
@@ -1160,6 +1160,15 @@ importers:
       did-key-creator:
         specifier: ^1.2.0
         version: 1.2.0
+      document-drive:
+        specifier: workspace:*
+        version: link:../document-drive
+      document-model:
+        specifier: workspace:*
+        version: link:../document-model
+      document-model-libs:
+        specifier: workspace:*
+        version: link:../document-model-libs
       jotai:
         specifier: ^2.10.3
         version: 2.11.0(@types/react@18.3.18)(react@18.3.1)
@@ -1179,15 +1188,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.1
         version: 18.3.5(@types/react@18.3.18)
-      document-drive:
-        specifier: workspace:*
-        version: link:../document-drive
-      document-model:
-        specifier: workspace:*
-        version: link:../document-model
-      document-model-libs:
-        specifier: workspace:*
-        version: link:../document-model-libs
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -7835,8 +7835,8 @@ packages:
       react-dom: ^18.2.0
       storybook: ^7.0.17
 
-  document-model-libs@1.125.3:
-    resolution: {integrity: sha512-+hweh4rVrnrRJrQRbkQ/JpG0bIsx/k/MLgjKr8MfMU0/iR87lK4iTNvkS08fjt3OgasEdtWWkqADgX4fbOBVVw==}
+  document-model-libs@1.125.5:
+    resolution: {integrity: sha512-tOUSYUXV2O9vOOYQ3wPGQhupxYIIS4/L5RiVfTgPnPn6A8kIa2jrjhhYCJURCU1kfVMrbD3QAEdd2gy5Ml8wDg==}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -22315,7 +22315,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@5.0.10)
 
-  document-model-libs@1.125.3(@codemirror/language@6.10.8)(@codemirror/state@6.5.0)(@codemirror/view@6.36.1)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  document-model-libs@1.125.5(@codemirror/language@6.10.8)(@codemirror/state@6.5.0)(@codemirror/view@6.36.1)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@codemirror/lang-json': 6.0.1
       '@codemirror/search': 6.5.8
@@ -22416,12 +22416,12 @@ snapshots:
 
   dset@3.1.4: {}
 
-  dspot-powerhouse-components@1.1.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@mui/material@5.16.13(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(document-model-libs@1.125.3(@codemirror/language@6.10.8)(@codemirror/state@6.5.0)(@codemirror/view@6.36.1)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  dspot-powerhouse-components@1.1.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@mui/material@5.16.13(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(document-model-libs@1.125.5(@codemirror/language@6.10.8)(@codemirror/state@6.5.0)(@codemirror/view@6.36.1)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.18)(react@18.3.1)
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
       '@mui/material': 5.16.13(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      document-model-libs: 1.125.3(@codemirror/language@6.10.8)(@codemirror/state@6.5.0)(@codemirror/view@6.36.1)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      document-model-libs: 1.125.5(@codemirror/language@6.10.8)(@codemirror/state@6.5.0)(@codemirror/view@6.36.1)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 


### PR DESCRIPTION
Currently we have several usages of peer dependencies that are pointless at best and harmful at worst.

Let's differentiate between some different types of dependencies:

- `dependencies` - these are the dependencies that are required for the package to work. Their code must be bundled with the package, or the package will either not build or break at runtime.

- `devDependencies` - these are the dependencies that are only needed for the package to build. They are not required for the package to work at runtime. _These are not included in the bundle, so they do not contribute to the bundle size._

The vast majority of dependencies should fall into one of the categories above.

- `peerDependencies` - these are the dependencies that _are_ required for the package to work. However, _we assume that the consumer of the package has already installed them_. An example is how `design-system` has `react` and `react-dom` as peer dependencies. We can safely assume that the consumer would not be using our components in an app that does not have `react` and `react-dom` installed.

Peer dependencies, like dev dependencies, are not included in the bundle. This has lead to a lot of issues where people are trying to use peer dependencies to reduce bundle size. This is a mistake in most cases.

First example:

Putting dev dependencies in peer dependencies is a mistake. Here in `scalars`, we have `zod` and `graphql` as both dev and peer dependencies.

```json
 "devDependencies": {
    "glob": "^11.0.0",
    "graphql": "^16.9.0",
    "zod": "^3.23.8"
  },
  "peerDependencies": {
    "graphql": "^16.9.0",
    "zod": "^3.23.8"
  },
```

- this is pointless because since they are already dev dependencies, they are _already not included in the bundle_.

- this tells that package manager to complain if the consumer does not have these packages installed, _but they don't even need to have them because they are dev dependencies_.

Second example:

Putting our own packages in that are needed for our packages to work in peer dependencies is a mistake. Here in `reactor-browser`, we have several of our own packages as peer dependencies.

```json
"peerDependencies": {
    "@powerhousedao/config": "workspace:*",
    "@powerhousedao/design-system": "workspace:*",
    "@powerhousedao/scalars": "workspace:*",
    "document-drive": "workspace:*",
    "document-model": "workspace:*",
    "document-model-libs": "workspace:*",
  },
```

There are actually multiple issues here:

```json
    "@powerhousedao/config": "workspace:*",
    "@powerhousedao/design-system": "workspace:*",
    "@powerhousedao/scalars": "workspace:*",
    ```

These dependencies are in fact only used as dev dependencies in the `renown` package. This tells the user they need to install these packages, even though our package is not even going to use them.

```json
    "document-drive": "workspace:*",
    "document-model": "workspace:*",
    "document-model-libs": "workspace:*",
```

These packages have code that the package can't run without. They should be dependencies. When the package is bundled, the code from these packages _that is actually used_ will be included in the bundle, with the rest being ignored. By making these peer dependencies, we are making the `reactor-browser` a tiny bit smaller by not including this code. But then we are making the consumer install _the entire package_, even if we only actually need one line of code from it.

In my opinion we are optimizing our library code in the wrong way. We are packaging and bundling code that is intended to be consumed by an app, which will have its own bundling process. Our bundling / optimizing is maybe making our npm packages a bit smaller, but at the cost of making the code harder to tree shake and bundle efficiently for the consumer. This makes the _consumer's bundler heavier_, which is the opposite of what we are trying to achieve.

I believe that removing these problematic peer dependencies is a good first step, especially since it will fix a lot of the build issues that have caused problems when implementing `ph-cmd`.