### PR TITLE
feat(scalars): add the factory function for currencies type

### DIFF
--- a/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
@@ -135,10 +135,3 @@ export const Disabled: Story = {
     currencyType: CurrencyType.FIAT,
   },
 };
-
-// export const DefaultCurrencies: Story = {
-//   args: {
-//     label: "Currency",
-//     currencyType: CurrencyType.CRYPTO,
-//   },
-// };

--- a/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../lib/storybook-arg-types.js";
 import { CurrencyCodeField } from "./currency-code-field.js";
 import { commonCryptoCurrencies, commonFiatCurrencies } from "./defaults.js";
+import { CurrencyType } from "./types.js";
 
 const meta: Meta<typeof CurrencyCodeField> = {
   title: "Document Engineering/Simple Components/Currency Code Field",
@@ -66,11 +67,20 @@ const meta: Meta<typeof CurrencyCodeField> = {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
+    currencyType: {
+      control: "select",
+      description: "Type of currency to display",
+      options: ["fiat", "crypto", "all"],
+      table: {
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+    },
   },
 
   args: {
     name: "currency-code-field",
     placeholder: "Select a currency",
+    favoriteCurrencies: [],
   },
 };
 
@@ -122,5 +132,13 @@ export const Disabled: Story = {
     value: "EUR",
     disabled: true,
     currencies: commonFiatCurrencies,
+    currencyType: CurrencyType.FIAT,
   },
 };
+
+// export const DefaultCurrencies: Story = {
+//   args: {
+//     label: "Currency",
+//     currencyType: CurrencyType.CRYPTO,
+//   },
+// };

--- a/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
@@ -6,9 +6,7 @@ import {
   StorybookControlCategory,
 } from "../../lib/storybook-arg-types.js";
 import { CurrencyCodeField } from "./currency-code-field.js";
-import { commonCryptoCurrencies, commonFiatCurrencies } from "./defaults.js";
-import { CurrencyType } from "./types.js";
-
+import { cryptoCurrencies, fiatCurrencies } from "./utils.js";
 const meta: Meta<typeof CurrencyCodeField> = {
   title: "Document Engineering/Simple Components/Currency Code Field",
   component: CurrencyCodeField,
@@ -67,14 +65,6 @@ const meta: Meta<typeof CurrencyCodeField> = {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
-    currencyType: {
-      control: "select",
-      description: "Type of currency to display",
-      options: ["fiat", "crypto", "all"],
-      table: {
-        category: StorybookControlCategory.COMPONENT_SPECIFIC,
-      },
-    },
   },
 
   args: {
@@ -90,7 +80,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     label: "Currency",
-    currencies: commonCryptoCurrencies,
+    currencies: cryptoCurrencies(),
   },
 };
 export const FavoriteCurrencies: Story = {
@@ -131,7 +121,6 @@ export const Disabled: Story = {
     label: "Currency",
     value: "EUR",
     disabled: true,
-    currencies: commonFiatCurrencies,
-    currencyType: CurrencyType.FIAT,
+    currencies: fiatCurrencies(),
   },
 };

--- a/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.test.tsx
+++ b/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { renderWithForm } from "../../lib/testing.js";
 import { Form } from "../form/index.js";
 import { CurrencyCodeField } from "./currency-code-field.js";
+import { currencies } from "./utils.js";
 
 describe("CurrencyCodeField", () => {
   window.HTMLElement.prototype.scrollIntoView = vi.fn();
@@ -15,13 +16,20 @@ describe("CurrencyCodeField", () => {
         label="Currency"
         description="Select a currency"
         value="USD"
+        currencies={currencies()}
       />,
     );
     expect(container).toMatchSnapshot();
   });
 
   it("should render with default props", () => {
-    renderWithForm(<CurrencyCodeField name="currency" label="Currency" />);
+    renderWithForm(
+      <CurrencyCodeField
+        name="currency"
+        label="Currency"
+        currencies={currencies()}
+      />,
+    );
     expect(screen.getByRole("combobox")).toBeInTheDocument();
     expect(screen.getByText("Currency")).toBeInTheDocument();
   });
@@ -30,7 +38,12 @@ describe("CurrencyCodeField", () => {
     const user = userEvent.setup();
     renderWithForm(
       <>
-        <CurrencyCodeField name="currency" label="Currency" required />
+        <CurrencyCodeField
+          name="currency"
+          label="Currency"
+          required
+          currencies={currencies()}
+        />
         <button type="submit">Submit</button>
       </>,
     );
@@ -43,7 +56,12 @@ describe("CurrencyCodeField", () => {
     const user = userEvent.setup();
     render(
       <Form onSubmit={onSubmit}>
-        <CurrencyCodeField name="currency" label="Currency" value="USD" />
+        <CurrencyCodeField
+          name="currency"
+          label="Currency"
+          value="USD"
+          currencies={currencies()}
+        />
         <button type="submit">Submit</button>
       </Form>,
     );
@@ -53,7 +71,12 @@ describe("CurrencyCodeField", () => {
 
   it("should handle disabled state", () => {
     renderWithForm(
-      <CurrencyCodeField name="currency" label="Currency" disabled />,
+      <CurrencyCodeField
+        name="currency"
+        label="Currency"
+        disabled
+        currencies={currencies()}
+      />,
     );
     expect(screen.getByRole("combobox")).toBeDisabled();
   });
@@ -61,7 +84,12 @@ describe("CurrencyCodeField", () => {
   it("should display custom errors", async () => {
     const errors = ["Please select a valid currency"];
     renderWithForm(
-      <CurrencyCodeField name="currency" label="Currency" errors={errors} />,
+      <CurrencyCodeField
+        name="currency"
+        label="Currency"
+        errors={errors}
+        currencies={currencies()}
+      />,
     );
     expect(await screen.findByText(errors[0])).toBeInTheDocument();
   });
@@ -73,6 +101,7 @@ describe("CurrencyCodeField", () => {
         name="currency"
         label="Currency"
         warnings={warnings}
+        currencies={currencies()}
       />,
     );
     expect(await screen.findByText(warnings[0])).toBeInTheDocument();

--- a/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.tsx
+++ b/packages/design-system/src/scalars/components/currency-code-field/currency-code-field.tsx
@@ -7,8 +7,7 @@ import {
 } from "../fragments/index.js";
 import { withFieldValidation } from "../fragments/with-field-validation/with-field-validation.js";
 import type { FieldErrorHandling, InputBaseProps } from "../types.js";
-import type { Currency, CurrencyType } from "./types.js";
-import { getDefaultCurrencies } from "./utils.js";
+import type { Currency } from "./types.js";
 
 type CurrencyCodeFieldBaseProps = Omit<
   React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -25,14 +24,13 @@ export interface CurrencyCodeFieldProps
   placeholder?: string;
   onChange?: (value: string | string[]) => void;
   onBlur?: () => void;
-  currencies?: Currency[];
+  currencies: Currency[];
   includeCurrencySymbols?: boolean;
   favoriteCurrencies?: string[];
   symbolPosition?: "left" | "right";
   searchable?: boolean;
   contentClassName?: string;
   contentAlign?: "start" | "end" | "center";
-  currencyType?: CurrencyType;
 }
 
 export const CurrencyCodeFieldRaw = React.forwardRef<
@@ -43,7 +41,6 @@ export const CurrencyCodeFieldRaw = React.forwardRef<
     {
       placeholder,
       currencies,
-      currencyType,
       favoriteCurrencies = [],
       includeCurrencySymbols = true,
       symbolPosition = "right",
@@ -56,16 +53,11 @@ export const CurrencyCodeFieldRaw = React.forwardRef<
     },
     ref,
   ) => {
-    const finalCurrencies = useMemo(
-      () => currencies ?? getDefaultCurrencies(currencyType),
-      [currencies, currencyType],
-    );
-
     const options: SelectOption[] = useMemo(() => {
       const favoriteTickers = new Set(favoriteCurrencies);
 
       return (
-        (finalCurrencies
+        (currencies
           .map((currency) => {
             if (favoriteTickers.has(currency.ticker)) {
               return null;
@@ -92,7 +84,7 @@ export const CurrencyCodeFieldRaw = React.forwardRef<
           .filter(Boolean) as SelectOption[]) ?? []
       );
     }, [
-      finalCurrencies,
+      currencies,
       includeCurrencySymbols,
       symbolPosition,
       favoriteCurrencies,
@@ -101,7 +93,7 @@ export const CurrencyCodeFieldRaw = React.forwardRef<
     const favoriteOptions: SelectOption[] = useMemo(() => {
       const favoriteTickers = new Set(favoriteCurrencies);
       return (
-        finalCurrencies
+        currencies
           .filter((currency) => favoriteTickers.has(currency.ticker))
           .map((currency) => {
             let label = currency.label ?? currency.ticker;
@@ -124,7 +116,7 @@ export const CurrencyCodeFieldRaw = React.forwardRef<
           }) ?? []
       );
     }, [
-      finalCurrencies,
+      currencies,
       favoriteCurrencies,
       includeCurrencySymbols,
       symbolPosition,

--- a/packages/design-system/src/scalars/components/currency-code-field/index.ts
+++ b/packages/design-system/src/scalars/components/currency-code-field/index.ts
@@ -1,3 +1,6 @@
-export { commonCryptoCurrencies, commonFiatCurrencies } from "./defaults.js";
+/* eslint-disable prettier/prettier */
 export { CurrencyCodeField } from "./currency-code-field.js";
+export { commonCryptoCurrencies, commonFiatCurrencies } from "./defaults.js";
 export type { Currency, CurrencyType } from "./types.js";
+export { cryptoCurrencies, currencies, fiatCurrencies } from "./utils.js";
+

--- a/packages/design-system/src/scalars/components/currency-code-field/types.ts
+++ b/packages/design-system/src/scalars/components/currency-code-field/types.ts
@@ -9,4 +9,8 @@ export interface Currency {
   icon?: IconName | React.ComponentType<{ className?: string }>;
 }
 
-export type CurrencyType = "Fiat" | "Crypto";
+export enum CurrencyType {
+  FIAT = "fiat",
+  CRYPTO = "crypto",
+  ALL = "all",
+}

--- a/packages/design-system/src/scalars/components/currency-code-field/utils.ts
+++ b/packages/design-system/src/scalars/components/currency-code-field/utils.ts
@@ -1,12 +1,19 @@
-import { CurrencyType } from "./types.js";
-
-const fiatCurrencies = [
+// add docs
+/**
+ * Get the fiat currencies
+ * @returns {Currency[]} The fiat currencies
+ */
+export const fiatCurrencies = () => [
   { ticker: "USD", crypto: false, label: "USD", symbol: "$" },
   { ticker: "EUR", crypto: false, label: "EUR", symbol: "€" },
   { ticker: "GBP", crypto: false, label: "GBP", symbol: "£" },
 ];
 
-const cryptoCurrencies = [
+/**
+ * Get the crypto currencies
+ * @returns {Currency[]} The crypto currencies
+ */
+export const cryptoCurrencies = () => [
   { ticker: "DAI", crypto: true, label: "DAI", symbol: "DAI" },
   { ticker: "ETH", crypto: true, label: "ETH", symbol: "ETH" },
   { ticker: "MKR", crypto: true, label: "MKR", symbol: "MKR" },
@@ -14,8 +21,11 @@ const cryptoCurrencies = [
   { ticker: "USDC", crypto: true, label: "USDC", symbol: "USDC" },
   { ticker: "USDS", crypto: true, label: "USDS", symbol: "USDS" },
 ];
-export function getDefaultCurrencies(type: CurrencyType = CurrencyType.ALL) {
-  if (type === CurrencyType.FIAT) return fiatCurrencies;
-  if (type === CurrencyType.CRYPTO) return cryptoCurrencies;
-  return [...fiatCurrencies, ...cryptoCurrencies];
-}
+
+/**
+ * Get the currencies
+ * @returns {Currency[]} The currencies
+ */
+export const currencies = () => {
+  return [...fiatCurrencies(), ...cryptoCurrencies()];
+};

--- a/packages/design-system/src/scalars/components/currency-code-field/utils.ts
+++ b/packages/design-system/src/scalars/components/currency-code-field/utils.ts
@@ -1,0 +1,21 @@
+import { CurrencyType } from "./types.js";
+
+const fiatCurrencies = [
+  { ticker: "USD", crypto: false, label: "USD", symbol: "$" },
+  { ticker: "EUR", crypto: false, label: "EUR", symbol: "€" },
+  { ticker: "GBP", crypto: false, label: "GBP", symbol: "£" },
+];
+
+const cryptoCurrencies = [
+  { ticker: "DAI", crypto: true, label: "DAI", symbol: "DAI" },
+  { ticker: "ETH", crypto: true, label: "ETH", symbol: "ETH" },
+  { ticker: "MKR", crypto: true, label: "MKR", symbol: "MKR" },
+  { ticker: "SKY", crypto: true, label: "SKY", symbol: "SKY" },
+  { ticker: "USDC", crypto: true, label: "USDC", symbol: "USDC" },
+  { ticker: "USDS", crypto: true, label: "USDS", symbol: "USDS" },
+];
+export function getDefaultCurrencies(type: CurrencyType = CurrencyType.ALL) {
+  if (type === CurrencyType.FIAT) return fiatCurrencies;
+  if (type === CurrencyType.CRYPTO) return cryptoCurrencies;
+  return [...fiatCurrencies, ...cryptoCurrencies];
+}


### PR DESCRIPTION
## Ticket
https://trello.com/c/RQlyOdrZ/778-12-currencycodefield-currencycodefiat-currencycodecrypto

## Description
- Should implements a functions to get the default list of the currencies base in the typeCurrency props