### PR TITLE
fix(vetra): update package.json to include src files

### DIFF
--- a/packages/vetra/package.json
+++ b/packages/vetra/package.json
@@ -11,14 +11,7 @@
     "access": "public"
   },
   "files": [
-    "dist",
-    "document-models",
-    "editors",
-    "subgraphs",
-    "processors",
-    "utils",
-    "index.ts",
-    "style.css"
+    "dist"
   ],
   "exports": {
     ".": {

--- a/packages/vetra/package.json
+++ b/packages/vetra/package.json
@@ -11,7 +11,14 @@
     "access": "public"
   },
   "files": [
-    "dist"
+    "dist",
+    "document-models",
+    "editors",
+    "subgraphs",
+    "processors",
+    "utils",
+    "index.ts",
+    "style.css"
   ],
   "exports": {
     ".": {

--- a/packages/vetra/tsconfig.json
+++ b/packages/vetra/tsconfig.json
@@ -13,7 +13,7 @@
     "lib": ["ESNext", "dom", "dom.iterable"],
 
     // Other Outputs
-    "sourceMap": true,
+    "sourceMap": false,
     "declaration": true,
     "declarationMap": true,
 

--- a/packages/vetra/tsconfig.json
+++ b/packages/vetra/tsconfig.json
@@ -1,42 +1,10 @@
 {
   "extends": "../../tsconfig.options.json",
   "compilerOptions": {
-    "composite": true,
-    // File Layout
     "outDir": "./dist",
-
-    // Environment Settings
-    // See also https://aka.ms/tsconfig/module
-    "module": "nodenext",
-    "target": "esnext",
     "types": ["node", "vitest/globals"],
     "lib": ["ESNext", "dom", "dom.iterable"],
-
-    // Other Outputs
-    "sourceMap": false,
-    "declaration": true,
-    "declarationMap": true,
-
-    // Stricter Typechecking Options
-    // "noUncheckedIndexedAccess": true,
-    // "exactOptionalPropertyTypes": true,
-
-    // Style Options
-    // "noImplicitReturns": true,
-    // "noImplicitOverride": true,
-    // "noUnusedLocals": true,
-    // "noUnusedParameters": true,
-    // "noFallthroughCasesInSwitch": true,
-    // "noPropertyAccessFromIndexSignature": true,
-
-    // Recommended Options
-    "strict": true,
-    "jsx": "react-jsx",
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true
+    "sourceMap": false
   },
   "include": ["**/*", "./powerhouse.manifest.json"],
   "exclude": ["dist", "node_modules", ".ph"],


### PR DESCRIPTION
## Description:

This PR fixes the sourcemap warning in Vetra. Since we publish the Vetra package with sourcemaps enabled, we also need to include the source files to ensure they work correctly

<img width="989" height="479" alt="Screenshot 2025-10-16 at 1 12 25 PM" src="https://github.com/user-attachments/assets/73886bbd-09e9-45ac-8318-cf0d5006a5b2" />
