### PR TITLE
feat(scalars): add min-data and fix some style issues

### DIFF
--- a/packages/design-system/src/scalars/components/date-picker-field/__snapshots__/date-picker-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/date-picker-field/__snapshots__/date-picker-field.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`DatePickerField > should match the snapshot 1`] = `
             aria-controls="radix-:r1:"
             aria-expanded="false"
             aria-haspopup="dialog"
-            class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground w-[50px] rounded-l-md border-none px-2 focus:bg-none focus:text-selected-foreground button-ghost"
+            class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground w-[50px] rounded-l-md border-none pl-3 pr-2 focus:bg-none focus:text-selected-foreground button-ghost"
             data-state="closed"
             type="button"
           >

--- a/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.tsx
@@ -143,7 +143,7 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
             )}
             monthGridClassName={cn("w-full", "px-[5.5px]")}
             dayClassName={cn(
-              "w-[34px] cursor-pointer hover:rounded-[4px] hover:bg-gray-200",
+              "w-[34px] cursor-pointer text-[12px] hover:rounded-[4px] hover:bg-gray-200 text-gray-900",
               // dark
               "dark:text-gray-50 hover:dark:bg-gray-900",
             )}
@@ -173,6 +173,7 @@ export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
               "dark:bg-gray-50 dark:text-gray-900",
               "dark:hover:bg-gray-50 dark:hover:text-gray-900",
             )}
+            dayButtonClassName={cn("text-[12px] font-medium")}
             weekClassName={cn("w-full")}
             {...props}
           />

--- a/packages/design-system/src/scalars/components/date-picker-field/subcomponents/caption-label/caption-label.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/subcomponents/caption-label/caption-label.tsx
@@ -32,7 +32,7 @@ const CaptionLabel: React.FC<CaptionLabelProps> = ({
       )}
     >
       <Button
-        className="truncate text-sm font-medium"
+        className="truncate text-sm font-semibold"
         variant="ghost"
         onClick={() => setNavView("months")}
       >
@@ -40,7 +40,7 @@ const CaptionLabel: React.FC<CaptionLabelProps> = ({
       </Button>
       <Button
         className={cn(
-          "truncate text-sm font-medium",
+          "truncate text-sm font-semibold",
           isSelectedYear ? "text-gray-900" : "text-gray-600",
         )}
         variant="ghost"

--- a/packages/design-system/src/scalars/components/date-time-field/base-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/date-time-field/base-picker-field.tsx
@@ -73,7 +73,7 @@ export const BasePickerField = React.forwardRef<
                 variant="ghost"
                 disabled={disabled}
                 className={cn(
-                  "w-[50px] rounded-l-md border-none px-2",
+                  "w-[50px] rounded-l-md border-none pl-3 pr-2",
                   "focus:bg-none focus:text-selected-foreground",
                   "button-ghost",
                   disabled && "cursor-not-allowed  hover:bg-transparent",

--- a/packages/design-system/src/scalars/components/time-picker-field/__snapshots__/time-picker-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/time-picker-field/__snapshots__/time-picker-field.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`TimePickerField > should match the snapshot 1`] = `
             aria-controls="radix-:r1:"
             aria-expanded="false"
             aria-haspopup="dialog"
-            class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground w-[50px] rounded-l-md border-none px-2 focus:bg-none focus:text-selected-foreground button-ghost"
+            class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground w-[50px] rounded-l-md border-none pl-3 pr-2 focus:bg-none focus:text-selected-foreground button-ghost"
             data-state="closed"
             type="button"
           >

--- a/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-period-selector.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-period-selector.tsx
@@ -18,8 +18,10 @@ const TimePeriodSelector: React.FC<TimePeriodSelectorProps> = ({
         key={period}
         onClick={() => setSelectedPeriod(period as TimePeriod)}
         className={cn(
-          "h-[20px] w-[16px] text-[12px] leading-[28px] transition-colors",
-          selectedPeriod === period ? "text-gray-900" : "text-gray-300",
+          "h-[20px] w-[16px] text-[12px] leading-[28px] transition-colors font-normal",
+          selectedPeriod === period
+            ? "text-gray-900 font-normal"
+            : "text-gray-300 font-normal",
         )}
       >
         {period}

--- a/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-selector.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-selector.tsx
@@ -24,8 +24,8 @@ const TimeSelector: React.FC<TimeSelectorProps> = ({
           className={cn(
             "px-3 py-2 text-[12px] flex cursor-pointer items-center justify-center",
             selectedValue === value
-              ? "rounded-[6px] bg-white border border-gray-300 text-gray-900"
-              : "text-gray-900 w-[16px] h-[20px]",
+              ? "rounded-[6px] bg-white border border-gray-300 text-gray-900 font-normal"
+              : "text-gray-900 w-[16px] h-[20px] font-normal",
           )}
         >
           {value}

--- a/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useState } from "react";
+import { forwardRef } from "react";
 import {
   FormDescription,
   FormGroup,


### PR DESCRIPTION
## Ticket
https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time

## Description
- Should the field allow insert the earliest date up to the date specified in minDate prop.