### PR TITLE
fix(scalars): keep the validations for minDate and maxDate for user i…

### DIFF
--- a/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.test.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.test.tsx
@@ -1,5 +1,5 @@
 import { renderWithForm } from "@/scalars/lib/testing";
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { DatePickerField } from "./date-picker-field";
 import userEvent from "@testing-library/user-event";
 
@@ -132,9 +132,8 @@ describe("DatePickerField", () => {
     const input = screen.getByRole("textbox");
 
     expect(input).toBeInTheDocument();
-    // Intentamos escribir una fecha anterior al minDate
     await userEvent.type(input, "2025-01-10");
-    await userEvent.tab(); // Trigger validation on blur
+    await userEvent.tab();
     expect(screen.getByText(/Date must be on or after/i)).toBeInTheDocument();
   });
 });
@@ -151,8 +150,7 @@ it("should disable dates after minDate when user adds a value in the input", asy
   const input = screen.getByRole("textbox");
 
   expect(input).toBeInTheDocument();
-  // Intentamos escribir una fecha anterior al minDate
   await userEvent.type(input, "2025-01-20");
-  await userEvent.tab(); // Trigger validation on blur
+  await userEvent.tab();
   expect(screen.getByText(/Date must be on or before/i)).toBeInTheDocument();
 });

--- a/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.test.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.test.tsx
@@ -119,4 +119,40 @@ describe("DatePickerField", () => {
 
     expect(input).toHaveValue("");
   });
+  // Validate minDate when user add value in the input
+  it("should disable dates after minDate when user adds a value in the input", async () => {
+    renderWithForm(
+      <DatePickerField
+        label="Test Label"
+        name="test-date"
+        minDate="2025-01-16"
+        showErrorOnBlur
+      />,
+    );
+    const input = screen.getByRole("textbox");
+
+    expect(input).toBeInTheDocument();
+    // Intentamos escribir una fecha anterior al minDate
+    await userEvent.type(input, "2025-01-10");
+    await userEvent.tab(); // Trigger validation on blur
+    expect(screen.getByText(/Date must be on or after/i)).toBeInTheDocument();
+  });
+});
+// Validate maxDate when user add value in the input
+it("should disable dates after minDate when user adds a value in the input", async () => {
+  renderWithForm(
+    <DatePickerField
+      label="Test Label"
+      name="test-date"
+      maxDate="2025-01-16"
+      showErrorOnBlur
+    />,
+  );
+  const input = screen.getByRole("textbox");
+
+  expect(input).toBeInTheDocument();
+  // Intentamos escribir una fecha anterior al minDate
+  await userEvent.type(input, "2025-01-20");
+  await userEvent.tab(); // Trigger validation on blur
+  expect(screen.getByText(/Date must be on or before/i)).toBeInTheDocument();
 });

--- a/packages/design-system/src/scalars/components/date-picker-field/date-picker-validations.ts
+++ b/packages/design-system/src/scalars/components/date-picker-field/date-picker-validations.ts
@@ -1,5 +1,6 @@
+import { format } from "date-fns";
 import { DatePickerFieldProps } from "./date-picker-field";
-import { getDateFromValue } from "./utils";
+import { formatDateToValidCalendarDateFormat, getDateFromValue } from "./utils";
 import { DateFieldValue } from "./types";
 import {
   getDateFormat,
@@ -8,7 +9,7 @@ import {
 } from "../date-time-field/utils";
 
 export const validateDatePicker =
-  ({ dateFormat }: DatePickerFieldProps) =>
+  ({ dateFormat, minDate, maxDate }: DatePickerFieldProps) =>
   (value: unknown) => {
     if (value === "" || value === undefined) {
       return true;
@@ -23,6 +24,24 @@ export const validateDatePicker =
 
     if (!isValid) {
       return `Invalid date format. Please use a valid format`;
+    }
+    const isoDate = formatDateToValidCalendarDateFormat(stringDate);
+    const validDate = new Date(isoDate);
+
+    if (minDate) {
+      const minDateValue = new Date(minDate);
+      if (validDate < minDateValue) {
+        const formattedMinDate = format(minDateValue, "dd/MM/yyyy");
+        return `Date must be on or after ${formattedMinDate}.`;
+      }
+    }
+
+    if (maxDate) {
+      const maxDateValue = new Date(maxDate);
+      if (validDate > maxDateValue) {
+        const formattedMaxDate = format(maxDateValue, "dd/MM/yyyy");
+        return `Date must be on or before ${formattedMaxDate}.`;
+      }
     }
     return true;
   };

--- a/packages/design-system/src/scalars/components/date-time-field/date-time-field-validations.ts
+++ b/packages/design-system/src/scalars/components/date-time-field/date-time-field-validations.ts
@@ -1,4 +1,5 @@
 import {
+  formatDateToValidCalendarDateFormat,
   getDateFromValue,
   splitIso8601DateTime,
 } from "../date-picker-field/utils";
@@ -10,9 +11,10 @@ import {
   normalizeMonthFormat,
 } from "./utils";
 import { DateFieldValue } from "../date-picker-field/types";
+import { format } from "date-fns";
 
 export const dateTimeFieldValidations =
-  ({ dateFormat }: DatePickerFieldProps) =>
+  ({ dateFormat, minDate, maxDate }: DatePickerFieldProps) =>
   (value: unknown) => {
     if (value === "" || value === undefined) {
       return true;
@@ -38,6 +40,24 @@ export const dateTimeFieldValidations =
 
     if (!isValidTime(time)) {
       return "Invalid time format. Use HH:mm.";
+    }
+    const isoDate = formatDateToValidCalendarDateFormat(stringDate);
+    const validDate = new Date(isoDate);
+
+    if (minDate) {
+      const minDateValue = new Date(minDate);
+      if (validDate < minDateValue) {
+        const formattedMinDate = format(minDateValue, "dd/MM/yyyy");
+        return `Date must be on or after ${formattedMinDate}.`;
+      }
+    }
+
+    if (maxDate) {
+      const maxDateValue = new Date(maxDate);
+      if (validDate > maxDateValue) {
+        const formattedMaxDate = format(maxDateValue, "dd/MM/yyyy");
+        return `Date must be on or before ${formattedMaxDate}.`;
+      }
     }
 
     return true;


### PR DESCRIPTION
## Ticket
https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time

## Description
 Should change the minDate and maxDate to be disable only of show message or error when user write