### PR TITLE
fix(scalars): remove some props from stories and show symbol props as…

### DIFF
--- a/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
@@ -62,28 +62,16 @@ const meta: Meta<typeof CurrencyCodeField> = {
         type: { summary: "string" },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
+      if: {
+        arg: "includeCurrencySymbols",
+        eq: true,
+      },
     },
     searchable: {
       control: "boolean",
       description: "Whether the dropdown is searchable",
       table: {
         defaultValue: { summary: "false" },
-        category: StorybookControlCategory.COMPONENT_SPECIFIC,
-      },
-    },
-    contentAlign: {
-      control: "select",
-      description: "Alignment of the dropdown",
-      options: ["start", "end", "center"],
-      table: {
-        defaultValue: { summary: "start" },
-        category: StorybookControlCategory.COMPONENT_SPECIFIC,
-      },
-    },
-    contentClassName: {
-      control: "text",
-      description: "Custom class name for the dropdown content",
-      table: {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },


### PR DESCRIPTION
## Ticket
https://trello.com/c/RQlyOdrZ/778-12-currencycodefield-currencycodefiat-currencycodecrypto

## Description
- SymbolPosition prop should be visible only if includeCurrencySymbols is true. 
- Remove contentAlign prop 
- Remove contentClassName prop