### PR TITLE
fix(scalars): avoid transformation of valid value

### DIFF
--- a/packages/design-system/src/scalars/components/date-time-field/use-date-time.tsx
+++ b/packages/design-system/src/scalars/components/date-time-field/use-date-time.tsx
@@ -258,6 +258,24 @@ export const useDateTime = ({
       return;
     }
 
+    //  If the time is valid, and is 12 hour format, do nothing not transform the time
+    if (
+      is12HourFormat &&
+      isValidTimeInput(timeValue) &&
+      (inputValue.includes("AM") || inputValue.includes("PM"))
+    ) {
+      return;
+    }
+
+    // if is 24 hour format, and the time is valid, and the time is not AM or PM, do nothing
+    if (
+      !is12HourFormat &&
+      isValidTimeInput(timeValue) &&
+      !inputValue.includes("AM") &&
+      !inputValue.includes("PM")
+    ) {
+      return;
+    }
     const datetimeFormatted = formatInputToDisplayValid(
       timeValue,
       is12HourFormat,

--- a/packages/design-system/src/scalars/components/time-picker-field/use-time-picker-field.ts
+++ b/packages/design-system/src/scalars/components/time-picker-field/use-time-picker-field.ts
@@ -217,7 +217,6 @@ export const useTimePickerField = ({
           },
         ]
       : options;
-  console.log("timeZonesOptions", timeZonesOptions);
   return {
     selectedHour,
     selectedMinute,


### PR DESCRIPTION
## Ticket
https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time

## Description
- Avoid to transform value when already had correct value
