### PR TITLE
feat(scalars): replace sidebar resizing callback with event listeners

### DIFF
--- a/packages/design-system/src/scalars/components/sidebar/sidebar.stories.tsx
+++ b/packages/design-system/src/scalars/components/sidebar/sidebar.stories.tsx
@@ -1,9 +1,10 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Sidebar } from "./sidebar";
 import { Icon } from "@/powerhouse";
-import { SidebarProvider } from "./subcomponents/sidebar-provider";
+import { SidebarProvider, useSidebar } from "./subcomponents/sidebar-provider";
 import mockedTree from "./mocked_tree.json";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { SidebarNode } from "./types";
 
 /**
@@ -43,6 +44,37 @@ import { SidebarNode } from "./types";
  *
  * The `icon` and `expandedIcon` properties are optional and can be used to display an icon in the sidebar item.
  * This icons must be one of the [available icons](?path=/docs/powerhouse-iconography--readme)
+ *
+ * ## Sidebar Events
+ *
+ * The `Sidebar` component emits the following custom events:
+ *
+ * - `sidebar:resize:start`: it is triggered when the sidebar resize starts at the moment the user clicks down in the resizing handle.
+ *  - Data: `{ isSidebarOpen: boolean }`
+ * - `sidebar:resize:active`: it is triggered when the sidebar is being resized while the user is dragging the resizing handle.
+ * It could be triggered multiple times while the user is dragging the resizing handle.
+ *  - Data: `{ isSidebarOpen: boolean, sidebarWidth: number }`
+ * - `sidebar:resize`: it is triggered when the sidebar resize stops at the moment the user releases the resizing handle.
+ *  - Data: `{ isSidebarOpen: boolean, sidebarWidth: number }`
+ * - `sidebar:resize:toggle`: it is triggered when the sidebar is toggled (collapsed or expanded).
+ *  - Data: `{ isSidebarOpen: boolean }`
+ *
+ * ### Example of listening to the events
+ * ```
+ * useEffect(() => {
+ *   const onResize = (event: Event) => {
+ *     console.log("sidebar:resize", event);
+ *   };
+ *
+ *   // you can add the listener directly to the document or add a
+ *   // `className`, get the sidebar element and add the listener to it.
+ *   document.addEventListener("sidebar:resize", onResize);
+ *
+ *   return () => {
+ *     document.removeEventListener("sidebar:resize", onResize);
+ *   };
+ * }, []);
+ * ```
  */
 const meta: Meta<typeof Sidebar> = {
   title: "Document Engineering/Complex Components/Sidebar",
@@ -143,14 +175,6 @@ const meta: Meta<typeof Sidebar> = {
       control: "number",
       description: "The maximum width of the sidebar.",
     },
-    onWidthChange: {
-      control: "object",
-      description:
-        "A callback function that is called when the width of the sidebar changes.",
-      table: {
-        readonly: true,
-      },
-    },
   },
   args: {
     sidebarTitle: "Title Sidebar",
@@ -162,9 +186,6 @@ const meta: Meta<typeof Sidebar> = {
     enableMacros: 4,
     onActiveNodeChange: (node) => {
       console.log("onActiveNodeChange", node);
-    },
-    onWidthChange: (width) => {
-      console.log("onWidthChange", width);
     },
   },
 };
@@ -184,13 +205,58 @@ export const WithinLayoutAndContent: Story = {
     showStatusFilter: true,
   },
   render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const [activeNode, setActiveNode] = useState<string>(
       "4281ab93-ef4f-4974-988d-7dad149a693d",
     );
+
+    // useEffect(() => {
+    //   const sidebarElement = document.querySelector(".sidebar");
+    //   console.log("sidebarElement", sidebarElement);
+    //   if (sidebarElement) {
+    //     document.addEventListener("sidebar:resize", (event) => {
+    //       console.log("sidebar:resize", event);
+    //     });
+    //     document.addEventListener("sidebar:resize:start", (event) => {
+    //       console.log("sidebar:resize:start", event);
+    //     });
+    //     document.addEventListener("sidebar:resize:active", (event) => {
+    //       console.log("sidebar:resize:active", event);
+    //     });
+    //     document.addEventListener("sidebar:resize:toggle", (event) => {
+    //       console.log("sidebar:resize:toggle", event);
+    //     });
+    //   }
+    //   return () => {
+    //     if (sidebarElement) {
+    //       document.removeEventListener("sidebar:resize", (event) => {
+    //         console.log("sidebar:resize", event);
+    //       });
+    //       document.removeEventListener("sidebar:resize:start", (event) => {
+    //         console.log("sidebar:resize:start", event);
+    //       });
+    //       document.removeEventListener("sidebar:resize:active", (event) => {
+    //         console.log("sidebar:resize:active", event);
+    //       });
+    //       document.removeEventListener("sidebar:resize:toggle", (event) => {
+    //         console.log("sidebar:resize:toggle", event);
+    //       });
+    //     }
+    //   };
+    // }, []);
+    useEffect(() => {
+      const onResize = (event: Event) => {
+        console.log("sidebar:resize", event);
+      };
+      document.addEventListener("sidebar:resize", onResize);
+      return () => {
+        document.removeEventListener("sidebar:resize", onResize);
+      };
+    }, []);
+
     return (
       <main className="flex h-svh w-full">
         <Sidebar
+          className="sidebar"
           {...args}
           onActiveNodeChange={(node) => setActiveNode(node.id)}
           activeNodeId={activeNode}

--- a/packages/design-system/src/scalars/components/sidebar/sidebar.stories.tsx
+++ b/packages/design-system/src/scalars/components/sidebar/sidebar.stories.tsx
@@ -209,50 +209,6 @@ export const WithinLayoutAndContent: Story = {
       "4281ab93-ef4f-4974-988d-7dad149a693d",
     );
 
-    // useEffect(() => {
-    //   const sidebarElement = document.querySelector(".sidebar");
-    //   console.log("sidebarElement", sidebarElement);
-    //   if (sidebarElement) {
-    //     document.addEventListener("sidebar:resize", (event) => {
-    //       console.log("sidebar:resize", event);
-    //     });
-    //     document.addEventListener("sidebar:resize:start", (event) => {
-    //       console.log("sidebar:resize:start", event);
-    //     });
-    //     document.addEventListener("sidebar:resize:active", (event) => {
-    //       console.log("sidebar:resize:active", event);
-    //     });
-    //     document.addEventListener("sidebar:resize:toggle", (event) => {
-    //       console.log("sidebar:resize:toggle", event);
-    //     });
-    //   }
-    //   return () => {
-    //     if (sidebarElement) {
-    //       document.removeEventListener("sidebar:resize", (event) => {
-    //         console.log("sidebar:resize", event);
-    //       });
-    //       document.removeEventListener("sidebar:resize:start", (event) => {
-    //         console.log("sidebar:resize:start", event);
-    //       });
-    //       document.removeEventListener("sidebar:resize:active", (event) => {
-    //         console.log("sidebar:resize:active", event);
-    //       });
-    //       document.removeEventListener("sidebar:resize:toggle", (event) => {
-    //         console.log("sidebar:resize:toggle", event);
-    //       });
-    //     }
-    //   };
-    // }, []);
-    useEffect(() => {
-      const onResize = (event: Event) => {
-        console.log("sidebar:resize", event);
-      };
-      document.addEventListener("sidebar:resize", onResize);
-      return () => {
-        document.removeEventListener("sidebar:resize", onResize);
-      };
-    }, []);
-
     return (
       <main className="flex h-svh w-full">
         <Sidebar

--- a/packages/design-system/src/scalars/components/sidebar/sidebar.tsx
+++ b/packages/design-system/src/scalars/components/sidebar/sidebar.tsx
@@ -76,10 +76,6 @@ export interface SidebarProps {
    */
   maxWidth?: number;
   /**
-   * A callback function that is called when the width of the sidebar changes.
-   */
-  onWidthChange?: (width: number) => void;
-  /**
    * Optional className for the sidebar container
    */
   className?: string;
@@ -100,7 +96,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
   extraFooterContent,
   initialWidth = 300,
   maxWidth,
-  onWidthChange,
   className,
 }) => {
   const {
@@ -113,7 +108,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
     defaultWidth: initialWidth,
     minWidth: 220,
     maxWidth,
-    onWidthChange,
   });
 
   const {

--- a/packages/design-system/src/scalars/components/sidebar/use-sidebar-resize.ts
+++ b/packages/design-system/src/scalars/components/sidebar/use-sidebar-resize.ts
@@ -1,19 +1,18 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { triggerEvent } from "./utils";
 
 interface SidebarResizeProps {
   defaultWidth?: number;
   minWidth?: number;
   maxWidth?: number;
-  onWidthChange?: (width: number) => void;
 }
 
 export const useSidebarResize = ({
   defaultWidth = 300,
   minWidth = 100,
   maxWidth,
-  onWidthChange,
 }: SidebarResizeProps) => {
   const [isResizing, setIsResizing] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(
@@ -25,6 +24,12 @@ export const useSidebarResize = ({
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const handleToggleSidebar = useCallback(() => {
     setIsSidebarOpen(!isSidebarOpen);
+    // trigger event
+    triggerEvent(
+      "sidebar:resize:toggle",
+      { isSidebarOpen: !isSidebarOpen },
+      sidebarRef.current,
+    );
   }, [isSidebarOpen]);
 
   useEffect(() => {
@@ -38,13 +43,29 @@ export const useSidebarResize = ({
   const startResizing = useCallback(() => {
     if (isSidebarOpen) {
       setIsResizing(true);
+      // trigger event
+      triggerEvent(
+        "sidebar:resize:start",
+        {
+          isSidebarOpen,
+        },
+        sidebarRef.current,
+      );
     }
-  }, [isSidebarOpen]);
+  }, [isSidebarOpen, sidebarWidth]);
 
   const stopResizing = useCallback(() => {
     setIsResizing(false);
-    onWidthChange?.(isSidebarOpen ? sidebarWidth : 8);
-  }, [isSidebarOpen, sidebarWidth, onWidthChange]);
+    // trigger event
+    triggerEvent(
+      "sidebar:resize",
+      {
+        isSidebarOpen,
+        sidebarWidth: isSidebarOpen ? sidebarWidth : 8,
+      },
+      sidebarRef.current,
+    );
+  }, [isSidebarOpen, sidebarWidth]);
 
   const resize = useCallback(
     (mouseMoveEvent: MouseEvent) => {
@@ -61,9 +82,18 @@ export const useSidebarResize = ({
         }
 
         setSidebarWidth(newWidth);
+        // trigger event
+        triggerEvent(
+          "sidebar:resize:active",
+          {
+            isSidebarOpen,
+            sidebarWidth: newWidth,
+          },
+          sidebarRef.current,
+        );
       }
     },
-    [isResizing, minWidth, maxWidth],
+    [isResizing, minWidth, maxWidth, isSidebarOpen],
   );
 
   useEffect(() => {

--- a/packages/design-system/src/scalars/components/sidebar/utils.ts
+++ b/packages/design-system/src/scalars/components/sidebar/utils.ts
@@ -197,3 +197,18 @@ export const filterStatuses = (
     return filteredNodes;
   }, []);
 };
+
+// event listener
+export const triggerEvent = (
+  eventType: string,
+  data: unknown,
+  element: HTMLElement | Document | null = document,
+) => {
+  const event = new CustomEvent(eventType, {
+    detail: data,
+    bubbles: true,
+    cancelable: false,
+  });
+  if (!element) element = document;
+  element.dispatchEvent(event);
+};


### PR DESCRIPTION
## Ticket
https://trello.com/c/krAwOShg/830-sidebar-high-priorities-tasks

## Description
- The `onWidthChange` callback was replaced with several events that can be listened to from anywhere in the app without the need to pass callbacks to the sidebar
- A proper documentation was added to the sidebar readme