### PR TITLE
fix(ui): default path & default button cursor pointer styles

### DIFF
--- a/packages/design-system/src/ui/components/data-entry/aid-input/aid-input.tsx
+++ b/packages/design-system/src/ui/components/data-entry/aid-input/aid-input.tsx
@@ -65,7 +65,7 @@ const AIDInput = React.forwardRef<HTMLInputElement, AIDInputProps>(
           path={
             displayProps?.asPlaceholder
               ? previewPlaceholder?.path || "URL not available"
-              : option.path
+              : option.path || "URL not available"
           }
           value={
             displayProps?.asPlaceholder
@@ -76,7 +76,7 @@ const AIDInput = React.forwardRef<HTMLInputElement, AIDInputProps>(
           agentType={
             displayProps?.asPlaceholder
               ? previewPlaceholder?.agentType || "Agent type not available"
-              : option.agentType
+              : option.agentType || "Agent type not available"
           }
           placeholderIcon={previewPlaceholder?.icon || "Person"}
           {...displayProps}

--- a/packages/design-system/src/ui/components/data-entry/oid-input/oid-input.tsx
+++ b/packages/design-system/src/ui/components/data-entry/oid-input/oid-input.tsx
@@ -57,7 +57,7 @@ const OIDInput = React.forwardRef<HTMLInputElement, OIDInputProps>(
           path={
             displayProps?.asPlaceholder
               ? previewPlaceholder?.path || "Type not available"
-              : option.path
+              : option.path || "Type not available"
           }
           value={
             displayProps?.asPlaceholder

--- a/packages/design-system/src/ui/components/data-entry/phid-input/phid-input.tsx
+++ b/packages/design-system/src/ui/components/data-entry/phid-input/phid-input.tsx
@@ -66,7 +66,7 @@ const PHIDInput = React.forwardRef<HTMLInputElement, PHIDInputProps>(
           path={
             displayProps?.asPlaceholder
               ? previewPlaceholder?.path || "Type not available"
-              : option.path
+              : option.path || "Type not available"
           }
           value={
             displayProps?.asPlaceholder

--- a/packages/design-system/style.css
+++ b/packages/design-system/style.css
@@ -258,4 +258,7 @@ input[type="number"] {
   p {
     color: var(--color-gray-900);
   }
+  button {
+    @apply cursor-pointer;
+  }
 }


### PR DESCRIPTION
## Ticket
https://trello.com/c/HAFtVnyw/947-split-view-edit-mode-for-foundational-and-grounding-documents

## Description
- PHID: when the type is not specified, the placeholder message displayed is "Path not available" instead of "Type not available".
- The cursor pointer should be a hand when is hovering over the copy and reload icons.