### PR TITLE
feat(scalars): add the docs for dropdown

### DIFF
--- a/packages/design-system/src/scalars/components/dropdown/dropdown.stories.tsx
+++ b/packages/design-system/src/scalars/components/dropdown/dropdown.stories.tsx
@@ -9,6 +9,28 @@ import { StorybookControlCategory } from "@/scalars/lib/storybook-arg-types";
  * - `DropdownContent` wraps the menu items
  * - `DropdownItem` represents individual menu options
  *
+ * ## How to setup the component
+ *
+ * First import the necessary components:
+ * ```
+ * import { Dropdown, DropdownTrigger, DropdownContent, DropdownItem } from "@powerhousedao/design-system/scalars";
+ * ```
+ *
+ * Basic implementation:
+ * ```
+ * function MyComponent() {
+ *   return (
+ *     <Dropdown>
+ *       <DropdownTrigger>Open Menu</DropdownTrigger>
+ *       <DropdownContent>
+ *         <DropdownItem>Item 1</DropdownItem>
+ *         <DropdownItem>Item 2</DropdownItem>
+ *       </DropdownContent>
+ *     </Dropdown>
+ *   );
+ * }
+ * ```
+ *
  * Basic usage with icons:
  * ```
  * <Dropdown>

--- a/packages/design-system/src/scalars/components/dropdown/dropdown.stories.tsx
+++ b/packages/design-system/src/scalars/components/dropdown/dropdown.stories.tsx
@@ -1,7 +1,137 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import DropdownExample from "./dropdown-example";
 import { StorybookControlCategory } from "@/scalars/lib/storybook-arg-types";
-
+/**
+ * The `Dropdown` component system provides a flexible way to create interactive menus.
+ * It follows a strict parent-child component structure where:
+ * - `Dropdown` is the root container
+ * - `DropdownTrigger` activates the menu
+ * - `DropdownContent` wraps the menu items
+ * - `DropdownItem` represents individual menu options
+ *
+ * Basic usage with icons:
+ * ```
+ * <Dropdown>
+ *   <DropdownTrigger className="w-[184px]">
+ *     <DownloadIcon width={16} height={16} />
+ *     Export Options
+ *   </DropdownTrigger>
+ *   <DropdownContent>
+ *     <DropdownItem>
+ *       <PDFIcon width={16} height={16} />
+ *       Save as PDF
+ *     </DropdownItem>
+ *     <DropdownItem>
+ *       <CSVIcon width={16} height={16} />
+ *       Export CSV
+ *     </DropdownItem>
+ *   </DropdownContent>
+ * </Dropdown>
+ * ```
+ *
+ * ## Component Structure Rules
+ * 1. `DropdownItem` must always be wrapped in `DropdownContent`
+ * 2. `DropdownContent` must be a direct child of `Dropdown`
+ * 3. Icons should be placed as direct children before text content
+ *
+ * ## Creating Different Menu Types
+ *
+ * Example 1: Export Menu (from current implementation)
+ * ```
+ * <Dropdown>
+ *   <DropdownTrigger>
+ *     <DownloadFileIcon />
+ *     Export Format
+ *   </DropdownTrigger>
+ *   <DropdownContent>
+ *     <DropdownItem><ZipIcon /> ZIP Archive</DropdownItem>
+ *     <DropdownItem><UBLIcon /> UBL Format</DropdownItem>
+ *     <DropdownItem><PDFIcon /> PDF Document</DropdownItem>
+ *   </DropdownContent>
+ * </Dropdown>
+ * ```
+ *
+ * Example 2: Settings Menu
+ * ```
+ * <Dropdown>
+ *   <DropdownTrigger>
+ *     <SettingsIcon />
+ *     Configuration
+ *   </DropdownTrigger>
+ *   <DropdownContent>
+ *     <DropdownItem><UserIcon /> Profile</DropdownItem>
+ *     <DropdownItem><SecurityIcon /> Privacy</DropdownItem>
+ *     <DropdownItem><NotificationIcon /> Alerts</DropdownItem>
+ *   </DropdownContent>
+ * </Dropdown>
+ * ```
+ *
+ * Example 3: Navigation Menu
+ * ```
+ * <Dropdown>
+ *   <DropdownTrigger>
+ *     <MenuIcon />
+ *     Quick Links
+ *   </DropdownTrigger>
+ *   <DropdownContent>
+ *     <DropdownItem><HomeIcon /> Dashboard</DropdownItem>
+ *     <DropdownItem><AnalyticsIcon /> Reports</DropdownItem>
+ *     <DropdownItem><SupportIcon /> Help Center</DropdownItem>
+ *   </DropdownContent>
+ * </Dropdown>
+ * ```
+ *
+ * ## Icon Implementation
+ * Icons can be used in two ways:
+ *
+ * ** Direct SVG Import** (Recommended for custom icons):
+ * ```
+ * import DownloadFile from "@/assets/icon-components/DownloadFile";
+ * <DropdownItem>
+ *   <DownloadFile width={16} height={16} /> Download File
+ * </DropdownItem>
+ * ```
+ *
+ *
+ * ** Using Icon Component** (Recommended for dynamic icons):
+ * ```
+ * import { Icon } from "@/powerhouse";
+ * <Dropdown>
+ *   <DropdownTrigger>
+ *     <Icon name="DownloadFile" />
+ *     Download File
+ *   </DropdownTrigger>
+ *   <DropdownContent>
+ *     <DropdownItem>
+ *       <Icon name="DownloadFile" />
+ *       Download File
+ *     </DropdownItem>
+ *     <DropdownItem>
+ *       <Icon name="Settings" />
+ *       Configuration
+ *     </DropdownItem>
+ *   </DropdownContent>
+ * </Dropdown>
+ * ```
+ *
+ * ## Event Handling
+ * `DropdownItem` component extends `HTMLDivElement` attributes. To handle click events:
+ *
+ * **Inline implementation:**
+ * ```
+ * <DropdownItem onClick={() => console.log('Item clicked')}>
+ *   <SettingsIcon /> Configuration
+ * </DropdownItem>
+ * ```
+ *
+ * The component accepts all `div` element props including:
+ * - `onClick`: Mouse click handler
+ * - `onMouseEnter`: Hover handler
+ * - `data-*`: Custom data attributes
+ * - `aria-*`: Accessibility attributes
+ *
+ * TypeScript users get full type checking for native div element props.
+ */
 const meta: Meta<typeof DropdownExample> = {
   title: "Document Engineering/Simple Components/Dropdown",
   component: DropdownExample,


### PR DESCRIPTION
## Ticket
https://trello.com/c/ByzwUrNR/843-create-a-dropdown-component-to-be-used-as-export-as-option

## Description
- Should make the documentation available on how to use the dropdown control.
- Should add some documentation on how to use a custom icon set.