### PR TITLE
fix(scalars): check that type match with value

### DIFF
--- a/packages/design-system/src/scalars/components/amount-field/amount-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/amount-field/amount-field.stories.tsx
@@ -216,7 +216,7 @@ export const WithAmount: Story = {
   },
   args: {
     placeholder: "Enter Amount",
-    label: "EnterAmout ",
+    label: "Enter Amout ",
     type: "Amount",
     value: 345,
   },
@@ -283,6 +283,7 @@ export const Disable: Story = {
     label: "Enter Amount ",
     placeholder: "Enter Amount",
     type: "AmountCurrencyFiat",
+    placeholderSelect: "CUR",
     allowedCurrencies: ["USD", "EUR"],
     disabled: true,
     value: {
@@ -306,6 +307,7 @@ export const WithValueUniversalAmountCurrency: Story = {
   args: {
     label: "Label",
     placeholder: "Enter Amount",
+    placeholderSelect: "CUR",
     type: "AmountCurrencyUniversal",
     allowedCurrencies: ["USD", "EUR"],
     value: {


### PR DESCRIPTION
## Ticket
https://trello.com/c/iV03PjGR/757-9-amountfield

## Description

- Step to reproduce Type = AmountCurrencyFiat.  **Expected Output:** The Generics and specifics props should be displayed.  **Current Output:** The CurrencySymbol prop is not visible.  Please, add the CurrencySymbol prop to the proper type.

- Step to reproduce Type = AmountCurrencyCrypto. Changing the type to Amount or Percentage. **Expected Output:** The field should represent the proper type. **Current Output:** The field is displayed with "[object Object]" inside. 