### PR TITLE
fix: remove connect reference from ph-cli ts config file

### DIFF
--- a/clis/ph-cli/tsconfig.json
+++ b/clis/ph-cli/tsconfig.json
@@ -29,9 +29,6 @@
       "path": "../../packages/scalars"
     },
     {
-      "path": "../../apps/connect"
-    },
-    {
       "path": "../../packages/design-system"
     },
     {


### PR DESCRIPTION
## Description:

- Since we are not importing code directly from connect in ph-cli, this reference is not needed.