### PR TITLE
feat(scalars): add show time zone and start day week with the auto close

### DIFF
--- a/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.stories.tsx
@@ -91,6 +91,15 @@ const meta: Meta<typeof DatePickerField> = {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
+    autoClose: {
+      control: "boolean",
+      description: "Close the date picker when a date is selected",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+    },
   },
   args: {
     name: "date-picker-field",

--- a/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.stories.tsx
@@ -72,6 +72,25 @@ const meta: Meta<typeof DatePickerField> = {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
+    weekStart: {
+      control: "select",
+      options: [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+      ],
+      table: {
+        defaultValue: { summary: "Monday" },
+        type: {
+          summary: "string",
+        },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+    },
   },
   args: {
     name: "date-picker-field",

--- a/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.tsx
@@ -34,6 +34,7 @@ export interface DatePickerFieldProps extends FieldCommonProps<DateFieldValue> {
   disablePastDates?: boolean;
   disableFutureDates?: boolean;
   dateFormat?: string;
+  weekStart?: string;
 }
 
 export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
@@ -56,6 +57,7 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
       disablePastDates,
       disableFutureDates,
       dateFormat = "yyyy-MM-dd",
+      weekStart,
       ...props
     },
     ref,
@@ -69,6 +71,7 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
       setIsOpen,
       handleBlur,
       disabledDates,
+      weekStartDay,
     } = useDatePickerField({
       value,
       defaultValue,
@@ -77,6 +80,7 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
       disablePastDates,
       disableFutureDates,
       dateFormat,
+      weekStart,
     });
 
     return (
@@ -112,6 +116,7 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
             mode="single"
             required={true}
             selected={date}
+            weekStartsOn={weekStartDay}
             onSelect={handleDateSelect}
             disabled={disabledDates}
             className={cn(

--- a/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.tsx
@@ -35,6 +35,7 @@ export interface DatePickerFieldProps extends FieldCommonProps<DateFieldValue> {
   disableFutureDates?: boolean;
   dateFormat?: string;
   weekStart?: string;
+  autoClose?: boolean;
 }
 
 export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
@@ -58,6 +59,7 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
       disableFutureDates,
       dateFormat = "yyyy-MM-dd",
       weekStart,
+      autoClose = false,
       ...props
     },
     ref,
@@ -72,6 +74,7 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
       handleBlur,
       disabledDates,
       weekStartDay,
+      handleDayClick,
     } = useDatePickerField({
       value,
       defaultValue,
@@ -81,6 +84,7 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
       disableFutureDates,
       dateFormat,
       weekStart,
+      autoClose,
     });
 
     return (
@@ -114,11 +118,11 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
         >
           <Calendar
             mode="single"
-            required={true}
             selected={date}
             weekStartsOn={weekStartDay}
             onSelect={handleDateSelect}
             disabled={disabledDates}
+            onDayClick={handleDayClick}
             className={cn(
               "w-full",
               "p-0",

--- a/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import { FieldCommonProps } from "../types";
+import { ErrorHandling, FieldCommonProps } from "../types";
 import { DateFieldValue } from "./types";
 import { withFieldValidation } from "../fragments/with-field-validation";
 
@@ -14,7 +14,9 @@ import { useDatePickerField } from "./use-date-picker-field";
 import { InputProps } from "../fragments";
 import { validateDatePicker } from "./date-picker-validations";
 
-export interface DatePickerFieldProps extends FieldCommonProps<DateFieldValue> {
+export interface DatePickerFieldProps
+  extends FieldCommonProps<DateFieldValue>,
+    ErrorHandling {
   label?: string;
   id?: string;
   name: string;
@@ -64,6 +66,7 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
     },
     ref,
   ) => {
+    console.log("minDate", props.minDate);
     const {
       date,
       inputValue,
@@ -139,9 +142,9 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
               "gap-x-[3px]",
               "dark:text-gray-600",
             )}
-            monthGridClassName={cn("w-full", "pr-[5.5px] pl-[5.5px]")}
+            monthGridClassName={cn("w-full", "px-[5.5px]")}
             dayClassName={cn(
-              "w-[34px] hover:bg-gray-200 hover:rounded-[4px] cursor-pointer",
+              "w-[34px] cursor-pointer hover:rounded-[4px] hover:bg-gray-200",
               // dark
               "dark:text-gray-50 hover:dark:bg-gray-900",
             )}
@@ -155,7 +158,7 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
               "border border-gray-200 ",
               "hover:bg-gray-200 dark:hover:bg-gray-900",
               // dark
-              "dark:text-gray-300 dark:border-gray-900",
+              "dark:border-gray-900 dark:text-gray-300",
             )}
             todayClassName={cn(
               "rounded-[4px]",

--- a/packages/design-system/src/scalars/components/date-picker-field/subcomponents/calendar/calendar.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/subcomponents/calendar/calendar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/scalars/lib/utils";
-import { differenceInCalendarDays, format, startOfDay } from "date-fns";
+import { differenceInCalendarDays, format } from "date-fns";
 import * as React from "react";
 import { DayPicker, useDayPicker, type DayPickerProps } from "react-day-picker";
 import { buttonVariants } from "../../../fragments/button/button";
@@ -12,7 +12,6 @@ import { DatePickerView } from "../../types";
 import CaptionLabel from "../caption-label/caption-label";
 import NavCalendar from "../calendar-nav/calendar-nav";
 import CalendarDateHeader from "../calendar-date-header/calendar-date-header";
-import { useMemo } from "react";
 
 export type CalendarProps = DayPickerProps & {
   /**

--- a/packages/design-system/src/scalars/components/date-picker-field/types.ts
+++ b/packages/design-system/src/scalars/components/date-picker-field/types.ts
@@ -1,2 +1,3 @@
 export type DateFieldValue = string | Date | null;
 export type DatePickerView = "years" | "months" | "days";
+export type WeekStartDayNumber = 0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined;

--- a/packages/design-system/src/scalars/components/date-picker-field/use-date-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/use-date-picker-field.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from "react";
-import { DateFieldValue } from "./types";
+import { DateFieldValue, WeekStartDayNumber } from "./types";
 import { format, isValid, parse, startOfDay } from "date-fns";
 import { createChangeEvent } from "../time-picker-field/utils";
 interface DatePickerFieldProps {
@@ -10,6 +10,7 @@ interface DatePickerFieldProps {
   disablePastDates?: boolean;
   disableFutureDates?: boolean;
   dateFormat?: string;
+  weekStart?: string;
 }
 
 export const useDatePickerField = ({
@@ -20,6 +21,7 @@ export const useDatePickerField = ({
   disablePastDates,
   disableFutureDates,
   dateFormat = "yyyy-MM-dd",
+  weekStart = "Monday",
 }: DatePickerFieldProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -92,6 +94,19 @@ export const useDatePickerField = ({
             : undefined,
     [disablePastDates, disableFutureDates, today],
   );
+  const weekStartDay = useMemo(() => {
+    const days = [
+      "sunday",
+      "monday",
+      "tuesday",
+      "wednesday",
+      "thursday",
+      "friday",
+      "saturday",
+    ];
+    const dayIndex = days.indexOf(weekStart.toLowerCase());
+    return (dayIndex >= 0 ? dayIndex : 1) as WeekStartDayNumber;
+  }, [weekStart]);
 
   return {
     date,
@@ -103,5 +118,6 @@ export const useDatePickerField = ({
     formatDate,
     handleBlur,
     disabledDates,
+    weekStartDay,
   };
 };

--- a/packages/design-system/src/scalars/components/date-picker-field/use-date-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/use-date-picker-field.tsx
@@ -11,6 +11,7 @@ interface DatePickerFieldProps {
   disableFutureDates?: boolean;
   dateFormat?: string;
   weekStart?: string;
+  autoClose?: boolean;
 }
 
 export const useDatePickerField = ({
@@ -22,6 +23,7 @@ export const useDatePickerField = ({
   disableFutureDates,
   dateFormat = "yyyy-MM-dd",
   weekStart = "Monday",
+  autoClose = false,
 }: DatePickerFieldProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -108,6 +110,12 @@ export const useDatePickerField = ({
     return (dayIndex >= 0 ? dayIndex : 1) as WeekStartDayNumber;
   }, [weekStart]);
 
+  // Close the calendar when a date is selected
+  const handleDayClick = () => {
+    if (autoClose) {
+      setIsOpen(false);
+    }
+  };
   return {
     date,
     inputValue,
@@ -119,5 +127,6 @@ export const useDatePickerField = ({
     handleBlur,
     disabledDates,
     weekStartDay,
+    handleDayClick,
   };
 };

--- a/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-picker-content.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-picker-content.tsx
@@ -20,6 +20,7 @@ interface TimePickerContentProps {
   timeZonesOptions: SelectBaseProps["options"];
   selectProps?: Omit<SelectFieldProps, "name" | "options" | "selectionIcon">;
   is12HourFormat: boolean;
+  showTimezoneSelect?: boolean;
 }
 
 const TimePickerContent: React.FC<TimePickerContentProps> = ({
@@ -36,12 +37,14 @@ const TimePickerContent: React.FC<TimePickerContentProps> = ({
   timeZonesOptions,
   selectProps,
   is12HourFormat,
+  showTimezoneSelect,
 }) => {
   return (
     <div className="w-full mx-auto relative">
       <SelectFieldRaw
         name=""
         options={timeZonesOptions}
+        disabled={!showTimezoneSelect}
         searchable={true}
         placeholder="Select a timezone"
         className="w-full"

--- a/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.stories.tsx
@@ -24,6 +24,14 @@ const meta: Meta<typeof TimePickerField> = {
       options: ["hh:mm a", "HH:mm"],
       defaultValue: { summary: "hh:mm a" },
     },
+    showTimezoneSelect: {
+      control: {
+        type: "boolean",
+        defaultValue: false,
+        description: "Show timezone select",
+      },
+      defaultValue: { summary: false },
+    },
   },
 
   args: {

--- a/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.tsx
@@ -27,6 +27,7 @@ export interface TimePickerFieldProps
   inputProps?: Omit<InputProps, "name" | "onChange" | "value" | "defaultValue">;
   selectProps?: Omit<SelectFieldProps, "name" | "options" | "selectionIcon">;
   timeFormat?: string;
+  showTimezoneSelect?: boolean;
 }
 
 export const TimePickerRaw = forwardRef<HTMLInputElement, TimePickerFieldProps>(
@@ -48,6 +49,7 @@ export const TimePickerRaw = forwardRef<HTMLInputElement, TimePickerFieldProps>(
       inputProps,
       selectProps,
       timeFormat = "hh:mm a",
+      showTimezoneSelect,
     },
     ref,
   ) => {
@@ -118,6 +120,7 @@ export const TimePickerRaw = forwardRef<HTMLInputElement, TimePickerFieldProps>(
             timeZonesOptions={timeZonesOptions}
             selectProps={selectProps}
             is12HourFormat={is12HourFormat}
+            showTimezoneSelect={showTimezoneSelect}
           />
         </BasePickerField>
         {description && <FormDescription>{description}</FormDescription>}


### PR DESCRIPTION
## Ticket
https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time

## Description
- Should set the **showTimezoneSelect** as a Boolean.
- Should set the **weekStart** as a String (Monday by Default).
- Should set the **customValidator** as a Function. 
- Should set the **autoClose** as a Boolean.