### PR TITLE
fix(scalars): allow withFieldValidation HOC to pass ref & improve components types (second batch)

### DIFF
--- a/packages/design-system/src/scalars/components/amount-field/amount-field.tsx
+++ b/packages/design-system/src/scalars/components/amount-field/amount-field.tsx
@@ -10,12 +10,11 @@ import {
 } from "../fragments";
 import { useAmountField } from "./use-amount-field";
 import { cn } from "@/scalars/lib";
-import { InputNumberProps } from "../number-field/types";
-import { AmountValue } from "./types";
-import { AmountFieldPropsGeneric } from "./types";
+import type { InputNumberProps } from "../number-field/types";
+import type { AmountValue, AmountFieldPropsGeneric } from "./types";
 
 import { validateAmount } from "./amount-field-validations";
-import { Currency } from "../currency-code-field/types";
+import type { Currency } from "../currency-code-field/types";
 import { CurrencyCodeFieldRaw } from "../currency-code-field/currency-code-field";
 
 export type AmountFieldProps = AmountFieldPropsGeneric &
@@ -42,7 +41,7 @@ export type AmountFieldProps = AmountFieldPropsGeneric &
     includeCurrencySymbols?: boolean;
   };
 
-export const AmountFieldRaw = forwardRef<HTMLInputElement, AmountFieldProps>(
+const AmountFieldRaw = forwardRef<HTMLInputElement, AmountFieldProps>(
   (
     {
       label,

--- a/packages/design-system/src/scalars/components/boolean-field/boolean-field.tsx
+++ b/packages/design-system/src/scalars/components/boolean-field/boolean-field.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   CheckboxField,
   type CheckboxFieldProps,
@@ -12,18 +13,19 @@ export interface BooleanFieldProps
   value?: boolean;
 }
 
-export const BooleanField: React.FC<BooleanFieldProps> = ({
-  isToggle,
-  onChange,
-  ...props
-}) => {
+export const BooleanField = React.forwardRef<
+  HTMLButtonElement,
+  BooleanFieldProps
+>(({ isToggle, onChange, ...props }, ref) => {
   const handleChange = (value: string | boolean) => {
     onChange?.(Boolean(value));
   };
 
   return isToggle ? (
-    <ToggleField {...props} onChange={handleChange} />
+    <ToggleField onChange={handleChange} ref={ref} {...props} />
   ) : (
-    <CheckboxField {...props} onChange={handleChange} />
+    <CheckboxField onChange={handleChange} ref={ref} {...props} />
   );
-};
+});
+
+BooleanField.displayName = "BooleanField";

--- a/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.tsx
+++ b/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.tsx
@@ -1,10 +1,20 @@
 import React, { useMemo } from "react";
-import { ErrorHandling, FieldCommonProps } from "../types";
+import type { ErrorHandling, FieldCommonProps } from "../types";
 import { SelectFieldRaw, withFieldValidation } from "../fragments";
 import type { SelectOption } from "../enum-field/types";
 import type { Currency, CurrencyType } from "./types";
+
+type CurrencyCodeFieldBaseProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  | keyof FieldCommonProps<string | string[]>
+  | keyof ErrorHandling
+  | "onChange"
+  | "onBlur"
+>;
+
 export interface CurrencyCodeFieldProps
-  extends FieldCommonProps<string | string[]>,
+  extends CurrencyCodeFieldBaseProps,
+    FieldCommonProps<string | string[]>,
     ErrorHandling {
   placeholder?: string;
   onChange?: (value: string | string[]) => void;

--- a/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/date-picker-field/date-picker-field.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react";
-import { ErrorHandling, FieldCommonProps } from "../types";
-import { DateFieldValue } from "./types";
+import type { ErrorHandling, FieldCommonProps } from "../types";
+import type { DateFieldValue } from "./types";
 import { withFieldValidation } from "../fragments/with-field-validation";
 
 import { BasePickerField } from "../date-time-field/base-picker-field";
@@ -40,7 +40,7 @@ export interface DatePickerFieldProps
   autoClose?: boolean;
 }
 
-export const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
+const DatePickerRaw = forwardRef<HTMLInputElement, DatePickerFieldProps>(
   (
     {
       label,

--- a/packages/design-system/src/scalars/components/date-time-field/date-time-field.tsx
+++ b/packages/design-system/src/scalars/components/date-time-field/date-time-field.tsx
@@ -1,12 +1,15 @@
 import React from "react";
-import { ErrorHandling, FieldCommonProps } from "../types";
-import { DateFieldValue } from "../date-picker-field/types";
+import type { ErrorHandling, FieldCommonProps } from "../types";
+import type { DateFieldValue } from "../date-picker-field/types";
 import {
   DatePickerField,
-  DatePickerFieldProps,
+  type DatePickerFieldProps,
 } from "../date-picker-field/date-picker-field";
-import { TimePickerField, TimePickerFieldProps } from "../time-picker-field";
-import { TimeFieldValue } from "../time-picker-field/type";
+import {
+  TimePickerField,
+  type TimePickerFieldProps,
+} from "../time-picker-field";
+import type { TimeFieldValue } from "../time-picker-field/type";
 import { DateTimeField as DateTimeRaw } from "./date-time";
 
 type CommonOmittedProps =
@@ -55,73 +58,38 @@ interface DateTimeFieldProps
   timeZone?: string;
   dateIntervals?: number;
 }
-export const DateTimeField: React.FC<
-  DateTimeFieldProps & DateTimeFieldPropsDate & DateTimeFieldPropsTime
-> = ({
-  showDateSelect = true,
-  showTimeSelect = true,
-  name,
-  label,
-  dateFormat = "yyyy-MM-dd",
-  timeFormat = "hh:mm a",
-  minDate,
-  maxDate,
-  onChange,
-  onBlur,
-  placeholder,
-  weekStart,
-  disablePastDates,
-  disableFutureDates,
-  autoClose,
-  showTimezoneSelect,
-  value,
-  timeZone,
-  dateIntervals,
-  ...props
-}) => {
-  if (!showDateSelect && !showTimeSelect) {
-    return (
-      <DatePickerField
-        name={name}
-        label={label}
-        onBlur={onBlur}
-        onChange={onChange}
-        placeholder={placeholder}
-        dateFormat={dateFormat}
-        minDate={minDate}
-        maxDate={maxDate}
-        weekStart={weekStart}
-        disablePastDates={disablePastDates}
-        disableFutureDates={disableFutureDates}
-        autoClose={autoClose}
-        {...props}
-      />
-    );
-  }
 
-  return (
-    <div>
-      {showDateSelect && showTimeSelect && (
-        <DateTimeRaw
-          name={name}
-          value={value}
-          placeholder={placeholder}
-          label={label}
-          weekStart={weekStart}
-          autoClose={autoClose}
-          disableFutureDates={disableFutureDates}
-          disablePastDates={disablePastDates}
-          minDate={minDate}
-          maxDate={maxDate}
-          dateFormat={dateFormat}
-          onChange={onChange}
-          onBlur={onBlur}
-          timeZone={timeZone}
-          timeFormat={timeFormat}
-          {...props}
-        />
-      )}
-      {showDateSelect && !showTimeSelect && (
+export const DateTimeField = React.forwardRef<
+  HTMLInputElement,
+  DateTimeFieldProps & DateTimeFieldPropsDate & DateTimeFieldPropsTime
+>(
+  (
+    {
+      showDateSelect = true,
+      showTimeSelect = true,
+      name,
+      label,
+      dateFormat = "yyyy-MM-dd",
+      timeFormat = "hh:mm a",
+      minDate,
+      maxDate,
+      onChange,
+      onBlur,
+      placeholder,
+      weekStart,
+      disablePastDates,
+      disableFutureDates,
+      autoClose,
+      showTimezoneSelect,
+      value,
+      timeZone,
+      dateIntervals,
+      ...props
+    },
+    ref,
+  ) => {
+    if (!showDateSelect && !showTimeSelect) {
+      return (
         <DatePickerField
           name={name}
           label={label}
@@ -135,23 +103,71 @@ export const DateTimeField: React.FC<
           disablePastDates={disablePastDates}
           disableFutureDates={disableFutureDates}
           autoClose={autoClose}
+          ref={ref}
           {...props}
         />
-      )}
-      {!showDateSelect && showTimeSelect && (
-        <TimePickerField
-          name={name}
-          label={label}
-          onBlur={onBlur}
-          onChange={onChange}
-          placeholder={placeholder}
-          timeFormat={timeFormat}
-          showTimezoneSelect={showTimezoneSelect}
-          timeZone={timeZone}
-          dateIntervals={dateIntervals}
-          {...props}
-        />
-      )}
-    </div>
-  );
-};
+      );
+    }
+
+    return (
+      <div>
+        {showDateSelect && showTimeSelect && (
+          <DateTimeRaw
+            name={name}
+            value={value}
+            placeholder={placeholder}
+            label={label}
+            weekStart={weekStart}
+            autoClose={autoClose}
+            disableFutureDates={disableFutureDates}
+            disablePastDates={disablePastDates}
+            minDate={minDate}
+            maxDate={maxDate}
+            dateFormat={dateFormat}
+            onChange={onChange}
+            onBlur={onBlur}
+            timeZone={timeZone}
+            timeFormat={timeFormat}
+            ref={ref}
+            {...props}
+          />
+        )}
+        {showDateSelect && !showTimeSelect && (
+          <DatePickerField
+            name={name}
+            label={label}
+            onBlur={onBlur}
+            onChange={onChange}
+            placeholder={placeholder}
+            dateFormat={dateFormat}
+            minDate={minDate}
+            maxDate={maxDate}
+            weekStart={weekStart}
+            disablePastDates={disablePastDates}
+            disableFutureDates={disableFutureDates}
+            autoClose={autoClose}
+            ref={ref}
+            {...props}
+          />
+        )}
+        {!showDateSelect && showTimeSelect && (
+          <TimePickerField
+            name={name}
+            label={label}
+            onBlur={onBlur}
+            onChange={onChange}
+            placeholder={placeholder}
+            timeFormat={timeFormat}
+            showTimezoneSelect={showTimezoneSelect}
+            timeZone={timeZone}
+            dateIntervals={dateIntervals}
+            ref={ref}
+            {...props}
+          />
+        )}
+      </div>
+    );
+  },
+);
+
+DateTimeField.displayName = "DateTimeField";

--- a/packages/design-system/src/scalars/components/fragments/checkbox-field/checkbox-field.tsx
+++ b/packages/design-system/src/scalars/components/fragments/checkbox-field/checkbox-field.tsx
@@ -1,74 +1,86 @@
-import { useId } from "react";
+import React, { useId } from "react";
 import { FormLabel } from "../form-label";
 import { Checkbox, CheckboxValue } from "./checkbox";
 import { cn } from "@/scalars/lib/utils";
 import { FormMessageList } from "../form-message";
-import { FieldCommonProps } from "../../types";
+import type { FieldCommonProps } from "../../types";
 import { withFieldValidation } from "../with-field-validation";
 
-export interface CheckboxFieldProps extends FieldCommonProps<CheckboxValue> {
+type CheckboxFieldBaseProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  keyof FieldCommonProps<CheckboxValue> | "onChange"
+>;
+
+export interface CheckboxFieldProps
+  extends CheckboxFieldBaseProps,
+    FieldCommonProps<CheckboxValue> {
   onChange?: (checked: CheckboxValue) => void;
 }
 
-const CheckboxRaw: React.FC<CheckboxFieldProps> = ({
-  id: idProp,
-  name,
-  label,
-  value,
-  defaultValue,
-  disabled,
-  required,
-  description,
-  errors,
-  warnings,
-  onChange,
-  className,
-  ...props
-}) => {
-  const generatedId = useId();
-  const id = idProp ?? generatedId;
-  const hasError = !!errors?.length;
+const CheckboxRaw = React.forwardRef<HTMLButtonElement, CheckboxFieldProps>(
+  (
+    {
+      id: idProp,
+      name,
+      label,
+      value,
+      defaultValue,
+      disabled,
+      required,
+      description,
+      errors,
+      warnings,
+      onChange,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const generatedId = useId();
+    const id = idProp ?? generatedId;
+    const hasError = !!errors?.length;
 
-  const castValue = (value: unknown) => {
-    if (value === "true") return true;
-    if (value === "false") return false;
-    return value;
-  };
+    const castValue = (value: unknown) => {
+      if (value === "true") return true;
+      if (value === "false") return false;
+      return value;
+    };
 
-  return (
-    <div className={cn("flex flex-col gap-2")}>
-      <div className={cn("group flex items-center space-x-2", className)}>
-        <Checkbox
-          id={id}
-          name={name}
-          checked={castValue(value ?? defaultValue) as CheckboxValue}
-          disabled={disabled}
-          onCheckedChange={onChange}
-          required={required}
-          invalid={hasError}
-          aria-invalid={hasError}
-          {...props}
-        />
-        <FormLabel
-          htmlFor={id}
-          required={required}
-          disabled={disabled}
-          hasError={hasError}
-          description={description}
-          className={cn(!disabled && "group-hover:cursor-pointer")}
-          inline
-        >
-          {label}
-        </FormLabel>
+    return (
+      <div className={cn("flex flex-col gap-2")}>
+        <div className={cn("group flex items-center space-x-2", className)}>
+          <Checkbox
+            id={id}
+            name={name}
+            checked={castValue(value ?? defaultValue) as CheckboxValue}
+            disabled={disabled}
+            onCheckedChange={onChange}
+            required={required}
+            invalid={hasError}
+            aria-invalid={hasError}
+            ref={ref}
+            {...props}
+          />
+          <FormLabel
+            htmlFor={id}
+            required={required}
+            disabled={disabled}
+            hasError={hasError}
+            description={description}
+            className={cn(!disabled && "group-hover:cursor-pointer")}
+            inline
+          >
+            {label}
+          </FormLabel>
+        </div>
+        {warnings && <FormMessageList type="warning" messages={warnings} />}
+        {errors && <FormMessageList type="error" messages={errors} />}
       </div>
-      {warnings && <FormMessageList type="warning" messages={warnings} />}
-      {errors && <FormMessageList type="error" messages={errors} />}
-    </div>
-  );
-};
+    );
+  },
+);
 
-const CheckboxField = withFieldValidation<CheckboxFieldProps>(CheckboxRaw);
+export const CheckboxField =
+  withFieldValidation<CheckboxFieldProps>(CheckboxRaw);
 
 CheckboxField.displayName = "CheckboxField";
-
-export { CheckboxField };

--- a/packages/design-system/src/scalars/components/fragments/toggle-field/toggle-field.tsx
+++ b/packages/design-system/src/scalars/components/fragments/toggle-field/toggle-field.tsx
@@ -6,66 +6,81 @@ import { FormMessageList } from "../form-message";
 import type { FieldCommonProps } from "../../types";
 import { withFieldValidation } from "../with-field-validation";
 
-export interface ToggleFieldProps extends FieldCommonProps<boolean> {
+type ToggleFieldBaseProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  keyof FieldCommonProps<boolean> | "onChange"
+>;
+
+export interface ToggleFieldProps
+  extends ToggleFieldBaseProps,
+    FieldCommonProps<boolean> {
   onChange?: (checked: boolean) => void;
 }
 
-const ToggleRaw: React.FC<ToggleFieldProps> = ({
-  id: idProp,
-  name,
-  label,
-  disabled = false,
-  value,
-  onChange,
-  errors = [],
-  warnings = [],
-  required = false,
-  className,
-  defaultValue,
-  description,
-}) => {
-  const generatedId = useId();
-  const id = idProp ?? generatedId;
+const ToggleRaw = React.forwardRef<HTMLButtonElement, ToggleFieldProps>(
+  (
+    {
+      id: idProp,
+      name,
+      label,
+      disabled = false,
+      value,
+      onChange,
+      errors = [],
+      warnings = [],
+      required = false,
+      className,
+      defaultValue,
+      description,
+      ...props
+    },
+    ref,
+  ) => {
+    const generatedId = useId();
+    const id = idProp ?? generatedId;
 
-  return (
-    <div
-      className={cn("flex flex-col gap-1", className)}
-      data-testid="custom-class"
-    >
-      <div className="flex items-center">
-        <Toggle
-          aria-labelledby={`${id}-label`}
-          required={required}
-          disabled={disabled}
-          name={name}
-          id={id}
-          checked={value ?? defaultValue}
-          onCheckedChange={onChange}
-        />
-        {label && (
-          <FormLabel
-            htmlFor={id}
-            className="ml-2"
-            disabled={disabled}
+    return (
+      <div
+        className={cn("flex flex-col gap-1", className)}
+        data-testid="custom-class"
+      >
+        <div className="flex items-center">
+          <Toggle
+            aria-labelledby={`${id}-label`}
             required={required}
-            description={description}
-            inline
-            id={`${id}-label`}
-          >
-            {label}
-          </FormLabel>
+            disabled={disabled}
+            name={name}
+            id={id}
+            checked={value ?? defaultValue}
+            onCheckedChange={onChange}
+            ref={ref}
+            {...props}
+          />
+          {label && (
+            <FormLabel
+              htmlFor={id}
+              className="ml-2"
+              disabled={disabled}
+              required={required}
+              description={description}
+              inline
+              id={`${id}-label`}
+            >
+              {label}
+            </FormLabel>
+          )}
+        </div>
+        {warnings.length !== 0 && (
+          <FormMessageList messages={warnings} type="warning" />
+        )}
+        {errors.length !== 0 && (
+          <FormMessageList messages={errors} type="error" />
         )}
       </div>
-      {warnings.length !== 0 && (
-        <FormMessageList messages={warnings} type="warning" />
-      )}
-      {errors.length !== 0 && (
-        <FormMessageList messages={errors} type="error" />
-      )}
-    </div>
-  );
-};
+    );
+  },
+);
 
-const ToggleField = withFieldValidation<ToggleFieldProps>(ToggleRaw);
+export const ToggleField = withFieldValidation<ToggleFieldProps>(ToggleRaw);
 
-export { ToggleField };
+ToggleField.displayName = "ToggleField";

--- a/packages/design-system/src/scalars/components/number-field/number-field.tsx
+++ b/packages/design-system/src/scalars/components/number-field/number-field.tsx
@@ -9,7 +9,7 @@ import { withFieldValidation } from "../fragments/with-field-validation";
 import { validateNumericType } from "./number-field-validations";
 import { Icon } from "@/powerhouse/components/icon";
 import { regex } from "./utils";
-import { InputNumberProps } from "./types";
+import type { InputNumberProps } from "./types";
 import { useNumberField } from "./use-number-field";
 
 export interface NumberFieldProps extends InputNumberProps {

--- a/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.tsx
@@ -8,12 +8,12 @@ import {
   SelectFieldProps,
   withFieldValidation,
 } from "../fragments";
-import { ErrorHandling, FieldCommonProps } from "../types";
-import { TimeFieldValue } from "./type";
+import type { ErrorHandling, FieldCommonProps } from "../types";
+import type { TimeFieldValue } from "./type";
 import { BasePickerField } from "../date-time-field/base-picker-field";
 import TimePickerContent from "./subcomponents/time-picker-content";
 import { useTimePickerField } from "./use-time-picker-field";
-import { InputNumberProps } from "../number-field/types";
+import type { InputNumberProps } from "../number-field/types";
 import { validateTimePicker } from "./time-picker-validations";
 import { cn } from "@/scalars/lib";
 import { handleKeyDown } from "./utils";
@@ -36,7 +36,7 @@ export interface TimePickerFieldProps
   timeZone?: string;
 }
 
-export const TimePickerRaw = forwardRef<HTMLInputElement, TimePickerFieldProps>(
+const TimePickerRaw = forwardRef<HTMLInputElement, TimePickerFieldProps>(
   (
     {
       label,

--- a/packages/design-system/src/scalars/components/url-field/url-field.tsx
+++ b/packages/design-system/src/scalars/components/url-field/url-field.tsx
@@ -8,7 +8,7 @@ import {
   FormDescription,
   FormMessageList,
 } from "../fragments";
-import { ErrorHandling, FieldCommonProps } from "../types";
+import type { ErrorHandling, FieldCommonProps } from "../types";
 import { cn } from "@/scalars/lib";
 import { IconName } from "@/powerhouse";
 import { useURLWarnings } from "./useURLWarnings";
@@ -31,10 +31,7 @@ interface UrlFieldProps
   platformIcons?: Record<string, PlatformIcon>;
 }
 
-const UrlFieldRaw: React.FC<UrlFieldProps> = React.forwardRef<
-  HTMLInputElement,
-  UrlFieldProps
->(
+const UrlFieldRaw = React.forwardRef<HTMLInputElement, UrlFieldProps>(
   (
     {
       label,


### PR DESCRIPTION
## Ticket
https://trello.com/c/LMOL17mF/870-fix-type-error-and-ref

## Description
- Should ensure that all components support the onBlur prop
- Should ensure that all components allow ref

AmountField
BooleanField
CheckboxField
ToggleField
CurrencyCodeField
DateTimeField
DatePickerField
TimePickerField
NumberField
UrlField