### PR TITLE
fix(ui): show agent type at the right taking into account the field width

### DIFF
--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete/id-autocomplete-list-option.tsx
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete/id-autocomplete-list-option.tsx
@@ -215,7 +215,7 @@ const IdAutocompleteListOption: React.FC<IdAutocompleteListOptionProps> = ({
   return (
     <div
       className={cn(
-        "max-w-full rounded-md bg-transparent px-3 pb-2",
+        "w-full max-w-full rounded-md bg-transparent px-3 pb-2",
         variant === "withValue" ? "pt-2" : "pt-3",
         className,
       )}


### PR DESCRIPTION
## Ticket
https://trello.com/c/zIPQ2aH6/910-adapt-aid-component-to-be-used-outside-of-the-form

## Description
- The agent type should be displayed at the right taking into account the field width