### PR TITLE
feat(scalars): add supportedNetworks config and validation

### DIFF
--- a/packages/design-system/src/scalars/components/aid-field/aid-field.tsx
+++ b/packages/design-system/src/scalars/components/aid-field/aid-field.tsx
@@ -151,7 +151,20 @@ export const AIDField = withFieldValidation<AIDFieldProps>(AIDFieldRaw, {
           return true;
         }
 
-        // TODO: add validation
+        // Validate supportedNetworks if present
+        const chainIdMatch = /^did:ethr:(0x[0-9a-fA-F]+):.+$/.exec(value);
+        if (
+          chainIdMatch &&
+          Array.isArray(supportedNetworks) &&
+          supportedNetworks.length > 0
+        ) {
+          const chainId = chainIdMatch[1];
+          if (
+            !supportedNetworks.some((network) => network.chainId === chainId)
+          ) {
+            return `Invalid chainId. Allowed chainIds are: ${supportedNetworks.map((network) => network.chainId).join(", ")}`;
+          }
+        }
 
         return true;
       },

--- a/packages/design-system/src/scalars/components/aid-field/types.ts
+++ b/packages/design-system/src/scalars/components/aid-field/types.ts
@@ -1,5 +1,10 @@
 import type { AutocompleteProps } from "@/scalars/components/fragments/autocomplete-field/types";
 
+export interface Network {
+  chainId: string;
+  name?: string;
+}
+
 export type AIDProps = Omit<AutocompleteProps, "renderOption"> & {
-  supportedNetworks?: string[]; // TODO: add configs
+  supportedNetworks?: Network[];
 };

--- a/packages/design-system/src/scalars/components/aid-field/utils.ts
+++ b/packages/design-system/src/scalars/components/aid-field/utils.ts
@@ -1,0 +1,45 @@
+import { AutocompleteOption } from "@/scalars/components/fragments/autocomplete-field/types";
+
+export const mockedOptions: AutocompleteOption[] = [
+  {
+    icon: "Person",
+    title: "Agent A",
+    path: "agents/agent-a",
+    value: "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+    description: "Agent A description",
+  },
+  {
+    icon: "Person",
+    title: "Agent B",
+    path: "agents/agent-b",
+    value: "did:ethr:0x5:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+    description: "Agent B description",
+  },
+  {
+    icon: "Person",
+    title: "Agent C",
+    path: "agents/agent-c",
+    value: "did:ethr:0x89:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+    description: "Agent C description",
+  },
+];
+
+export const fetchOptions = async (): Promise<AutocompleteOption[]> => {
+  // Simulate 2s network delay
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  // Add 30% chance of error
+  if (Math.random() < 0.3) {
+    throw new Error();
+  }
+
+  return mockedOptions;
+};
+
+export const fetchSelectedOption = async (
+  value: string,
+): Promise<AutocompleteOption | undefined> => {
+  // Simulate 2s network delay
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  return mockedOptions.find((option) => option.value === value);
+};

--- a/packages/design-system/src/scalars/docs/getting-started.mdx
+++ b/packages/design-system/src/scalars/docs/getting-started.mdx
@@ -36,6 +36,8 @@ pnpm add @powerhousedao/design-system react-hook-form
 - [AmountField](?path=/docs/document-engineering-simple-components-amount-field--readme)
 - [CountryCodeField](?path=/docs/document-engineering-simple-components-country-code-field--readme)
 - [PHIDField](?path=/docs/document-engineering-simple-components-phid-field--readme)
+  - [AutocompleteField](?path=/docs/document-engineering-fragments-autocomplete-field--readme)
+- [AIDField](?path=/docs/document-engineering-simple-components-aid-field--readme)
 - [DatePickerField](?path=/docs/document-engineering-simple-components-date-picker-field--readme)
 - [TimePickerField](?path=/docs/document-engineering-simple-components-time-picker-field--readme)
 - *CurrencyCodeField (Coming soon)*


### PR DESCRIPTION
## Ticket
https://trello.com/c/ET3Uf7pc/789-7-aid-ethereum-dids

## Description
- Should set the supportedNetworks as an Array of objects.
- Should the supported network inserted be set in the supportedNetworks prop.