### PR TITLE
fix(scalars): change the name props, and fix the cast to send string …

### DIFF
--- a/packages/design-system/src/scalars/components/date-time-field/date-time-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/date-time-field/date-time-field.stories.tsx
@@ -152,7 +152,7 @@ const meta: Meta<typeof DateTimeField> = {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
-    dateIntervals: {
+    timeIntervals: {
       control: "number",
       description: "Date intervals",
       if: { arg: "showTimeSelect", truthy: true },

--- a/packages/design-system/src/scalars/components/date-time-field/date-time-field.tsx
+++ b/packages/design-system/src/scalars/components/date-time-field/date-time-field.tsx
@@ -53,7 +53,7 @@ interface DateTimeFieldProps
   showTimezoneSelect?: boolean;
   timeFormat?: string;
   timeZone?: string;
-  dateIntervals?: number;
+  timeIntervals?: number;
 }
 export const DateTimeField: React.FC<
   DateTimeFieldProps & DateTimeFieldPropsDate & DateTimeFieldPropsTime
@@ -76,7 +76,7 @@ export const DateTimeField: React.FC<
   showTimezoneSelect,
   value,
   timeZone,
-  dateIntervals,
+  timeIntervals,
   ...props
 }) => {
   if (!showDateSelect && !showTimeSelect) {
@@ -118,6 +118,8 @@ export const DateTimeField: React.FC<
           onBlur={onBlur}
           timeZone={timeZone}
           timeFormat={timeFormat}
+          timeIntervals={timeIntervals}
+          showTimezoneSelect={showTimezoneSelect}
           {...props}
         />
       )}
@@ -148,7 +150,7 @@ export const DateTimeField: React.FC<
           timeFormat={timeFormat}
           showTimezoneSelect={showTimezoneSelect}
           timeZone={timeZone}
-          dateIntervals={dateIntervals}
+          timeIntervals={timeIntervals}
           {...props}
         />
       )}

--- a/packages/design-system/src/scalars/components/date-time-field/date-time.tsx
+++ b/packages/design-system/src/scalars/components/date-time-field/date-time.tsx
@@ -24,7 +24,7 @@ interface DateTimePickerProps extends FieldCommonProps<DateFieldValue> {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   timeFormat?: string;
-  dateIntervals?: number;
+  timeIntervals?: number;
   timeZone?: string;
   showTimezoneSelect?: boolean;
   // Date Picker Field
@@ -64,7 +64,7 @@ const DateTimeRaw = forwardRef<HTMLInputElement, DateTimePickerProps>(
       onChangeDate,
       onBlurDate,
       timeFormat,
-      dateIntervals,
+      timeIntervals,
       timeZone,
       showTimezoneSelect,
       minDate,
@@ -123,7 +123,7 @@ const DateTimeRaw = forwardRef<HTMLInputElement, DateTimePickerProps>(
 
       // Time Picker Field
       timeFormat,
-      dateIntervals,
+      timeIntervals,
       timeZone,
       showTimezoneSelect,
       minDate,

--- a/packages/design-system/src/scalars/components/date-time-field/use-date-time.tsx
+++ b/packages/design-system/src/scalars/components/date-time-field/use-date-time.tsx
@@ -48,7 +48,7 @@ interface DateTimeFieldProps {
   onChangeTime?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlurTime?: (e: React.FocusEvent<HTMLInputElement>) => void;
   timeFormat?: string;
-  dateIntervals?: number;
+  timeIntervals?: number;
   timeZone?: string;
   showTimezoneSelect?: boolean;
   onChangeWraper?: (value: DateFieldValue, time: TimeFieldValue) => void;
@@ -152,7 +152,7 @@ export const useDateTime = ({
 
   // Time Picker Field
   timeFormat,
-  dateIntervals,
+  timeIntervals,
   timeZone,
   showTimezoneSelect = true,
   minDate,
@@ -181,7 +181,7 @@ export const useDateTime = ({
     const transformedTime = formatInputToDisplayValid(
       splitTime,
       is12HourFormat,
-      dateIntervals,
+      timeIntervals,
     );
 
     const { hours, minutes, period } = getHoursAndMinutes(transformedTime);
@@ -260,7 +260,7 @@ export const useDateTime = ({
     const datetimeFormatted = formatInputToDisplayValid(
       timeValue,
       is12HourFormat,
-      dateIntervals,
+      timeIntervals,
     );
 
     const validValue = convert12hTo24h(datetimeFormatted);
@@ -303,7 +303,7 @@ export const useDateTime = ({
     onChange: onChangeTime,
     onBlur: handleOnBlur,
     timeFormat,
-    dateIntervals,
+    timeIntervals,
     timeZone,
     showTimezoneSelect,
   });

--- a/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.stories.tsx
@@ -37,7 +37,7 @@ const meta: Meta<typeof TimePickerField> = {
       },
       defaultValue: { summary: false },
     },
-    dateIntervals: {
+    timeIntervals: {
       control: {
         description: "The interval between each time option",
         type: "number",

--- a/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.test.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.test.tsx
@@ -54,13 +54,13 @@ describe("TimePickerField", () => {
     expect(label).toHaveClass("text-gray-700");
   });
 
-  it("should handle dateIntervals prop correctly with 15-minute intervals", async () => {
+  it("should handle timeIntervals prop correctly with 15-minute intervals", async () => {
     const user = userEvent.setup();
     renderWithForm(
       <TimePickerField
         name="test-time"
         label="Test Label"
-        dateIntervals={15}
+        timeIntervals={15}
       />,
     );
     // Open the time picker using the button instead of the input
@@ -84,13 +84,13 @@ describe("TimePickerField", () => {
     });
   });
 
-  it("should handle dateIntervals prop correctly with 30-minute intervals", async () => {
+  it("should handle timeIntervals prop correctly with 30-minute intervals", async () => {
     const user = userEvent.setup();
     renderWithForm(
       <TimePickerField
         name="test-time"
         label="Test Label"
-        dateIntervals={30}
+        timeIntervals={30}
       />,
     );
 

--- a/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.tsx
@@ -31,7 +31,7 @@ export interface TimePickerFieldProps
   inputProps?: Omit<InputProps, "name" | "onChange" | "value" | "defaultValue">;
   selectProps?: Omit<SelectFieldProps, "name" | "options" | "selectionIcon">;
   timeFormat?: string;
-  dateIntervals?: number;
+  timeIntervals?: number;
   showTimezoneSelect?: boolean;
   timeZone?: string;
 }
@@ -56,7 +56,7 @@ export const TimePickerRaw = forwardRef<HTMLInputElement, TimePickerFieldProps>(
       selectProps,
       timeFormat = "hh:mm a",
       showTimezoneSelect,
-      dateIntervals,
+      timeIntervals,
       timeZone,
     },
     ref,
@@ -88,7 +88,7 @@ export const TimePickerRaw = forwardRef<HTMLInputElement, TimePickerFieldProps>(
       onChange,
       onBlur,
       timeFormat,
-      dateIntervals,
+      timeIntervals,
       timeZone,
       showTimezoneSelect,
     });

--- a/packages/design-system/src/scalars/components/time-picker-field/use-time-picker-field.ts
+++ b/packages/design-system/src/scalars/components/time-picker-field/use-time-picker-field.ts
@@ -29,7 +29,7 @@ interface TimePickerFieldProps {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   timeFormat?: string;
-  dateIntervals?: number;
+  timeIntervals?: number;
   timeZone?: string;
   showTimezoneSelect?: boolean;
 }
@@ -40,7 +40,7 @@ export const useTimePickerField = ({
   onChange,
   onBlur,
   timeFormat = "hh:mm a",
-  dateIntervals = 1,
+  timeIntervals = 1,
   timeZone,
   showTimezoneSelect = true,
 }: TimePickerFieldProps) => {
@@ -98,7 +98,7 @@ export const useTimePickerField = ({
     const validDisplay = formatInputToDisplayValid(
       input,
       is12HourFormat,
-      dateIntervals,
+      timeIntervals,
     );
     // Check if the validDisplay is empty and if it is, set the inputValue to an empty string
     if (!validDisplay) {
@@ -135,15 +135,15 @@ export const useTimePickerField = ({
     : Array.from({ length: 24 }, (_, i) => String(i).padStart(2, "0")); // 0-23
 
   const minutes = useMemo(() => {
-    if (dateIntervals > 1) {
+    if (timeIntervals > 1) {
       const arr: string[] = [];
-      for (let i = 0; i < 60; i += dateIntervals) {
+      for (let i = 0; i < 60; i += timeIntervals) {
         arr.push(String(i).padStart(2, "0"));
       }
       return arr;
     }
     return Array.from({ length: 60 }, (_, i) => String(i).padStart(2, "0"));
-  }, [dateIntervals]);
+  }, [timeIntervals]);
 
   const handleSave = () => {
     setIsOpen(false);

--- a/packages/design-system/src/scalars/components/time-picker-field/utils.ts
+++ b/packages/design-system/src/scalars/components/time-picker-field/utils.ts
@@ -331,7 +331,7 @@ export const convert12hTo24h = (input: string) => {
  *   - Short format (e.g., "1430", "0800")
  * @param is12HourFormat - If true, outputs in 12-hour format with AM/PM
  *                        If false, outputs in 24-hour format
- * @param dateIntervals - Optional interval in minutes to round the time to
+ * @param timeIntervals - Optional interval in minutes to round the time to
  *                       (e.g., 15 would round to nearest quarter hour)
  * @returns Formatted time string
  *   - 12-hour format: "hh:mm AM/PM" (e.g., "02:30 PM")
@@ -340,12 +340,12 @@ export const convert12hTo24h = (input: string) => {
 export const formatInputToDisplayValid = (
   input: string,
   is12HourFormat: boolean,
-  dateIntervals?: number,
+  timeIntervals?: number,
 ) => {
   const { hour, minute, period } = transformInputTime(
     input,
     is12HourFormat,
-    dateIntervals,
+    timeIntervals,
   );
   if (!hour && !minute) return "";
 

--- a/packages/design-system/src/scalars/lib/value-cast.ts
+++ b/packages/design-system/src/scalars/lib/value-cast.ts
@@ -60,7 +60,8 @@ export const castFunctions: Record<
     const newValue = parseInputString(date, correctFormat);
 
     const fechaUTC = parse(newValue, correctFormat ?? "yyyy-MM-dd", new Date());
-    return fechaUTC;
+    const isoDate = format(fechaUTC, "yyyy-MM-dd");
+    return isoDate;
   },
   DateTimeString: (value: string, dateFormat = "yyyy-MM-dd") => {
     const [datePart, timePart] = value.split("T");
@@ -70,9 +71,14 @@ export const castFunctions: Record<
     const correctFormat = getDateFormat(dateFormat);
 
     const normalizedDate = parseInputString(date, correctFormat);
+    const parsedDate = parse(
+      normalizedDate,
+      correctFormat ?? "yyyy-MM-dd",
+      new Date(),
+    );
 
-    const parsedDate = parse(normalizedDate, correctFormat ?? "", new Date());
     const isoDate = format(parsedDate, "yyyy-MM-dd");
+
     return `${isoDate}T${timePart}`;
   },
 };


### PR DESCRIPTION
## Ticket 
https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time


## Description
-  DateTime Picker. showTimezoneSelect prop. **Expected Output:** The timezone field should be disabled when the showTimezoneSelect prop = false. **Current Output:** The  field allows select the timezones even when the prop is false. 

- **Expected Output:** The prop should be timeIntervals **Current Output:** The props is named dateIntervals. *