### PR TITLE
fix(scalars): should the auto-expanded String field resize with any container

### DIFF
--- a/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.stories.tsx
@@ -166,6 +166,31 @@ export const WithAutoExpandSingleLine: Story = {
   },
 };
 
+export const WithResizableContainer: Story = {
+  args: {
+    label: "Auto-expanding textarea inside a resizable container",
+    autoExpand: true,
+    placeholder: "Type something...",
+    multiline: true,
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          resize: "horizontal",
+          overflow: "auto",
+          padding: "16px",
+          border: "1px dotted black",
+          minWidth: "200px",
+          minHeight: "150px",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
 export const WithSpellCheck: Story = {
   args: {
     label: "Spell-checked textarea",

--- a/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.tsx
+++ b/packages/design-system/src/scalars/components/fragments/textarea-field/textarea-field.tsx
@@ -1,4 +1,4 @@
-import React, { useId, useEffect, useMemo } from "react";
+import React, { useId, useEffect, useMemo, useRef } from "react";
 import { FormLabel } from "@/scalars/components/fragments/form-label";
 import { FormMessageList } from "@/scalars/components/fragments/form-message";
 import { FormGroup } from "@/scalars/components/fragments/form-group";
@@ -15,7 +15,7 @@ import ValueTransformer, {
   type TransformerType,
 } from "@/scalars/components/fragments/value-transformer";
 import { sharedValueTransformers } from "@/scalars/lib/shared-value-transformers";
-import { useWindowSize } from "usehooks-ts";
+import { useResizeObserver } from "usehooks-ts";
 
 type TextareaFieldBaseProps = Omit<
   React.TextareaHTMLAttributes<HTMLTextAreaElement>,
@@ -88,7 +88,35 @@ const TextareaFieldRaw = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     const prefix = useId();
     const id = propId ?? `${prefix}-textarea`;
 
-    const { width } = useWindowSize();
+    const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+    const mergedRef = (node: HTMLTextAreaElement | null) => {
+      textareaRef.current = node;
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+    };
+
+    const adjustHeight = () => {
+      if (textareaRef.current) {
+        // Reset height to allow shrinking
+        textareaRef.current.style.height = "auto";
+        // Set to scrollHeight to expand based on content
+        textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+      }
+    };
+
+    useResizeObserver({
+      ref: textareaRef,
+      onResize: () => {
+        if (value !== undefined && autoExpand) {
+          adjustHeight();
+        }
+      },
+      box: "border-box",
+    });
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       // Prevent Enter key if multiline is falsy
@@ -100,19 +128,10 @@ const TextareaFieldRaw = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     };
 
     useEffect(() => {
-      const adjustHeight = () => {
-        const textarea = document.getElementById(id);
-        if (textarea) {
-          // Reset height to allow shrinking
-          textarea.style.height = "auto";
-          // Set to scrollHeight to expand based on content
-          textarea.style.height = `${textarea.scrollHeight}px`;
-        }
-      };
       if (value !== undefined && autoExpand) {
         adjustHeight();
       }
-    }, [id, value, autoExpand, width]);
+    }, [value, autoExpand]);
 
     const transformers: TransformerType = useMemo(
       () => [
@@ -163,7 +182,7 @@ const TextareaFieldRaw = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
                     ],
                 className,
               )}
-              ref={ref}
+              ref={mergedRef}
               id={id}
               name={name}
               value={value}


### PR DESCRIPTION
## Ticket
https://trello.com/c/sGVapKDG/826-string-field-does-not-resize-based-on-its-container

## Description
- Should the auto-expanded String field adjust its size according to any container (div, window...)