### PR TITLE
Handle invalid getDocument calls and clearStorage UX tweaks

### DIFF
--- a/packages/reactor-browser/src/utils/drives.ts
+++ b/packages/reactor-browser/src/utils/drives.ts
@@ -6,6 +6,17 @@ import type {
 } from "document-drive";
 import type { PHDocument } from "document-model";
 
+function handleSettledResults<T>(results: PromiseSettledResult<T>[]): T[] {
+  return results.reduce((acc, result) => {
+    if (result.status === "fulfilled") {
+      acc.push(result.value);
+    } else {
+      console.warn(result.reason);
+    }
+    return acc;
+  }, [] as T[]);
+}
+
 /** Returns the sharing type for a drive. */
 export function getDriveSharingType(
   drive:
@@ -74,10 +85,10 @@ export async function getDocumentsForDriveId(
 ): Promise<PHDocument[]> {
   if (!reactor || !driveId) return [];
   const documentIds = await reactor.getDocuments(driveId);
-  const documents = await Promise.all(
+  const documents = await Promise.allSettled(
     documentIds.map((id) => reactor.getDocument(id)),
   );
-  return documents;
+  return handleSettledResults(documents);
 }
 
 export async function getDrives(
@@ -85,8 +96,10 @@ export async function getDrives(
 ): Promise<DocumentDriveDocument[]> {
   if (!reactor) return [];
   const driveIds = await reactor.getDrives();
-  const drives = await Promise.all(driveIds.map((id) => reactor.getDrive(id)));
-  return drives;
+  const drives = await Promise.allSettled(
+    driveIds.map((id) => reactor.getDrive(id)),
+  );
+  return handleSettledResults(drives);
 }
 
 export async function getDocuments(
@@ -94,13 +107,12 @@ export async function getDocuments(
 ): Promise<PHDocument[]> {
   if (!reactor) return [];
   const driveIds = await reactor.getDrives();
-  const documentIds = await Promise.all(
-    driveIds.map((id) => reactor.getDocuments(id)),
+  const documentIds = handleSettledResults(
+    await Promise.allSettled(driveIds.map((id) => reactor.getDocuments(id))),
+  ).flat();
+  return handleSettledResults(
+    await Promise.allSettled(documentIds.map((id) => reactor.getDocument(id))),
   );
-  const documents = await Promise.all(
-    documentIds.flat().map((id) => reactor.getDocument(id)),
-  );
-  return documents;
 }
 
 export async function getDriveById(


### PR DESCRIPTION
Fixes #1865.

The Document not found error was due to trying to get all documents on every update on a drive.
I was able to reproduce to issue by creating a remote drive, and creating and then deleting a document.

When syncing that drive on a fresh Connect, it would try to load that deleted document, which failed due to that document not existing since the sync protocol doesn't sync deleted documents.

By using `Promise.allSettled` instead of `Promise.all` we still get back the documents that do exist, as this could be causing document to not appear.
For now, I've changed it to log a warning as I'm hoping to get a better fix for this by debouncing `refreshReactorData` calls. 

Also added some tweaks to the Clear Storage flow to avoid flashing the HomeScreen with the drives that were just deleted.