### PR TITLE
Handle imports config issues

### DIFF
--- a/apps/connect/tsconfig.json
+++ b/apps/connect/tsconfig.json
@@ -42,6 +42,9 @@
         },
         {
             "path": "../../packages/reactor-browser"
+        },
+        {
+            "path": "../../packages/common"
         }
     ],
     "include": ["src", "src/**/*.json", "package.json"],

--- a/clis/ph-cli/package.json
+++ b/clis/ph-cli/package.json
@@ -8,15 +8,14 @@
     "access": "public"
   },
   "bin": {
-    "ph-cli": "dist/cli.js"
+    "ph-cli": "dist/src/cli.js"
   },
   "files": [
     "dist"
   ],
   "scripts": {
     "build": "tsc --build",
-    "check-types": "tsc --build",
-    "dev": "tsx src/cli.ts",
+    "dev": "concurrently -P 'pnpm -w run check-types --watch' 'nodemon --watch \"../..\" -e ts,tsx,js,json dist/src/cli.js -- {@}' --",
     "prepublishOnly": "npm run build",
     "lint": "eslint .",
     "lint:nx": "eslint . --fix --quiet",
@@ -28,19 +27,21 @@
     "@powerhousedao/analytics-engine-core": "^0.3.2",
     "@powerhousedao/analytics-engine-graphql": "^0.2.2",
     "@powerhousedao/analytics-engine-pg": "^0.4.0",
+    "concurrently": "^9.1.2",
     "document-drive": "workspace:*",
     "graphql-tag": "^2.12.6",
     "knex": "^3.1.0",
-    "luxon": "^3.5.0"
+    "luxon": "^3.5.0",
+    "nodemon": "^3.1.9"
   },
   "dependencies": {
+    "@powerhousedao/builder-tools": "workspace:*",
     "@powerhousedao/codegen": "workspace:*",
     "@powerhousedao/config": "workspace:*",
     "@powerhousedao/connect": "workspace:*",
     "@powerhousedao/design-system": "workspace:*",
     "@powerhousedao/reactor-local": "workspace:*",
     "@powerhousedao/scalars": "workspace:*",
-    "@powerhousedao/builder-tools": "workspace:*",
     "colorette": "^2.0.20",
     "commander": "^12.1.0",
     "document-model": "workspace:*",

--- a/clis/ph-cli/tsconfig.json
+++ b/clis/ph-cli/tsconfig.json
@@ -3,12 +3,11 @@
   "compilerOptions": {
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "rootDir": "./src",
     "outDir": "./dist",
     "isolatedModules": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*", "*.config.ts", "package.json"],
+  "include": ["**/*", "package.json"],
   "references": [
     {
       "path": "../../packages/codegen"

--- a/packages/codegen/src/create-lib/create-project.ts
+++ b/packages/codegen/src/create-lib/create-project.ts
@@ -1,10 +1,11 @@
+import { parseArgs, promptDirectories } from "#utils/cli";
+import { getPackageManager } from "#utils/package-manager";
 import arg from "arg";
 import { execSync } from "child_process";
 import enquirer from "enquirer";
 import fs from "node:fs";
 import path from "path";
-import { parseArgs, promptDirectories } from "../utils/cli.js";
-import { getPackageManager } from "../utils/package-manager.js";
+
 const BOILERPLATE_REPO =
   "https://github.com/powerhouse-inc/document-model-boilerplate.git";
 

--- a/packages/codegen/src/create-lib/create-project.ts
+++ b/packages/codegen/src/create-lib/create-project.ts
@@ -1,10 +1,10 @@
-import { promptDirectories, parseArgs } from "#utils/cli";
-import { getPackageManager } from "#utils/package-manager";
 import arg from "arg";
 import { execSync } from "child_process";
 import enquirer from "enquirer";
 import fs from "node:fs";
 import path from "path";
+import { parseArgs, promptDirectories } from "../utils/cli.js";
+import { getPackageManager } from "../utils/package-manager.js";
 const BOILERPLATE_REPO =
   "https://github.com/powerhouse-inc/document-model-boilerplate.git";
 

--- a/packages/reactor-api/src/subgraphs/manager.ts
+++ b/packages/reactor-api/src/subgraphs/manager.ts
@@ -1,6 +1,7 @@
 import { Db } from "#types.js";
 import { createSchema } from "#utils/create-schema.js";
 import { ApolloServer } from "@apollo/server";
+import { expressMiddleware } from "@apollo/server/express4";
 import { ApolloServerPluginInlineTraceDisabled } from "@apollo/server/plugin/disabled";
 import { IAnalyticsStore } from "@powerhousedao/analytics-engine-core";
 import bodyParser from "body-parser";
@@ -82,10 +83,8 @@ export class SubgraphManager {
       const path = `/${subgraphConfig.name}`;
       newRouter.use(
         path,
-        /* eslint-disable */
-        // @ts-ignore
+        // @ts-expect-error todo check type defs
         expressMiddleware(server, {
-          // @ts-ignore
           context: ({ req }): Context => ({
             headers: req.headers,
             driveId: req.params.drive ?? undefined,
@@ -94,7 +93,6 @@ export class SubgraphManager {
             ...this.getAdditionalContextFields(),
           }),
         }),
-        /* eslint-enable */
       );
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -643,6 +643,9 @@ importers:
       '@powerhousedao/analytics-engine-pg':
         specifier: ^0.4.0
         version: 0.4.0
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.1.2
       document-drive:
         specifier: workspace:*
         version: link:../../packages/document-drive
@@ -655,6 +658,9 @@ importers:
       luxon:
         specifier: ^3.5.0
         version: 3.5.0
+      nodemon:
+        specifier: ^3.1.9
+        version: 3.1.9
 
   clis/ph-cmd:
     dependencies:
@@ -8455,6 +8461,11 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  concurrently@9.1.2:
+    resolution: {integrity: sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   conf@10.2.0:
     resolution: {integrity: sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==}
     engines: {node: '>=12'}
@@ -10653,6 +10664,9 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  ignore-by-default@1.0.1:
+    resolution: {integrity: sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==}
+
   ignore-walk@4.0.1:
     resolution: {integrity: sha512-rzDQLaW4jQbh2YrOFlJdCtX8qgJTehFRYiUB2r1osqTeDzV/3+Jh8fz1oAPzUThf3iku8Ds4IDqawI5d8mUiQw==}
     engines: {node: '>=10'}
@@ -12256,6 +12270,11 @@ packages:
     resolution: {integrity: sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==}
     engines: {node: '>=10'}
 
+  nodemon@3.1.9:
+    resolution: {integrity: sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   noms@0.0.0:
     resolution: {integrity: sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==}
 
@@ -13116,6 +13135,9 @@ packages:
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
+  pstree.remy@1.1.8:
+    resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
+
   public-encrypt@4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
 
@@ -13955,6 +13977,10 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
+  simple-update-notifier@2.0.0:
+    resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
+    engines: {node: '>=10'}
+
   sirv@3.0.0:
     resolution: {integrity: sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==}
     engines: {node: '>=18'}
@@ -14569,6 +14595,10 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  touch@3.1.1:
+    resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
+    hasBin: true
+
   tough-cookie@2.4.3:
     resolution: {integrity: sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==}
     engines: {node: '>=0.8'}
@@ -14884,6 +14914,9 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undefsafe@2.0.5:
+    resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
@@ -16926,7 +16959,7 @@ snapshots:
       '@babel/parser': 7.26.7
       '@babel/template': 7.25.9
       '@babel/types': 7.26.7
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -25016,6 +25049,16 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  concurrently@9.1.2:
+    dependencies:
+      chalk: 4.1.2
+      lodash: 4.17.21
+      rxjs: 7.8.1
+      shell-quote: 1.8.2
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+
   conf@10.2.0:
     dependencies:
       ajv: 8.17.1
@@ -25499,9 +25542,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.0:
+  debug@4.4.0(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 5.5.0
 
   debug@4.4.0(supports-color@8.1.1):
     dependencies:
@@ -26178,7 +26223,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.24.2):
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       esbuild: 0.24.2
     transitivePeerDependencies:
       - supports-color
@@ -27888,6 +27933,8 @@ snapshots:
       harmony-reflect: 1.6.2
 
   ieee754@1.2.1: {}
+
+  ignore-by-default@1.0.1: {}
 
   ignore-walk@4.0.1:
     dependencies:
@@ -29742,6 +29789,19 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
 
+  nodemon@3.1.9:
+    dependencies:
+      chokidar: 3.6.0
+      debug: 4.4.0(supports-color@5.5.0)
+      ignore-by-default: 1.0.1
+      minimatch: 3.1.2
+      pstree.remy: 1.1.8
+      semver: 7.7.0
+      simple-update-notifier: 2.0.0
+      supports-color: 5.5.0
+      touch: 3.1.1
+      undefsafe: 2.0.5
+
   noms@0.0.0:
     dependencies:
       inherits: 2.0.4
@@ -30722,6 +30782,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  pstree.remy@1.1.8: {}
+
   public-encrypt@4.0.3:
     dependencies:
       bn.js: 4.12.1
@@ -31685,6 +31747,10 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.2
 
+  simple-update-notifier@2.0.0:
+    dependencies:
+      semver: 7.7.0
+
   sirv@3.0.0:
     dependencies:
       '@polka/url': 1.0.0-next.28
@@ -32371,6 +32437,8 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  touch@3.1.1: {}
+
   tough-cookie@2.4.3:
     dependencies:
       psl: 1.15.0
@@ -32716,6 +32784,8 @@ snapshots:
   unc-path-regex@0.1.2: {}
 
   uncrypto@0.1.3: {}
+
+  undefsafe@2.0.5: {}
 
   undici-types@6.19.8: {}
 


### PR DESCRIPTION
This should never be happening. The imports field is supported by all environments, and I am able to run with the code as it was before after a clean install. I suspect that something is wrong with dependencies and tsx.

If something like this happens, it is a sign that either something is misconfigured or there is something wrong in the environment. 

@gpuente lets have a call later and debug.

When looking at the bug here I found that there was a ts-ignore that was masking a missing import, which might also have contributed to broken builds. I have fixed that here.

We also want to move away from tsx, because it does its own compilation and caching which can also lead to inconsistencies that cause bugs like this.

What we want to do instead for node cli code that needs transpiled typescript to run is to run the workspace type building in watch mode and monitor for changes when running the cli with node. this is essentially what tsx does under the hood, but in a way that we don't control.

I've updated the dev script to use nodemon and concurrently instead. it achieves the same result, but will also restart the server if you change something anywhere in the monorepo.