### PR TITLE
feat(scalars): add support for react element as icons in the sidebar

### DIFF
--- a/packages/design-system/src/scalars/components/sidebar/sidebar.stories.tsx
+++ b/packages/design-system/src/scalars/components/sidebar/sidebar.stories.tsx
@@ -28,8 +28,8 @@ import { SidebarNode } from "./types";
  *   id: string;
  *   title: string;
  *   children: SidebarNode[];
- *   icon?: IconName;
- *   expandedIcon?: IconName;
+ *   icon?: IconName | ReactElement;
+ *   expandedIcon?: IconName | ReactElement;
  *   status?: NodeStatus;
  * };
  * enum NodeStatus {

--- a/packages/design-system/src/scalars/components/sidebar/subcomponents/sidebar-item.tsx
+++ b/packages/design-system/src/scalars/components/sidebar/subcomponents/sidebar-item.tsx
@@ -1,12 +1,11 @@
 /* eslint-disable react/jsx-max-depth */
 import { SidebarNode, FlattenedNode, NodeStatus } from "../types";
-import { forwardRef, useCallback, useMemo, useRef } from "react";
+import { cloneElement, forwardRef, useCallback, useMemo, useRef } from "react";
 import { cn } from "@/scalars/lib";
 import { Tooltip, TooltipProvider } from "../../fragments";
 import { Icon } from "@/powerhouse";
 import { StatusIcon } from "./status-icon";
 import { useEllipsis } from "@/scalars/hooks/useEllipsis";
-import CaretRight from "@/assets/icon-components/CaretRight";
 import CaretDown from "@/assets/icon-components/CaretDown";
 import PinFilled from "@/assets/icon-components/PinFilled";
 import Pin from "@/assets/icon-components/Pin";
@@ -48,7 +47,7 @@ export const SidebarItem = ({
   const paddingLeft = node.depth * 24;
   const isSearchActive =
     searchResults.length > 0 && searchResults[activeSearchIndex].id === node.id;
-  const iconName = node.isExpanded
+  const IconComponent = node.isExpanded
     ? (node.expandedIcon ?? node.icon)
     : node.icon;
   const isDescendenceModified = useMemo(() => {
@@ -153,8 +152,12 @@ export const SidebarItem = ({
                 </div>
               )}
 
-              {iconName ? (
-                <Icon name={iconName} size={16} className="min-w-4" />
+              {IconComponent ? (
+                typeof IconComponent === "string" ? (
+                  <Icon name={IconComponent} size={16} className="min-w-4" />
+                ) : (
+                  cloneElement(IconComponent, { className: "min-w-4 w-4" })
+                )
               ) : pinnedMode ? (
                 <PinnedModeCircleIcon isPinned={isPinned} />
               ) : null}

--- a/packages/design-system/src/scalars/components/sidebar/types.ts
+++ b/packages/design-system/src/scalars/components/sidebar/types.ts
@@ -9,12 +9,14 @@ export enum NodeStatus {
   UNCHANGED = "UNCHANGED", // default
 }
 
+export type SidebarIcon = IconName | React.ReactElement;
+
 export type SidebarNode = {
   title: string;
   id: string;
   children?: SidebarNode[];
-  icon?: IconName;
-  expandedIcon?: IconName;
+  icon?: SidebarIcon;
+  expandedIcon?: SidebarIcon;
   status?: NodeStatus;
 };
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/krAwOShg/830-sidebar-high-priorities-tasks

## Description
- Add support to the sidebar nodes to allow `ReactElement` as icons to allow any icons from third-party icon libraries or any custom icon