### PR TITLE
feat(atlas): add splitted text area for diff area

### DIFF
--- a/packages/design-system/src/ui/components/data-entry/input/subcomponent/input-diff.tsx
+++ b/packages/design-system/src/ui/components/data-entry/input/subcomponent/input-diff.tsx
@@ -6,6 +6,7 @@ interface InputDiffProps {
   ellipsis?: boolean;
   multiline?: boolean;
   rows?: number;
+  hasPadding?: boolean;
 }
 
 export const InputDiff = ({
@@ -14,6 +15,7 @@ export const InputDiff = ({
   ellipsis = true,
   multiline = false,
   rows = 3,
+  hasPadding = false,
 }: InputDiffProps) => {
   return (
     <div
@@ -22,6 +24,7 @@ export const InputDiff = ({
         "cursor-not-allowed border border-gray-300 bg-transparent px-3",
         !multiline && ellipsis && "truncate [&>span]:truncate",
         className,
+        hasPadding && "items-start py-2",
       )}
       style={{
         minHeight: multiline ? `${rows * 1.5}rem` : "2.25rem",

--- a/packages/design-system/src/ui/components/data-entry/textarea/subcomponent/splitted-textarea-diff.tsx
+++ b/packages/design-system/src/ui/components/data-entry/textarea/subcomponent/splitted-textarea-diff.tsx
@@ -1,0 +1,53 @@
+import { cn, FormGroup, FormLabel, type WithDifference } from "#scalars";
+import { InputDiff } from "../../input/subcomponent/input-diff.js";
+import { TextDiff } from "../../input/subcomponent/text-diff.js";
+// import type { WithDifference } from "../../../../scalars/components/types.js";
+// import { SplittedInputDiff } from "../input/splitted-input-diff.js";
+interface TextInputDiffProps extends WithDifference<string> {
+  value: string;
+  label?: React.ReactNode;
+  required?: boolean;
+  ellipsis?: boolean;
+  multiline?: boolean;
+  rows?: number;
+  hasPadding?: boolean;
+}
+const SplittedTextareaDiff = ({
+  value,
+  label,
+  required,
+  baseValue = "",
+  viewMode = "edition",
+  diffMode,
+  ellipsis = true,
+  multiline = false,
+  rows = 3,
+  hasPadding = false,
+}: TextInputDiffProps) => {
+  return (
+    <FormGroup>
+      {label && (
+        <FormLabel disabled={true} required={required}>
+          {label}
+        </FormLabel>
+      )}
+
+      <InputDiff
+        ellipsis={ellipsis}
+        multiline={multiline}
+        rows={rows}
+        hasPadding={true}
+      >
+        <TextDiff
+          baseValue={baseValue}
+          value={value}
+          viewMode={viewMode}
+          diffMode={diffMode}
+          className={cn("flex-1")}
+        />
+      </InputDiff>
+    </FormGroup>
+  );
+};
+
+export default SplittedTextareaDiff;

--- a/packages/design-system/src/ui/components/data-entry/textarea/subcomponent/splitted-textarea-diff.tsx
+++ b/packages/design-system/src/ui/components/data-entry/textarea/subcomponent/splitted-textarea-diff.tsx
@@ -1,8 +1,7 @@
 import { cn, FormGroup, FormLabel, type WithDifference } from "#scalars";
 import { InputDiff } from "../../input/subcomponent/input-diff.js";
 import { TextDiff } from "../../input/subcomponent/text-diff.js";
-// import type { WithDifference } from "../../../../scalars/components/types.js";
-// import { SplittedInputDiff } from "../input/splitted-input-diff.js";
+
 interface TextInputDiffProps extends WithDifference<string> {
   value: string;
   label?: React.ReactNode;

--- a/packages/design-system/src/ui/components/data-entry/textarea/textarea.stories.tsx
+++ b/packages/design-system/src/ui/components/data-entry/textarea/textarea.stories.tsx
@@ -3,6 +3,7 @@ import {
   getDefaultArgTypes,
   getValidationArgTypes,
   PrebuiltArgTypes,
+  StorybookControlCategory,
 } from "../../../../scalars/lib/storybook-arg-types.js";
 import { Textarea } from "./textarea.js";
 
@@ -49,6 +50,17 @@ const meta = {
     }),
     ...PrebuiltArgTypes.minLength,
     ...PrebuiltArgTypes.maxLength,
+    ...PrebuiltArgTypes.viewMode,
+
+    ...PrebuiltArgTypes.baseValue,
+    diffMode: {
+      control: "select",
+      description: "The mode of the input field",
+      options: ["words"],
+      table: {
+        category: StorybookControlCategory.DIFF,
+      },
+    },
     autoExpand: {
       control: "boolean",
       description:

--- a/packages/design-system/src/ui/components/data-entry/textarea/textarea.tsx
+++ b/packages/design-system/src/ui/components/data-entry/textarea/textarea.tsx
@@ -9,8 +9,13 @@ import { FormMessageList } from "../../../../scalars/components/fragments/form-m
 import ValueTransformer, {
   type TransformerType,
 } from "../../../../scalars/components/fragments/value-transformer/index.js";
-import type { InputBaseProps } from "../../../../scalars/components/types.js";
+import type {
+  DiffMode,
+  InputBaseProps,
+  WithDifference,
+} from "../../../../scalars/components/types.js";
 import type { CommonTextProps } from "../text-input/types.js";
+import SplittedTextareaDiff from "./subcomponent/splitted-textarea-diff.js";
 
 type TextareaBaseProps = Omit<
   React.TextareaHTMLAttributes<HTMLTextAreaElement>,
@@ -20,9 +25,11 @@ type TextareaBaseProps = Omit<
 interface TextareaProps
   extends TextareaBaseProps,
     InputBaseProps<string>,
-    CommonTextProps {
+    CommonTextProps,
+    Omit<WithDifference<string>, "diffMode"> {
   autoExpand?: boolean;
   multiline?: boolean;
+  diffMode?: Extract<DiffMode, "words">;
 }
 
 const textareaBaseStyles = cn(
@@ -67,6 +74,9 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       uppercase,
       value,
       warnings,
+      viewMode = "edition",
+      diffMode = "words",
+      baseValue,
       ...props
     },
     ref,
@@ -143,67 +153,81 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       [trim, lowercase, uppercase, multiline],
     );
 
-    return (
-      <FormGroup>
-        {label && (
-          <FormLabel
-            htmlFor={id}
-            disabled={props.disabled}
-            hasError={hasError}
-            required={required}
-          >
-            {label}
-          </FormLabel>
-        )}
-        <div className="relative">
-          <ValueTransformer transformers={transformers}>
-            <textarea
-              aria-invalid={hasError}
-              aria-required={required}
-              autoComplete={autoCompleteValue}
-              className={cn(
-                textareaBaseStyles,
-                // Resize behavior based on autoExpand
-                autoExpand
-                  ? "resize-none overflow-hidden"
-                  : [
-                      "resize-y",
-                      "scrollbar-thin scrollbar-gutter-stable",
-                      "scrollbar-track-transparent",
-                      "scrollbar-thumb-gray-300 hover:scrollbar-thumb-gray-300",
-                      "dark:scrollbar-thumb-charcoal-700 dark:hover:scrollbar-thumb-charcoal-700",
-                      "scrollbar-thumb-rounded-md",
-                    ],
-                className,
-              )}
-              ref={mergedRef}
-              id={id}
-              name={name}
-              value={value}
-              defaultValue={defaultValue}
-              minLength={minLength}
-              placeholder={placeholder}
-              rows={multiline ? rows : 1}
-              onChange={onChange}
-              onKeyDown={handleKeyDown}
-              {...props}
-            />
-          </ValueTransformer>
-          {typeof maxLength === "number" && maxLength > 0 && (
-            <div
-              className={cn(
-                "mt-0.5 flex justify-end",
-                hasContentBelow && "-mb-1",
-              )}
+    if (viewMode === "edition") {
+      return (
+        <FormGroup>
+          {label && (
+            <FormLabel
+              htmlFor={id}
+              disabled={props.disabled}
+              hasError={hasError}
+              required={required}
             >
-              <CharacterCounter maxLength={maxLength} value={value ?? ""} />
-            </div>
+              {label}
+            </FormLabel>
           )}
-        </div>
-        {description && <FormDescription>{description}</FormDescription>}
-        {warnings && <FormMessageList messages={warnings} type="warning" />}
-        {errors && <FormMessageList messages={errors} type="error" />}
-      </FormGroup>
+          <div className="relative">
+            <ValueTransformer transformers={transformers}>
+              <textarea
+                aria-invalid={hasError}
+                aria-required={required}
+                autoComplete={autoCompleteValue}
+                className={cn(
+                  textareaBaseStyles,
+                  // Resize behavior based on autoExpand
+                  autoExpand
+                    ? "resize-none overflow-hidden"
+                    : [
+                        "resize-y",
+                        "scrollbar-thin scrollbar-gutter-stable",
+                        "scrollbar-track-transparent",
+                        "scrollbar-thumb-gray-300 hover:scrollbar-thumb-gray-300",
+                        "dark:scrollbar-thumb-charcoal-700 dark:hover:scrollbar-thumb-charcoal-700",
+                        "scrollbar-thumb-rounded-md",
+                      ],
+                  className,
+                )}
+                ref={mergedRef}
+                id={id}
+                name={name}
+                value={value}
+                defaultValue={defaultValue}
+                minLength={minLength}
+                placeholder={placeholder}
+                rows={multiline ? rows : 1}
+                onChange={onChange}
+                onKeyDown={handleKeyDown}
+                {...props}
+              />
+            </ValueTransformer>
+            {typeof maxLength === "number" && maxLength > 0 && (
+              <div
+                className={cn(
+                  "mt-0.5 flex justify-end",
+                  hasContentBelow && "-mb-1",
+                )}
+              >
+                <CharacterCounter maxLength={maxLength} value={value ?? ""} />
+              </div>
+            )}
+          </div>
+          {description && <FormDescription>{description}</FormDescription>}
+          {warnings && <FormMessageList messages={warnings} type="warning" />}
+          {errors && <FormMessageList messages={errors} type="error" />}
+        </FormGroup>
+      );
+    }
+    return (
+      <SplittedTextareaDiff
+        label={label}
+        value={value ?? defaultValue ?? ""}
+        viewMode={viewMode}
+        diffMode={diffMode}
+        baseValue={baseValue}
+        multiline={multiline}
+        rows={rows}
+        hasPadding={true}
+      />
     );
   },
 );


### PR DESCRIPTION
## Ticket
https://trello.com/c/0XhT0WwE/985-create-a-read-only-diff-status-for-the-string-component

## Description
- Should a new prop be visible when the disabled prop is true.
- Should the new variant allow to see the diff given the additions/removals and changes.
