### PR TITLE
fix(scalars): fix the message and fixed minDate and maxDate with disa…

### DIFF
--- a/packages/design-system/src/scalars/components/date-field/date-validations.ts
+++ b/packages/design-system/src/scalars/components/date-field/date-validations.ts
@@ -12,28 +12,6 @@ import {
   normalizeMonthFormat,
 } from "../date-time-field/utils.js";
 
-/**
- * Creates a validator function for date fields that checks various date constraints
- *
- * @param options - Configuration options for date validation
- * @param {string} [options.dateFormat] - Expected format for date input
- * @param {Date | string} [options.minDate] - Minimum allowed date
- * @param {Date | string} [options.maxDate] - Maximum allowed date
- * @param {boolean} [options.disablePastDates] - If true, dates before today are invalid
- * @param {boolean} [options.disableFutureDates] - If true, dates after today are invalid
- *
- * @returns A validation function that accepts a date value and returns either:
- *  - true: if the date is valid and meets all constraints
- *  - string: error message if the date is invalid or violates any constraints
- *
- * @example
- * const validator = validateDatePicker({
- *   minDate: '2024-01-01',
- *   disableFutureDates: true
- * });
- *
- * const result = validator('2024-02-15'); // returns true or error message
- */
 export const validateDatePicker =
   ({
     dateFormat,

--- a/packages/design-system/src/scalars/components/date-field/date-validations.ts
+++ b/packages/design-system/src/scalars/components/date-field/date-validations.ts
@@ -55,7 +55,7 @@ export const validateDatePicker =
       }
     }
 
-    // Obtener la fecha más restrictiva entre maxDate y disableFutureDates
+    // Get the most restrictive date between maxDate and disableFutureDates
     let effectiveMaxDate: Date | null = null;
     if (maxDate) {
       const maxDateValue = new Date(maxDate);
@@ -81,11 +81,6 @@ export const validateDatePicker =
         validDateStartOfDay < effectiveMinDate ||
         validDateStartOfDay > effectiveMaxDate
       ) {
-        console.log({
-          validDateStartOfDay,
-          effectiveMinDate,
-          effectiveMaxDate,
-        });
         const formattedMinDate = format(effectiveMinDate, "dd/MM/yyyy");
         const formattedMaxDate = format(effectiveMaxDate, "dd/MM/yyyy");
         return `Date should be between ${formattedMinDate} - ${formattedMaxDate}`;

--- a/packages/design-system/src/scalars/components/date-field/date-validations.ts
+++ b/packages/design-system/src/scalars/components/date-field/date-validations.ts
@@ -12,6 +12,28 @@ import {
   normalizeMonthFormat,
 } from "../date-time-field/utils.js";
 
+/**
+ * Creates a validator function for date fields that checks various date constraints
+ *
+ * @param options - Configuration options for date validation
+ * @param {string} [options.dateFormat] - Expected format for date input
+ * @param {Date | string} [options.minDate] - Minimum allowed date
+ * @param {Date | string} [options.maxDate] - Maximum allowed date
+ * @param {boolean} [options.disablePastDates] - If true, dates before today are invalid
+ * @param {boolean} [options.disableFutureDates] - If true, dates after today are invalid
+ *
+ * @returns A validation function that accepts a date value and returns either:
+ *  - true: if the date is valid and meets all constraints
+ *  - string: error message if the date is invalid or violates any constraints
+ *
+ * @example
+ * const validator = validateDatePicker({
+ *   minDate: '2024-01-01',
+ *   disableFutureDates: true
+ * });
+ *
+ * const result = validator('2024-02-15'); // returns true or error message
+ */
 export const validateDatePicker =
   ({
     dateFormat,
@@ -36,36 +58,71 @@ export const validateDatePicker =
       return `Invalid date format. Please use a valid format`;
     }
     const isoDate = formatDateToValidCalendarDateFormat(stringDate);
-    const validDate = new Date(isoDate);
+    // Split the date and time parts
+    const [datePart] = isoDate.split("T");
+    // Create a valid date object with the date part and set the time to 00:00:00
+    const validDateStartOfDay = new Date(`${datePart}T00:00:00`);
 
+    // Get the most restrictive date between minDate and disablePastDates
+    let effectiveMinDate: Date | null = null;
     if (minDate) {
       const minDateValue = new Date(minDate);
-      if (validDate < minDateValue) {
-        const formattedMinDate = format(minDateValue, "dd/MM/yyyy");
-        return `Date must be on or after ${formattedMinDate}.`;
-      }
-    }
-
-    if (maxDate) {
-      const maxDateValue = new Date(maxDate);
-      if (validDate > maxDateValue) {
-        const formattedMaxDate = format(maxDateValue, "dd/MM/yyyy");
-        return `Date must be on or before ${formattedMaxDate}.`;
-      }
+      effectiveMinDate = new Date(minDateValue.setHours(0, 0, 0, 0));
     }
     if (disablePastDates) {
       const today = new Date();
-      if (validDate < today) {
-        const formattedToday = format(today, "dd/MM/yyyy");
-        return `Date must be on or after ${formattedToday}.`;
+      const todayStartOfDay = new Date(today.setHours(0, 0, 0, 0));
+      if (!effectiveMinDate || todayStartOfDay > effectiveMinDate) {
+        effectiveMinDate = todayStartOfDay;
       }
+    }
+
+    // Obtener la fecha más restrictiva entre maxDate y disableFutureDates
+    let effectiveMaxDate: Date | null = null;
+    if (maxDate) {
+      const maxDateValue = new Date(maxDate);
+      effectiveMaxDate = new Date(maxDateValue.setHours(0, 0, 0, 0));
     }
     if (disableFutureDates) {
       const today = new Date();
-      if (validDate > today) {
-        const formattedToday = format(today, "dd/MM/yyyy");
-        return `Date must be on or before ${formattedToday}.`;
+      const todayStartOfDay = new Date(today.setHours(0, 0, 0, 0));
+      if (!effectiveMaxDate || todayStartOfDay < effectiveMaxDate) {
+        effectiveMaxDate = todayStartOfDay;
       }
     }
+
+    // Validate against the effective dates
+    if (effectiveMinDate && effectiveMaxDate) {
+      if (effectiveMinDate > effectiveMaxDate) {
+        const formattedMinDate = format(effectiveMinDate, "dd/MM/yyyy");
+        const formattedMaxDate = format(effectiveMaxDate, "dd/MM/yyyy");
+        return `Invalid date range: ${formattedMinDate} is after ${formattedMaxDate}`;
+      }
+
+      if (
+        validDateStartOfDay < effectiveMinDate ||
+        validDateStartOfDay > effectiveMaxDate
+      ) {
+        console.log({
+          validDateStartOfDay,
+          effectiveMinDate,
+          effectiveMaxDate,
+        });
+        const formattedMinDate = format(effectiveMinDate, "dd/MM/yyyy");
+        const formattedMaxDate = format(effectiveMaxDate, "dd/MM/yyyy");
+        return `Date should be between ${formattedMinDate} - ${formattedMaxDate}`;
+      }
+    } else if (effectiveMinDate) {
+      if (validDateStartOfDay < effectiveMinDate) {
+        const formattedMinDate = format(effectiveMinDate, "dd/MM/yyyy");
+        return `Date must be after ${formattedMinDate}`;
+      }
+    } else if (effectiveMaxDate) {
+      if (validDateStartOfDay > effectiveMaxDate) {
+        const formattedMaxDate = format(effectiveMaxDate, "dd/MM/yyyy");
+        return `Date must be before ${formattedMaxDate}`;
+      }
+    }
+
     return true;
   };

--- a/packages/design-system/src/scalars/components/date-field/use-date-field.tsx
+++ b/packages/design-system/src/scalars/components/date-field/use-date-field.tsx
@@ -89,17 +89,17 @@ export const useDatePickerField = ({
     let beforeDate: Date | undefined;
     let afterDate: Date | undefined;
 
-    // Convertir minDate y maxDate a objetos Date si existen
+    // Convert minDate and maxDate to Date objects if they exist
     const minDateObj = minDate ? startOfDay(new Date(minDate)) : undefined;
     const maxDateObj = maxDate ? startOfDay(new Date(maxDate)) : undefined;
     const todayDate = startOfDay(today);
 
-    // Si tenemos disablePastDates y disableFutureDates, solo today es válido
+    // If we have both disablePastDates and disableFutureDates, only today is valid
     if (disablePastDates && disableFutureDates) {
       beforeDate = todayDate;
       afterDate = todayDate;
     } else {
-      // Determinar beforeDate (fecha mínima permitida)
+      // Determine beforeDate (minimum allowed date)
       if (minDateObj && disablePastDates) {
         beforeDate = minDateObj > todayDate ? minDateObj : todayDate;
       } else if (minDateObj) {
@@ -108,7 +108,7 @@ export const useDatePickerField = ({
         beforeDate = todayDate;
       }
 
-      // Determinar afterDate (fecha máxima permitida)
+      // Determine afterDate (maximum allowed date)
       if (maxDateObj && disableFutureDates) {
         afterDate = maxDateObj < todayDate ? maxDateObj : todayDate;
       } else if (maxDateObj) {
@@ -118,9 +118,9 @@ export const useDatePickerField = ({
       }
     }
 
-    // Si beforeDate es mayor que afterDate, deshabilitar todas las fechas
+    // If beforeDate is greater than afterDate, disable all dates
     if (beforeDate && afterDate && beforeDate > afterDate) {
-      // Usar una fecha en el pasado como before y after para deshabilitar todo
+      // Use a date in the past as before and after to disable everything
       const disableAllDates = new Date(0); // 1970-01-01
       return { before: disableAllDates, after: disableAllDates };
     }

--- a/packages/design-system/src/scalars/components/date-time-field/date-time-field-validations.ts
+++ b/packages/design-system/src/scalars/components/date-time-field/date-time-field-validations.ts
@@ -48,36 +48,63 @@ export const dateTimeFieldValidations =
       return "Invalid time format. Use HH:mm.";
     }
     const isoDate = formatDateToValidCalendarDateFormat(stringDate);
-    const validDate = new Date(isoDate);
+    const [datePart] = isoDate.split("T");
+    const validDateStartOfDay = new Date(`${datePart}T00:00:00`);
 
+    let effectiveMinDate: Date | null = null;
     if (minDate) {
       const minDateValue = new Date(minDate);
-      if (validDate < minDateValue) {
-        const formattedMinDate = format(minDateValue, "dd/MM/yyyy");
-        return `Date must be on or after ${formattedMinDate}.`;
-      }
-    }
-
-    if (maxDate) {
-      const maxDateValue = new Date(maxDate);
-      if (validDate > maxDateValue) {
-        const formattedMaxDate = format(maxDateValue, "dd/MM/yyyy");
-        return `Date must be on or before ${formattedMaxDate}.`;
-      }
+      effectiveMinDate = new Date(minDateValue.setHours(0, 0, 0, 0));
     }
     if (disablePastDates) {
       const today = new Date();
-      if (validDate < today) {
-        const formattedToday = format(today, "dd/MM/yyyy");
-        return `Date must be on or after ${formattedToday}.`;
+      const todayStartOfDay = new Date(today.setHours(0, 0, 0, 0));
+      if (!effectiveMinDate || todayStartOfDay > effectiveMinDate) {
+        effectiveMinDate = todayStartOfDay;
       }
+    }
+
+    // Get the most restrictive date between maxDate and disableFutureDates
+    let effectiveMaxDate: Date | null = null;
+    if (maxDate) {
+      const maxDateValue = new Date(maxDate);
+      effectiveMaxDate = new Date(maxDateValue.setHours(0, 0, 0, 0));
     }
     if (disableFutureDates) {
       const today = new Date();
-      if (validDate > today) {
-        const formattedToday = format(today, "dd/MM/yyyy");
-        return `Date must be on or before ${formattedToday}.`;
+      const todayStartOfDay = new Date(today.setHours(0, 0, 0, 0));
+      if (!effectiveMaxDate || todayStartOfDay < effectiveMaxDate) {
+        effectiveMaxDate = todayStartOfDay;
       }
     }
+
+    // Validate against the effective dates
+    if (effectiveMinDate && effectiveMaxDate) {
+      if (effectiveMinDate > effectiveMaxDate) {
+        const formattedMinDate = format(effectiveMinDate, "dd/MM/yyyy");
+        const formattedMaxDate = format(effectiveMaxDate, "dd/MM/yyyy");
+        return `Invalid date range: ${formattedMinDate} is after ${formattedMaxDate}`;
+      }
+
+      if (
+        validDateStartOfDay < effectiveMinDate ||
+        validDateStartOfDay > effectiveMaxDate
+      ) {
+        const formattedMinDate = format(effectiveMinDate, "dd/MM/yyyy");
+        const formattedMaxDate = format(effectiveMaxDate, "dd/MM/yyyy");
+        return `Date should be between ${formattedMinDate} - ${formattedMaxDate}`;
+      }
+    } else if (effectiveMinDate) {
+      if (validDateStartOfDay < effectiveMinDate) {
+        const formattedMinDate = format(effectiveMinDate, "dd/MM/yyyy");
+        return `Date must be after ${formattedMinDate}`;
+      }
+    } else if (effectiveMaxDate) {
+      if (validDateStartOfDay > effectiveMaxDate) {
+        const formattedMaxDate = format(effectiveMaxDate, "dd/MM/yyyy");
+        return `Date must be before ${formattedMaxDate}`;
+      }
+    }
+
     return true;
   };

--- a/packages/design-system/src/scalars/components/date-time-field/use-date-time.tsx
+++ b/packages/design-system/src/scalars/components/date-time-field/use-date-time.tsx
@@ -241,6 +241,8 @@ export const useDateTime = ({
     }
     // Get the time and tran
     const timeValue = inputValue.split(" ")[1];
+    // Get period from input if exists
+    const periodInput = inputValue.split(" ")[2] as TimePeriod;
 
     if (!isValidTimeInput(timeValue)) {
       if (inputValue === "") {
@@ -258,30 +260,12 @@ export const useDateTime = ({
       return;
     }
 
-    //  If the time is valid, and is 12 hour format, do nothing not transform the time
-    if (
-      is12HourFormat &&
-      isValidTimeInput(timeValue) &&
-      (inputValue.includes("AM") || inputValue.includes("PM"))
-    ) {
-      return;
-    }
-
-    // if is 24 hour format, and the time is valid, and the time is not AM or PM, do nothing
-    if (
-      !is12HourFormat &&
-      isValidTimeInput(timeValue) &&
-      !inputValue.includes("AM") &&
-      !inputValue.includes("PM")
-    ) {
-      return;
-    }
     const datetimeFormatted = formatInputToDisplayValid(
       timeValue,
       is12HourFormat,
       timeIntervals,
+      periodInput,
     );
-
     const validValue = convert12hTo24h(datetimeFormatted);
     const offsetUTC = getOffset(timeZone);
     const { minutes, hours, period } = getHoursAndMinutes(validValue);

--- a/packages/design-system/src/scalars/components/time-field/use-time-field.ts
+++ b/packages/design-system/src/scalars/components/time-field/use-time-field.ts
@@ -83,6 +83,8 @@ export const useTimePickerField = ({
   };
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const input = e.target.value;
+    // Get the period from the input if exists to avoid use the default period
+    const inputPeriod = input.split(" ")[1] as TimePeriod;
 
     if (!isValidTimeInput(input)) {
       if (input === "") {
@@ -102,6 +104,7 @@ export const useTimePickerField = ({
       input,
       is12HourFormat,
       timeIntervals,
+      inputPeriod,
     );
     // Check if the validDisplay is empty and if it is, set the inputValue to an empty string
     if (!validDisplay) {

--- a/packages/design-system/src/scalars/components/time-field/utils.ts
+++ b/packages/design-system/src/scalars/components/time-field/utils.ts
@@ -351,27 +351,27 @@ export const convert12hTo24h = (input: string) => {
 };
 
 /**
- * Formatea una cadena de entrada de tiempo en un formato de visualización estandarizado
- * @param input - La cadena de tiempo de entrada. Puede estar en varios formatos:
- *   - Formato 24 horas (ej., "14:30", "08:00")
- *   - Formato 12 horas (ej., "2:30 PM", "8:00 AM")
- *   - Formato corto (ej., "1430", "0800")
- * @param is12HourFormat - Si es true, devuelve en formato 12 horas con AM/PM
- *                        Si es false, devuelve en formato 24 horas
- * @param timeIntervals - Intervalo opcional en minutos para redondear el tiempo
- *                       (ej., 15 redondeará al cuarto de hora más cercano)
- * @param periodToCheck - Período específico (AM/PM) para forzar en la salida,
- *                       evitando la conversión automática del período
- * @returns Cadena de tiempo formateada
- *   - Formato 12 horas: "hh:mm AM/PM" (ej., "02:30 PM")
- *   - Formato 24 horas: "HH:mm" (ej., "14:30")
+ * Formats a time input string into a standardized display format
+ * @param input - The input time string. Can be in various formats:
+ *   - 24-hour format (e.g., "14:30", "08:00")
+ *   - 12-hour format (e.g., "2:30 PM", "8:00 AM")
+ *   - Short format (e.g., "1430", "0800")
+ * @param is12HourFormat - If true, returns in 12-hour format with AM/PM
+ *                        If false, returns in 24-hour format
+ * @param timeIntervals - Optional interval in minutes to round the time
+ *                       (e.g., 15 will round to the nearest quarter hour)
+ * @param periodToCheck - Specific period (AM/PM) to force in the output,
+ *                       avoiding automatic period conversion
+ * @returns Formatted time string
+ *   - 12-hour format: "hh:mm AM/PM" (e.g., "02:30 PM")
+ *   - 24-hour format: "HH:mm" (e.g., "14:30")
  * @example
- * // Con formato 12 horas
- * formatInputToDisplayValid("14:30", true) // Retorna "02:30 PM"
- * formatInputToDisplayValid("14:30", true, undefined, "AM") // Retorna "02:30 AM"
+ * // With 12-hour format
+ * formatInputToDisplayValid("14:30", true) // Returns "02:30 PM"
+ * formatInputToDisplayValid("14:30", true, undefined, "AM") // Returns "02:30 AM"
  *
- * // Con formato 24 horas
- * formatInputToDisplayValid("2:30 PM", false) // Retorna "14:30"
+ * // With 24-hour format
+ * formatInputToDisplayValid("2:30 PM", false) // Returns "14:30"
  */
 export const formatInputToDisplayValid = (
   input: string,

--- a/packages/design-system/src/scalars/components/time-field/utils.ts
+++ b/packages/design-system/src/scalars/components/time-field/utils.ts
@@ -87,6 +87,7 @@ export const transformInputTime = (
   input: string,
   is12HourFormat: boolean,
   interval = 1,
+  periodToCheck?: TimePeriod,
 ): { hour: string; minute: string; period?: TimePeriod } => {
   if (!input) return { hour: "", minute: "", period: undefined };
   input = input.trim();
@@ -126,6 +127,9 @@ export const transformInputTime = (
     // If still no period assigned, determine based on hour
     if (!period) {
       period = hourNum >= 8 && hourNum <= 11 ? "AM" : "PM";
+    }
+    if (periodToCheck) {
+      period = periodToCheck;
     }
   } else {
     // Convert any AM/PM designator to 24h
@@ -347,23 +351,33 @@ export const convert12hTo24h = (input: string) => {
 };
 
 /**
- * Formats a time input string into a standardized display format
- * @param input - The input time string. Can be in various formats:
- *   - 24-hour format (e.g., "14:30", "08:00")
- *   - 12-hour format (e.g., "2:30 PM", "8:00 AM")
- *   - Short format (e.g., "1430", "0800")
- * @param is12HourFormat - If true, outputs in 12-hour format with AM/PM
- *                        If false, outputs in 24-hour format
- * @param timeIntervals - Optional interval in minutes to round the time to
- *                       (e.g., 15 would round to nearest quarter hour)
- * @returns Formatted time string
- *   - 12-hour format: "hh:mm AM/PM" (e.g., "02:30 PM")
- *   - 24-hour format: "HH:mm" (e.g., "14:30")
+ * Formatea una cadena de entrada de tiempo en un formato de visualización estandarizado
+ * @param input - La cadena de tiempo de entrada. Puede estar en varios formatos:
+ *   - Formato 24 horas (ej., "14:30", "08:00")
+ *   - Formato 12 horas (ej., "2:30 PM", "8:00 AM")
+ *   - Formato corto (ej., "1430", "0800")
+ * @param is12HourFormat - Si es true, devuelve en formato 12 horas con AM/PM
+ *                        Si es false, devuelve en formato 24 horas
+ * @param timeIntervals - Intervalo opcional en minutos para redondear el tiempo
+ *                       (ej., 15 redondeará al cuarto de hora más cercano)
+ * @param periodToCheck - Período específico (AM/PM) para forzar en la salida,
+ *                       evitando la conversión automática del período
+ * @returns Cadena de tiempo formateada
+ *   - Formato 12 horas: "hh:mm AM/PM" (ej., "02:30 PM")
+ *   - Formato 24 horas: "HH:mm" (ej., "14:30")
+ * @example
+ * // Con formato 12 horas
+ * formatInputToDisplayValid("14:30", true) // Retorna "02:30 PM"
+ * formatInputToDisplayValid("14:30", true, undefined, "AM") // Retorna "02:30 AM"
+ *
+ * // Con formato 24 horas
+ * formatInputToDisplayValid("2:30 PM", false) // Retorna "14:30"
  */
 export const formatInputToDisplayValid = (
   input: string,
   is12HourFormat: boolean,
   timeIntervals?: number,
+  periodToCheck?: TimePeriod,
 ) => {
   const { hour, minute, period } = transformInputTime(
     input,
@@ -373,7 +387,7 @@ export const formatInputToDisplayValid = (
   if (!hour && !minute) return "";
 
   return is12HourFormat
-    ? `${hour}:${minute} ${period ?? ""}`
+    ? `${hour}:${minute} ${periodToCheck ? periodToCheck : (period ?? "")}`
     : `${hour}:${minute}`;
 };
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time

## Description
- DateTime Field. maxDate = 03/21/2025. Selecting 03/21/2025 thought the date picker. **Expected Output:** The date should be allowed. **Current Output:** An error message is displayed referring to the date should be on or before of the maxDate set (03/21/2025) but the validation is not allowing to submit it.  

- DateTime Field. disableFutureDates = true, minDate = 03/06/2025.  The date before 03/06/2025 should be disabled, the dates after the current day should be disabled.  **Current Output:** Combining these two props, the date before the minDate value are enabled. **Using maxDate and disablePastDtaes happens the same issue