### PR TITLE
fix(scalars): enum multiselect should show a checkbox instead of a radiobutton

### DIFF
--- a/packages/design-system/src/scalars/components/fragments/select-field/content.tsx
+++ b/packages/design-system/src/scalars/components/fragments/select-field/content.tsx
@@ -138,6 +138,7 @@ export const Content: React.FC<ContentProps> = ({
           <CommandItemList
             options={favoriteOptions}
             selectedValues={selectedValues}
+            multiple={multiple}
             selectionIcon={selectionIcon}
             selectionIconPosition={selectionIconPosition}
             hasAnyIcon={hasAnyIcon}
@@ -150,6 +151,7 @@ export const Content: React.FC<ContentProps> = ({
           <CommandItemList
             options={options}
             selectedValues={selectedValues}
+            multiple={multiple}
             selectionIcon={selectionIcon}
             selectionIconPosition={selectionIconPosition}
             hasAnyIcon={hasAnyIcon}


### PR DESCRIPTION
## Ticket
https://trello.com/c/TYC1u6Dl/937-unified-view-edit-mode-for-atlas-foundational-and-grounding-documents

## Description
- Enum. Multiselect: Should show a checkbox instead of a radiobutton.