### PR TITLE
fix(scalars): fix-with-no-select-value-amount-fix-values-stories

### DIFF
--- a/packages/design-system/src/scalars/components/amount-field/amount-field.stories.tsx
+++ b/packages/design-system/src/scalars/components/amount-field/amount-field.stories.tsx
@@ -41,6 +41,10 @@ const meta = {
         type: { summary: "Currency[]" },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
+      if: {
+        arg: "type",
+        neq: "AmountPercentage",
+      },
     },
     includeCurrencySymbols: {
       control: "boolean",
@@ -48,6 +52,10 @@ const meta = {
       table: {
         defaultValue: { summary: "true" },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+      if: {
+        arg: "type",
+        neq: "AmountPercentage",
       },
     },
     symbolPosition: {
@@ -57,6 +65,10 @@ const meta = {
       table: {
         type: { summary: "string" },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+      if: {
+        arg: "type",
+        neq: "AmountPercentage",
       },
     },
     step: {
@@ -77,6 +89,10 @@ const meta = {
         defaultValue: { summary: "right" },
         type: { summary: "string" },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+      if: {
+        arg: "type",
+        neq: "AmountPercentage",
       },
     },
 
@@ -185,8 +201,8 @@ export const Default: Story = {
     placeholderSelect: "CUR",
     type: "Amount",
     value: {
-      amount: 234,
-      unit: "EUR",
+      amount: undefined,
+      unit: "",
     },
   },
 };
@@ -270,7 +286,6 @@ export const WithValuePercent: Story = {
     },
   },
   args: {
-    units: mappedCryptoCurrencies,
     label: "Enter Percentage ",
     placeholder: "Enter Amount",
     type: "AmountPercentage",

--- a/packages/design-system/src/scalars/components/amount-field/amount-field.test.tsx
+++ b/packages/design-system/src/scalars/components/amount-field/amount-field.test.tsx
@@ -63,7 +63,6 @@ describe("AmountField Component", () => {
         type="AmountPercentage"
         value={345}
         step={0}
-        units={commonCryptoCurrencies}
       />,
     );
     expect(screen.getByText("%")).toBeInTheDocument();

--- a/packages/design-system/src/scalars/components/amount-field/amount-field.tsx
+++ b/packages/design-system/src/scalars/components/amount-field/amount-field.tsx
@@ -124,7 +124,7 @@ const AmountFieldRaw = forwardRef<HTMLInputElement, AmountFieldProps>(
             {isShowSelect && currencyPosition === "left" && (
               <CurrencyCodeFieldRaw
                 contentAlign="start"
-                contentClassName="min-w-[160px]"
+                contentClassName="[&]:!w-[100px] w-full"
                 disabled={disabled}
                 currencies={options ?? []}
                 onChange={handleOnChangeSelect}
@@ -191,7 +191,7 @@ const AmountFieldRaw = forwardRef<HTMLInputElement, AmountFieldProps>(
           {isShowSelect && currencyPosition === "right" && (
             <CurrencyCodeFieldRaw
               contentAlign="end"
-              contentClassName="min-w-[160px]"
+              contentClassName="[&]:!w-[100px] w-full"
               disabled={disabled}
               includeCurrencySymbols={includeCurrencySymbols}
               currencies={options ?? []}

--- a/packages/design-system/src/scalars/components/amount-field/types.ts
+++ b/packages/design-system/src/scalars/components/amount-field/types.ts
@@ -1,6 +1,6 @@
 import { type Currency } from "../currency-code-field/types.js";
 export type Amount = {
-  amount: number;
+  amount?: number;
   unit?: CurrencyTicker;
 };
 export type AmountPercentage = number | undefined;
@@ -36,6 +36,7 @@ export type AmountFieldPropsGeneric =
       type: "AmountPercentage";
       value?: AmountPercentage;
       trailingZeros?: boolean;
+      units?: never;
     }
   | {
       type: "AmountCrypto";


### PR DESCRIPTION
## Ticket
https://trello.com/c/iV03PjGR/757-9-amountfield

## Description
- The only unit for this variant should be %. A list of units is added to the controls.
- The placeholder should be represented by default.  The entire field is represented with value.
 - The props should be displayed according of the variant/type. There are props with none effect over the field because doesn't have relation with the percent.
- The dropdown should have a proper width. The items are displayed with a big blank space at the right side. 

ScreenShots
<img width="455" alt="image" src="https://github.com/user-attachments/assets/b3b0fd2a-16aa-4a08-8d43-a837a8846dd9" />
