### PR TITLE
feat(common,vetra,connect): render document editor as child of drive

### DIFF
--- a/apps/connect/src/components/drive-editor-container.tsx
+++ b/apps/connect/src/components/drive-editor-container.tsx
@@ -4,6 +4,7 @@ import type { DriveEditorProps } from "@powerhousedao/reactor-browser";
 import {
   useDefaultDriveEditorModule,
   useDriveEditorModuleById,
+  useSelectedDocument,
   useSelectedDrive,
 } from "@powerhousedao/reactor-browser";
 import type { DocumentModelModule } from "document-model";
@@ -11,6 +12,7 @@ import type { FC } from "react";
 import { useCallback } from "react";
 import type { FallbackProps } from "react-error-boundary";
 import { ErrorBoundary } from "react-error-boundary";
+import { DocumentEditorContainer } from "./document-editor-container.js";
 import { useModal } from "./modal/index.js";
 
 function DriveEditorError({ error }: FallbackProps) {
@@ -24,7 +26,8 @@ function DriveEditorError({ error }: FallbackProps) {
 }
 
 export function DriveEditorContainer() {
-  const [selectedDrive, dispatch] = useSelectedDrive();
+  const [selectedDrive] = useSelectedDrive();
+  const [selectedDocument] = useSelectedDocument();
   const nodeActions = useNodeActions();
   const { showModal } = useModal();
   const showCreateDocumentModal = useCallback(
@@ -67,7 +70,9 @@ export function DriveEditorContainer() {
         }}
         documentId={selectedDrive.header.id}
         editorConfig={editorConfig}
-      />
+      >
+        {selectedDocument ? <DocumentEditorContainer /> : null}
+      </DriveEditorComponent>
     </ErrorBoundary>
   );
 }

--- a/apps/connect/src/pages/content.tsx
+++ b/apps/connect/src/pages/content.tsx
@@ -14,7 +14,6 @@ import {
   useSelectedFolder,
 } from "@powerhousedao/reactor-browser";
 import type { DocumentDriveDocument } from "document-drive";
-import { DocumentEditorContainer } from "../components/document-editor-container.js";
 import { DriveEditorContainer } from "../components/drive-editor-container.js";
 import { DriveIcon } from "../components/drive-icon.js";
 
@@ -22,13 +21,10 @@ export default function Content() {
   const [selectedDrive] = useSelectedDrive();
   const selectedFolder = useSelectedFolder();
   const [selectedDocument] = useSelectedDocument();
+  const showHomeScreen = !selectedDocument && !selectedDrive && !selectedFolder;
   return (
     <ContentContainer>
-      {selectedDocument && <DocumentEditorContainer />}
-      {(!!selectedDrive || !!selectedFolder) && !selectedDocument && (
-        <DriveEditorContainer />
-      )}
-      {!selectedDocument && !selectedDrive && <HomeScreenContainer />}
+      {showHomeScreen ? <HomeScreenContainer /> : <DriveEditorContainer />}
     </ContentContainer>
   );
 }

--- a/packages/common/editors/generic-drive-explorer/editor.tsx
+++ b/packages/common/editors/generic-drive-explorer/editor.tsx
@@ -74,49 +74,58 @@ export function BaseEditor(props: GenericDriveExplorerEditorProps) {
     setSelectedNode(selectedFolder);
   }
 
+  const showDocumentEditor = !!children;
+
   return (
     <DriveLayout className={className}>
-      {children}
-      <DriveLayout.Header>
-        <Breadcrumbs
-          breadcrumbs={breadcrumbs}
-          createEnabled={isAllowedToCreateDocuments}
-          onCreate={onAddAndSelectNewFolder}
-          onBreadcrumbSelected={onBreadcrumbSelected}
-        />
-        {showSearchBar && <SearchBar />}
-      </DriveLayout.Header>
-      <DriveLayout.Content
-        {...dropProps}
-        className={isDropTarget ? "rounded-xl bg-blue-100" : ""}
-      >
-        <FolderView
-          node={selectedFolder ?? selectedDriveAsFolderNode}
-          sharingType={sharingType}
-          getSyncStatusSync={getSyncStatusSync}
-          setSelectedNode={setSelectedNode}
-          onRenameNode={onRenameNode}
-          onDuplicateNode={onDuplicateNode}
-          onAddFolder={onAddFolder}
-          onAddFile={onAddFile}
-          onCopyNode={onCopyNode}
-          onMoveNode={onMoveNode}
-          onAddAndSelectNewFolder={onAddAndSelectNewFolder}
-          showDeleteNodeModal={showDeleteNodeModal}
-          isAllowedToCreateDocuments={isAllowedToCreateDocuments}
-        />
-      </DriveLayout.Content>
-      <DriveLayout.Footer>
-        {isAllowedToCreateDocuments && (
-          <CreateDocument
-            documentModels={documentModels?.filter(
-              (module) =>
-                module.documentModel.id !== "powerhouse/document-drive",
-            )}
-            createDocument={onCreateDocument}
+      {!showDocumentEditor && (
+        <DriveLayout.Header>
+          <Breadcrumbs
+            breadcrumbs={breadcrumbs}
+            createEnabled={isAllowedToCreateDocuments}
+            onCreate={onAddAndSelectNewFolder}
+            onBreadcrumbSelected={onBreadcrumbSelected}
           />
-        )}
-      </DriveLayout.Footer>
+          {showSearchBar && <SearchBar />}
+        </DriveLayout.Header>
+      )}
+      {showDocumentEditor ? (
+        children
+      ) : (
+        <DriveLayout.Content
+          {...dropProps}
+          className={isDropTarget ? "rounded-xl bg-blue-100" : ""}
+        >
+          <FolderView
+            node={selectedFolder ?? selectedDriveAsFolderNode}
+            sharingType={sharingType}
+            getSyncStatusSync={getSyncStatusSync}
+            setSelectedNode={setSelectedNode}
+            onRenameNode={onRenameNode}
+            onDuplicateNode={onDuplicateNode}
+            onAddFolder={onAddFolder}
+            onAddFile={onAddFile}
+            onCopyNode={onCopyNode}
+            onMoveNode={onMoveNode}
+            onAddAndSelectNewFolder={onAddAndSelectNewFolder}
+            showDeleteNodeModal={showDeleteNodeModal}
+            isAllowedToCreateDocuments={isAllowedToCreateDocuments}
+          />
+        </DriveLayout.Content>
+      )}
+      {!showDocumentEditor && (
+        <DriveLayout.Footer>
+          {isAllowedToCreateDocuments && (
+            <CreateDocument
+              documentModels={documentModels?.filter(
+                (module) =>
+                  module.documentModel.id !== "powerhouse/document-drive",
+              )}
+              createDocument={onCreateDocument}
+            />
+          )}
+        </DriveLayout.Footer>
+      )}
     </DriveLayout>
   );
 }

--- a/packages/reactor-browser/src/types/drive-editor.ts
+++ b/packages/reactor-browser/src/types/drive-editor.ts
@@ -72,6 +72,7 @@ export type DriveEditorConfig = {
 };
 
 export type DriveEditorProps = EditorProps & {
+  children?: React.ReactNode;
   context: IDriveContext;
   editorConfig?: DriveEditorConfig;
 };

--- a/packages/vetra/editors/vetra-drive-app/editor.tsx
+++ b/packages/vetra/editors/vetra-drive-app/editor.tsx
@@ -19,7 +19,7 @@ import { withDropZone } from "./utils/withDropZone.js";
 export type IProps = DriveEditorProps;
 
 export function BaseEditor(props: IProps) {
-  const { context, documentId } = props;
+  const { children, context, documentId } = props;
 
   const [document] = useDriveDocument(documentId);
 
@@ -68,7 +68,11 @@ export function BaseEditor(props: IProps) {
     );
   }, [driveId]);
 
-  return (
+  const showDocumentEditor = !!children;
+
+  return showDocumentEditor ? (
+    children
+  ) : (
     <div
       style={{ height: "100%" }}
       className="bg-white after:pointer-events-none after:absolute after:inset-0 after:bg-blue-500 after:opacity-0 after:transition after:content-['']"


### PR DESCRIPTION
We can achieve the same behavior as current in connect while also rendering the document editor as a child of the drive editor. This means that selecting a document no longer unmounts a given drive editor, allowing both to coexist.