### PR TITLE
fix(scalars): improve the message for incorrect format

### DIFF
--- a/packages/design-system/src/scalars/components/date-time-field/date-time-field-validations.ts
+++ b/packages/design-system/src/scalars/components/date-time-field/date-time-field-validations.ts
@@ -19,6 +19,7 @@ export const dateTimeFieldValidations =
     if (value === "" || value === undefined) {
       return true;
     }
+    const internalFormat = getDateFormat(dateFormat ?? "");
 
     // 1. Validate that it has date and time separated by space
     const { date, time } = splitIso8601DateTime(value as string);
@@ -27,7 +28,6 @@ export const dateTimeFieldValidations =
       return "Invalid format. Use DATE and TIME separated by a space.";
     }
 
-    const internalFormat = getDateFormat(dateFormat ?? "");
     const stringDate = normalizeMonthFormat(
       getDateFromValue(value as DateFieldValue),
     );
@@ -35,7 +35,7 @@ export const dateTimeFieldValidations =
     const isValid = isDateFormatAllowed(stringDate, internalFormat);
 
     if (!isValid) {
-      return "Invalid date format.";
+      return "Invalid format. Use DATE and TIME separated by a space.";
     }
 
     if (!isValidTime(time)) {


### PR DESCRIPTION
## Ticket
https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time

##Description
- A message error is displayed: "Invalid time format." but actually the time/date has not been inserted.
