### PR TITLE
feat(scalars): add default, empty story variants, base tests & rename Autocomplete to IdAutocomplete

### DIFF
--- a/packages/design-system/src/scalars/components/aid-field/__snapshots__/aid-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/aid-field/__snapshots__/aid-field.test.tsx.snap
@@ -1,0 +1,58 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AIDField Component > should match snapshot 1`] = `
+<DocumentFragment>
+  <form
+    id=":r0:"
+    novalidate=""
+  >
+    <div
+      class="flex flex-col gap-2"
+    >
+      <label
+        class="inline-flex items-center text-sm font-medium leading-4 text-gray-900 dark:text-gray-50 mb-[3px]"
+        for=":r1:-aid"
+      >
+        AID Field
+      </label>
+      <div
+        class="flex size-full flex-col rounded-md [&_[cmdk-label]]:hidden dark:bg-charcoal-900 bg-gray-100"
+        cmdk-root=""
+        tabindex="-1"
+      >
+        <label
+          cmdk-label=""
+          for="radix-:r6:"
+          id="radix-:r5:"
+          style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"
+        />
+        <div
+          class="group relative"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-controls="radix-:r4:"
+            aria-expanded="false"
+            aria-invalid="false"
+            aria-labelledby="radix-:r5:"
+            autocomplete="off"
+            autocorrect="off"
+            class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-white disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-9"
+            cmdk-input=""
+            id=":r1:-aid"
+            name="aid"
+            placeholder="did:ethr:"
+            role="combobox"
+            spellcheck="false"
+            type="text"
+            value=""
+          />
+          <div
+            class="absolute right-3 top-1/2 flex size-4 -translate-y-1/2 items-center pointer-events-none"
+          />
+        </div>
+      </div>
+    </div>
+  </form>
+</DocumentFragment>
+`;

--- a/packages/design-system/src/scalars/components/aid-field/aid-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/aid-field/aid-field.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { withForm } from "@/scalars/lib/decorators";
-import { AutocompleteField } from "./autocomplete-field";
-import { mockedOptions, fetchOptions, fetchSelectedOption } from "./utils";
+import { AIDField } from "./aid-field";
+import { fetchOptions, fetchSelectedOption } from "./utils";
 import {
   getDefaultArgTypes,
   getValidationArgTypes,
@@ -9,9 +9,9 @@ import {
   StorybookControlCategory,
 } from "@/scalars/lib/storybook-arg-types";
 
-const meta: Meta<typeof AutocompleteField> = {
-  title: "Document Engineering/Fragments/Autocomplete Field",
-  component: AutocompleteField,
+const meta: Meta<typeof AIDField> = {
+  title: "Document Engineering/Simple Components/AID Field",
+  component: AIDField,
   decorators: [
     withForm,
     (Story) => (
@@ -28,6 +28,16 @@ const meta: Meta<typeof AutocompleteField> = {
     ...getDefaultArgTypes(),
     ...PrebuiltArgTypes.placeholder,
     ...PrebuiltArgTypes.maxLength,
+
+    supportedNetworks: {
+      control: "object",
+      description:
+        "List of supported networks for DID validation. Each network must have a chainId (string) and optional name (string).",
+      table: {
+        type: { summary: "Network[]" },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+    },
 
     autoComplete: {
       control: "boolean",
@@ -52,7 +62,7 @@ const meta: Meta<typeof AutocompleteField> = {
         "description?: string\n\n",
       table: {
         type: {
-          summary: "(userInput: string) => Promise<AutocompleteOption[]>",
+          summary: "(userInput: string) => Promise<IdAutocompleteOption[]>",
         },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
         readonly: true,
@@ -73,7 +83,8 @@ const meta: Meta<typeof AutocompleteField> = {
         "or undefined if the option is not found",
       table: {
         type: {
-          summary: "(value: string) => Promise<AutocompleteOption | undefined>",
+          summary:
+            "(value: string) => Promise<IdAutocompleteOption | undefined>",
         },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
         readonly: true,
@@ -101,49 +112,21 @@ const meta: Meta<typeof AutocompleteField> = {
       if: { arg: "autoComplete", neq: false },
     },
 
-    renderOption: {
-      control: "object",
-      description:
-        "Custom render function for autocomplete options. " +
-        "Receives the option object and an optional displayProps object with the following properties:\n\n" +
-        "asPlaceholder?: boolean\n\n" +
-        "showValue?: boolean\n\n" +
-        "isLoadingSelectedOption?: boolean\n\n" +
-        "handleFetchSelectedOption?: (value: string) => void\n\n" +
-        "className?: string\n\n" +
-        "Must return a ReactNode.",
-      table: {
-        type: {
-          summary:
-            "(option: AutocompleteOption, displayProps?: {\n" +
-            "  asPlaceholder?: boolean,\n" +
-            "  showValue?: boolean,\n" +
-            "  isLoadingSelectedOption?: boolean,\n" +
-            "  handleFetchSelectedOption?: (value: string) => void,\n" +
-            "  className?: string\n" +
-            "}) => React.ReactNode",
-        },
-        category: StorybookControlCategory.COMPONENT_SPECIFIC,
-        readonly: true,
-      },
-      if: { arg: "autoComplete", neq: false },
-    },
-
     ...getValidationArgTypes(),
   },
   args: {
-    name: "autocomplete-field",
+    name: "aid-field",
   },
-} satisfies Meta<typeof AutocompleteField>;
+} satisfies Meta<typeof AIDField>;
 
 export default meta;
 
-type Story = StoryObj<typeof AutocompleteField>;
+type Story = StoryObj<typeof AIDField>;
 
 export const Default: Story = {
   args: {
-    label: "Autocomplete field",
-    placeholder: "Search...",
+    label: "AID field",
+    placeholder: "did:ethr:",
     fetchOptionsCallback: fetchOptions,
     fetchSelectedOptionCallback: fetchSelectedOption,
   },
@@ -151,35 +134,10 @@ export const Default: Story = {
 
 export const Empty: Story = {
   args: {
-    label: "Autocomplete field",
-    placeholder: "Search...",
+    label: "AID field",
+    placeholder: "did:ethr:",
     isOpenByDefault: true,
-    defaultValue: "with no matching options",
-    variant: "withValueTitleAndDescription",
-    fetchOptionsCallback: fetchOptions,
-    fetchSelectedOptionCallback: fetchSelectedOption,
-  },
-};
-
-export const Open: Story = {
-  args: {
-    label: "Autocomplete field",
-    placeholder: "Search...",
-    isOpenByDefault: true,
-    defaultValue: "with matching options",
-    initialOptions: mockedOptions,
-    variant: "withValueTitleAndDescription",
-    fetchOptionsCallback: fetchOptions,
-    fetchSelectedOptionCallback: fetchSelectedOption,
-  },
-};
-
-export const Filled: Story = {
-  args: {
-    label: "Autocomplete field",
-    placeholder: "Search...",
-    defaultValue: mockedOptions[0].value,
-    initialOptions: mockedOptions,
+    defaultValue: "did:ethr:",
     variant: "withValueTitleAndDescription",
     fetchOptionsCallback: fetchOptions,
     fetchSelectedOptionCallback: fetchSelectedOption,

--- a/packages/design-system/src/scalars/components/aid-field/aid-field.test.tsx
+++ b/packages/design-system/src/scalars/components/aid-field/aid-field.test.tsx
@@ -138,6 +138,7 @@ describe("AIDField Component", () => {
 
     const input = screen.getByRole("combobox");
     await user.click(input);
+    await user.clear(input);
     await user.type(input, "test");
 
     await waitFor(() => {

--- a/packages/design-system/src/scalars/components/aid-field/aid-field.test.tsx
+++ b/packages/design-system/src/scalars/components/aid-field/aid-field.test.tsx
@@ -1,0 +1,279 @@
+import { describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithForm } from "@/scalars/lib/testing";
+import { AIDField } from "./aid-field";
+
+describe("AIDField Component", () => {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  window.Element.prototype.scrollTo = vi.fn();
+  window.matchMedia = vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query as string,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+
+  const mockedOptions = [
+    {
+      icon: "Person",
+      title: "Agent A",
+      path: "agents/agent-a",
+      value: "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+      description: "Agent A description",
+    },
+    {
+      icon: "Person",
+      title: "Agent B",
+      path: "agents/agent-b",
+      value: "did:ethr:0x5:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+      description: "Agent B description",
+    },
+  ];
+
+  const defaultGetOptions = vi.fn().mockResolvedValue(mockedOptions);
+  const defaultGetSelectedOption = vi
+    .fn()
+    .mockImplementation((value: string) => {
+      return mockedOptions.find((option) => option.value === value);
+    });
+
+  it("should match snapshot", () => {
+    const { asFragment } = renderWithForm(
+      <AIDField
+        name="aid"
+        label="AID Field"
+        placeholder="did:ethr:"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("should render with label", () => {
+    renderWithForm(
+      <AIDField
+        name="aid"
+        label="Test Label"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />,
+    );
+    expect(screen.getByText("Test Label")).toBeInTheDocument();
+  });
+
+  it("should render with description", () => {
+    renderWithForm(
+      <AIDField
+        name="aid"
+        label="Test Label"
+        description="Test Description"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />,
+    );
+    expect(screen.getByText("Test Description")).toBeInTheDocument();
+  });
+
+  it("should handle disabled state", () => {
+    renderWithForm(
+      <AIDField
+        name="aid"
+        label="Test Label"
+        disabled
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />,
+    );
+    expect(screen.getByRole("combobox")).toBeDisabled();
+  });
+
+  it("should display error messages", async () => {
+    renderWithForm(
+      <AIDField
+        name="aid"
+        label="Test Label"
+        errors={["Invalid AID format"]}
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Invalid AID format")).toBeInTheDocument(),
+    );
+  });
+
+  it("should display warning messages", () => {
+    renderWithForm(
+      <AIDField
+        name="aid"
+        label="Test Label"
+        warnings={["AID may be deprecated"]}
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />,
+    );
+    expect(screen.getByText("AID may be deprecated")).toBeInTheDocument();
+  });
+
+  it("should show autocomplete options", async () => {
+    const user = userEvent.setup();
+    const originalRandom = Math.random;
+    Math.random = vi.fn().mockReturnValue(1);
+
+    renderWithForm(
+      <AIDField
+        name="aid"
+        label="Test Label"
+        variant="withValueTitleAndDescription"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />,
+    );
+
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.type(input, "test");
+
+    await waitFor(() => {
+      expect(defaultGetOptions).toHaveBeenCalledWith("test");
+    });
+
+    await waitFor(() => {
+      expect(input).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getByText(mockedOptions[0].title)).toBeInTheDocument();
+      expect(screen.getByText(mockedOptions[1].title)).toBeInTheDocument();
+    });
+
+    Math.random = originalRandom;
+  });
+
+  it("should have correct ARIA attributes", async () => {
+    renderWithForm(
+      <AIDField
+        name="aid"
+        label="Test Label"
+        required
+        errors={["Error message"]}
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />,
+    );
+
+    const input = screen.getByRole("combobox");
+    expect(input).toHaveAttribute("aria-required", "true");
+    await waitFor(() => expect(input).toHaveAttribute("aria-invalid", "true"));
+    expect(input).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("should show correct placeholders for different variants", () => {
+    const { rerender } = renderWithForm(
+      <AIDField
+        name="aid"
+        label="Test Label"
+        variant="withValueTitleAndDescription"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />,
+    );
+
+    expect(screen.getByText("Title not available")).toBeInTheDocument();
+    expect(screen.getByText("Path not available")).toBeInTheDocument();
+    expect(screen.getByText("Description not available")).toBeInTheDocument();
+
+    rerender(
+      <AIDField
+        name="aid"
+        label="Test Label"
+        variant="withValueAndTitle"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />,
+    );
+
+    expect(screen.getByText("Title not available")).toBeInTheDocument();
+    expect(screen.queryByText("Path not available")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Description not available"),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <AIDField
+        name="aid"
+        label="Test Label"
+        variant="withValue"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />,
+    );
+
+    expect(screen.queryByText("Title not available")).not.toBeInTheDocument();
+    expect(screen.queryByText("Path not available")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Description not available"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should handle autoComplete disabled", () => {
+    renderWithForm(
+      <AIDField name="aid" label="Test Label" autoComplete={false} />,
+    );
+
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("should handle value changes and auto selection", async () => {
+    const user = userEvent.setup();
+    const originalRandom = Math.random;
+    Math.random = vi.fn().mockReturnValue(1);
+
+    renderWithForm(
+      <AIDField
+        name="aid"
+        label="Test Label"
+        variant="withValueTitleAndDescription"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />,
+    );
+
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.type(input, mockedOptions[0].value);
+
+    await waitFor(() => {
+      expect(input).toHaveAttribute("aria-expanded", "false");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(mockedOptions[0].title)).toBeInTheDocument();
+      expect(screen.getByText(mockedOptions[0].path)).toBeInTheDocument();
+      expect(
+        screen.getByText(mockedOptions[0].description),
+      ).toBeInTheDocument();
+    });
+
+    Math.random = originalRandom;
+  });
+
+  it("should not invoke onChange on mount when it has a defaultValue", () => {
+    const onChange = vi.fn();
+    renderWithForm(
+      <AIDField
+        name="aid"
+        label="Test Label"
+        defaultValue={mockedOptions[0].value}
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+        onChange={onChange}
+      />,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/design-system/src/scalars/components/aid-field/aid-field.tsx
+++ b/packages/design-system/src/scalars/components/aid-field/aid-field.tsx
@@ -1,14 +1,14 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { useId, useCallback } from "react";
-import { AutocompleteFieldRaw } from "@/scalars/components/fragments/autocomplete-field";
-import { AutocompleteListOption } from "@/scalars/components/fragments/autocomplete-field/autocomplete-list-option";
+import { IdAutocompleteFieldRaw } from "@/scalars/components/fragments/id-autocomplete-field";
+import { IdAutocompleteListOption } from "@/scalars/components/fragments/id-autocomplete-field/id-autocomplete-list-option";
 import { withFieldValidation } from "@/scalars/components/fragments/with-field-validation";
 import type {
   FieldCommonProps,
   ErrorHandling,
 } from "@/scalars/components/types";
 import type { AIDProps } from "./types";
-import type { AutocompleteOption } from "@/scalars/components/fragments/autocomplete-field/types";
+import type { IdAutocompleteOption } from "@/scalars/components/fragments/id-autocomplete-field/types";
 
 type AIDFieldBaseProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -60,7 +60,7 @@ const AIDFieldRaw = React.forwardRef<HTMLInputElement, AIDFieldProps>(
 
     const renderOption = useCallback(
       (
-        option: AutocompleteOption,
+        option: IdAutocompleteOption,
         displayProps?: {
           asPlaceholder?: boolean;
           showValue?: boolean;
@@ -69,17 +69,19 @@ const AIDFieldRaw = React.forwardRef<HTMLInputElement, AIDFieldProps>(
           className?: string;
         },
       ) => (
-        <AutocompleteListOption
+        <IdAutocompleteListOption
           variant={variant}
           icon={option.icon}
           title={option.title}
           path={option.path}
           value={
+            displayProps?.asPlaceholder &&
             option.value === "value not available"
-              ? "aid not available"
+              ? "did not available"
               : option.value
           }
           description={option.description}
+          placeholderIcon="Person"
           {...displayProps}
         />
       ),
@@ -87,7 +89,7 @@ const AIDFieldRaw = React.forwardRef<HTMLInputElement, AIDFieldProps>(
     );
 
     return autoComplete && fetchOptionsCallback ? (
-      <AutocompleteFieldRaw
+      <IdAutocompleteFieldRaw
         id={id}
         name={name}
         className={className}
@@ -116,7 +118,7 @@ const AIDFieldRaw = React.forwardRef<HTMLInputElement, AIDFieldProps>(
         ref={ref}
       />
     ) : (
-      <AutocompleteFieldRaw
+      <IdAutocompleteFieldRaw
         id={id}
         name={name}
         className={className}

--- a/packages/design-system/src/scalars/components/aid-field/types.ts
+++ b/packages/design-system/src/scalars/components/aid-field/types.ts
@@ -1,10 +1,10 @@
-import type { AutocompleteProps } from "@/scalars/components/fragments/autocomplete-field/types";
+import type { IdAutocompleteProps } from "@/scalars/components/fragments/id-autocomplete-field/types";
 
 export interface Network {
   chainId: string;
   name?: string;
 }
 
-export type AIDProps = Omit<AutocompleteProps, "renderOption"> & {
+export type AIDProps = Omit<IdAutocompleteProps, "renderOption"> & {
   supportedNetworks?: Network[];
 };

--- a/packages/design-system/src/scalars/components/aid-field/utils.ts
+++ b/packages/design-system/src/scalars/components/aid-field/utils.ts
@@ -1,6 +1,6 @@
-import { AutocompleteOption } from "@/scalars/components/fragments/autocomplete-field/types";
+import { IdAutocompleteOption } from "@/scalars/components/fragments/id-autocomplete-field/types";
 
-export const mockedOptions: AutocompleteOption[] = [
+export const mockedOptions: IdAutocompleteOption[] = [
   {
     icon: "Person",
     title: "Agent A",
@@ -24,7 +24,7 @@ export const mockedOptions: AutocompleteOption[] = [
   },
 ];
 
-export const fetchOptions = async (): Promise<AutocompleteOption[]> => {
+export const fetchOptions = async (): Promise<IdAutocompleteOption[]> => {
   // Simulate 2s network delay
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
@@ -38,7 +38,7 @@ export const fetchOptions = async (): Promise<AutocompleteOption[]> => {
 
 export const fetchSelectedOption = async (
   value: string,
-): Promise<AutocompleteOption | undefined> => {
+): Promise<IdAutocompleteOption | undefined> => {
   // Simulate 2s network delay
   await new Promise((resolve) => setTimeout(resolve, 2000));
   return mockedOptions.find((option) => option.value === value);

--- a/packages/design-system/src/scalars/components/fragments/autocomplete-field/index.ts
+++ b/packages/design-system/src/scalars/components/fragments/autocomplete-field/index.ts
@@ -1,1 +1,0 @@
-export * from "./autocomplete-field";

--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/__snapshots__/id-autocomplete-field.test.tsx.snap
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/__snapshots__/id-autocomplete-field.test.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`AutocompleteField Component > should match snapshot 1`] = `
+exports[`IdAutocompleteField Component > should match snapshot 1`] = `
 <DocumentFragment>
   <form
     id=":r0:"
@@ -11,9 +11,9 @@ exports[`AutocompleteField Component > should match snapshot 1`] = `
     >
       <label
         class="inline-flex items-center text-sm font-medium leading-4 text-gray-900 dark:text-gray-50 mb-[3px]"
-        for=":r1:-autocomplete"
+        for=":r1:-id-autocomplete"
       >
-        Autocomplete Field
+        Id Autocomplete Field
       </label>
       <div
         class="flex size-full flex-col rounded-md [&_[cmdk-label]]:hidden dark:bg-charcoal-900 bg-gray-100"
@@ -39,8 +39,8 @@ exports[`AutocompleteField Component > should match snapshot 1`] = `
             autocorrect="off"
             class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-white disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-9"
             cmdk-input=""
-            id=":r1:-autocomplete"
-            name="autocomplete"
+            id=":r1:-id-autocomplete"
+            name="id-autocomplete"
             placeholder="Search..."
             role="combobox"
             spellcheck="false"

--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/id-autocomplete-field.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/id-autocomplete-field.test.tsx
@@ -138,6 +138,7 @@ describe("IdAutocompleteField Component", () => {
 
     const input = screen.getByRole("combobox");
     await user.click(input);
+    await user.clear(input);
     await user.type(input, "test");
 
     await waitFor(() => {

--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/id-autocomplete-field.test.tsx
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/id-autocomplete-field.test.tsx
@@ -2,9 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithForm } from "@/scalars/lib/testing";
-import { AutocompleteField } from "./autocomplete-field";
+import { IdAutocompleteField } from "./id-autocomplete-field";
 
-describe("AutocompleteField Component", () => {
+describe("IdAutocompleteField Component", () => {
   window.HTMLElement.prototype.scrollIntoView = vi.fn();
   window.Element.prototype.scrollTo = vi.fn();
   window.matchMedia = vi.fn().mockImplementation((query) => ({
@@ -44,9 +44,9 @@ describe("AutocompleteField Component", () => {
 
   it("should match snapshot", () => {
     const { asFragment } = renderWithForm(
-      <AutocompleteField
-        name="autocomplete"
-        label="Autocomplete Field"
+      <IdAutocompleteField
+        name="id-autocomplete"
+        label="Id Autocomplete Field"
         placeholder="Search..."
         fetchOptionsCallback={defaultGetOptions}
         fetchSelectedOptionCallback={defaultGetSelectedOption}
@@ -57,8 +57,8 @@ describe("AutocompleteField Component", () => {
 
   it("should render with label", () => {
     renderWithForm(
-      <AutocompleteField
-        name="autocomplete"
+      <IdAutocompleteField
+        name="id-autocomplete"
         label="Test Label"
         fetchOptionsCallback={defaultGetOptions}
         fetchSelectedOptionCallback={defaultGetSelectedOption}
@@ -69,8 +69,8 @@ describe("AutocompleteField Component", () => {
 
   it("should render with description", () => {
     renderWithForm(
-      <AutocompleteField
-        name="autocomplete"
+      <IdAutocompleteField
+        name="id-autocomplete"
         label="Test Label"
         description="Test Description"
         fetchOptionsCallback={defaultGetOptions}
@@ -82,8 +82,8 @@ describe("AutocompleteField Component", () => {
 
   it("should handle disabled state", () => {
     renderWithForm(
-      <AutocompleteField
-        name="autocomplete"
+      <IdAutocompleteField
+        name="id-autocomplete"
         label="Test Label"
         disabled
         fetchOptionsCallback={defaultGetOptions}
@@ -95,8 +95,8 @@ describe("AutocompleteField Component", () => {
 
   it("should display error messages", async () => {
     renderWithForm(
-      <AutocompleteField
-        name="autocomplete"
+      <IdAutocompleteField
+        name="id-autocomplete"
         label="Test Label"
         errors={["Invalid format"]}
         fetchOptionsCallback={defaultGetOptions}
@@ -110,8 +110,8 @@ describe("AutocompleteField Component", () => {
 
   it("should display warning messages", () => {
     renderWithForm(
-      <AutocompleteField
-        name="autocomplete"
+      <IdAutocompleteField
+        name="id-autocomplete"
         label="Test Label"
         warnings={["Option may be deprecated"]}
         fetchOptionsCallback={defaultGetOptions}
@@ -127,8 +127,8 @@ describe("AutocompleteField Component", () => {
     Math.random = vi.fn().mockReturnValue(1);
 
     renderWithForm(
-      <AutocompleteField
-        name="autocomplete"
+      <IdAutocompleteField
+        name="id-autocomplete"
         label="Test Label"
         variant="withValueTitleAndDescription"
         fetchOptionsCallback={defaultGetOptions}
@@ -155,8 +155,8 @@ describe("AutocompleteField Component", () => {
 
   it("should have correct ARIA attributes", async () => {
     renderWithForm(
-      <AutocompleteField
-        name="autocomplete"
+      <IdAutocompleteField
+        name="id-autocomplete"
         label="Test Label"
         required
         errors={["Error message"]}
@@ -173,8 +173,8 @@ describe("AutocompleteField Component", () => {
 
   it("should show correct placeholders for different variants", () => {
     const { rerender } = renderWithForm(
-      <AutocompleteField
-        name="autocomplete"
+      <IdAutocompleteField
+        name="id-autocomplete"
         label="Test Label"
         variant="withValueTitleAndDescription"
         fetchOptionsCallback={defaultGetOptions}
@@ -187,8 +187,8 @@ describe("AutocompleteField Component", () => {
     expect(screen.getByText("Description not available")).toBeInTheDocument();
 
     rerender(
-      <AutocompleteField
-        name="autocomplete"
+      <IdAutocompleteField
+        name="id-autocomplete"
         label="Test Label"
         variant="withValueAndTitle"
         fetchOptionsCallback={defaultGetOptions}
@@ -203,8 +203,8 @@ describe("AutocompleteField Component", () => {
     ).not.toBeInTheDocument();
 
     rerender(
-      <AutocompleteField
-        name="autocomplete"
+      <IdAutocompleteField
+        name="id-autocomplete"
         label="Test Label"
         variant="withValue"
         fetchOptionsCallback={defaultGetOptions}
@@ -221,8 +221,8 @@ describe("AutocompleteField Component", () => {
 
   it("should handle autoComplete disabled", () => {
     renderWithForm(
-      <AutocompleteField
-        name="autocomplete"
+      <IdAutocompleteField
+        name="id-autocomplete"
         label="Test Label"
         autoComplete={false}
       />,
@@ -238,8 +238,8 @@ describe("AutocompleteField Component", () => {
     Math.random = vi.fn().mockReturnValue(1);
 
     renderWithForm(
-      <AutocompleteField
-        name="autocomplete"
+      <IdAutocompleteField
+        name="id-autocomplete"
         label="Test Label"
         variant="withValueTitleAndDescription"
         fetchOptionsCallback={defaultGetOptions}
@@ -269,8 +269,8 @@ describe("AutocompleteField Component", () => {
   it("should not invoke onChange on mount when it has a defaultValue", () => {
     const onChange = vi.fn();
     renderWithForm(
-      <AutocompleteField
-        name="autocomplete"
+      <IdAutocompleteField
+        name="id-autocomplete"
         label="Test Label"
         defaultValue={mockedOptions[0].value}
         fetchOptionsCallback={defaultGetOptions}

--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/id-autocomplete-field.tsx
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/id-autocomplete-field.tsx
@@ -19,28 +19,28 @@ import type {
   FieldCommonProps,
   ErrorHandling,
 } from "@/scalars/components/types";
-import type { AutocompleteProps } from "./types";
-import { useAutocompleteField } from "./use-autocomplete-field";
-import { AutocompleteInputContainer } from "./autocomplete-input-container";
-import { AutocompleteList } from "./autocomplete-list";
-import { AutocompleteListOption } from "./autocomplete-list-option";
+import type { IdAutocompleteProps } from "./types";
+import { useIdAutocompleteField } from "./use-id-autocomplete-field";
+import { IdAutocompleteInputContainer } from "./id-autocomplete-input-container";
+import { IdAutocompleteList } from "./id-autocomplete-list";
+import { IdAutocompleteListOption } from "./id-autocomplete-list-option";
 
-type AutocompleteFieldBaseProps = Omit<
+type IdAutocompleteFieldBaseProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
   | keyof FieldCommonProps<string>
   | keyof ErrorHandling
-  | keyof AutocompleteProps
+  | keyof IdAutocompleteProps
   | "pattern"
 >;
 
-export type AutocompleteFieldProps = AutocompleteFieldBaseProps &
+export type IdAutocompleteFieldProps = IdAutocompleteFieldBaseProps &
   FieldCommonProps<string> &
   ErrorHandling &
-  AutocompleteProps;
+  IdAutocompleteProps;
 
-export const AutocompleteFieldRaw = React.forwardRef<
+export const IdAutocompleteFieldRaw = React.forwardRef<
   HTMLInputElement,
-  AutocompleteFieldProps
+  IdAutocompleteFieldProps
 >(
   (
     {
@@ -73,7 +73,7 @@ export const AutocompleteFieldRaw = React.forwardRef<
     ref,
   ) => {
     const prefix = useId();
-    const id = idProp ?? `${prefix}-autocomplete`;
+    const id = idProp ?? `${prefix}-id-autocomplete`;
 
     const hasWarning = Array.isArray(warnings) && warnings.length > 0;
     const hasError = Array.isArray(errors) && errors.length > 0;
@@ -95,7 +95,7 @@ export const AutocompleteFieldRaw = React.forwardRef<
       handleCommandValue,
       handleFetchSelectedOption,
       handlePaste,
-    } = useAutocompleteField({
+    } = useIdAutocompleteField({
       autoComplete,
       defaultValue,
       value,
@@ -136,7 +136,7 @@ export const AutocompleteFieldRaw = React.forwardRef<
               className={cn("dark:bg-charcoal-900 bg-gray-100")}
             >
               <PopoverAnchor asChild={true}>
-                <AutocompleteInputContainer
+                <IdAutocompleteInputContainer
                   id={id}
                   name={name}
                   value={selectedValue}
@@ -182,7 +182,7 @@ export const AutocompleteFieldRaw = React.forwardRef<
                     },
                   )
                 ) : (
-                  <AutocompleteListOption
+                  <IdAutocompleteListOption
                     variant={variant}
                     icon={selectedOption?.icon}
                     title={selectedOption?.title}
@@ -209,7 +209,7 @@ export const AutocompleteFieldRaw = React.forwardRef<
                   }
                 }}
               >
-                <AutocompleteList
+                <IdAutocompleteList
                   variant={variant}
                   commandListRef={commandListRef}
                   selectedValue={selectedValue}
@@ -233,7 +233,7 @@ export const AutocompleteFieldRaw = React.forwardRef<
             onMouseDown={onMouseDown}
             placeholder={placeholder}
             aria-invalid={hasError}
-            aria-label={!label ? "Autocomplete field" : undefined}
+            aria-label={!label ? "Id Autocomplete field" : undefined}
             aria-required={required}
             maxLength={maxLength}
             {...props}
@@ -248,7 +248,7 @@ export const AutocompleteFieldRaw = React.forwardRef<
   },
 );
 
-export const AutocompleteField =
-  withFieldValidation<AutocompleteFieldProps>(AutocompleteFieldRaw);
+export const IdAutocompleteField =
+  withFieldValidation<IdAutocompleteFieldProps>(IdAutocompleteFieldRaw);
 
-AutocompleteField.displayName = "AutocompleteField";
+IdAutocompleteField.displayName = "IdAutocompleteField";

--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/id-autocomplete-input-container.tsx
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/id-autocomplete-input-container.tsx
@@ -8,9 +8,9 @@ import {
   TooltipProvider,
 } from "@/scalars/components/fragments/tooltip";
 import { cn } from "@/scalars/lib/utils";
-import type { AutocompleteOption } from "./types";
+import type { IdAutocompleteOption } from "./types";
 
-interface AutocompleteInputContainerProps {
+interface IdAutocompleteInputContainerProps {
   id: string;
   name: string;
   value: string;
@@ -21,7 +21,7 @@ interface AutocompleteInputContainerProps {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   onClick?: (e: React.MouseEvent<HTMLInputElement>) => void;
-  selectedOption?: AutocompleteOption;
+  selectedOption?: IdAutocompleteOption;
   handleOpenChange?: (open: boolean) => void;
   onMouseDown?: (e: React.MouseEvent<HTMLInputElement>) => void;
   placeholder?: string;
@@ -34,9 +34,9 @@ interface AutocompleteInputContainerProps {
   onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void;
 }
 
-export const AutocompleteInputContainer = React.forwardRef<
+export const IdAutocompleteInputContainer = React.forwardRef<
   HTMLInputElement,
-  AutocompleteInputContainerProps
+  IdAutocompleteInputContainerProps
 >(
   (
     {
@@ -106,7 +106,7 @@ export const AutocompleteInputContainer = React.forwardRef<
             }}
             placeholder={placeholder}
             aria-invalid={hasError}
-            aria-label={!label ? "Autocomplete field" : undefined}
+            aria-label={!label ? "Id Autocomplete field" : undefined}
             aria-required={required}
             aria-expanded={isPopoverOpen}
             maxLength={maxLength}

--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/id-autocomplete-list-option.tsx
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/id-autocomplete-list-option.tsx
@@ -1,17 +1,23 @@
 import React from "react";
 import { Icon, type IconName } from "@/powerhouse/components/icon";
 import { cn } from "@/scalars/lib/utils";
-import type { AutocompleteProps, AutocompleteOption } from "./types";
+import type { IdAutocompleteProps, IdAutocompleteOption } from "./types";
 
 const IconRenderer: React.FC<{
   customIcon?: IconName | React.ReactElement;
-}> = ({ customIcon }) => {
+  asPlaceholder?: boolean;
+}> = ({ customIcon, asPlaceholder }) => {
   if (typeof customIcon === "string") {
     return (
       <Icon
         name={customIcon}
         size={24}
-        className={cn("shrink-0 text-gray-900 dark:text-gray-300")}
+        className={cn(
+          "shrink-0",
+          asPlaceholder
+            ? "text-gray-400 dark:text-gray-700"
+            : "text-gray-900 dark:text-gray-300",
+        )}
       />
     );
   }
@@ -53,16 +59,19 @@ const ReloadButton: React.FC<{
   </div>
 );
 
-export type AutocompleteListOptionProps = {
-  variant: AutocompleteProps["variant"];
+export type IdAutocompleteListOptionProps = {
+  variant: IdAutocompleteProps["variant"];
   asPlaceholder?: boolean;
   showValue?: boolean;
   isLoadingSelectedOption?: boolean;
   handleFetchSelectedOption?: (value: string) => void;
   className?: string;
-} & AutocompleteOption;
+  placeholderIcon?: IconName | React.ReactElement;
+} & IdAutocompleteOption;
 
-export const AutocompleteListOption: React.FC<AutocompleteListOptionProps> = ({
+export const IdAutocompleteListOption: React.FC<
+  IdAutocompleteListOptionProps
+> = ({
   variant = "withValue",
   icon,
   title = "Title not available",
@@ -74,6 +83,7 @@ export const AutocompleteListOption: React.FC<AutocompleteListOptionProps> = ({
   isLoadingSelectedOption,
   handleFetchSelectedOption,
   className,
+  placeholderIcon = "PowerhouseLogoSmall",
 }) => {
   const renderWithValue = () => (
     <div className={cn("flex w-full items-center")}>
@@ -93,15 +103,10 @@ export const AutocompleteListOption: React.FC<AutocompleteListOptionProps> = ({
   const renderWithValueAndTitle = () => (
     <div className={cn("flex w-full flex-col gap-1")}>
       <div className={cn("flex items-center gap-2")}>
-        {asPlaceholder ? (
-          <Icon
-            name="PowerhouseLogoSmall"
-            size={24}
-            className={cn("shrink-0 text-gray-400 dark:text-gray-700")}
-          />
-        ) : (
-          <IconRenderer customIcon={icon} />
-        )}
+        <IconRenderer
+          customIcon={asPlaceholder ? placeholderIcon : icon}
+          asPlaceholder={asPlaceholder}
+        />
         <span
           className={cn(
             "grow truncate text-sm font-bold leading-5",
@@ -140,15 +145,10 @@ export const AutocompleteListOption: React.FC<AutocompleteListOptionProps> = ({
   const renderWithValueTitleAndDescription = () => (
     <div className={cn("flex w-full flex-col gap-1")}>
       <div className={cn("flex gap-2")}>
-        {asPlaceholder ? (
-          <Icon
-            name="PowerhouseLogoSmall"
-            size={24}
-            className={cn("shrink-0 text-gray-400 dark:text-gray-700")}
-          />
-        ) : (
-          <IconRenderer customIcon={icon} />
-        )}
+        <IconRenderer
+          customIcon={asPlaceholder ? placeholderIcon : icon}
+          asPlaceholder={asPlaceholder}
+        />
         <div className={cn("flex min-w-0 grow flex-col gap-[-2px]")}>
           <span
             className={cn(

--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/id-autocomplete-list.tsx
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/id-autocomplete-list.tsx
@@ -7,17 +7,17 @@ import {
 } from "@/scalars/components/fragments/command";
 import { useCommandState } from "cmdk";
 import { cn } from "@/scalars/lib/utils";
-import { AutocompleteListOption } from "./autocomplete-list-option";
-import type { AutocompleteProps, AutocompleteOption } from "./types";
+import { IdAutocompleteListOption } from "./id-autocomplete-list-option";
+import type { IdAutocompleteProps, IdAutocompleteOption } from "./types";
 
-interface AutocompleteListProps {
-  variant: AutocompleteProps["variant"];
+interface IdAutocompleteListProps {
+  variant: IdAutocompleteProps["variant"];
   commandListRef?: React.RefObject<HTMLDivElement>;
   selectedValue?: string;
-  options?: AutocompleteOption[];
+  options?: IdAutocompleteOption[];
   toggleOption?: (value: string) => void;
   renderOption?: (
-    option: AutocompleteOption,
+    option: IdAutocompleteOption,
     displayProps?: {
       asPlaceholder?: boolean;
       showValue?: boolean;
@@ -28,7 +28,7 @@ interface AutocompleteListProps {
   ) => React.ReactNode;
 }
 
-export const AutocompleteList: React.FC<AutocompleteListProps> = ({
+export const IdAutocompleteList: React.FC<IdAutocompleteListProps> = ({
   variant,
   commandListRef,
   selectedValue,
@@ -37,7 +37,7 @@ export const AutocompleteList: React.FC<AutocompleteListProps> = ({
   renderOption,
 }) => {
   const cmdkSearch = useCommandState((state) => state.search) as string;
-  const defaultOption: AutocompleteOption = {
+  const defaultOption: IdAutocompleteOption = {
     value: "value not available",
     title: "Title not available",
     path: "Path not available",
@@ -58,7 +58,7 @@ export const AutocompleteList: React.FC<AutocompleteListProps> = ({
             className: cn("pb-0"),
           })
         ) : (
-          <AutocompleteListOption
+          <IdAutocompleteListOption
             variant={variant}
             value="value not available"
             asPlaceholder
@@ -88,7 +88,7 @@ export const AutocompleteList: React.FC<AutocompleteListProps> = ({
                   showValue: true,
                 })
               ) : (
-                <AutocompleteListOption variant={variant} {...opt} />
+                <IdAutocompleteListOption variant={variant} {...opt} />
               )}
             </CommandItem>
           );

--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/index.ts
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/index.ts
@@ -1,0 +1,1 @@
+export * from "./id-autocomplete-field";

--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/types.ts
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/types.ts
@@ -1,12 +1,12 @@
 import type { IconName } from "@/powerhouse/components/icon";
 
-export interface AutocompleteBaseProps {
+export interface IdAutocompleteBaseProps {
   onChange?: (value: string) => void;
   placeholder?: string;
   maxLength?: number;
 }
 
-export type AutocompleteProps = AutocompleteBaseProps &
+export type IdAutocompleteProps = IdAutocompleteBaseProps &
   (
     | {
         autoComplete: false;
@@ -24,15 +24,15 @@ export type AutocompleteProps = AutocompleteBaseProps &
           | "withValueAndTitle"
           | "withValueTitleAndDescription";
         isOpenByDefault?: boolean;
-        initialOptions?: AutocompleteOption[];
+        initialOptions?: IdAutocompleteOption[];
         fetchOptionsCallback: (
           userInput: string,
-        ) => Promise<AutocompleteOption[]>;
+        ) => Promise<IdAutocompleteOption[]>;
         fetchSelectedOptionCallback?: (
           value: string,
-        ) => Promise<AutocompleteOption | undefined>;
+        ) => Promise<IdAutocompleteOption | undefined>;
         renderOption?: (
-          option: AutocompleteOption,
+          option: IdAutocompleteOption,
           displayProps?: {
             asPlaceholder?: boolean;
             showValue?: boolean;
@@ -44,7 +44,7 @@ export type AutocompleteProps = AutocompleteBaseProps &
       }
   );
 
-export interface AutocompleteOption {
+export interface IdAutocompleteOption {
   icon?: IconName | React.ReactElement;
   title?: string;
   path?: string;

--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/use-id-autocomplete-field.ts
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/use-id-autocomplete-field.ts
@@ -1,20 +1,20 @@
 import React, { useCallback, useState, useEffect, useRef } from "react";
 import { useDebounceCallback } from "usehooks-ts";
-import type { AutocompleteProps, AutocompleteOption } from "./types";
+import type { IdAutocompleteProps, IdAutocompleteOption } from "./types";
 
-interface UseAutocompleteFieldParams {
-  autoComplete: AutocompleteProps["autoComplete"];
+interface UseIdAutocompleteFieldParams {
+  autoComplete: IdAutocompleteProps["autoComplete"];
   defaultValue?: string;
   value?: string;
-  isOpenByDefault: AutocompleteProps["isOpenByDefault"];
-  initialOptions: AutocompleteProps["initialOptions"];
-  onChange?: AutocompleteProps["onChange"];
+  isOpenByDefault: IdAutocompleteProps["isOpenByDefault"];
+  initialOptions: IdAutocompleteProps["initialOptions"];
+  onChange?: IdAutocompleteProps["onChange"];
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
-  fetchOptions: AutocompleteProps["fetchOptionsCallback"];
-  fetchSelectedOption: AutocompleteProps["fetchSelectedOptionCallback"];
+  fetchOptions: IdAutocompleteProps["fetchOptionsCallback"];
+  fetchSelectedOption: IdAutocompleteProps["fetchSelectedOptionCallback"];
 }
 
-export function useAutocompleteField({
+export function useIdAutocompleteField({
   autoComplete,
   defaultValue,
   value,
@@ -24,13 +24,13 @@ export function useAutocompleteField({
   onBlur,
   fetchOptions,
   fetchSelectedOption,
-}: UseAutocompleteFieldParams) {
+}: UseIdAutocompleteFieldParams) {
   const shouldFetchOptions = useRef(false);
   const isInternalChange = useRef(false);
   const commandListRef = useRef<HTMLDivElement>(null);
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(isOpenByDefault ?? false);
-  const [options, setOptions] = useState<AutocompleteOption[]>(
+  const [options, setOptions] = useState<IdAutocompleteOption[]>(
     initialOptions ?? [],
   );
   const [isLoading, setIsLoading] = useState(false);
@@ -40,7 +40,7 @@ export function useAutocompleteField({
     value ?? defaultValue ?? "",
   );
   const [selectedOption, setSelectedOption] = useState<
-    AutocompleteOption | undefined
+    IdAutocompleteOption | undefined
   >(undefined);
   const [commandValue, setCommandValue] = useState("");
   const [haveBeenOpened, setHaveBeenOpened] = useState(false);

--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/utils.ts
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/utils.ts
@@ -1,6 +1,6 @@
-import { AutocompleteOption } from "./types";
+import { IdAutocompleteOption } from "./types";
 
-export const mockedOptions: AutocompleteOption[] = [
+export const mockedOptions: IdAutocompleteOption[] = [
   {
     icon: "PowerhouseLogoSmall",
     title: "Document A",
@@ -24,7 +24,7 @@ export const mockedOptions: AutocompleteOption[] = [
   },
 ];
 
-export const fetchOptions = async (): Promise<AutocompleteOption[]> => {
+export const fetchOptions = async (): Promise<IdAutocompleteOption[]> => {
   // Simulate 2s network delay
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
@@ -38,7 +38,7 @@ export const fetchOptions = async (): Promise<AutocompleteOption[]> => {
 
 export const fetchSelectedOption = async (
   value: string,
-): Promise<AutocompleteOption | undefined> => {
+): Promise<IdAutocompleteOption | undefined> => {
   // Simulate 2s network delay
   await new Promise((resolve) => setTimeout(resolve, 2000));
   return mockedOptions.find((option) => option.value === value);

--- a/packages/design-system/src/scalars/components/fragments/index.ts
+++ b/packages/design-system/src/scalars/components/fragments/index.ts
@@ -1,4 +1,3 @@
-export * from "./autocomplete-field";
 export * from "./character-counter";
 export * from "./checkbox-field";
 export * from "./form-description";

--- a/packages/design-system/src/scalars/components/index.ts
+++ b/packages/design-system/src/scalars/components/index.ts
@@ -1,3 +1,4 @@
+export * from "./aid-field";
 export * from "./amount-field";
 export * from "./boolean-field";
 export * from "./country-code-field";

--- a/packages/design-system/src/scalars/components/phid-field/phid-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/phid-field/phid-field.stories.tsx
@@ -71,7 +71,7 @@ const meta: Meta<typeof PHIDField> = {
         "description?: string\n\n",
       table: {
         type: {
-          summary: "(userInput: string) => Promise<AutocompleteOption[]>",
+          summary: "(userInput: string) => Promise<IdAutocompleteOption[]>",
         },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
         readonly: true,
@@ -92,7 +92,8 @@ const meta: Meta<typeof PHIDField> = {
         "or undefined if the option is not found",
       table: {
         type: {
-          summary: "(value: string) => Promise<AutocompleteOption | undefined>",
+          summary:
+            "(value: string) => Promise<IdAutocompleteOption | undefined>",
         },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
         readonly: true,

--- a/packages/design-system/src/scalars/components/phid-field/phid-field.test.tsx
+++ b/packages/design-system/src/scalars/components/phid-field/phid-field.test.tsx
@@ -139,6 +139,7 @@ describe("PHIDField Component", () => {
 
     const input = screen.getByRole("combobox");
     await user.click(input);
+    await user.clear(input);
     await user.type(input, "test");
 
     await waitFor(() => {

--- a/packages/design-system/src/scalars/components/phid-field/phid-field.tsx
+++ b/packages/design-system/src/scalars/components/phid-field/phid-field.tsx
@@ -1,14 +1,14 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { useId, useCallback } from "react";
-import { AutocompleteFieldRaw } from "@/scalars/components/fragments/autocomplete-field";
-import { AutocompleteListOption } from "@/scalars/components/fragments/autocomplete-field/autocomplete-list-option";
+import { IdAutocompleteFieldRaw } from "@/scalars/components/fragments/id-autocomplete-field";
+import { IdAutocompleteListOption } from "@/scalars/components/fragments/id-autocomplete-field/id-autocomplete-list-option";
 import { withFieldValidation } from "@/scalars/components/fragments/with-field-validation";
 import type {
   FieldCommonProps,
   ErrorHandling,
 } from "@/scalars/components/types";
 import type { PHIDProps } from "./types";
-import type { AutocompleteOption } from "@/scalars/components/fragments/autocomplete-field/types";
+import type { IdAutocompleteOption } from "@/scalars/components/fragments/id-autocomplete-field/types";
 
 type PHIDFieldBaseProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -61,7 +61,7 @@ const PHIDFieldRaw = React.forwardRef<HTMLInputElement, PHIDFieldProps>(
 
     const renderOption = useCallback(
       (
-        option: AutocompleteOption,
+        option: IdAutocompleteOption,
         displayProps?: {
           asPlaceholder?: boolean;
           showValue?: boolean;
@@ -70,12 +70,13 @@ const PHIDFieldRaw = React.forwardRef<HTMLInputElement, PHIDFieldProps>(
           className?: string;
         },
       ) => (
-        <AutocompleteListOption
+        <IdAutocompleteListOption
           variant={variant}
           icon={option.icon}
           title={option.title}
           path={option.path}
           value={
+            displayProps?.asPlaceholder &&
             option.value === "value not available"
               ? "phd not available"
               : option.value
@@ -88,7 +89,7 @@ const PHIDFieldRaw = React.forwardRef<HTMLInputElement, PHIDFieldProps>(
     );
 
     return autoComplete && fetchOptionsCallback ? (
-      <AutocompleteFieldRaw
+      <IdAutocompleteFieldRaw
         id={id}
         name={name}
         className={className}
@@ -117,7 +118,7 @@ const PHIDFieldRaw = React.forwardRef<HTMLInputElement, PHIDFieldProps>(
         ref={ref}
       />
     ) : (
-      <AutocompleteFieldRaw
+      <IdAutocompleteFieldRaw
         id={id}
         name={name}
         className={className}

--- a/packages/design-system/src/scalars/components/phid-field/types.ts
+++ b/packages/design-system/src/scalars/components/phid-field/types.ts
@@ -1,6 +1,6 @@
-import type { AutocompleteProps } from "@/scalars/components/fragments/autocomplete-field/types";
+import type { IdAutocompleteProps } from "@/scalars/components/fragments/id-autocomplete-field/types";
 
-export type PHIDProps = Omit<AutocompleteProps, "renderOption"> & {
+export type PHIDProps = Omit<IdAutocompleteProps, "renderOption"> & {
   allowedScopes?: string[];
   allowUris?: boolean;
 };

--- a/packages/design-system/src/scalars/components/phid-field/utils.ts
+++ b/packages/design-system/src/scalars/components/phid-field/utils.ts
@@ -1,6 +1,6 @@
-import { AutocompleteOption } from "@/scalars/components/fragments/autocomplete-field/types";
+import { IdAutocompleteOption } from "@/scalars/components/fragments/id-autocomplete-field/types";
 
-export const mockedOptions: AutocompleteOption[] = [
+export const mockedOptions: IdAutocompleteOption[] = [
   {
     icon: "PowerhouseLogoSmall",
     title: "Document A",
@@ -24,7 +24,7 @@ export const mockedOptions: AutocompleteOption[] = [
   },
 ];
 
-export const fetchOptions = async (): Promise<AutocompleteOption[]> => {
+export const fetchOptions = async (): Promise<IdAutocompleteOption[]> => {
   // Simulate 2s network delay
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
@@ -38,7 +38,7 @@ export const fetchOptions = async (): Promise<AutocompleteOption[]> => {
 
 export const fetchSelectedOption = async (
   value: string,
-): Promise<AutocompleteOption | undefined> => {
+): Promise<IdAutocompleteOption | undefined> => {
   // Simulate 2s network delay
   await new Promise((resolve) => setTimeout(resolve, 2000));
   return mockedOptions.find((option) => option.value === value);

--- a/packages/design-system/src/scalars/docs/getting-started.mdx
+++ b/packages/design-system/src/scalars/docs/getting-started.mdx
@@ -36,7 +36,6 @@ pnpm add @powerhousedao/design-system react-hook-form
 - [AmountField](?path=/docs/document-engineering-simple-components-amount-field--readme)
 - [CountryCodeField](?path=/docs/document-engineering-simple-components-country-code-field--readme)
 - [PHIDField](?path=/docs/document-engineering-simple-components-phid-field--readme)
-  - [AutocompleteField](?path=/docs/document-engineering-fragments-autocomplete-field--readme)
 - [AIDField](?path=/docs/document-engineering-simple-components-aid-field--readme)
 - [DatePickerField](?path=/docs/document-engineering-simple-components-date-picker-field--readme)
 - [TimePickerField](?path=/docs/document-engineering-simple-components-time-picker-field--readme)


### PR DESCRIPTION
## Ticket
https://trello.com/c/ET3Uf7pc/789-7-aid-ethereum-dids

## Description
- Add "Default" & "Empty" story variants
- Add base tests
- Rename "Autocomplete" to "IdAutocomplete"
- Add support for custom "placeholderIcon"