### PR TITLE
fix(ui): should the PHID, AID & OID components show the defaultValue set

### DIFF
--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete/id-autocomplete-list-option.tsx
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete/id-autocomplete-list-option.tsx
@@ -138,7 +138,7 @@ const IdAutocompleteListOption: React.FC<IdAutocompleteListOptionProps> = ({
               target="_blank"
               rel="noopener noreferrer"
               className={cn(
-                "truncate text-xs leading-5 text-blue-900 hover:underline",
+                "truncate text-xs leading-5 text-blue-900 hover:underline focus-visible:outline-none",
               )}
             >
               {path.text}

--- a/packages/design-system/src/scalars/components/fragments/id-autocomplete/use-id-autocomplete.ts
+++ b/packages/design-system/src/scalars/components/fragments/id-autocomplete/use-id-autocomplete.ts
@@ -249,7 +249,7 @@ export function useIdAutocomplete({
   useEffect(() => {
     if (!isInternalChange.current) {
       shouldFetchOptions.current = false;
-      setSelectedValue(value ?? "");
+      setSelectedValue(value ?? defaultValue ?? "");
       setSelectedOption(undefined);
     }
     isInternalChange.current = false;


### PR DESCRIPTION
## Ticket
https://trello.com/c/TYC1u6Dl/937-unified-view-edit-mode-for-atlas-foundational-and-grounding-documents

## Description
- Should the PHID, AID & OID components show the defaultValue set.