### PR TITLE
fix(scalars): fix the scroll in main browsers

### DIFF
--- a/packages/design-system/src/scalars/components/time-field/subcomponents/time-picker-content.tsx
+++ b/packages/design-system/src/scalars/components/time-field/subcomponents/time-picker-content.tsx
@@ -1,14 +1,14 @@
 import type * as React from "react";
 
-import { Button } from "../../fragments/button/index.js";
-import { type TimePeriod } from "../type.js";
 import { type SelectBaseProps } from "../../enum-field/types.js";
-import TimePeriodSelector from "./time-period-selector.js";
-import TimeSelector from "./time-selector.js";
+import { Button } from "../../fragments/button/index.js";
 import {
   type SelectFieldProps,
   SelectFieldRaw,
 } from "../../fragments/select-field/index.js";
+import { type TimePeriod } from "../type.js";
+import TimePeriodSelector from "./time-period-selector.js";
+import TimeSelector from "./time-selector.js";
 interface TimePickerContentProps {
   onSave?: (time: string) => void;
   onCancel?: () => void;

--- a/packages/design-system/src/scalars/components/time-field/subcomponents/time-selector.tsx
+++ b/packages/design-system/src/scalars/components/time-field/subcomponents/time-selector.tsx
@@ -27,7 +27,7 @@ const TimeSelector: React.FC<TimeSelectorProps> = ({
     <div className="relative w-[43px] overflow-hidden">
       <div
         ref={containerRef}
-        className="scrollbar-hide no-scrollbar absolute inset-0 flex flex-col items-center gap-1 overflow-y-auto"
+        className="absolute inset-0 flex flex-col items-center gap-1 overflow-hidden overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar-thumb]:!hidden [&::-webkit-scrollbar-track]:!hidden [&::-webkit-scrollbar]:!hidden"
       >
         {isCyclic && <div className="h-[60px]" />}
         {displayOptions.map((option, index) => {


### PR DESCRIPTION
## Ticket
https://trello.com/c/t0aw2hKJ/903-update-styles-on-datetimefield-component-after-migration-to-tailwind-v4

## Description
- Should apply the styles defined on the design for the date picker.
- Should apply the styles defined on the design for the time picker.