### PR TITLE
fix(scalars): handles changes to the "multiple" prop avoiding calling onChange on mount on Select field

### DIFF
--- a/packages/design-system/src/scalars/components/fragments/select-field/use-select-field.ts
+++ b/packages/design-system/src/scalars/components/fragments/select-field/use-select-field.ts
@@ -99,6 +99,26 @@ export function useSelectField({
     }
   }, [isPopoverOpen, haveBeenOpened, onBlur]);
 
+  // handles changes to the "multiple" prop avoiding calling onChange on mount
+  const prevMultiple = useRef(multiple);
+  useEffect(() => {
+    if (prevMultiple.current === multiple) {
+      return;
+    }
+    prevMultiple.current = multiple;
+
+    if (!multiple && selectedValues.length > 1) {
+      isInternalChange.current = true;
+      setSelectedValues([selectedValues[0]]);
+      onChange?.(selectedValues[0]);
+      return;
+    }
+    if (selectedValues.length > 0) {
+      isInternalChange.current = true;
+      onChange?.(multiple ? [selectedValues[0]] : selectedValues[0]);
+    }
+  }, [multiple]);
+
   return {
     selectedValues,
     isPopoverOpen,


### PR DESCRIPTION
## Ticket
https://trello.com/c/73OWlp1E/827-fix-issue-where-multiple-selected-items-persist-in-the-single-select-field

## Description
- Should the field show only the first element selected when change from multi select to single select.