### PR TITLE
[DO NOT MERGE] <RESEARCH> Hashing benchmarks on expanded crypto hash support

### DIFF
--- a/packages/document-model/bench/hash.bench.ts
+++ b/packages/document-model/bench/hash.bench.ts
@@ -8,6 +8,8 @@ import {
   supportedEncodings,
 } from "../src/core/crypto.js";
 
+import type { HashConfig } from "../src/core/ph-types.js";
+
 // Node shim as it doesn't have `btoa`. Polyfill so the code's base64 path works if used
 (globalThis as any).btoa ??= (bin: string) =>
   Buffer.from(bin, "binary").toString("base64");
@@ -91,10 +93,10 @@ describe("signature pipeline", () => {
   for (const algorithm of supportedAlgorithms) {
     for (const encoding of supportedEncodings) {
       bench(`buildOperationSignatureParams (${algorithm}/${encoding})`, () => {
-        const params = buildOperationSignatureParams({
-          ...baseDocument,
-          hashFormat: { algorithm: algorithm, encoding: encoding },
-        } as any);
+        const params = buildOperationSignatureParams(
+          {...baseDocument} as any,
+          { algorithm, encoding } as HashConfig,
+        );
         buildOperationSignatureMessage(params);
       });
     }

--- a/packages/document-model/bench/hash.bench.ts
+++ b/packages/document-model/bench/hash.bench.ts
@@ -1,0 +1,85 @@
+import stringifyJson from "safe-stable-stringify";
+import { bench, describe } from "vitest";
+import {
+  buildOperationSignatureMessage,
+  buildOperationSignatureParams,
+  hashBrowser,
+  supportedAlgorithms,
+  supportedEncodings,
+} from "../src/core/crypto.js";
+
+// Node shim as it doesn't have `btoa`. Polyfill so the code's base64 path works if used
+(globalThis as any).btoa ??= (bin: string) =>
+  Buffer.from(bin, "binary").toString("base64");
+
+// Helpers
+function makeBytes(n: number): Uint8Array {
+  // fast deterministic pseudo-random bytes (doesn't have RNG dependency)
+  const u = new Uint8Array(n);
+  for (let i = 0; i < n; i++) u[i] = (i * 31 + 97) & 0xff;
+  return u;
+}
+
+const smallStr = "hello world";
+const jsonStr = stringifyJson({
+  doc: "abc123",
+  scope: "test",
+  type: "update",
+  input: { a: 1, b: 2, c: [1, 2, 3] },
+})!;
+
+const data1k = makeBytes(1024);
+const data64k = makeBytes(64 * 1024);
+const data1m = makeBytes(1024 * 1024);
+
+const stringPayloads = {"smallStr": smallStr, "jsonStr": jsonStr}
+const bytePayloads = {"data1k":data1k, "data64k":data64k, "data1m":data1m};
+
+const baseDocument = {
+  documentId: "doc-123",
+  previousStateHash: "",
+  signer: { app: { key: "app-key-xyz" } },
+  action: {
+    scope: "doc",
+    type: "update",
+    input: { foo: "bar", n: 42 },
+  },
+} as const;
+
+describe("hashBrowser - strings", () => {
+  for (const algorithm of supportedAlgorithms) {
+    for (const encoding of supportedEncodings) {
+      for (const [strName, strValue] of Object.entries(stringPayloads)) {
+        bench(`${algorithm} ${encoding}, ${strName}`, () => {
+          hashBrowser(strValue, algorithm, encoding);
+        });
+      }
+    }
+  }
+});
+
+describe("hashBrowser - bytes", () => {
+  for (const algorithm of supportedAlgorithms) {
+    for (const encoding of supportedEncodings) {
+      for (const [byteName, byteValue] of Object.entries(bytePayloads)) {
+        bench(`${algorithm} ${encoding}, ${byteName}`, () => {
+          hashBrowser(byteValue, algorithm, encoding);
+        });
+      }
+    }
+  }
+});
+
+describe("signature pipeline", () => {
+  for (const algorithm of supportedAlgorithms) {
+    for (const encoding of supportedEncodings) {
+      bench(`buildOperationSignatureParams (${algorithm}/${encoding})`, () => {
+        const params = buildOperationSignatureParams({
+          ...baseDocument,
+          hashFormat: { algorithm: algorithm, encoding: encoding },
+        } as any);
+        buildOperationSignatureMessage(params);
+      });
+    }
+  }
+});

--- a/packages/document-model/bench/hash.bench.ts
+++ b/packages/document-model/bench/hash.bench.ts
@@ -33,7 +33,6 @@ const data64k = makeBytes(64 * 1024);
 const data1m = makeBytes(1024 * 1024);
 
 const stringPayloads = {"smallStr": smallStr, "jsonStr": jsonStr}
-const bytePayloads = {"data1k":data1k, "data64k":data64k, "data1m":data1m};
 
 const baseDocument = {
   documentId: "doc-123",
@@ -58,14 +57,32 @@ describe("hashBrowser - strings", () => {
   }
 });
 
-describe("hashBrowser - bytes", () => {
+describe("hashBrowser - bytes (1kb)", () => {
   for (const algorithm of supportedAlgorithms) {
     for (const encoding of supportedEncodings) {
-      for (const [byteName, byteValue] of Object.entries(bytePayloads)) {
-        bench(`${algorithm} ${encoding}, ${byteName}`, () => {
-          hashBrowser(byteValue, algorithm, encoding);
-        });
-      }
+      bench(`${algorithm} ${encoding}, 1kb`, () => {
+        hashBrowser(data1k, algorithm, encoding);
+      });
+    }
+  }
+});
+
+describe("hashBrowser - bytes (64kb)", () => {
+  for (const algorithm of supportedAlgorithms) {
+    for (const encoding of supportedEncodings) {
+      bench(`${algorithm} ${encoding}, 64kb`, () => {
+        hashBrowser(data64k, algorithm, encoding);
+      });
+    }
+  }
+});
+
+describe("hashBrowser - bytes (lmb)", () => {
+  for (const algorithm of supportedAlgorithms) {
+    for (const encoding of supportedEncodings) {
+      bench(`${algorithm} ${encoding}, 1mb`, () => {
+        hashBrowser(data1m, algorithm, encoding);
+      });
     }
   }
 });

--- a/packages/document-model/bench/hash.bench.ts
+++ b/packages/document-model/bench/hash.bench.ts
@@ -33,6 +33,7 @@ const jsonStr = stringifyJson({
 const data1k = makeBytes(1024);
 const data64k = makeBytes(64 * 1024);
 const data1m = makeBytes(1024 * 1024);
+const data64m = makeBytes(64 * 1024 * 1024);
 
 const stringPayloads = {"smallStr": smallStr, "jsonStr": jsonStr}
 
@@ -79,11 +80,21 @@ describe("hashBrowser - bytes (64kb)", () => {
   }
 });
 
-describe("hashBrowser - bytes (lmb)", () => {
+describe("hashBrowser - bytes (1mb)", () => {
   for (const algorithm of supportedAlgorithms) {
     for (const encoding of supportedEncodings) {
       bench(`${algorithm} ${encoding}, 1mb`, () => {
         hashBrowser(data1m, algorithm, encoding);
+      });
+    }
+  }
+});
+
+describe("hashBrowser - bytes (64mb)", () => {
+  for (const algorithm of supportedAlgorithms) {
+    for (const encoding of supportedEncodings) {
+      bench(`${algorithm} ${encoding}, 64mb`, () => {
+        hashBrowser(data64m, algorithm, encoding);
       });
     }
   }

--- a/packages/document-model/package.json
+++ b/packages/document-model/package.json
@@ -34,7 +34,8 @@
     "tsc": "tsc",
     "lint": "eslint",
     "test": "vitest run",
-    "test:watch": "vitest watch"
+    "test:watch": "vitest watch",
+    "bench": "vitest bench --run"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/packages/document-model/package.json
+++ b/packages/document-model/package.json
@@ -50,6 +50,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "@noble/hashes": "^2.0.1",
     "change-case": "^5.4.4",
     "jszip": "^3.10.1",
     "mime": "^4.0.4",

--- a/packages/document-model/package.json
+++ b/packages/document-model/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@noble/hashes": "^2.0.1",
     "change-case": "^5.4.4",
+    "hash-wasm": "^4.12.0",
     "jszip": "^3.10.1",
     "mime": "^4.0.4",
     "mutative": "^1.0.5",

--- a/packages/document-model/package.json
+++ b/packages/document-model/package.json
@@ -53,7 +53,9 @@
   "dependencies": {
     "@noble/hashes": "^2.0.1",
     "change-case": "^5.4.4",
+    "farmhash": "^5.0.1",
     "hash-wasm": "^4.12.0",
+    "highwayhash": "^3.1.1",
     "jszip": "^3.10.1",
     "mime": "^4.0.4",
     "mutative": "^1.0.5",

--- a/packages/document-model/src/core/crypto.ts
+++ b/packages/document-model/src/core/crypto.ts
@@ -1,4 +1,9 @@
+import { blake256 } from "@noble/hashes/blake1.js";
+import { blake2b, blake2s, } from "@noble/hashes/blake2.js";
 import { blake3 as blake3Hash } from "@noble/hashes/blake3.js";
+import { sha256, sha512 } from "@noble/hashes/sha2.js";
+import { keccak_256, sha3_256, shake256, shake256_64 } from "@noble/hashes/sha3.js";
+
 import stringifyJson from "safe-stable-stringify";
 import { createHash as createSha1Hash } from "sha1-uint8array";
 import type { ActionSignatureContext } from "./types.js";
@@ -18,7 +23,19 @@ export function generateUUIDBrowser() {
   return crypto.randomUUID();
 }
 
-export const supportedAlgorithms = ["sha1", "blake3"];
+export const supportedAlgorithms = [
+  "sha1",
+  "blake3",
+  "blake1",
+  "blake2b",
+  "blake2s",
+  "sha2_256",
+  "sha2_512",
+  "keccak_256",
+  "sha3_256",
+  "shake256",
+  "shake256_64",
+];
 export const supportedEncodings = ["base64", "hex"];
 const defaultAlg = "sha1"
 const defaultEnc = "base64"
@@ -89,7 +106,25 @@ function hashUIntArray(
     case "sha1":
       return createSha1Hash("sha1").update(bytes).digest();
     case "blake3":
-      return blake3Hash(bytes); // returns Uint8Array
+      return blake3Hash(bytes);
+    case "blake1":
+      return blake256(bytes);
+    case "blake2b":
+      return blake2b(bytes);
+    case "blake2s":
+      return blake2s(bytes);
+    case "sha2_256":
+      return sha256(bytes);
+    case "sha2_512":
+      return sha512(bytes);
+    case "keccak_256":
+      return keccak_256(bytes);
+    case "sha3_256":
+      return sha3_256(bytes);
+    case "shake256":
+      return shake256(bytes);
+    case "shake256_64":
+      return shake256_64(bytes);
     default:
       throw new Error(`Unsupported algorithm: ${algorithm}`);
   }

--- a/packages/document-model/src/core/crypto.ts
+++ b/packages/document-model/src/core/crypto.ts
@@ -16,6 +16,7 @@ import {
 
 import stringifyJson from "safe-stable-stringify";
 import { createHash as createSha1Hash } from "sha1-uint8array";
+import type { HashConfig } from "./ph-types.js";
 import type { ActionSignatureContext } from "./types.js";
 
 /**
@@ -250,8 +251,8 @@ export function buildOperationSignatureParams({
   signer,
   action,
   previousStateHash,
-  hashFormat,
-}: ActionSignatureContext): [string, string, string, string,] {
+}: ActionSignatureContext,
+hashFormat?: HashConfig): [string, string, string, string,] {
   const { /*id, timestamp,*/ scope, type } = action;
   return [
     /*getUnixTimestamp(timestamp)*/ getUnixTimestamp(new Date()),

--- a/packages/document-model/src/core/crypto.ts
+++ b/packages/document-model/src/core/crypto.ts
@@ -57,6 +57,8 @@ export const supportedEncodings = ["base64", "hex"];
 const defaultAlg = "sha1"
 const defaultEnc = "base64"
 
+const textEncoder = new TextEncoder();
+
 export const hashBrowser = (
   data: string | Uint8Array | ArrayBufferView | DataView,
   algorithm = defaultAlg,
@@ -102,8 +104,6 @@ function uint8ArrayToHex(uint8Array: Uint8Array) {
 }
 
 function toUint8(data: string | Uint8Array | ArrayBufferView ): Uint8Array {
-  const textEncoder = new TextEncoder();
-
   if (typeof data === "string") return textEncoder.encode(data);
   if (data instanceof Uint8Array) return data;
   if (ArrayBuffer.isView(data)) {
@@ -265,14 +265,12 @@ export function buildOperationSignatureParams({
   ];
 }
 
-const textEncode = new TextEncoder();
-
 export function buildOperationSignatureMessage(
   params: [string, string, string, string],
 ): Uint8Array {
   const message = params.join("");
   const prefix = "\x19Signed Operation:\n" + message.length.toString();
-  return textEncode.encode(prefix + message);
+  return textEncoder.encode(prefix + message);
 }
 
 export function ab2hex(ab: ArrayBuffer | ArrayBufferView): string {

--- a/packages/document-model/src/core/crypto.ts
+++ b/packages/document-model/src/core/crypto.ts
@@ -1,17 +1,7 @@
-import { blake256 } from "@noble/hashes/blake1.js";
-import { blake2b, blake2s, } from "@noble/hashes/blake2.js";
-import { blake3 } from "@noble/hashes/blake3.js";
-import { sha256, sha512 } from "@noble/hashes/sha2.js";
-import { keccak_256, sha3_256, shake256, shake256_64 } from "@noble/hashes/sha3.js";
-
 import {
   createBLAKE2b as blake2b_wasm,
-  createBLAKE2s as blake2s_wasm,
   createBLAKE3 as blake3_wasm,
   createSHA1 as sha1_wasm,
-  createSHA256 as sha256_wasm,
-  createSHA3 as sha3_wasm,
-  createSHA512 as sha512_wasm,
 } from "hash-wasm";
 
 import stringifyJson from "safe-stable-stringify";
@@ -36,22 +26,8 @@ export function generateUUIDBrowser() {
 
 export const supportedAlgorithms = [
   "sha1",
-  "blake3",
-  "blake1",
-  "blake2b",
-  "blake2s",
-  "sha2_256",
-  "sha2_512",
-  "keccak_256",
-  "sha3_256",
-  "shake256",
-  "shake256_64",
   "sha1_wasm",
-  "sha256_wasm",
-  "sha512_wasm",
-  "sha3_wasm",
   "blake2b_wasm",
-  "blake2s_wasm",
   "blake3_wasm",
 ];
 export const supportedEncodings = ["base64", "hex"];
@@ -121,40 +97,12 @@ async function initAsyncSHA1Hasher() {
 }
 const sha1Hasher = await initAsyncSHA1Hasher();
 
-async function initAsyncSHA256Hasher() {
-  const hasher = await sha256_wasm();
-  hasher.init();
-  return hasher;
-}
-const sha256Hasher = await initAsyncSHA256Hasher();
-
-async function initAsyncSHA512Hasher() {
-  const hasher = await sha512_wasm();
-  hasher.init();
-  return hasher;
-}
-const sha512Hasher = await initAsyncSHA512Hasher();
-
-async function initAsyncSHA3Hasher() {
-  const hasher = await sha3_wasm();
-  hasher.init();
-  return hasher;
-}
-const sha3Hasher = await initAsyncSHA3Hasher();
-
 async function initAsyncBlake2bHasher() {
   const hasher = await blake2b_wasm();
   hasher.init();
   return hasher;
 }
 const blake2bHasher = await initAsyncBlake2bHasher();
-
-async function initAsyncBlake2sHasher() {
-  const hasher = await blake2s_wasm();
-  hasher.init();
-  return hasher;
-}
-const blake2sHasher = await initAsyncBlake2sHasher();
 
 async function initAsyncBlake3Hasher() {
   const hasher = await blake3_wasm();
@@ -172,56 +120,16 @@ function hashUIntArray(
   switch (algorithm) {
     case "sha1":
       return createSha1Hash("sha1").update(bytes).digest();
-    case "blake3":
-      return blake3(bytes);
-    case "blake1":
-      return blake256(bytes);
-    case "blake2b":
-      return blake2b(bytes);
-    case "blake2s":
-      return blake2s(bytes);
-    case "sha2_256":
-      return sha256(bytes);
-    case "sha2_512":
-      return sha512(bytes);
-    case "keccak_256":
-      return keccak_256(bytes);
-    case "sha3_256":
-      return sha3_256(bytes);
-    case "shake256":
-      return shake256(bytes);
-    case "shake256_64":
-      return shake256_64(bytes);
     case "sha1_wasm":
       sha1Hasher.update(bytes);
       let sha1Hash = sha1Hasher.digest("binary");
       sha1Hasher.init();
       return sha1Hash;
-    case "sha256_wasm":
-      sha256Hasher.update(bytes);
-      let sha256Hash = sha256Hasher.digest("binary");
-      sha256Hasher.init();
-      return sha256Hash;
-    case "sha512_wasm":
-      sha512Hasher.update(bytes);
-      let sha512Hash = sha512Hasher.digest("binary");
-      sha512Hasher.init();
-      return sha512Hash;
-    case "sha3_wasm":
-      sha3Hasher.update(bytes);
-      let sha3Hash = sha3Hasher.digest("binary");
-      sha3Hasher.init();
-      return sha3Hash;
     case "blake2b_wasm":
       blake2bHasher.update(bytes);
       let blake2bHash = blake2bHasher.digest("binary");
       blake2bHasher.init();
       return blake2bHash;
-    case "blake2s_wasm":
-      blake2sHasher.update(bytes);
-      let blake2sHash = blake2sHasher.digest("binary");
-      blake2sHasher.init();
-      return blake2sHash;
     case "blake3_wasm":
       blake3Hasher.update(bytes);
       let blake3HashDigest = blake3Hasher.digest("binary");

--- a/packages/document-model/src/core/crypto.ts
+++ b/packages/document-model/src/core/crypto.ts
@@ -18,8 +18,8 @@ export function generateUUIDBrowser() {
   return crypto.randomUUID();
 }
 
-const supportedAlgorithms = ["sha1", "blake3"];
-const supportedEncodings = ["base64", "hex"];
+export const supportedAlgorithms = ["sha1", "blake3"];
+export const supportedEncodings = ["base64", "hex"];
 const defaultAlg = "sha1"
 const defaultEnc = "base64"
 

--- a/packages/document-model/src/core/types.ts
+++ b/packages/document-model/src/core/types.ts
@@ -461,17 +461,11 @@ export type MappedOperation = {
 
 export type DocumentOperationsIgnoreMap = Record<string, MappedOperation[]>;
 
-export type HashFormat = {
-  algorithm: string;
-  encoding: string;
-}
-
 export type ActionSignatureContext = {
   documentId: string;
   signer: ActionSigner;
   action: Action;
   previousStateHash: string;
-  hashFormat?: HashFormat;
 };
 
 export type ActionSigningHandler = (message: Uint8Array) => Promise<Uint8Array>;

--- a/packages/document-model/src/core/types.ts
+++ b/packages/document-model/src/core/types.ts
@@ -461,11 +461,17 @@ export type MappedOperation = {
 
 export type DocumentOperationsIgnoreMap = Record<string, MappedOperation[]>;
 
+export type HashFormat = {
+  algorithm: string;
+  encoding: string;
+}
+
 export type ActionSignatureContext = {
   documentId: string;
   signer: ActionSigner;
   action: Action;
   previousStateHash: string;
+  hashFormat?: HashFormat;
 };
 
 export type ActionSigningHandler = (message: Uint8Array) => Promise<Uint8Array>;

--- a/packages/document-model/test/document/crypto.test.ts
+++ b/packages/document-model/test/document/crypto.test.ts
@@ -16,6 +16,7 @@ import {
   buildOperationSignatureParams,
   buildSignedAction,
   generateUUIDBrowser,
+  hashBrowser,
   hashDocumentStateForScope,
   hex2ab,
   sign,
@@ -385,5 +386,244 @@ describe("Crypto utils", () => {
     const signature = await sign(parameters, signer);
 
     await verify(parameters, signature, signer);
+  });
+});
+
+describe("hashBrowser", () => {
+  const testString = "Hello, World!";
+  const testUint8Array = new TextEncoder().encode(testString);
+
+  const sha1HelloWorldBase64Hash = "CgqfKmdylCVXq1NV12r0Qvj2XgE=";
+  const sha1HelloWorldHexHash = "0a0a9f2a6772942557ab5355d76af442f8f65e01";
+  const sha1EmptyStringBase64Hash = "2jmj7l5rSw0yVb/vlWAYkK/YBwk=";
+  const sha1EmptyStringHexHash = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+
+  const blake2bHelloWorldBase64Hash = "ff24iK9x6uDmprdR6ONBPXZ+9PpSp5k9qp7wl/eqPZSRmcETyqN8lPgM87IvfZ1uT13vT/kngwz/5IV8NL49iQ==";
+  const blake2bHelloWorldHexHash = "7dfdb888af71eae0e6a6b751e8e3413d767ef4fa52a7993daa9ef097f7aa3d949199c113caa37c94f80cf3b22f7d9d6e4f5def4ff927830cffe4857c34be3d89";
+  const blake2bEmptyStringBase64Hash = "eGoC90IBWQPGxv2FJVLScpEvR0DhWEdhiobiF/cfVBnSXhAxr+5YUxOJZESTTrBLkDpoWxRIt1XVb3Aa/pvizg==";
+  const blake2bEmptyStringHexHash = "786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce";
+
+  const blake3HelloWorldBase64Hash = "KIqGp58go9bczcp3E76u0Xh5gpa9+nkT+ipi2XJ7+Pg=";
+  const blake3HelloWorldHexHash = "288a86a79f20a3d6dccdca7713beaed178798296bdfa7913fa2a62d9727bf8f8";
+  const blake3EmptyStringBase64Hash = "rxNJufX5oaagQE3qNtzJSZvLJcmtwRK3zJqTyuQfMmI=";
+  const blake3EmptyStringHexHash = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262";
+
+  describe("SHA1 algorithm", () => {
+    it("should hash string with default algorithm (sha1) and default encoding (base64)", () => {
+      const result = hashBrowser(testString);
+      expect(result).toBe(sha1HelloWorldBase64Hash);
+    });
+
+    it("should hash string with sha1 algorithm and base64 encoding", () => {
+      const result = hashBrowser(testString, "sha1", "base64");
+      expect(result).toBe(sha1HelloWorldBase64Hash);
+    });
+
+    it("should hash string with sha1 algorithm and hex encoding", () => {
+      const result = hashBrowser(testString, "sha1", "hex");
+      expect(result).toBe(sha1HelloWorldHexHash);
+    });
+
+    it("should hash Uint8Array with sha1 algorithm and base64 encoding", () => {
+      const result = hashBrowser(testUint8Array, "sha1", "base64");
+      expect(result).toBe(sha1HelloWorldBase64Hash);
+    });
+
+    it("should hash Uint8Array with sha1 algorithm and hex encoding", () => {
+      const result = hashBrowser(testUint8Array, "sha1", "hex");
+      expect(result).toBe(sha1HelloWorldHexHash);
+    });
+
+    it("should hash empty string with sha1", () => {
+      const resultBase64 = hashBrowser("", "sha1", "base64");
+      const resultHex = hashBrowser("", "sha1", "hex");
+
+      expect(resultBase64).toBe(sha1EmptyStringBase64Hash);
+      expect(resultHex).toBe(sha1EmptyStringHexHash);
+    });
+  });
+
+  describe("SHA1 WASM algorithm", () => {
+    it("should hash string with sha1_wasm algorithm and base64 encoding", () => {
+      const result = hashBrowser(testString, "sha1_wasm", "base64");
+      // Should produce same result as sha1
+      expect(result).toBe(sha1HelloWorldBase64Hash);
+    });
+
+    it("should hash string with sha1_wasm algorithm and hex encoding", () => {
+      const result = hashBrowser(testString, "sha1_wasm", "hex");
+      expect(result).toBe(sha1HelloWorldHexHash);
+    });
+
+    it("should hash Uint8Array with sha1_wasm algorithm", () => {
+      const result = hashBrowser(testUint8Array, "sha1_wasm", "base64");
+      expect(result).toBe(sha1HelloWorldBase64Hash);
+    });
+
+    it("should hash empty string with sha1_wasm", () => {
+      const resultBase64 = hashBrowser("", "sha1_wasm", "base64");
+      const resultHex = hashBrowser("", "sha1_wasm", "hex");
+
+      expect(resultBase64).toBe(sha1EmptyStringBase64Hash);
+      expect(resultHex).toBe(sha1EmptyStringHexHash);
+    });
+  });
+
+  describe("BLAKE2b WASM algorithm", () => {
+    it("should hash string with blake2b_wasm algorithm and base64 encoding", () => {
+      const result = hashBrowser(testString, "blake2b_wasm", "base64");
+      // Known BLAKE2b hash of "Hello, World!" in base64 (64 bytes output)
+      expect(result).toBe(blake2bHelloWorldBase64Hash);
+    });
+
+    it("should hash string with blake2b_wasm algorithm and hex encoding", () => {
+      const result = hashBrowser(testString, "blake2b_wasm", "hex");
+      // Known BLAKE2b hash of "Hello, World!" in hex (64 bytes output)
+      expect(result).toBe(blake2bHelloWorldHexHash);
+    });
+
+    it("should hash Uint8Array with blake2b_wasm algorithm", () => {
+      const result = hashBrowser(testUint8Array, "blake2b_wasm", "base64");
+      expect(result).toBe(blake2bHelloWorldBase64Hash);
+    });
+
+    it("should hash empty string with blake2b_wasm", () => {
+      const resultBase64 = hashBrowser("", "blake2b_wasm", "base64");
+      const resultHex = hashBrowser("", "blake2b_wasm", "hex");
+
+      expect(resultBase64).toBe(blake2bEmptyStringBase64Hash);
+      expect(resultHex).toBe(blake2bEmptyStringHexHash);
+    });
+  });
+
+  describe("BLAKE3 WASM algorithm", () => {
+    it("should hash string with blake3_wasm algorithm and base64 encoding", () => {
+      const result = hashBrowser(testString, "blake3_wasm", "base64");
+      // Known BLAKE3 hash of "Hello, World!" in base64
+      expect(result).toBe(blake3HelloWorldBase64Hash);
+    });
+
+    it("should hash string with blake3_wasm algorithm and hex encoding", () => {
+      const result = hashBrowser(testString, "blake3_wasm", "hex");
+      // Known BLAKE3 hash of "Hello, World!" in hex
+      expect(result).toBe(blake3HelloWorldHexHash);
+    });
+
+    it("should hash Uint8Array with blake3_wasm algorithm", () => {
+      const result = hashBrowser(testUint8Array, "blake3_wasm", "base64");
+      expect(result).toBe(blake3HelloWorldBase64Hash);
+    });
+
+    it("should hash empty string with blake3_wasm", () => {
+      const resultBase64 = hashBrowser("", "blake3_wasm", "base64");
+      const resultHex = hashBrowser("", "blake3_wasm", "hex");
+
+      expect(resultBase64).toBe(blake3EmptyStringBase64Hash);
+      expect(resultHex).toBe(blake3EmptyStringHexHash);
+    });
+  });
+
+  describe("Different input types", () => {
+    it("should handle ArrayBuffer view (Uint16Array)", () => {
+      const uint16Array = new Uint16Array([72, 101, 108, 108, 111]); // "Hello" in character codes
+      const result = hashBrowser(uint16Array, "sha1", "hex");
+      // This should hash the bytes of the Uint16Array
+      expect(result).toMatch(/^[0-9a-f]{40}$/);
+    });
+
+    it("should handle DataView", () => {
+      const buffer = new ArrayBuffer(13);
+      const dataView = new DataView(buffer);
+      const encoder = new TextEncoder();
+      const encoded = encoder.encode(testString);
+      encoded.forEach((byte, index) => {
+        dataView.setUint8(index, byte);
+      });
+      
+      const result = hashBrowser(dataView, "sha1", "base64");
+      expect(result).toBe(sha1HelloWorldBase64Hash);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should throw error for unsupported algorithm", () => {
+      expect(() => {
+        hashBrowser(testString, "md5", "base64");
+      }).toThrow('Hashing algorithm not supported: "md5"');
+    });
+
+    it("should throw error for unsupported encoding", () => {
+      expect(() => {
+        hashBrowser(testString, "sha1", "base32");
+      }).toThrow('Hash encoding not supported: "base32"');
+    });
+  });
+
+  describe("Consistency across multiple calls", () => {
+    it("should produce consistent hashes for same input", () => {
+      const result1 = hashBrowser(testString, "sha1", "base64");
+      const result2 = hashBrowser(testString, "sha1", "base64");
+      expect(result1).toBe(result2);
+    });
+
+    it("should produce consistent hashes across all algorithms", () => {
+      const sha1Result1 = hashBrowser(testString, "sha1", "hex");
+      const sha1Result2 = hashBrowser(testString, "sha1", "hex");
+      
+      const sha1WasmResult1 = hashBrowser(testString, "sha1_wasm", "hex");
+      const sha1WasmResult2 = hashBrowser(testString, "sha1_wasm", "hex");
+      
+      const blake2bResult1 = hashBrowser(testString, "blake2b_wasm", "hex");
+      const blake2bResult2 = hashBrowser(testString, "blake2b_wasm", "hex");
+      
+      const blake3Result1 = hashBrowser(testString, "blake3_wasm", "hex");
+      const blake3Result2 = hashBrowser(testString, "blake3_wasm", "hex");
+      
+      expect(sha1Result1).toBe(sha1Result2);
+      expect(sha1WasmResult1).toBe(sha1WasmResult2);
+      expect(blake2bResult1).toBe(blake2bResult2);
+      expect(blake3Result1).toBe(blake3Result2);
+    });
+
+    it("should produce same result for sha1 and sha1_wasm", () => {
+      const sha1Result = hashBrowser(testString, "sha1", "base64");
+      const sha1WasmResult = hashBrowser(testString, "sha1_wasm", "base64");
+      expect(sha1Result).toBe(sha1WasmResult);
+    });
+
+    it("should produce same result for default, sha1, and sha1_wasm", () => {
+      const defaultResult = hashBrowser(testString);
+      const sha1Result = hashBrowser(testString, "sha1", "base64");
+      const sha1WasmResult = hashBrowser(testString, "sha1_wasm", "base64");
+      
+      expect(defaultResult).toBe(sha1Result);
+      expect(defaultResult).toBe(sha1WasmResult);
+      expect(sha1Result).toBe(sha1WasmResult);
+      
+      // All should be the known SHA1 hash
+      expect(defaultResult).toBe(sha1HelloWorldBase64Hash);
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle very long strings", () => {
+      const longString = "a".repeat(10000);
+      const result = hashBrowser(longString, "sha1", "hex");
+      expect(result).toMatch(/^[0-9a-f]{40}$/);
+      expect(result).toBe("a080cbda64850abb7b7f67ee875ba068074ff6fe");
+    });
+
+    it("should handle special characters", () => {
+      const specialString = "Hello, 世界! 🌍";
+      const result = hashBrowser(specialString, "sha1", "hex");
+      expect(result).toMatch(/^[0-9a-f]{40}$/);
+    });
+
+    it("should handle binary data", () => {
+      const binaryData = new Uint8Array([0, 1, 2, 3, 255, 254, 253]);
+      const result = hashBrowser(binaryData, "sha1", "hex");
+      expect(result).toMatch(/^[0-9a-f]{40}$/);
+      expect(result).toBe("0522b606c40c0a31c98311e2ac0b526ef157932c");
+    });
   });
 });

--- a/packages/document-model/test/document/crypto.test.ts
+++ b/packages/document-model/test/document/crypto.test.ts
@@ -523,6 +523,138 @@ describe("hashBrowser", () => {
     });
   });
 
+  describe("FarmHash algorithm", () => {
+    // FarmHash produces 64-bit hashes (8 bytes)
+    const farmhashHelloWorldBase64Hash = "naDhy/rqKEI=";
+    const farmhashHelloWorldHexHash = "9da0e1cbfaea2842";
+    const farmhashEmptyStringBase64Hash = "muFqOy+QQE8=";
+    const farmhashEmptyStringHexHash = "9ae16a3b2f90404f";
+
+    it("should hash string with farmhash algorithm and base64 encoding", () => {
+      const result = hashBrowser(testString, "farmhash", "base64");
+      expect(result).toBe(farmhashHelloWorldBase64Hash);
+    });
+
+    it("should hash string with farmhash algorithm and hex encoding", () => {
+      const result = hashBrowser(testString, "farmhash", "hex");
+      expect(result).toBe(farmhashHelloWorldHexHash);
+    });
+
+    it("should hash Uint8Array with farmhash algorithm", () => {
+      const result = hashBrowser(testUint8Array, "farmhash", "base64");
+      expect(result).toBe(farmhashHelloWorldBase64Hash);
+    });
+
+    it("should hash empty string with farmhash", () => {
+      const resultBase64 = hashBrowser("", "farmhash", "base64");
+      const resultHex = hashBrowser("", "farmhash", "hex");
+
+      expect(resultBase64).toBe(farmhashEmptyStringBase64Hash);
+      expect(resultHex).toBe(farmhashEmptyStringHexHash);
+    });
+
+    it("should produce consistent hashes for farmhash", () => {
+      const result1 = hashBrowser(testString, "farmhash", "base64");
+      const result2 = hashBrowser(testString, "farmhash", "base64");
+      expect(result1).toBe(result2);
+      expect(result1).toBe(farmhashHelloWorldBase64Hash);
+    });
+
+    it("should handle different input strings with farmhash", () => {
+      const input1 = "test1";
+      const input2 = "test2";
+      const hash1 = hashBrowser(input1, "farmhash", "hex");
+      const hash2 = hashBrowser(input2, "farmhash", "hex");
+      
+      // Different inputs should produce different hashes
+      expect(hash1).not.toBe(hash2);
+      // Both should be 16 hex characters (64 bits = 8 bytes)
+      expect(hash1).toMatch(/^[0-9a-f]{16}$/);
+      expect(hash2).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it("should handle special characters with farmhash", () => {
+      const specialString = "Hello, 世界! 🌍";
+      const result = hashBrowser(specialString, "farmhash", "hex");
+      expect(result).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it("should handle binary data with farmhash", () => {
+      const binaryData = new Uint8Array([0, 1, 2, 3, 255, 254, 253]);
+      const result = hashBrowser(binaryData, "farmhash", "hex");
+      expect(result).toMatch(/^[0-9a-f]{16}$/);
+    });
+  });
+
+  describe("HighwayHash algorithm", () => {
+    // HighwayHash produces 64-bit hashes (8 bytes) by default
+    const highwayhashHelloWorldBase64Hash = "0nFK3A1UjeY=";
+    const highwayhashHelloWorldHexHash = "d2714adc0d548de6";
+    const highwayhashEmptyStringBase64Hash = "SV9C8I7omVg=";
+    const highwayhashEmptyStringHexHash = "495f42f08ee89958";
+
+    it("should hash string with highwayhash algorithm and base64 encoding", () => {
+      const result = hashBrowser(testString, "highwayhash", "base64");
+      expect(result).toBe(highwayhashHelloWorldBase64Hash);
+    });
+
+    it("should hash string with highwayhash algorithm and hex encoding", () => {
+      const result = hashBrowser(testString, "highwayhash", "hex");
+      expect(result).toBe(highwayhashHelloWorldHexHash);
+    });
+
+    it("should hash Uint8Array with highwayhash algorithm", () => {
+      const result = hashBrowser(testUint8Array, "highwayhash", "base64");
+      expect(result).toBe(highwayhashHelloWorldBase64Hash);
+    });
+
+    it("should hash empty string with highwayhash", () => {
+      const resultBase64 = hashBrowser("", "highwayhash", "base64");
+      const resultHex = hashBrowser("", "highwayhash", "hex");
+
+      expect(resultBase64).toBe(highwayhashEmptyStringBase64Hash);
+      expect(resultHex).toBe(highwayhashEmptyStringHexHash);
+    });
+
+    it("should produce consistent hashes for highwayhash", () => {
+      const result1 = hashBrowser(testString, "highwayhash", "base64");
+      const result2 = hashBrowser(testString, "highwayhash", "base64");
+      expect(result1).toBe(result2);
+      expect(result1).toBe(highwayhashHelloWorldBase64Hash);
+    });
+
+    it("should handle different input strings with highwayhash", () => {
+      const input1 = "test1";
+      const input2 = "test2";
+      const hash1 = hashBrowser(input1, "highwayhash", "hex");
+      const hash2 = hashBrowser(input2, "highwayhash", "hex");
+      
+      // Different inputs should produce different hashes
+      expect(hash1).not.toBe(hash2);
+      // Both should be 16 hex characters (64 bits = 8 bytes)
+      expect(hash1).toMatch(/^[0-9a-f]{16}$/);
+      expect(hash2).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it("should handle special characters with highwayhash", () => {
+      const specialString = "Hello, 世界! 🌍";
+      const result = hashBrowser(specialString, "highwayhash", "hex");
+      expect(result).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it("should handle binary data with highwayhash", () => {
+      const binaryData = new Uint8Array([0, 1, 2, 3, 255, 254, 253]);
+      const result = hashBrowser(binaryData, "highwayhash", "hex");
+      expect(result).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it("should handle very long strings with highwayhash", () => {
+      const longString = "a".repeat(10000);
+      const result = hashBrowser(longString, "highwayhash", "hex");
+      expect(result).toMatch(/^[0-9a-f]{16}$/);
+    });
+  });
+
   describe("Different input types", () => {
     it("should handle ArrayBuffer view (Uint16Array)", () => {
       const uint16Array = new Uint16Array([72, 101, 108, 108, 111]); // "Hello" in character codes
@@ -579,10 +711,18 @@ describe("hashBrowser", () => {
       const blake3Result1 = hashBrowser(testString, "blake3_wasm", "hex");
       const blake3Result2 = hashBrowser(testString, "blake3_wasm", "hex");
       
+      const farmhashResult1 = hashBrowser(testString, "farmhash", "hex");
+      const farmhashResult2 = hashBrowser(testString, "farmhash", "hex");
+      
+      const highwayhashResult1 = hashBrowser(testString, "highwayhash", "hex");
+      const highwayhashResult2 = hashBrowser(testString, "highwayhash", "hex");
+      
       expect(sha1Result1).toBe(sha1Result2);
       expect(sha1WasmResult1).toBe(sha1WasmResult2);
       expect(blake2bResult1).toBe(blake2bResult2);
       expect(blake3Result1).toBe(blake3Result2);
+      expect(farmhashResult1).toBe(farmhashResult2);
+      expect(highwayhashResult1).toBe(highwayhashResult2);
     });
 
     it("should produce same result for sha1 and sha1_wasm", () => {


### PR DESCRIPTION
# Summary

This PR is a research product and not intended to be merged in its current state. Benchmark results to follow in a comment below.

The main value of this work lies in validating which hashing algorithms perform best within our environment and in establishing a clear, workable path toward more mature, production-grade hashing functionality.

It explores performance, compatibility, and implementation complexity across multiple cryptographic and WASM-backed hashing libraries.

This PR introduces a comprehensive benchmark suite for hashing and extends the `crypto` utilities to support multiple algorithms and encodings. It also adds an optional `hashFormat` to the operation signature flow so callers can select the algorithm and output format.

# What's Changed?

## New

**Benchmarks:** `packages/document-model/bench/hash.bench.ts`
- Covers:
  - `hashBrowser` on strings (`"hello world"`, JSON payload)
  - `hashBrowser` on bytes (1 KB, 64 KB, 1 MB)
  - End-to-end signature pipeline via `buildOperationSignatureParams` + `buildOperationSignatureMessage`
- Iterates over every `supportedAlgorithms × supportedEncodings` combination.

## Crypto Module Updates

### **Dependencies added**
  * `@noble/hashes`
  * `hash-wasm`
### **Algorithms supported** (`supportedAlgorithms`)
  * Sync (noble): `sha1`, `sha2_256`, `sha2_512`, `keccak_256`, `sha3_256`, `shake256`, `shake256_64`, `blake2b`, `blake2s`, `blake3`
  * WASM (hash-wasm): `sha1_wasm`, `sha256_wasm`, `sha512_wasm`, `sha3_wasm`, `blake2b_wasm`, `blake2s_wasm`, `blake3_wasm`
### **Encodings supported**: `base64`, `hex`
### **`hashBrowser`**
  * Validates algorithm and encoding against the supported sets.
  * Produces `hex` or `base64` using a Uint8Array encoder.
### **`buildOperationSignatureParams`**
  * Accepts optional `hashFormat` to control algorithm and encoding.
  * Falls back to `defaultAlg = "sha1"` and `defaultEnc = "base64"` when unspecified.
### **Types**
  * Adds `HashFormat` and extends `ActionSignatureContext` with optional `hashFormat`.

# Why Make The Change?

* Provide empirical insight into hashing costs by algorithm, payload type, and output encoding.
* Allow products to choose a stronger or faster hash per use case.
* Make the signature pipeline configurable to enable future migrations without invasive API changes.

# How To Run

```bash
cd packages/document-model
pnpm vitest bench bench/hash.bench.ts --run
```

# Notes
## Reviewer Notes

These are not blockers but are worth tracking:

### API shape for async WASM hashers:
Current `hashBrowser` is synchronous. The PR initialises WASM hashers at top level and reuses instances by calling `update → digest → init`. This is OK in single-threaded, non-concurrent code, but concurrent calls could race. We should consider one of:
  * Provide an explicit **async API** (for WASM), keeping `hashBrowser` sync for pure JS algorithms.
  * Or introduce a small per-call factory that creates a new WASM hasher instance for thread-safety.
### Top-level `await`:
The crypto module initialises WASM hashers at module load with `await`. This requires ESM with top-level await support and may complicate some bundlers or test setups. If that is a concern, we could switch to a lazy async `init()` that callers run at app boot, which introduces its own trade-offs.
### Base64 in Node:
The library path uses `btoa` which does not exist in Node. The benchmark file polyfills it. Do we want to consider adding a runtime check in the library to prefer `Buffer.from(u8).toString('base64')` when `Buffer` is available?

## Security Note

`sha1` is included for compatibility but is not collision-resistant. As we've discussed we should move away from `sha1` as soon as we decide which hashing algorithm to use. I'd recommend `blake3 wasm` because it is both very fast and secure being a sha3 contender alg.

## Other Notes

- Benchmarks generate deterministic byte buffers to avoid RNG noise.
- The Node `btoa` shim is local to the bench file, not the library runtime.
- `toUint8` normalises inputs (`string | Uint8Array | ArrayBufferView`) to `Uint8Array`.
- 🚨 **Research** if current implementation is the best for performance because typically `blake3` is a MUCH fast alg than the below benchmarks show.
  - see https://www.infoq.com/news/2020/01/blake3-fast-crypto-hash/
  - <img width="1214" height="904" alt="image" src="https://github.com/user-attachments/assets/ce7990c3-0837-4595-b230-8376ec28f420" />


# Checklist

* [x] Add benchmark file
* [x] Expand supported algorithms and encodings
* [x] Add optional `hashFormat` to `ActionSignatureContext`
* [x] Add dependencies: `@noble/hashes`, `hash-wasm`
* [ ] Hoist `TextEncoder` and add Node-friendly base64 helper
  * Currently created inside `toUint8` on each call. Hoisting a single `const textEncoder = new TextEncoder()` would reduce allocations in hot paths.
* [ ] Decide on async strategy for WASM paths (follow-up)
