### PR TITLE
fix(scalars): add ciclic scroll for center the values

### DIFF
--- a/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-picker-content.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-picker-content.tsx
@@ -77,6 +77,7 @@ const TimePickerContent: React.FC<TimePickerContentProps> = ({
           options={hours}
           selectedValue={selectedHour}
           onSelect={setSelectedHour}
+          isCyclic={true}
         />
         <div className="flex items-center px-4 text-sm font-normal leading-[20px] text-gray-900">
           :
@@ -85,6 +86,7 @@ const TimePickerContent: React.FC<TimePickerContentProps> = ({
           options={minutes}
           selectedValue={selectedMinute}
           onSelect={setSelectedMinute}
+          isCyclic={true}
         />
       </div>
       <div className="flex items-center justify-between pt-[25px]">

--- a/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-selector.constants.ts
+++ b/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-selector.constants.ts
@@ -1,0 +1,4 @@
+export const SCROLL_TIMEOUT_MS = 200;
+export const BOTTOM_THRESHOLD_OFFSET = 20;
+export const TOP_THRESHOLD_OFFSET = 20;
+export const CENTERING_TIMEOUT_MS = 10;

--- a/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-selector.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/subcomponents/time-selector.tsx
@@ -1,53 +1,60 @@
 import * as React from "react";
-import { cn } from "@/scalars/lib/utils";
+import { useRef } from "react";
 import { Button } from "../../fragments/button";
-import { useEffect } from "react";
-
-interface TimeSelectorProps {
-  options: string[];
-  selectedValue: string;
-  onSelect: (value: string) => void;
-}
+import { useTimeSelector } from "./use-time-selector";
+import { cn } from "@/scalars/lib/utils";
+import { TimeSelectorProps } from "../type";
 
 const TimeSelector: React.FC<TimeSelectorProps> = ({
   options,
   selectedValue,
   onSelect,
+  isCyclic = true,
 }) => {
   const selectedRef = React.useRef<HTMLButtonElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
-  // Scroll to the selected value
-  useEffect(() => {
-    if (selectedRef.current) {
-      selectedRef.current.scrollIntoView({
-        behavior: "smooth",
-        block: "center",
-      });
-    }
-  }, [selectedValue]);
+  const { displayOptions, handleExplicitSelection } = useTimeSelector({
+    options,
+    selectedValue,
+    onSelect,
+    isCyclic,
+    containerRef,
+    selectedRef,
+  });
 
   return (
     <div className="relative w-[43px] overflow-hidden">
-      <div className="absolute inset-0 flex flex-col items-center overflow-y-auto scrollbar-hide gap-1 no-scrollbar">
-        <div className="h-[60px]" />
-        {options.map((option) => (
-          <Button
-            ref={option === selectedValue ? selectedRef : null}
-            variant="ghost"
-            key={option}
-            onClick={() => onSelect(option)}
-            className={cn(
-              "h-[37px] text-[12px] leading-[20px] flex cursor-pointer items-center justify-center",
-              selectedValue === option
-                ? "rounded-[6px] bg-white border border-gray-300 text-gray-900 font-normal px-3 py-2 "
-                : "text-gray-900 w-[16px] h-[20px] font-normal",
-            )}
-          >
-            {option}
-          </Button>
-        ))}
-        <div className="mb-1" />
+      <div
+        ref={containerRef}
+        className="absolute inset-0 flex flex-col items-center overflow-y-auto scrollbar-hide gap-1 no-scrollbar"
+      >
+        {isCyclic && <div className="h-[60px]" />}
+        {displayOptions.map((option, index) => {
+          // Determine if this is the middle set of options (for proper reference)
+          const isMiddleSet =
+            index >= options.length && index < options.length * 2;
+          const shouldUseRef = option === selectedValue && isMiddleSet;
+
+          return (
+            <Button
+              ref={shouldUseRef ? selectedRef : null}
+              variant="ghost"
+              key={`${option}-${index}`}
+              onClick={() => handleExplicitSelection(option)}
+              className={cn(
+                "h-[37px] text-[12px] leading-[20px] flex cursor-pointer items-center justify-center",
+                selectedValue === option
+                  ? "rounded-[6px] bg-white border border-gray-300 text-gray-900 font-normal px-3 py-2"
+                  : "text-gray-900 w-[16px] h-[20px] font-normal",
+              )}
+            >
+              {option}
+            </Button>
+          );
+        })}
       </div>
+      {isCyclic && <div className="h-[60px]" />}
     </div>
   );
 };

--- a/packages/design-system/src/scalars/components/time-picker-field/subcomponents/use-time-selector.ts
+++ b/packages/design-system/src/scalars/components/time-picker-field/subcomponents/use-time-selector.ts
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from "react";
+import { TimeSelectorProps } from "../type";
+import {
+  BOTTOM_THRESHOLD_OFFSET,
+  CENTERING_TIMEOUT_MS,
+  SCROLL_TIMEOUT_MS,
+  TOP_THRESHOLD_OFFSET,
+} from "./time-selector.constants";
+
+interface UseTimeSelectorProps extends TimeSelectorProps {
+  containerRef: React.RefObject<HTMLDivElement>;
+  selectedRef: React.RefObject<HTMLButtonElement>;
+}
+
+interface UseTimeSelectorReturn {
+  displayOptions: string[];
+  shouldCenter: boolean;
+  handleExplicitSelection: (option: string) => void;
+}
+
+export const useTimeSelector = ({
+  options,
+  selectedValue,
+  onSelect,
+  isCyclic = true,
+  containerRef,
+  selectedRef,
+}: UseTimeSelectorProps): UseTimeSelectorReturn => {
+  const [shouldCenter, setShouldCenter] = useState(false);
+  const lastScrollTop = useRef(0);
+  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const initialRenderRef = useRef(true);
+
+  // Initial centering on component mount
+  useEffect(() => {
+    if (initialRenderRef.current && selectedRef.current && selectedValue) {
+      // Center the selected value on initial render
+      selectedRef.current.scrollIntoView({
+        behavior: "auto", // Use 'auto' for initial centering to avoid animation on load
+        block: "center",
+      });
+      initialRenderRef.current = false;
+    }
+  }, [selectedValue, selectedRef]);
+
+  // Scroll to the selected value only when explicitly requested
+  useEffect(() => {
+    if (selectedRef.current && containerRef.current) {
+      const selected = selectedRef.current;
+      const container = containerRef.current;
+      const selectedRect = selected.getBoundingClientRect();
+      const containerRect = container.getBoundingClientRect();
+
+      // Verificar si el elemento seleccionado está visible
+      const isVisible =
+        selectedRect.top >= containerRect.top &&
+        selectedRect.bottom <= containerRect.bottom;
+
+      // Solo hacer scroll si el elemento no está visible o si se solicitó explícitamente centrar
+      if (!isVisible || shouldCenter) {
+        const offset =
+          selectedRect.top -
+          containerRect.top -
+          containerRect.height / 2 +
+          selectedRect.height / 2;
+
+        container.scrollBy({
+          top: offset,
+          behavior: initialRenderRef.current ? "auto" : "smooth",
+        });
+      }
+
+      initialRenderRef.current = false;
+      // Resetear shouldCenter después de centrar
+      if (shouldCenter) setShouldCenter(false);
+    }
+  }, [selectedValue, shouldCenter, containerRef, selectedRef]);
+
+  // Handle cyclic behavior
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !isCyclic) return;
+
+    const handleScroll = () => {
+      if (!container) return;
+
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current);
+      }
+
+      scrollTimeoutRef.current = setTimeout(() => {}, SCROLL_TIMEOUT_MS);
+
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      const currentScrollTop = scrollTop;
+      const scrollDirection =
+        currentScrollTop > lastScrollTop.current ? "down" : "up";
+      lastScrollTop.current = currentScrollTop;
+
+      const bottomThreshold =
+        scrollHeight - clientHeight - BOTTOM_THRESHOLD_OFFSET;
+      const topThreshold = TOP_THRESHOLD_OFFSET;
+
+      if (scrollDirection === "down" && scrollTop >= bottomThreshold) {
+        requestAnimationFrame(() => {
+          if (container) {
+            container.scrollTop = scrollHeight / 2;
+          }
+        });
+      } else if (scrollDirection === "up" && scrollTop <= topThreshold) {
+        requestAnimationFrame(() => {
+          if (container) {
+            container.scrollTop = scrollHeight / 2;
+          }
+        });
+      }
+    };
+
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      container.removeEventListener("scroll", handleScroll);
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current);
+      }
+    };
+  }, [options, selectedValue, onSelect, isCyclic, containerRef]);
+
+  // Create a repeating list of options for infinite scroll effect
+  const displayOptions = isCyclic
+    ? [...options, ...options, ...options]
+    : options;
+
+  // Function to handle explicit selection
+  const handleExplicitSelection = (option: string) => {
+    onSelect(option);
+
+    // Use a small timeout to ensure the ref is updated with the new selection
+    setTimeout(() => {
+      // Request centering through the useEffect hook
+      setShouldCenter(true);
+    }, CENTERING_TIMEOUT_MS);
+  };
+
+  return {
+    displayOptions,
+    shouldCenter,
+    handleExplicitSelection,
+  };
+};

--- a/packages/design-system/src/scalars/components/time-picker-field/subcomponents/use-time-selector.ts
+++ b/packages/design-system/src/scalars/components/time-picker-field/subcomponents/use-time-selector.ts
@@ -51,12 +51,12 @@ export const useTimeSelector = ({
       const selectedRect = selected.getBoundingClientRect();
       const containerRect = container.getBoundingClientRect();
 
-      // Verificar si el elemento seleccionado está visible
+      // Check if the selected element is visible
       const isVisible =
         selectedRect.top >= containerRect.top &&
         selectedRect.bottom <= containerRect.bottom;
 
-      // Solo hacer scroll si el elemento no está visible o si se solicitó explícitamente centrar
+      // Only scroll if the element is not visible or if centering was explicitly requested
       if (!isVisible || shouldCenter) {
         const offset =
           selectedRect.top -
@@ -71,7 +71,7 @@ export const useTimeSelector = ({
       }
 
       initialRenderRef.current = false;
-      // Resetear shouldCenter después de centrar
+      // Reset shouldCenter after centering
       if (shouldCenter) setShouldCenter(false);
     }
   }, [selectedValue, shouldCenter, containerRef, selectedRef]);

--- a/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.test.tsx
+++ b/packages/design-system/src/scalars/components/time-picker-field/time-picker-field.test.tsx
@@ -74,11 +74,13 @@ describe("TimePickerField", () => {
     // Now check for the minute values
     const minutes = ["00", "15", "30", "45"];
     for (const minute of minutes) {
-      const minuteElement = await screen.findByText(minute);
-      expect(minuteElement).toBeInTheDocument();
+      // Use findAllByText instead of findByText since there are multiple elements with the same text
+      const minuteElements = await screen.findAllByText(minute);
+      expect(minuteElements.length).toBeGreaterThan(0);
+      expect(minuteElements[0]).toBeInTheDocument();
     }
 
-    // // Verify that intermediate values are not present
+    // Verify that intermediate values are not present
     ["13", "20", "25", "35", "40", "50", "55"].forEach((minute) => {
       expect(screen.queryByText(minute)).not.toBeInTheDocument();
     });
@@ -105,10 +107,11 @@ describe("TimePickerField", () => {
     // Now check for the minute values
     const minutes = ["00", "30"];
     for (const minute of minutes) {
-      const minuteElement = await screen.findByText(minute);
-      expect(minuteElement).toBeInTheDocument();
+      const minuteElements = await screen.findAllByText(minute);
+      expect(minuteElements.length).toBeGreaterThan(0);
+      expect(minuteElements[0]).toBeInTheDocument();
     }
-    // // Verify that other values are not present
+    // Verify that other values are not present
     ["15", "45"].forEach((minute) => {
       expect(screen.queryByText(minute)).not.toBeInTheDocument();
     });

--- a/packages/design-system/src/scalars/components/time-picker-field/type.ts
+++ b/packages/design-system/src/scalars/components/time-picker-field/type.ts
@@ -1,3 +1,10 @@
 export type TimeFieldValue = string | undefined;
 
 export type TimePeriod = "AM" | "PM";
+
+export interface TimeSelectorProps {
+  options: string[];
+  selectedValue: string;
+  onSelect: (value: string) => void;
+  isCyclic?: boolean;
+}


### PR DESCRIPTION
## Ticket
https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time

## Description
- Selecting a date, the time is taking the local time. Selecting the time tab. The time representation should be centered.  The time indication is not centered. 