### PR TITLE
feat(scalars): fix timeZone error in the offset and reset form in tim…

### DIFF
--- a/packages/design-system/src/scalars/components/time-field/time-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/time-field/time-field.stories.tsx
@@ -12,6 +12,9 @@ const meta: Meta<typeof TimeField> = {
   component: TimeField,
   parameters: {
     layout: "centered",
+    form: {
+      resetBehavior: "unmount",
+    },
   },
   decorators: [withForm],
   tags: ["autodocs"],


### PR DESCRIPTION
## Ticket
https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time

## Description
 - Inserting a timezone into timeZone prop. The control should allow to insert a timezone.Storybook shows an error. 
 - Time Field. Using the Reset button. The field should be cleared. **Current Output:** The button is not working.