### PR TITLE
feat(scalars): remove the minutes in the display in the case are 00

### DIFF
--- a/packages/design-system/src/scalars/components/time-picker-field/utils.ts
+++ b/packages/design-system/src/scalars/components/time-picker-field/utils.ts
@@ -237,7 +237,12 @@ export const getOffset = (timeZone?: string) => {
  * getOffsetToDisplay()                   // Returns "UTC±00:00"
  */
 export const getOffsetToDisplay = (timeZone?: string) => {
-  return `UTC${getOffset(timeZone)}`;
+  const offset = getOffset(timeZone);
+  // Normalizar el formato para la visualización
+  const normalizedOffset = offset.endsWith(":00")
+    ? offset.slice(0, -3)
+    : offset;
+  return `UTC${normalizedOffset}`;
 };
 
 /**


### PR DESCRIPTION
## Ticket
https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time

## Description
- Short value of offset in the select view
- Should the chosen time be shown with the proper format in the field when the Save option is clicked.