### PR TITLE
fix(scalars): update content items font weight to normal in Select field

### DIFF
--- a/packages/design-system/src/scalars/components/fragments/select-field/content.tsx
+++ b/packages/design-system/src/scalars/components/fragments/select-field/content.tsx
@@ -135,7 +135,7 @@ export const Content: React.FC<ContentProps> = ({
                         )}
                     </div>
                   )}
-                <span className="text-[14px] font-semibold leading-4 text-gray-900 dark:text-gray-50">
+                <span className="text-[14px] font-normal leading-4 text-gray-900 dark:text-gray-50">
                   {selectedValues.length === enabledOptions.length
                     ? "Deselect All"
                     : "Select All"}


### PR DESCRIPTION
## Ticket
https://trello.com/c/EPExsKwE/837-change-the-weight-font-in-the-dropdown-items

## Description
- Should change the current font weight to 400