### PR TITLE
feat(scalars): add the format for both components

### DIFF
--- a/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.stories.tsx
@@ -4,6 +4,7 @@ import { DatePickerField } from "./date-picker-field";
 import {
   getDefaultArgTypes,
   getValidationArgTypes,
+  StorybookControlCategory,
 } from "@/scalars/lib/storybook-arg-types";
 
 const meta: Meta<typeof DatePickerField> = {
@@ -25,7 +26,7 @@ const meta: Meta<typeof DatePickerField> = {
       description: "Minimum selectable date in the date picker",
       table: {
         type: { summary: "string" },
-        category: "Component Specific",
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
     maxDate: {
@@ -33,7 +34,26 @@ const meta: Meta<typeof DatePickerField> = {
       description: "Maximum selectable date in the date picker",
       table: {
         type: { summary: "string" },
-        category: "Component Specific",
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+    },
+    dateFormat: {
+      control: {
+        type: "select",
+      },
+      options: [
+        "yyyy-MM-dd",
+        "dd-MM-yyyy",
+        "MM-dd-yyyy",
+        "dd-MMM-yyyy",
+        "MMM-dd-yyyy",
+      ],
+      table: {
+        defaultValue: { summary: "yyyy-MM-dd" },
+        type: {
+          summary: "string",
+        },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
   },

--- a/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.tsx
@@ -31,6 +31,7 @@ export interface DatePickerFieldProps extends FieldCommonProps<DateFieldValue> {
   >;
   minDate?: string;
   maxDate?: string;
+  dateFormat?: string;
 }
 
 export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
@@ -50,6 +51,7 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
       onChange,
       onBlur,
       inputProps,
+      dateFormat = "yyyy-MM-dd",
       ...props
     },
     ref,
@@ -67,6 +69,7 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
       defaultValue,
       onChange,
       onBlur,
+      dateFormat,
     });
 
     return (

--- a/packages/design-system/src/scalars/components/date-picker-field/use-date-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/use-date-picker-field.tsx
@@ -7,6 +7,7 @@ interface DatePickerFieldProps {
   defaultValue?: DateFieldValue;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
+  dateFormat?: string;
 }
 
 export const useDatePickerField = ({
@@ -14,6 +15,7 @@ export const useDatePickerField = ({
   defaultValue,
   onChange,
   onBlur,
+  dateFormat = "yyyy-MM-dd",
 }: DatePickerFieldProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
@@ -29,8 +31,8 @@ export const useDatePickerField = ({
 
   const handleDateSelect = useCallback(
     (date?: Date) => {
-      if (date) {
-        const formattedDate = format(date, "MM/dd/yyyy");
+      if (date && isValid(date)) {
+        const formattedDate = format(date, dateFormat);
         const changeEvent = createChangeEvent(formattedDate);
         onChange?.(changeEvent);
       } else {
@@ -38,7 +40,7 @@ export const useDatePickerField = ({
         onChange?.(changeEvent);
       }
     },
-    [onChange],
+    [dateFormat, onChange],
   );
 
   const formatDate = React.useCallback(
@@ -50,23 +52,22 @@ export const useDatePickerField = ({
       if (typeof value === "number") {
         const date = new Date(value);
         if (isValid(date)) {
-          const newValue = format(date, "MM/dd/yyyy");
+          const newValue = format(date, dateFormat);
           const changeEvent = createChangeEvent(newValue);
           onChange?.(changeEvent);
         }
       }
       if (typeof value === "object" && isValid(value)) {
-        return format(value, "dd/MM/yyyy");
+        return format(value, dateFormat);
       }
 
       return "";
     },
-    [onChange],
+    [dateFormat, onChange],
   );
   const inputValue = formatDate(value ?? defaultValue ?? "");
-  const parsedDate = parse(inputValue, "MM/dd/yyyy", new Date());
+  const parsedDate = parse(inputValue, dateFormat, new Date());
   const date = isValid(parsedDate) ? parsedDate : undefined;
-
   return {
     date,
     inputValue,

--- a/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-period-selector.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-period-selector.tsx
@@ -3,7 +3,7 @@ import { TimePeriod } from "../type";
 import { Button } from "../../fragments/button";
 
 interface TimePeriodSelectorProps {
-  selectedPeriod: TimePeriod;
+  selectedPeriod?: TimePeriod;
   setSelectedPeriod: (period: TimePeriod) => void;
 }
 

--- a/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-picker-content.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-picker-content.tsx
@@ -11,10 +11,10 @@ interface TimePickerContentProps {
   onCancel?: () => void;
   selectedHour: string;
   selectedMinute: string;
-  selectedPeriod: TimePeriod;
+  selectedPeriod?: TimePeriod;
   setSelectedHour: (hour: string) => void;
   setSelectedMinute: (minute: string) => void;
-  setSelectedPeriod: (period: TimePeriod) => void;
+  setSelectedPeriod: (period?: TimePeriod) => void;
   hours: string[];
   minutes: string[];
   timeZonesOptions: SelectBaseProps["options"];

--- a/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-picker-content.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-picker-content.tsx
@@ -19,6 +19,7 @@ interface TimePickerContentProps {
   minutes: string[];
   timeZonesOptions: SelectBaseProps["options"];
   selectProps?: Omit<SelectFieldProps, "name" | "options" | "selectionIcon">;
+  is12HourFormat: boolean;
 }
 
 const TimePickerContent: React.FC<TimePickerContentProps> = ({
@@ -34,6 +35,7 @@ const TimePickerContent: React.FC<TimePickerContentProps> = ({
   minutes,
   timeZonesOptions,
   selectProps,
+  is12HourFormat,
 }) => {
   return (
     <div className="w-full mx-auto relative">
@@ -47,10 +49,12 @@ const TimePickerContent: React.FC<TimePickerContentProps> = ({
         {...selectProps}
       />
 
-      <TimePeriodSelector
-        selectedPeriod={selectedPeriod}
-        setSelectedPeriod={setSelectedPeriod}
-      />
+      {is12HourFormat && (
+        <TimePeriodSelector
+          selectedPeriod={selectedPeriod}
+          setSelectedPeriod={setSelectedPeriod}
+        />
+      )}
       <div
         className="flex justify-center mt-[14px] h-[148px] mx-auto overflow-hidden"
         style={{

--- a/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.stories.tsx
@@ -17,6 +17,13 @@ const meta: Meta<typeof TimePickerField> = {
   argTypes: {
     ...getDefaultArgTypes(),
     ...getValidationArgTypes(),
+    timeFormat: {
+      control: {
+        type: "select",
+      },
+      options: ["hh:mm a", "HH:mm"],
+      defaultValue: { summary: "hh:mm a" },
+    },
   },
 
   args: {

--- a/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.tsx
@@ -68,6 +68,7 @@ export const TimePickerRaw = forwardRef<HTMLInputElement, TimePickerFieldProps>(
       handleCancel,
       timeZonesOptions,
       handleBlur,
+      is12HourFormat,
     } = useTimePickerField({
       value,
       defaultValue,
@@ -116,6 +117,7 @@ export const TimePickerRaw = forwardRef<HTMLInputElement, TimePickerFieldProps>(
             onCancel={handleCancel}
             timeZonesOptions={timeZonesOptions}
             selectProps={selectProps}
+            is12HourFormat={is12HourFormat}
           />
         </BasePickerField>
         {description && <FormDescription>{description}</FormDescription>}

--- a/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.tsx
@@ -26,6 +26,7 @@ interface TimePickerFieldProps
   placeholder?: string;
   inputProps?: Omit<InputProps, "name" | "onChange" | "value" | "defaultValue">;
   selectProps?: Omit<SelectFieldProps, "name" | "options" | "selectionIcon">;
+  timeFormat?: string;
 }
 
 export const TimePickerRaw = forwardRef<HTMLInputElement, TimePickerFieldProps>(
@@ -46,6 +47,7 @@ export const TimePickerRaw = forwardRef<HTMLInputElement, TimePickerFieldProps>(
       disabled,
       inputProps,
       selectProps,
+      timeFormat = "hh:mm a",
     },
     ref,
   ) => {
@@ -66,7 +68,13 @@ export const TimePickerRaw = forwardRef<HTMLInputElement, TimePickerFieldProps>(
       handleCancel,
       timeZonesOptions,
       handleBlur,
-    } = useTimePickerField(value, defaultValue, onChange, onBlur);
+    } = useTimePickerField({
+      value,
+      defaultValue,
+      onChange,
+      onBlur,
+      timeFormat,
+    });
 
     return (
       <FormGroup>

--- a/packages/design-system/src/scalars/components/time-picker-field/use-time-picker-field.ts
+++ b/packages/design-system/src/scalars/components/time-picker-field/use-time-picker-field.ts
@@ -1,60 +1,83 @@
-import { format, getHours, getMinutes, parse } from "date-fns";
+import { format, getHours, getMinutes, isValid, parse } from "date-fns";
 import React, { useMemo, useState } from "react";
 import { TimeFieldValue } from "./type";
 import { createChangeEvent } from "./utils";
 
-export const useTimePickerField = (
-  value?: TimeFieldValue,
-  defaultValue?: TimeFieldValue,
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void,
-  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void,
-) => {
-  // Get the current hour and minutes
+interface TimePickerFieldProps {
+  value?: TimeFieldValue;
+  defaultValue?: TimeFieldValue;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
+  timeFormat?: string;
+}
+
+export const useTimePickerField = ({
+  value,
+  defaultValue,
+  onChange,
+  onBlur,
+  timeFormat = "hh:mm a",
+}: TimePickerFieldProps) => {
   const now = new Date();
   const currentHour = getHours(now);
   const currentMinute = getMinutes(now);
-  // Input value format time
+
+  // Determine if the format is 12-hour or 24-hour
+  const is12HourFormat = timeFormat.includes("a");
+
+  // Initialize the hour and minutes according to the format
+  const initialHour = is12HourFormat
+    ? String(currentHour % 12 || 12).padStart(2, "0")
+    : String(currentHour).padStart(2, "0");
+
+  const initialMinute = String(currentMinute).padStart(2, "0");
+  const initialPeriod = is12HourFormat
+    ? currentHour >= 12
+      ? "PM"
+      : "AM"
+    : undefined;
+
+  const [selectedHour, setSelectedHour] = useState(initialHour);
+  const [selectedMinute, setSelectedMinute] = useState(initialMinute);
+  const [selectedPeriod, setSelectedPeriod] = useState<"AM" | "PM" | undefined>(
+    initialPeriod,
+  );
 
   const inputValue = value ?? defaultValue ?? "";
-
   const [isOpen, setIsOpen] = useState(false);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange?.(e);
   };
+
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     onBlur?.(e);
   };
-  // Convert the hour to 12-hour format and determine AM/PM
-  const formattedHour = currentHour % 12 || 12;
-  const period = currentHour >= 12 ? "PM" : "AM";
 
-  const [selectedHour, setSelectedHour] = React.useState(
-    String(formattedHour).padStart(2, "0"),
-  );
-  const [selectedMinute, setSelectedMinute] = React.useState(
-    String(currentMinute).padStart(2, "0"),
-  );
-  const [selectedPeriod, setSelectedPeriod] = React.useState<"AM" | "PM">(
-    period,
-  );
-  // Generate hours from 1 to 12
-  const hours = Array.from({ length: 12 }, (_, i) =>
-    String(i + 1).padStart(2, "0"),
-  );
+  // Generate hours according to the format
+  const hours = is12HourFormat
+    ? Array.from({ length: 12 }, (_, i) => String(i + 1).padStart(2, "0")) // 1-12
+    : Array.from({ length: 24 }, (_, i) => String(i).padStart(2, "0")); // 0-23
 
-  // Generate minutes from 0 to 59
+  // Generate minutes (0-59)
   const minutes = Array.from({ length: 60 }, (_, i) =>
     String(i).padStart(2, "0"),
   );
 
   const handleSave = () => {
-    // Format the time correctly with date-fns
-    const timeString = `${selectedHour}:${selectedMinute} ${selectedPeriod}`;
-    const parsedTime = parse(timeString, "hh:mm a", new Date());
+    let timeString: string;
 
-    // Convert it to a correctly formatted string
-    const formattedTime = format(parsedTime, "hh:mm a");
+    if (is12HourFormat) {
+      timeString = `${selectedHour}:${selectedMinute} ${selectedPeriod}`;
+    } else {
+      // 24-hour format: does not include AM/PM
+      timeString = `${selectedHour}:${selectedMinute}`;
+    }
+
+    // Parse and format the time according to the specified format
+    const parsedTime = parse(timeString, timeFormat, new Date());
+
+    const formattedTime = format(parsedTime, timeFormat);
 
     setIsOpen(false);
     onChange?.(createChangeEvent(formattedTime));
@@ -73,7 +96,6 @@ export const useTimePickerField = (
 
     const parts = formatter.formatToParts(date);
     const offsetPart = parts.find((part) => part.type === "timeZoneName");
-    // WIP: Return default offset of the time zone
     return offsetPart ? offsetPart.value : "";
   };
 
@@ -103,5 +125,6 @@ export const useTimePickerField = (
     handleSave,
     timeZonesOptions,
     handleBlur,
+    timeFormat,
   };
 };

--- a/packages/design-system/src/scalars/components/time-picker-field/use-time-picker-field.ts
+++ b/packages/design-system/src/scalars/components/time-picker-field/use-time-picker-field.ts
@@ -126,5 +126,6 @@ export const useTimePickerField = ({
     timeZonesOptions,
     handleBlur,
     timeFormat,
+    is12HourFormat,
   };
 };


### PR DESCRIPTION
## Ticket
https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time

## Description
- Should set the **dateFormat** as a String.
- Should set the **timeFormat** as a String.