### PR TITLE
fix: broken templates, drive app styles, local state schema and validation

### DIFF
--- a/apps/connect/src/utils/validate-document.ts
+++ b/apps/connect/src/utils/validate-document.ts
@@ -48,7 +48,7 @@ export const validateDocument = (document: PHDocument) => {
         ...acc,
         ...validateStateSchemaName(
           specs.state[scope].schema,
-          doc.header.name || doc.state.global?.name || "",
+          doc.state.global?.name || doc.header.name || "",
           !isGlobalScope ? scope : "",
           !isGlobalScope,
         ).map((err) => ({

--- a/packages/builder-tools/document-model-editor/components/state-schemas.tsx
+++ b/packages/builder-tools/document-model-editor/components/state-schemas.tsx
@@ -23,6 +23,8 @@ type Props = {
   localStateInitialValue: string;
   setStateSchema: (doc: string, scope: Scope) => void;
   setInitialState: (doc: string, scope: Scope) => void;
+  currentScope: Scope;
+  onScopeChange: (scope: Scope) => void;
 };
 
 type StateEditorProps = {
@@ -165,6 +167,8 @@ export function StateSchemas({
   localStateInitialValue,
   setStateSchema,
   setInitialState,
+  currentScope,
+  onScopeChange,
 }: Props) {
   const handleAddLocalState = useCallback(() => {
     const initialDoc = makeInitialSchemaDoc(modelName, "local");
@@ -173,7 +177,12 @@ export function StateSchemas({
   }, [modelName, setStateSchema, setInitialState]);
 
   return (
-    <Tabs className="pb-8" activationMode="manual" defaultValue="global">
+    <Tabs
+      className="pb-8"
+      activationMode="manual"
+      value={currentScope}
+      onValueChange={(value) => onScopeChange(value as Scope)}
+    >
       <div className="my-6">
         <TabsList className="mx-auto flex max-w-sm">
           <TabsTrigger value="global">Global</TabsTrigger>

--- a/packages/builder-tools/document-model-editor/editor.tsx
+++ b/packages/builder-tools/document-model-editor/editor.tsx
@@ -1,6 +1,4 @@
-import { useDocumentById } from "@powerhousedao/reactor-browser";
 import { pascalCase } from "change-case";
-import type { DocumentModelDocument, EditorProps } from "document-model";
 import {
   addModule,
   addOperation,
@@ -23,7 +21,7 @@ import {
   setStateSchema,
 } from "document-model";
 import { generateId } from "document-model/core";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Divider } from "./components/divider.js";
 import { ModelMetadata } from "./components/model-metadata-form.js";
 import { Modules } from "./components/modules.js";
@@ -39,6 +37,7 @@ import {
 
 export function DocumentModelEditor() {
   const [document, dispatch] = useSelectedDocumentModelDocument();
+  const [scope, setScope] = useState<Scope>("global");
 
   const documentNodeName = document.header.name;
   const {
@@ -179,7 +178,7 @@ export function DocumentModelEditor() {
           return;
         }
         const id = generateId();
-        dispatch(addOperation({ id, moduleId, name }));
+        dispatch(addOperation({ id, moduleId, name, scope }));
         resolve(id);
       } catch (error) {
         console.error("Failed to add operation:", error);
@@ -338,11 +337,18 @@ export function DocumentModelEditor() {
               localStateInitialValue={localStateInitialValue}
               setStateSchema={handleSetStateSchema}
               setInitialState={handleSetInitialState}
+              currentScope={scope}
+              onScopeChange={setScope}
             />
             <Divider />
-            <h3 className="mb-6 text-lg">Global Operations</h3>
+            <h3 className="mb-6 text-lg capitalize">{scope} Operations</h3>
             <Modules
-              modules={modules}
+              modules={modules.map((module) => ({
+                ...module,
+                operations: module.operations.filter(
+                  (op) => op.scope === scope,
+                ),
+              }))}
               allOperations={operations}
               addModule={handleAddModule}
               updateModuleName={handleSetModuleName}

--- a/packages/builder-tools/document-model-editor/hooks/useDocumentModelDocument.ts
+++ b/packages/builder-tools/document-model-editor/hooks/useDocumentModelDocument.ts
@@ -9,14 +9,18 @@ import type {
 
 export function useDocumentModelDocument(
   documentId: string | undefined | null,
-) {
+): ReturnType<
+  typeof useDocumentOfType<DocumentModelDocument, DocumentModelAction>
+> {
   return useDocumentOfType<DocumentModelDocument, DocumentModelAction>(
     documentId,
     "powerhouse/document-model",
   );
 }
 
-export function useSelectedDocumentModelDocument() {
+export function useSelectedDocumentModelDocument(): ReturnType<
+  typeof useSelectedDocumentOfType<DocumentModelDocument, DocumentModelAction>
+> {
   return useSelectedDocumentOfType<DocumentModelDocument, DocumentModelAction>(
     "powerhouse/document-model",
   );

--- a/packages/builder-tools/document-model-editor/types/documents.ts
+++ b/packages/builder-tools/document-model-editor/types/documents.ts
@@ -27,8 +27,8 @@ export type DocumentActionHandlers = {
   deleteModule: (id: string) => void;
   updateOperationName: (id: string, name: string) => void;
   updateOperationSchema: (id: string, schema: string) => void;
-  updateOperationScope: (id: string, scope: Scope) => void;
   setOperationDescription: (id: string, description: string) => void;
+  updateOperationScope: (id: string, scope: Scope) => void;
   deleteOperation: (id: string) => void;
   deleteOperationError: (id: string) => void;
   setOperationErrorName: (

--- a/packages/builder-tools/document-model-editor/utils/helpers.ts
+++ b/packages/builder-tools/document-model-editor/utils/helpers.ts
@@ -31,9 +31,10 @@ import type { Scope } from "../types/documents.js";
 export function makeStateSchemaNameForScope(modelName: string, scope: string) {
   const modelNamePascalCase = pascalCase(modelName);
   const scopePascalCase = pascalCase(scope);
-  const scopeStateTypeNamePrefix =
-    scopePascalCase === "Global" ? "" : scopePascalCase;
-  const name = `${scopeStateTypeNamePrefix}${modelNamePascalCase}State`;
+  const name =
+    scopePascalCase === "Global"
+      ? `${modelNamePascalCase}State`
+      : `${modelNamePascalCase}${scopePascalCase}State`;
   return name;
 }
 

--- a/packages/builder-tools/document-model-editor/utils/linting.ts
+++ b/packages/builder-tools/document-model-editor/utils/linting.ts
@@ -2,6 +2,7 @@ import type { Diagnostic } from "@codemirror/lint";
 import { pascalCase, sentenceCase } from "change-case";
 import { Kind } from "graphql";
 import { safeParseSdl } from "../context/schema-context.js";
+import { makeStateSchemaNameForScope } from "./helpers.js";
 
 export function ensureDocumentContainsNodeWithNameAndType(
   doc: string,
@@ -44,11 +45,7 @@ export function ensureValidStateSchemaName(
   scope: string,
 ) {
   if (!safeParseSdl(doc)) return [];
-  const scopePascalCase = pascalCase(scope);
-  const modelNamePascalCase = pascalCase(modelName);
-  const scopeStateTypeNamePrefix =
-    scopePascalCase === "Global" ? "" : scopePascalCase;
-  const requiredTypeName = `${scopeStateTypeNamePrefix}${modelNamePascalCase}State`;
+  const requiredTypeName = makeStateSchemaNameForScope(modelName, scope);
   if (
     !ensureDocumentContainsNodeWithNameAndType(
       doc,

--- a/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-document-model-subgraph/resolvers.esm.t
+++ b/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-document-model-subgraph/resolvers.esm.t
@@ -2,12 +2,12 @@
 to: "<%= rootDir %>/<%= h.changeCase.param(subgraph) %>/resolvers.ts"
 unless_exists: true
 ---
-import { type Subgraph } from "@powerhousedao/reactor-api";
+import type { BaseSubgraph } from "@powerhousedao/reactor-api";
 import { addFile } from "document-drive";
 import { actions <% modules.forEach(module => { %><% module.operations.forEach(op => { %>, type <%- h.changeCase.pascal(op.name) %>Input<%_ })}); %>, type <%- h.changeCase.pascal(documentType) %>Document } from "../../document-models/<%- h.changeCase.param(documentType) %>/index.js";
 import { setName } from "document-model";
 
-export const getResolvers = (subgraph: Subgraph): Record<string, unknown> => {
+export const getResolvers = (subgraph: BaseSubgraph): Record<string, unknown> => {
   const reactor = subgraph.reactor;
 
   return ({

--- a/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-drive-editor/components/CreateDocument.esm.t
+++ b/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-drive-editor/components/CreateDocument.esm.t
@@ -54,7 +54,7 @@ export const CreateDocument = (props: CreateDocumentProps) => {
             <Button
               key={documentModelModule.documentModel.global.id}
               color="light" // Customize button appearance
-              className="cursor-pointer"
+              className="cursor-pointer bg-gray-200 p-2 hover:bg-gray-300"
               title={documentModelModule.documentModel.global.name}
               aria-description={documentModelModule.documentModel.global.description}
               onClick={() => handleAddDocument(documentModelModule)}

--- a/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-drive-editor/components/DriveExplorer.esm.t
+++ b/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-drive-editor/components/DriveExplorer.esm.t
@@ -129,7 +129,10 @@ export function DriveExplorer(props: DriveEditorProps) {
                 </h2>
                 {/* Customize: Add more action buttons here */}
                 {isAllowedToCreateDocuments && (
-                  <Button onClick={() => handleCreateFolder()}>
+                  <Button
+                    onClick={() => handleCreateFolder()}
+                    className="bg-gray-200 p-2 hover:bg-gray-300"
+                  >
                     New Folder
                   </Button>
                 )}

--- a/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-subgraph/index.esm.t
+++ b/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-subgraph/index.esm.t
@@ -2,12 +2,12 @@
 to: "<%= rootDir %>/<%= h.changeCase.param(name) %>/index.ts"
 unless_exists: true
 ---
-import { Subgraph } from "@powerhousedao/reactor-api";
+import { BaseSubgraph } from "@powerhousedao/reactor-api";
 import type { DocumentNode } from "graphql";
 import { schema } from "./schema.js";
 import { getResolvers } from "./resolvers.js";
 
-export class <%= pascalName %>Subgraph extends Subgraph {
+export class <%= pascalName %>Subgraph extends BaseSubgraph {
   name = "<%= h.changeCase.param(name) %>";
   typeDefs: DocumentNode = schema;
   resolvers = getResolvers(this);

--- a/packages/codegen/src/codegen/utils.ts
+++ b/packages/codegen/src/codegen/utils.ts
@@ -17,7 +17,7 @@ export async function loadDocumentModel(
   try {
     if (!path) {
       throw new Error("Document model file not specified");
-    } else if (path.endsWith(".zip")) {
+    } else if (path.endsWith(".zip") || path.endsWith(".phd")) {
       const file = await baseLoadFromFile(path, documentModelReducer);
       documentModel = file.state.global;
     } else if (path.endsWith(".json")) {
@@ -29,7 +29,7 @@ export async function loadDocumentModel(
         documentModel = parsedData;
       }
     } else {
-      throw new Error("File type not supported. Must be zip or json.");
+      throw new Error("File type not supported. Must be zip, phd, or json.");
     }
     return documentModel;
   } catch (error) {

--- a/test/connect-e2e/tests/expected-zip-content/operations.json
+++ b/test/connect-e2e/tests/expected-zip-content/operations.json
@@ -271,7 +271,8 @@
       "input": {
         "id": "c17b3ca9-ee6b-4d62-b0d6-1126685e9c10",
         "moduleId": "0bac6d22-7268-4140-98e2-5216bf6a4d2d",
-        "name": "ADD_TODO_ITEM_INPUT"
+        "name": "ADD_TODO_ITEM_INPUT",
+        "scope": "global"
       },
       "scope": "global",
       "action": {
@@ -281,7 +282,8 @@
         "input": {
           "id": "c17b3ca9-ee6b-4d62-b0d6-1126685e9c10",
           "moduleId": "0bac6d22-7268-4140-98e2-5216bf6a4d2d",
-          "name": "ADD_TODO_ITEM_INPUT"
+          "name": "ADD_TODO_ITEM_INPUT",
+          "scope": "global"
         },
         "scope": "global"
       },
@@ -365,7 +367,8 @@
       "input": {
         "id": "38cecafa-fe77-44de-80c7-0d86cd4b8437",
         "moduleId": "0bac6d22-7268-4140-98e2-5216bf6a4d2d",
-        "name": "UPDATE_TODO_ITEM_INPUT"
+        "name": "UPDATE_TODO_ITEM_INPUT",
+        "scope": "global"
       },
       "scope": "global",
       "action": {
@@ -375,7 +378,8 @@
         "input": {
           "id": "38cecafa-fe77-44de-80c7-0d86cd4b8437",
           "moduleId": "0bac6d22-7268-4140-98e2-5216bf6a4d2d",
-          "name": "UPDATE_TODO_ITEM_INPUT"
+          "name": "UPDATE_TODO_ITEM_INPUT",
+          "scope": "global"
         },
         "scope": "global"
       },
@@ -459,7 +463,8 @@
       "input": {
         "id": "a79ec928-c17e-4c1e-a5b7-cee5b8c01c1c",
         "moduleId": "0bac6d22-7268-4140-98e2-5216bf6a4d2d",
-        "name": "DELETE_TODO_ITEM_INPUT"
+        "name": "DELETE_TODO_ITEM_INPUT",
+        "scope": "global"
       },
       "scope": "global",
       "action": {
@@ -469,7 +474,8 @@
         "input": {
           "id": "a79ec928-c17e-4c1e-a5b7-cee5b8c01c1c",
           "moduleId": "0bac6d22-7268-4140-98e2-5216bf6a4d2d",
-          "name": "DELETE_TODO_ITEM_INPUT"
+          "name": "DELETE_TODO_ITEM_INPUT",
+          "scope": "global"
         },
         "scope": "global"
       },


### PR DESCRIPTION
## Description
A set of minor bug fixes and improvements across multiple packages:

#### Generic Drive Explorer
- Added support for defining local scopes within the generic drive explorer  
- Fixed issues with local scope naming  
- Resolved incorrect behavior when toggling local operations within a local scope  

#### Codegen
- Fixed unstyled buttons in drive app templates  
- Fixed broken subgraph templates  
- Enabled support for `.phd` extension

#### Connect
- Fixed global and local schema state name validation to correctly default to `state.global.name`  
