### PR TITLE
feat(scalars): add OID field base, stories and tests

### DIFF
--- a/packages/design-system/src/scalars/components/oid-field/index.ts
+++ b/packages/design-system/src/scalars/components/oid-field/index.ts
@@ -1,0 +1,1 @@
+export * from "./oid-field.js";

--- a/packages/design-system/src/scalars/components/oid-field/mocks.ts
+++ b/packages/design-system/src/scalars/components/oid-field/mocks.ts
@@ -1,0 +1,157 @@
+import type { OIDOption } from "./types.js";
+
+export const mockedOptions: OIDOption[] = [
+  {
+    icon: "Braces",
+    title: "Object A",
+    path: {
+      text: "rwa-portfolio-a",
+    },
+    value: "baefc2a4-f9a0-4950-8161-fd8d8cc7dea7",
+    description: "Object A description",
+  },
+  {
+    icon: "Braces",
+    title: "Object B",
+    path: {
+      text: "rwa-portfolio-b",
+    },
+    value: "baefc2a4-f9a0-4950-8161-fd8d8cc6cdb8",
+    description: "Object B description",
+  },
+  {
+    icon: "Braces",
+    title: "Object C",
+    path: {
+      text: "rwa-portfolio-c",
+    },
+    value: "baefc2a4-f9a0-4950-8161-fd8d8cc5efc9",
+    description: "Object C description",
+  },
+  {
+    icon: "Braces",
+    title: "Object D",
+    path: {
+      text: "rwa-portfolio-d",
+    },
+    value: "baefc2a4-f9a0-4950-8161-fd8d8cc1cfe3",
+    description: "Object D description",
+  },
+  {
+    icon: "Braces",
+    title: "Object E",
+    path: {
+      text: "rwa-portfolio-e",
+    },
+    value: "baefc2a4-f9a0-4950-8161-fd8d8cc0bfe4",
+    description: "Object E description",
+  },
+  {
+    icon: "Braces",
+    title: "Object F",
+    path: {
+      text: "rwa-portfolio-f",
+    },
+    value: "baefc2a4-f9a0-4950-8161-fd8d8cc9aef5",
+    description: "Object F description",
+  },
+  {
+    icon: "Braces",
+    title: "Object G",
+    path: {
+      text: "rwa-portfolio-g",
+    },
+    value: "baefc2a4-f9a0-4950-8161-fd8d8cc8aef6",
+    description: "Object G description",
+  },
+  {
+    icon: "Braces",
+    title: "Object H",
+    path: {
+      text: "rwa-portfolio-h",
+    },
+    value: "baefc2a4-f9a0-4950-8161-fd8d8cc7aef7",
+    description: "Object H description",
+  },
+  {
+    icon: "Braces",
+    title: "Object I",
+    path: {
+      text: "rwa-portfolio-i",
+    },
+    value: "baefc2a4-f9a0-4950-8161-fd8d8cc6aef8",
+    description: "Object I description",
+  },
+  {
+    icon: "Braces",
+    title: "Object J",
+    path: {
+      text: "rwa-portfolio-j",
+    },
+    value: "baefc2a4-f9a0-4950-8161-fd8d8cc5aef9",
+    description: "Object J description",
+  },
+  {
+    icon: "Braces",
+    title: "Object K",
+    path: {
+      text: "rwa-portfolio-k",
+    },
+    value: "baefc2a4-f9a0-4950-8161-fd8d8cc4aea0",
+    description: "Object K description",
+  },
+  {
+    icon: "Braces",
+    title: "Object L",
+    path: {
+      text: "rwa-portfolio-l",
+    },
+    value: "baefc2a4-f9a0-4950-8161-fd8d8cc3aea1",
+    description: "Object L description",
+  },
+];
+
+const filterOptions = (options: OIDOption[], userInput: string) => {
+  const normalizedInput = userInput.toLowerCase();
+
+  return options.filter((opt) => {
+    return (
+      opt.title?.toLowerCase().includes(normalizedInput) ||
+      opt.path?.text.toLowerCase().includes(normalizedInput) ||
+      opt.value.toLowerCase().includes(normalizedInput) ||
+      opt.description?.toLowerCase().includes(normalizedInput)
+    );
+  });
+};
+
+// Async versions
+export const fetchOptions = async (userInput: string): Promise<OIDOption[]> => {
+  // Simulate 2s network delay
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  // Add 20% chance of error
+  if (Math.random() < 0.2) {
+    throw new Error();
+  }
+
+  return filterOptions(mockedOptions, userInput);
+};
+
+export const fetchSelectedOption = async (
+  value: string,
+): Promise<OIDOption | undefined> => {
+  // Simulate 2s network delay
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  return mockedOptions.find((option) => option.value === value);
+};
+
+// Sync versions
+export const fetchOptionsSync = (userInput: string): OIDOption[] => {
+  return filterOptions(mockedOptions, userInput);
+};
+
+export const fetchSelectedOptionSync = (
+  value: string,
+): OIDOption | undefined => {
+  return mockedOptions.find((option) => option.value === value);
+};

--- a/packages/design-system/src/scalars/components/oid-field/oid-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/oid-field/oid-field.stories.tsx
@@ -1,0 +1,160 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { withForm } from "../../lib/decorators.js";
+import {
+  getDefaultArgTypes,
+  getValidationArgTypes,
+  PrebuiltArgTypes,
+  StorybookControlCategory,
+} from "../../lib/storybook-arg-types.js";
+import { fetchOptions, fetchSelectedOption, mockedOptions } from "./mocks.js";
+import { OIDField } from "./oid-field.js";
+
+const meta: Meta<typeof OIDField> = {
+  title: "Document Engineering/Simple Components/OID Field",
+  component: OIDField,
+  decorators: [
+    withForm,
+    (Story) => (
+      <div style={{ maxWidth: "280px", margin: "1rem auto 0" }}>
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    ...getDefaultArgTypes(),
+    ...PrebuiltArgTypes.placeholder,
+
+    autoComplete: {
+      control: "boolean",
+      description:
+        "Enables autocomplete functionality to suggest options while typing",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "true" },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+    },
+
+    fetchOptionsCallback: {
+      control: "object",
+      description:
+        "Function to fetch options based on user input and context. " +
+        "Must return a Promise that resolves to an array of objects or an array of objects with the following properties:\n\n" +
+        "icon?: IconName | React.ReactElement\n\n" +
+        "title?: string\n\n" +
+        "path?: { text: string; url?: string; }\n\n" +
+        "value: string\n\n" +
+        "description?: string\n\n",
+      table: {
+        type: {
+          summary:
+            "(userInput: string; context?: {}) => Promise<OIDOption[]> | OIDOption[]",
+        },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+        readonly: true,
+      },
+      if: { arg: "autoComplete", neq: false },
+    },
+
+    fetchSelectedOptionCallback: {
+      control: "object",
+      description:
+        "Function to fetch details for a selected option. " +
+        "Must return a Promise that resolves to an object or an object with the following properties:\n\n" +
+        "icon?: IconName | React.ReactElement\n\n" +
+        "title?: string\n\n" +
+        "path?: { text: string; url?: string; }\n\n" +
+        "value: string\n\n" +
+        "description?: string\n\n" +
+        "or undefined if the option is not found",
+      table: {
+        type: {
+          summary:
+            "(value: string) => Promise<OIDOption | undefined> | OIDOption | undefined",
+        },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+        readonly: true,
+      },
+      if: { arg: "autoComplete", neq: false },
+    },
+
+    variant: {
+      control: "radio",
+      options: [
+        "withValue",
+        "withValueAndTitle",
+        "withValueTitleAndDescription",
+      ],
+      description:
+        "Controls the amount of information displayed for each option: value only, value with title, or value with title and description",
+      table: {
+        type: {
+          summary:
+            '"withValue" | "withValueAndTitle" | "withValueTitleAndDescription"',
+        },
+        defaultValue: { summary: "withValue" },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+      if: { arg: "autoComplete", neq: false },
+    },
+
+    ...getValidationArgTypes(),
+  },
+  args: {
+    name: "oid-field",
+  },
+} satisfies Meta<typeof OIDField>;
+
+export default meta;
+
+type Story = StoryObj<typeof OIDField>;
+
+export const Default: Story = {
+  args: {
+    label: "OID field",
+    placeholder: "uuid",
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    label: "OID field",
+    placeholder: "uuid",
+    isOpenByDefault: true,
+    defaultValue: "uuid",
+    variant: "withValueTitleAndDescription",
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+  },
+};
+
+export const Open: Story = {
+  args: {
+    label: "OID field",
+    placeholder: "uuid",
+    isOpenByDefault: true,
+    defaultValue: "uuid",
+    variant: "withValueTitleAndDescription",
+    initialOptions: mockedOptions,
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    label: "OID field",
+    placeholder: "uuid",
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    variant: "withValueTitleAndDescription",
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+  },
+};

--- a/packages/design-system/src/scalars/components/oid-field/oid-field.test.tsx
+++ b/packages/design-system/src/scalars/components/oid-field/oid-field.test.tsx
@@ -3,9 +3,9 @@ import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { renderWithForm } from "../../lib/testing.js";
 import { Form } from "../form/index.js";
-import { AIDField } from "./aid-field.js";
+import { OIDField } from "./oid-field.js";
 
-describe("AIDField Component", () => {
+describe("OIDField Component", () => {
   window.HTMLElement.prototype.scrollIntoView = vi.fn();
   window.Element.prototype.scrollTo = vi.fn();
   window.matchMedia = vi.fn().mockImplementation((query) => ({
@@ -22,25 +22,21 @@ describe("AIDField Component", () => {
   const mockedOptions = [
     {
       icon: "Braces",
-      title: "Agent A",
+      title: "Object A",
       path: {
-        text: "renown.id/0xb9c5714089478a327f09197987f16f9e5d936e8a",
-        url: "https://www.renown.id/",
+        text: "rwa-portfolio-a",
       },
-      value: "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
-      description: "Agent A description",
-      agentType: "Human Contributor",
+      value: "baefc2a4-f9a0-4950-8161-fd8d8cc7dea7",
+      description: "Object A description",
     },
     {
       icon: "Braces",
-      title: "Agent B",
+      title: "Object B",
       path: {
-        text: "renown.id/0x5:0xb9c5714089478a327f09197987f16f9e5d936e8a",
-        url: "https://www.renown.id/",
+        text: "rwa-portfolio-b",
       },
-      value: "did:ethr:0x5:0xb9c5714089478a327f09197987f16f9e5d936e8a",
-      description: "Agent B description",
-      agentType: "Contributor Team",
+      value: "baefc2a4-f9a0-4950-8161-fd8d8cc6cdb8",
+      description: "Object B description",
     },
   ];
 
@@ -53,10 +49,10 @@ describe("AIDField Component", () => {
 
   it("should match snapshot", () => {
     const { asFragment } = renderWithForm(
-      <AIDField
-        name="aid"
-        label="AID Field"
-        placeholder="did:ethr:"
+      <OIDField
+        name="oid"
+        label="OID Field"
+        placeholder="uuid"
         fetchOptionsCallback={defaultGetOptions}
         fetchSelectedOptionCallback={defaultGetSelectedOption}
       />,
@@ -66,8 +62,8 @@ describe("AIDField Component", () => {
 
   it("should render with label", () => {
     renderWithForm(
-      <AIDField
-        name="aid"
+      <OIDField
+        name="oid"
         label="Test Label"
         fetchOptionsCallback={defaultGetOptions}
         fetchSelectedOptionCallback={defaultGetSelectedOption}
@@ -78,8 +74,8 @@ describe("AIDField Component", () => {
 
   it("should render with description", () => {
     renderWithForm(
-      <AIDField
-        name="aid"
+      <OIDField
+        name="oid"
         label="Test Label"
         description="Test Description"
         fetchOptionsCallback={defaultGetOptions}
@@ -91,8 +87,8 @@ describe("AIDField Component", () => {
 
   it("should handle disabled state", () => {
     renderWithForm(
-      <AIDField
-        name="aid"
+      <OIDField
+        name="oid"
         label="Test Label"
         disabled
         fetchOptionsCallback={defaultGetOptions}
@@ -104,30 +100,30 @@ describe("AIDField Component", () => {
 
   it("should display error messages", async () => {
     renderWithForm(
-      <AIDField
-        name="aid"
+      <OIDField
+        name="oid"
         label="Test Label"
-        errors={["Invalid AID format"]}
+        errors={["Invalid OID format"]}
         fetchOptionsCallback={defaultGetOptions}
         fetchSelectedOptionCallback={defaultGetSelectedOption}
       />,
     );
     await waitFor(() =>
-      expect(screen.getByText("Invalid AID format")).toBeInTheDocument(),
+      expect(screen.getByText("Invalid OID format")).toBeInTheDocument(),
     );
   });
 
   it("should display warning messages", () => {
     renderWithForm(
-      <AIDField
-        name="aid"
+      <OIDField
+        name="oid"
         label="Test Label"
-        warnings={["AID may be deprecated"]}
+        warnings={["OID may be deprecated"]}
         fetchOptionsCallback={defaultGetOptions}
         fetchSelectedOptionCallback={defaultGetSelectedOption}
       />,
     );
-    expect(screen.getByText("AID may be deprecated")).toBeInTheDocument();
+    expect(screen.getByText("OID may be deprecated")).toBeInTheDocument();
   });
 
   it("should show autocomplete options", async () => {
@@ -136,8 +132,8 @@ describe("AIDField Component", () => {
     Math.random = vi.fn().mockReturnValue(1);
 
     renderWithForm(
-      <AIDField
-        name="aid"
+      <OIDField
+        name="oid"
         label="Test Label"
         variant="withValueTitleAndDescription"
         fetchOptionsCallback={defaultGetOptions}
@@ -151,9 +147,7 @@ describe("AIDField Component", () => {
     await user.type(input, "test");
 
     await waitFor(() => {
-      expect(defaultGetOptions).toHaveBeenCalledWith("test", {
-        supportedNetworks: undefined,
-      });
+      expect(defaultGetOptions).toHaveBeenCalledWith("test", {});
     });
 
     await waitFor(() => {
@@ -167,8 +161,8 @@ describe("AIDField Component", () => {
 
   it("should have correct ARIA attributes", async () => {
     renderWithForm(
-      <AIDField
-        name="aid"
+      <OIDField
+        name="oid"
         label="Test Label"
         required
         errors={["Error message"]}
@@ -185,8 +179,8 @@ describe("AIDField Component", () => {
 
   it("should show correct placeholders for different variants", () => {
     const { rerender } = renderWithForm(
-      <AIDField
-        name="aid"
+      <OIDField
+        name="oid"
         label="Test Label"
         variant="withValueTitleAndDescription"
         fetchOptionsCallback={defaultGetOptions}
@@ -197,11 +191,10 @@ describe("AIDField Component", () => {
     expect(screen.getByText("Title not available")).toBeInTheDocument();
     expect(screen.getByText("Path not available")).toBeInTheDocument();
     expect(screen.getByText("Description not available")).toBeInTheDocument();
-    expect(screen.getByText("Agent type not available")).toBeInTheDocument();
 
     rerender(
-      <AIDField
-        name="aid"
+      <OIDField
+        name="oid"
         label="Test Label"
         variant="withValueAndTitle"
         fetchOptionsCallback={defaultGetOptions}
@@ -214,13 +207,10 @@ describe("AIDField Component", () => {
     expect(
       screen.queryByText("Description not available"),
     ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText("Agent type not available"),
-    ).not.toBeInTheDocument();
 
     rerender(
-      <AIDField
-        name="aid"
+      <OIDField
+        name="oid"
         label="Test Label"
         variant="withValue"
         fetchOptionsCallback={defaultGetOptions}
@@ -233,37 +223,28 @@ describe("AIDField Component", () => {
     expect(
       screen.queryByText("Description not available"),
     ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText("Agent type not available"),
-    ).not.toBeInTheDocument();
   });
 
   it("should handle autoComplete disabled", () => {
     renderWithForm(
-      <AIDField name="aid" label="Test Label" autoComplete={false} />,
+      <OIDField name="oid" label="Test Label" autoComplete={false} />,
     );
 
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
     expect(screen.getByRole("textbox")).toBeInTheDocument();
   });
 
-  it("should validate AID format on submit", async () => {
+  it("should validate OID format on submit", async () => {
     const mockOnSubmit = vi.fn();
     const user = userEvent.setup();
-    const validAid = mockedOptions[1].value;
-    const invalidAid = "invalid-aid";
+    const validOID = mockedOptions[1].value;
+    const invalidOID = "invalid-oid";
 
     render(
       <Form onSubmit={mockOnSubmit}>
-        <AIDField
-          name="aid"
+        <OIDField
+          name="oid"
           label="Test Label"
-          supportedNetworks={[
-            {
-              chainId: "0x5",
-              name: "Goerli",
-            },
-          ]}
           fetchOptionsCallback={defaultGetOptions}
           fetchSelectedOptionCallback={defaultGetSelectedOption}
         />
@@ -273,21 +254,21 @@ describe("AIDField Component", () => {
 
     const input = screen.getByRole("combobox");
     await user.click(input);
-    await user.type(input, invalidAid);
+    await user.type(input, invalidOID);
 
     await user.click(screen.getByText("Submit"));
     await waitFor(() => {
       expect(mockOnSubmit).not.toHaveBeenCalled();
-      expect(screen.getByText(/Invalid DID format/)).toBeInTheDocument();
+      expect(screen.getByText(/Invalid OID format/)).toBeInTheDocument();
     });
 
     await user.clear(input);
-    await user.type(input, validAid);
+    await user.type(input, validOID);
 
     await user.click(screen.getByText("Submit"));
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalledWith({
-        aid: validAid,
+        oid: validOID,
       });
     });
   });
@@ -298,8 +279,8 @@ describe("AIDField Component", () => {
     Math.random = vi.fn().mockReturnValue(1);
 
     renderWithForm(
-      <AIDField
-        name="aid"
+      <OIDField
+        name="oid"
         label="Test Label"
         variant="withValueTitleAndDescription"
         fetchOptionsCallback={defaultGetOptions}
@@ -321,7 +302,6 @@ describe("AIDField Component", () => {
       expect(
         screen.getByText(mockedOptions[0].description),
       ).toBeInTheDocument();
-      expect(screen.getByText(mockedOptions[0].agentType)).toBeInTheDocument();
     });
 
     Math.random = originalRandom;
@@ -330,8 +310,8 @@ describe("AIDField Component", () => {
   it("should not invoke onChange on mount when it has a defaultValue", () => {
     const onChange = vi.fn();
     renderWithForm(
-      <AIDField
-        name="aid"
+      <OIDField
+        name="oid"
         label="Test Label"
         defaultValue={mockedOptions[0].value}
         fetchOptionsCallback={defaultGetOptions}

--- a/packages/design-system/src/scalars/components/oid-field/oid-field.tsx
+++ b/packages/design-system/src/scalars/components/oid-field/oid-field.tsx
@@ -1,0 +1,162 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React, { useCallback, useId } from "react";
+import { IdAutocompleteContext } from "../fragments/id-autocomplete-field/id-autocomplete-context.js";
+import { IdAutocompleteListOption } from "../fragments/id-autocomplete-field/id-autocomplete-list-option.js";
+import { IdAutocompleteFieldRaw } from "../fragments/id-autocomplete-field/index.js";
+import { withFieldValidation } from "../fragments/with-field-validation/index.js";
+import type { FieldErrorHandling, InputBaseProps } from "../types.js";
+import type { OIDOption, OIDProps } from "./types.js";
+
+type OIDFieldBaseProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  | keyof InputBaseProps<string>
+  | keyof FieldErrorHandling
+  | keyof OIDProps
+  | "pattern"
+>;
+
+export type OIDFieldProps = OIDFieldBaseProps &
+  InputBaseProps<string> &
+  FieldErrorHandling &
+  OIDProps;
+
+const OIDFieldRaw = React.forwardRef<HTMLInputElement, OIDFieldProps>(
+  (
+    {
+      id: idProp,
+      name,
+      className,
+      label,
+      description,
+      value,
+      defaultValue,
+      disabled,
+      placeholder,
+      required,
+      errors,
+      warnings,
+      onChange,
+      onBlur,
+      onClick,
+      onMouseDown,
+      autoComplete: autoCompleteProp,
+      variant = "withValue",
+      fetchOptionsCallback,
+      fetchSelectedOptionCallback,
+      isOpenByDefault, // to be used only in stories
+      initialOptions, // to be used only in stories
+      ...props
+    },
+    ref,
+  ) => {
+    const prefix = useId();
+    const id = idProp ?? `${prefix}-oid`;
+    const autoComplete = autoCompleteProp ?? true;
+
+    const renderOption = useCallback(
+      (
+        option: OIDOption,
+        displayProps?: {
+          asPlaceholder?: boolean;
+          showValue?: boolean;
+          isLoadingSelectedOption?: boolean;
+          handleFetchSelectedOption?: (value: string) => void;
+          isFetchSelectedOptionSync?: boolean;
+          className?: string;
+        },
+      ) => (
+        <IdAutocompleteListOption
+          variant={variant}
+          icon={option.icon}
+          title={option.title}
+          path={option.path}
+          value={
+            displayProps?.asPlaceholder ? "uuid not available" : option.value
+          }
+          description={option.description}
+          placeholderIcon="Braces"
+          {...displayProps}
+        />
+      ),
+      [variant],
+    );
+
+    return (
+      <IdAutocompleteContext.Provider value={{}}>
+        {autoComplete && fetchOptionsCallback ? (
+          <IdAutocompleteFieldRaw
+            id={id}
+            name={name}
+            className={className}
+            label={label}
+            description={description}
+            value={value}
+            defaultValue={defaultValue}
+            disabled={disabled}
+            placeholder={placeholder}
+            required={required}
+            errors={errors}
+            warnings={warnings}
+            onChange={onChange}
+            onBlur={onBlur}
+            onClick={onClick}
+            onMouseDown={onMouseDown}
+            autoComplete={true}
+            variant={variant}
+            fetchOptionsCallback={fetchOptionsCallback}
+            fetchSelectedOptionCallback={fetchSelectedOptionCallback}
+            isOpenByDefault={isOpenByDefault}
+            initialOptions={initialOptions}
+            renderOption={renderOption}
+            {...props}
+            ref={ref}
+          />
+        ) : (
+          <IdAutocompleteFieldRaw
+            id={id}
+            name={name}
+            className={className}
+            label={label}
+            description={description}
+            value={value}
+            defaultValue={defaultValue}
+            disabled={disabled}
+            placeholder={placeholder}
+            required={required}
+            errors={errors}
+            warnings={warnings}
+            onChange={onChange}
+            onBlur={onBlur}
+            onClick={onClick}
+            onMouseDown={onMouseDown}
+            autoComplete={false}
+            {...props}
+            ref={ref}
+          />
+        )}
+      </IdAutocompleteContext.Provider>
+    );
+  },
+);
+
+export const OIDField = withFieldValidation<OIDFieldProps>(OIDFieldRaw, {
+  validations: {
+    _validOIDFormat: () => (value: string | undefined) => {
+      if (value === "" || value === undefined) {
+        return true;
+      }
+
+      const uuidPattern =
+        "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$";
+
+      const isValidUUID = new RegExp(uuidPattern).test(value);
+      if (!isValidUUID) {
+        return "Invalid uuid format. Please enter a valid uuid.";
+      }
+
+      return true;
+    },
+  },
+});
+
+OIDField.displayName = "OIDField";

--- a/packages/design-system/src/scalars/components/oid-field/types.ts
+++ b/packages/design-system/src/scalars/components/oid-field/types.ts
@@ -1,0 +1,33 @@
+import type {
+  IdAutocompleteOption,
+  IdAutocompleteProps,
+} from "../fragments/id-autocomplete-field/types.js";
+
+export type OIDOption = IdAutocompleteOption;
+
+type OIDBaseProps = Omit<
+  IdAutocompleteProps,
+  | "autoComplete"
+  | "fetchOptionsCallback"
+  | "fetchSelectedOptionCallback"
+  | "renderOption"
+>;
+
+export type OIDProps = OIDBaseProps &
+  (
+    | {
+        autoComplete: false;
+        fetchOptionsCallback?: never;
+        fetchSelectedOptionCallback?: never;
+      }
+    | {
+        autoComplete?: true;
+        fetchOptionsCallback: (
+          userInput: string,
+          context?: Record<string, unknown>,
+        ) => Promise<OIDOption[]> | OIDOption[];
+        fetchSelectedOptionCallback?: (
+          value: string,
+        ) => Promise<OIDOption | undefined> | OIDOption | undefined;
+      }
+  );


### PR DESCRIPTION
## Ticket
https://trello.com/c/TKSOwkqL/821-23-oid

## Description
- Add Default, Empty, Filled and Open stories
- Should set "autoComplete" config as boolean (true by default)
- Should create the new OIDField wrapper component
- Should ensure the field is not empty if "required" is true
- Should "value" config reflect the current value of the field (the OID entered by the user), or null if not set
- Should "defaultValue" config reflect the default OID value if one is provided, or null if not set
- Should validate the OID format following the pattern 8-4-4-4-12 hexadecimal digits (uuid v4)
- Should implement the callback functions for OID
- Should show the error/warning messages according to the validations