### PR TITLE
fix(scalars): close popover when Enter is pressed and there is no matching option in IdAutocomplete based fields

### DIFF
--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/id-autocomplete-input-container.tsx
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete-field/id-autocomplete-input-container.tsx
@@ -102,6 +102,12 @@ export const IdAutocompleteInputContainer = React.forwardRef<
                 "ArrowDown",
                 "Enter",
               ].includes(e.key);
+
+              if (e.key === "Enter" && isPopoverOpen && optionsLength === 0) {
+                handleOpenChange?.(false);
+                e.preventDefault();
+                return;
+              }
               if (
                 !(isOptionsRelatedKey && isPopoverOpen && optionsLength > 0)
               ) {


### PR DESCRIPTION
## Ticket
https://trello.com/c/UHEOiN4v/776-8-phid-document-pointer-without-branch

## Description
- Close popover when Enter is pressed and there is no matching option