### PR TITLE
feat(scalars): improve autoComplete behavior on PHID field

### DIFF
--- a/packages/design-system/src/scalars/components/phid-field/phid-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/phid-field/phid-field.stories.tsx
@@ -107,6 +107,7 @@ const meta: Meta<typeof PHIDField> = {
         defaultValue: { summary: "withId" },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
+      if: { arg: "autoComplete", neq: false },
     },
 
     ...getValidationArgTypes(),

--- a/packages/design-system/src/scalars/components/phid-field/types.ts
+++ b/packages/design-system/src/scalars/components/phid-field/types.ts
@@ -1,6 +1,6 @@
 import React from "react";
 
-export interface PHIDProps {
+export interface PHIDBaseProps {
   onChange?: (value: string) => void;
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
   placeholder?: string;
@@ -9,12 +9,19 @@ export interface PHIDProps {
   allowedScopes?: string[];
   allowedDocumentTypes?: string[];
   allowUris?: boolean;
-  autoComplete?: boolean;
   allowDataObjectReference?: boolean;
-  variant?: "withId" | "withIdAndTitle" | "withIdTitleAndDescription";
   minLength?: number;
   maxLength?: number;
 }
+
+export type PHIDProps = PHIDBaseProps &
+  (
+    | { autoComplete?: false; variant: undefined }
+    | {
+        autoComplete: true;
+        variant?: "withId" | "withIdAndTitle" | "withIdTitleAndDescription";
+      }
+  );
 
 export interface PHIDListItemProps {
   title?: string;


### PR DESCRIPTION
## Ticket
https://trello.com/c/UHEOiN4v/776-8-phid-document-pointer-without-branch

## Description
- Should the field be represented as an input when **autoComplete** is false
- Should the field allow to select an item from the list when **autoComplete** is true
- Should the **variant** prop not be visible when **autoComplete** is false
- Select the input text only if not have the focus
- Position the dropdown below the input