### PR TITLE
fix(scalars): clear the "required" error message after the first change in all fields

### DIFF
--- a/packages/design-system/src/scalars/components/fragments/with-field-validation/with-field-validation.tsx
+++ b/packages/design-system/src/scalars/components/fragments/with-field-validation/with-field-validation.tsx
@@ -188,7 +188,7 @@ export const withFieldValidation = <
               // `internalValue` is the value of the field that is controlled by the form
               // it is used to trigger the validation on change, so we need to add it to the dependencies
               // otherwise the validation will not be triggered on change
-              [internalValue, showErrorOnChange, showErrorOnBlur],
+              [internalValue, showErrorOnChange, showErrorOnBlur, submitCount],
             );
 
             // extract ref from rest


### PR DESCRIPTION
## Ticket
https://trello.com/c/etnFekM9/881-required-field-error-persists-after-first-change

## Description
- Clear the "required" error message after the first change in all fields