### PR TITLE
feat(scalars): add non-editable if readOnly and validate for time format

### DIFF
--- a/packages/design-system/src/scalars/components/time-picker-field/time-picker-validations.ts
+++ b/packages/design-system/src/scalars/components/time-picker-field/time-picker-validations.ts
@@ -1,5 +1,5 @@
 import { TimePickerFieldProps } from "./time-picker-field";
-import { isFormatTimeAllowed } from "./utils";
+import { isFormatTimeAllowed, timeRegex12Hour, timeRegex24Hour } from "./utils";
 
 export const validateTimePicker =
   ({ timeFormat }: TimePickerFieldProps) =>
@@ -12,7 +12,21 @@ export const validateTimePicker =
     }
 
     if (timeFormat && !isFormatTimeAllowed(timeFormat)) {
-      return `Invalid time format.Plese select a valid format`;
+      return `Invalid time format. Please select a valid format`;
+    }
+
+    // For 24-hour format (HH:mm)
+    if (timeFormat === "HH:mm") {
+      if (!timeRegex24Hour.test(value as string)) {
+        return "Invalid time. Please enter time in 24-hour format";
+      }
+    }
+
+    // For 12-hour format (h:mm a)
+    if (timeFormat === "h:mm a") {
+      if (!timeRegex12Hour.test(value as string)) {
+        return "Invalid time. Please enter time in 12-hour format with AM/PM";
+      }
     }
 
     return true;

--- a/packages/design-system/src/scalars/components/time-picker-field/utils.ts
+++ b/packages/design-system/src/scalars/components/time-picker-field/utils.ts
@@ -19,3 +19,6 @@ export const ALLOWED_TIME_FORMATS = ["hh:mm a", "HH:mm", "hh:mm A"];
 export const isFormatTimeAllowed = (format: string): boolean => {
   return ALLOWED_TIME_FORMATS.includes(format);
 };
+
+export const timeRegex24Hour = /^(\d|0\d|1\d|2[0-3]):([0-5]\d)$/;
+export const timeRegex12Hour = /^(0?[1-9]|1[0-2]):([0-5]\d) (AM|PM|am|pm)$/;


### PR DESCRIPTION
## Ticket
https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time

## Description
- Should the field be non-editable if ReadOnly (Disabled) is true.
- Should show the error message when the field loses focus if showErrorOnBlur is true