### PR TITLE
fix(scalars): adjust selected option link color to blue-900 in AID

### DIFF
--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete/id-autocomplete-list-option.tsx
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete/id-autocomplete-list-option.tsx
@@ -138,7 +138,7 @@ const IdAutocompleteListOption: React.FC<IdAutocompleteListOptionProps> = ({
               target="_blank"
               rel="noopener noreferrer"
               className={cn(
-                "truncate text-xs leading-5 text-gray-500 hover:underline dark:text-gray-600",
+                "truncate text-xs leading-5 text-blue-900 hover:underline",
               )}
             >
               {path.text}


### PR DESCRIPTION
## Ticket
https://trello.com/c/zIPQ2aH6/910-adapt-aid-component-to-be-used-outside-of-the-form

## Description
- Should change the link color.