### PR TITLE
chore: update design-system font loading in HTML and documentation

### DIFF
--- a/apps/connect/index.html
+++ b/apps/connect/index.html
@@ -9,7 +9,9 @@
     />
     <title>Powerhouse Connect</title>
     <link rel="icon" href="/icon.ico" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
     <link rel="preconnect" href="https://esm.sh" crossorigin />
     <link href="/src/index.css" rel="stylesheet" />
   </head>

--- a/packages/builder-tools/.storybook/preview-body.html
+++ b/packages/builder-tools/.storybook/preview-body.html
@@ -1,1 +1,6 @@
+<head>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
+</head>
 <body id="document-editor-context"></body>

--- a/packages/common/.storybook/preview-body.html
+++ b/packages/common/.storybook/preview-body.html
@@ -1,1 +1,6 @@
+<head>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
+</head>
 <body id="document-editor-context"></body>

--- a/packages/design-system/.storybook/main.ts
+++ b/packages/design-system/.storybook/main.ts
@@ -1,5 +1,4 @@
 import type { StorybookConfig } from "@storybook/react-vite";
-import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const srcPath = fileURLToPath(new URL("../dist/src", import.meta.url));
@@ -31,11 +30,16 @@ const config: StorybookConfig = {
     const { mergeConfig } = await import("vite");
     const { default: tailwindcss } = await import("@tailwindcss/vite");
     return mergeConfig(config, {
-      plugins: [tailwindcss()],
+      plugins: [
+        tailwindcss(),
+      ],
       build: {
         rollupOptions: {
           external: ["node:crypto"],
         },
+      },
+      define: {
+        "process.env": {},
       },
     });
   },

--- a/packages/design-system/.storybook/preview-body.html
+++ b/packages/design-system/.storybook/preview-body.html
@@ -1,3 +1,8 @@
+<head>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
+</head>
 <body
   id="root-background"
   class="h-screen w-screen bg-[#ffffff] dark:bg-[#1c1e23]"

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -2,6 +2,36 @@
 
 This repository contains base and scoped (project) components, utilities, and hooks for the powerhouse org.
 
+## Installation & Setup
+
+After installing the package, you'll need to load the Inter font family for proper styling.
+
+### Font Loading (Required)
+
+The design system uses the **Inter** font family. Choose one of the following approaches:
+
+#### Option 1: HTML Link Tags (Recommended)
+
+Add these tags to your HTML `<head>` for optimal performance:
+
+```html
+<head>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
+</head>
+```
+
+#### Option 2: CSS Import (Fallback)
+
+Alternatively, import the font in your CSS file:
+
+```css
+@import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
+```
+
+**Note:** HTML link tags are preferred for better performance (preconnect support, earlier parsing, non-blocking).
+
 ### How to run this project:
 
 - Clone this repo: `git clone https://github.com/powerhouse-inc/design-system.git`

--- a/packages/design-system/style.css
+++ b/packages/design-system/style.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
 @import "react-toastify/dist/ReactToastify.css";
 @import "tailwindcss";
 @plugin "tailwind-scrollbar";

--- a/packages/vetra/index.html
+++ b/packages/vetra/index.html
@@ -9,7 +9,9 @@
     />
     <title>Powerhouse Connect</title>
     <link rel="icon" href="/icon.ico" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="./connect.css">
     <style>
       @import "@powerhousedao/design-system/style.css";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14394,6 +14394,7 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lie@3.1.1:
@@ -34231,7 +34232,7 @@ snapshots:
 
   extension-port-stream@3.0.0:
     dependencies:
-      readable-stream: 3.6.2
+      readable-stream: 4.7.0
       webextension-polyfill: 0.10.0
 
   external-editor@3.1.0:
@@ -37626,7 +37627,7 @@ snapshots:
 
   md5.js@1.3.5:
     dependencies:
-      hash-base: 3.0.5
+      hash-base: 3.1.2
       inherits: 2.0.4
       safe-buffer: 5.2.1
 


### PR DESCRIPTION
Switched to using a `<link>` tag for font loading instead of `@import` inside the design-system styles.css file. This avoids PostCSS ordering issues, improves loading performance (browser can fetch fonts earlier), and gives apps flexibility to choose how they load or self-host fonts

boilerplate update here: https://github.com/powerhouse-inc/document-model-boilerplate/pull/35