### PR TITLE
feat(connect,codegen): move dropzone wrapper component to connect

### DIFF
--- a/apps/connect/package.copy.json
+++ b/apps/connect/package.copy.json
@@ -1,7 +1,7 @@
 {
   "name": "@powerhousedao/connect",
   "productName": "Powerhouse-Connect",
-  "version": "4.1.0-dev.82",
+  "version": "4.1.0-dev.83",
   "description": "Powerhouse Connect",
   "main": "./dist/index.html",
   "type": "module",

--- a/apps/connect/src/components/drive-editor-container.tsx
+++ b/apps/connect/src/components/drive-editor-container.tsx
@@ -1,4 +1,5 @@
 import { GenericDriveExplorer } from "@powerhousedao/common";
+import { DropZoneWrapper } from "@powerhousedao/design-system";
 import {
   useDefaultDriveEditorModule,
   useDriveEditorModuleById,
@@ -38,9 +39,11 @@ export function DriveEditorContainer() {
       fallbackRender={DriveEditorError}
       key={selectedDrive.header.id}
     >
-      <DriveEditorComponent>
-        {selectedDocument ? <DocumentEditorContainer /> : null}
-      </DriveEditorComponent>
+      <DropZoneWrapper>
+        <DriveEditorComponent>
+          {selectedDocument ? <DocumentEditorContainer /> : null}
+        </DriveEditorComponent>
+      </DropZoneWrapper>
     </ErrorBoundary>
   );
 }

--- a/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-drive-editor/editor.esm.t
+++ b/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-drive-editor/editor.esm.t
@@ -2,7 +2,6 @@
 to: "<%= rootDir %>/<%= h.changeCase.param(name) %>/editor.tsx"
 unless_exists: true
 ---
-import { DropZoneWrapper } from "@powerhousedao/design-system";
 import { useSetPHDriveEditorConfig } from "@powerhousedao/reactor-browser";
 import type { EditorProps } from "document-model";
 import { DriveExplorer } from "./components/DriveExplorer.js";
@@ -11,8 +10,6 @@ import { editorConfig } from "./config.js";
 export function Editor(props: EditorProps) {
   useSetPHDriveEditorConfig(editorConfig);
   return (
-    <DropZoneWrapper>
-      <DriveExplorer {...props} />
-    </DropZoneWrapper>
+    <DriveExplorer {...props} />
   );
 }

--- a/packages/codegen/src/codegen/__tests__/generate-drive-editor.expected.ts
+++ b/packages/codegen/src/codegen/__tests__/generate-drive-editor.expected.ts
@@ -10,8 +10,7 @@ export const module: EditorModule = {
   },
 };`;
 
-export const EXPECTED_EDITOR_CONTENT = `import { DropZoneWrapper } from "@powerhousedao/design-system";
-import { useSetPHDriveEditorConfig } from "@powerhousedao/reactor-browser";
+export const EXPECTED_EDITOR_CONTENT = `import { useSetPHDriveEditorConfig } from "@powerhousedao/reactor-browser";
 import type { EditorProps } from "document-model";
 import { DriveExplorer } from "./components/DriveExplorer.js";
 import { editorConfig } from "./config.js";
@@ -19,9 +18,7 @@ import { editorConfig } from "./config.js";
 export function Editor(props: EditorProps) {
   useSetPHDriveEditorConfig(editorConfig);
   return (
-    <DropZoneWrapper>
-      <DriveExplorer {...props} />
-    </DropZoneWrapper>
+    <DriveExplorer {...props} />
   );
 }`;
 

--- a/packages/vetra/editors/vetra-drive-app/editor.tsx
+++ b/packages/vetra/editors/vetra-drive-app/editor.tsx
@@ -1,4 +1,4 @@
-import { DropZoneWrapper, WagmiContext } from "@powerhousedao/design-system";
+import { WagmiContext } from "@powerhousedao/design-system";
 
 import {
   addDocument,
@@ -114,19 +114,13 @@ export function BaseEditor(props: EditorProps) {
   );
 }
 
-const BaseEditorWithDropZone = (props: EditorProps) => (
-  <DropZoneWrapper>
-    <BaseEditor {...props} />
-  </DropZoneWrapper>
-);
-
 export function Editor(props: EditorProps) {
   useSetPHDriveEditorConfig(editorConfig);
   const analyticsDatabaseName = useAnalyticsDatabaseName();
   return (
     <WagmiContext>
       <AnalyticsProvider databaseName={analyticsDatabaseName}>
-        <BaseEditorWithDropZone {...props} />
+        <BaseEditor {...props} />
       </AnalyticsProvider>
     </WagmiContext>
   );


### PR DESCRIPTION
Move the dropzone wrapper component to connect, since it should be shared by all drive editors. the dropzone editor is aware of whether or not drag and drop is enabled via the global config, so there is no need for the component to be part of the external package.