### PR TITLE
feat(codegen): add DocumentToolbar and RevisionHistory components to editor template

### DIFF
--- a/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-editor/components/DocumentToolbar.esm.t
+++ b/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-editor/components/DocumentToolbar.esm.t
@@ -1,0 +1,127 @@
+---
+to: "<%= documentType ? `${rootDir}/${h.changeCase.param(name)}/components/DocumentToolbar.tsx` : null %>"
+unless_exists: true
+---
+<% if (documentType) { %>
+import {
+  exportDocument,
+  setSelectedNode,
+  useNodeParentFolderById,
+  type DocumentDispatch,
+} from "@powerhousedao/reactor-browser";
+import { redo, undo } from "document-model/core";
+import type { <%= documentType.name %>Action, <%= documentType.name %>Document } from "<%= documentType.importPath.startsWith('.') ? '../' + documentType.importPath : documentType.importPath %>";
+
+/**
+ * Props for the DocumentToolbar component
+ *
+ * @property document - The document being edited
+ * @property dispatch - Dispatch function for document operations
+ * @property onHistoryClick - Callback when history button is clicked
+ */
+type DocumentToolbarProps = {
+  document: <%= documentType.name %>Document;
+  dispatch: DocumentDispatch<<%= documentType.name %>Action>;
+  onHistoryClick?: () => void;
+};
+
+export function DocumentToolbar({
+  document,
+  dispatch,
+  onHistoryClick,
+}: DocumentToolbarProps) {
+  // Get the parent folder to navigate back to when closing
+  const parentFolder = useNodeParentFolderById(document.header.id);
+
+  // Handle close button click - navigate back to parent folder
+  const handleClose = () => {
+    setSelectedNode(parentFolder);
+  };
+
+  // Handle export button click - export the document
+  const handleExport = async () => {
+    await exportDocument(document);
+  };
+
+  // Handle undo button click - undo the last operation
+  const handleUndo = () => {
+    // Check if undo is available based on document revision numbers
+    const globalRevisionNumber = document.header.revision.global;
+    const localRevisionNumber = document.header.revision.local;
+    const canUndo = globalRevisionNumber > 0 || localRevisionNumber > 0;
+
+    if (canUndo) {
+      dispatch(undo());
+    }
+  };
+
+  // Handle redo button click - redo the last undone operation
+  const handleRedo = () => {
+    // Check if redo is available based on document clipboard
+    const canRedo = !!document.clipboard.length;
+
+    if (canRedo) {
+      dispatch(redo());
+    }
+  };
+
+  // Get document name or show a fallback
+  const documentName = document.header.name || "Untitled Document";
+
+  // Disable export button if there's no document
+  const isExportDisabled = !document;
+
+  return (
+    <div className="document-toolbar">
+      {/* Left section with Undo, Redo, and Export Buttons */}
+      <div className="actions-left">
+        <button
+          onClick={handleUndo}
+          className="undo-button"
+          aria-label="Undo last action"
+        >
+          ⟲
+        </button>
+        <button
+          onClick={handleRedo}
+          className="redo-button"
+          aria-label="Redo last action"
+        >
+          ⟳
+        </button>
+        <button
+          onClick={() => void handleExport()}
+          className="export-button"
+          disabled={isExportDisabled}
+          aria-label="Export document"
+        >
+          Export
+        </button>
+      </div>
+
+      {/* Document Title - Centered */}
+      <div className="title">{documentName}</div>
+
+      {/* Right section with History and Close Buttons */}
+      <div className="actions-right">
+        {onHistoryClick && (
+          <button
+            onClick={onHistoryClick}
+            className="history-button"
+            aria-label="View revision history"
+          >
+            🕐
+          </button>
+        )}
+        <button
+          onClick={handleClose}
+          className="close-button"
+          aria-label="Close document"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}
+<% } %>

--- a/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-editor/components/RevisionHistory.esm.t
+++ b/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-editor/components/RevisionHistory.esm.t
@@ -1,0 +1,52 @@
+---
+to: "<%= documentType ? `${rootDir}/${h.changeCase.param(name)}/components/RevisionHistory.tsx` : null %>"
+unless_exists: true
+---
+<% if (documentType) { %>
+import { RevisionHistory as RevisionHistoryComponent } from "@powerhousedao/design-system";
+import type { <%= documentType.name %>Document } from "<%= documentType.importPath.startsWith('.') ? '../' + documentType.importPath : documentType.importPath %>";
+
+/**
+ * Props for the RevisionHistory component
+ *
+ * @property document - The document to display revision history for
+ * @property onClose - Callback when closing the revision history view
+ */
+type RevisionHistoryProps = {
+  document: <%= documentType.name %>Document;
+  onClose: () => void;
+};
+
+export function RevisionHistory({ document, onClose }: RevisionHistoryProps) {
+  // Extract operations from document
+  const globalOperations = document.operations.global;
+  const localOperations = document.operations.local;
+
+  // Get document metadata
+  const documentTitle = document.header.name || "Untitled Document";
+  const documentId = document.header.id;
+
+  // Handle copy state action
+  const handleCopyState = async () => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(document.state, null, 2));
+      alert("Document state copied to clipboard");
+    } catch (error) {
+      console.error("Failed to copy state to clipboard:", error);
+      alert("Failed to copy state to clipboard");
+    }
+  };
+
+  return (
+    <RevisionHistoryComponent
+      documentTitle={documentTitle}
+      documentId={documentId}
+      globalOperations={globalOperations}
+      localOperations={localOperations}
+      onClose={onClose}
+      documentState={document.state}
+      onCopyState={handleCopyState}
+    />
+  );
+}
+<% } %>

--- a/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-editor/editor.esm.t
+++ b/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-editor/editor.esm.t
@@ -7,18 +7,119 @@ import {
   Form,
   FormLabel,
   StringField,
-} from "@powerhousedao/document-engineering";
-<% if(!documentType){ %>import { useSelectedDocument } from "@powerhousedao/reactor-browser";<% } else { %>import { useSelected<%= documentType.name %>Document %>} from "../hooks/use<%= documentType.name %>Document%>.js";<% } %>
-import { setName } from "document-model";<% if(documentType) { %>
-import { actions } from "<%= documentType.importPath %>";<% } %>
+} from "@powerhousedao/document-engineering";<% if (documentType) { %>
+
+import { setName } from "document-model";
+import { useState } from "react";
+import { useSelected<%= documentType.name %>Document } from "../hooks/use<%= documentType.name %>Document.js";
+import { DocumentToolbar } from "./components/DocumentToolbar.js";
+import { RevisionHistory } from "./components/RevisionHistory.js";
 
 export function Editor() {
-  const [document, dispatch] = <% if(documentType) { %>useSelected<%= documentType.name %>Document()<% } else { %>useSelectedDocument()<% } %>;
-<% if(!documentType){ %>
+  const [document, dispatch] = useSelected<%= documentType.name %>Document();
+  const [showRevisionHistory, setShowRevisionHistory] = useState(false);
+
+  function handleSetName(values: { name: string }) {
+    if (values.name) {
+      dispatch(setName(values.name));
+    }
+  }
+
+  return (
+    <div className="py-10 text-center">
+      {showRevisionHistory ? (
+        <RevisionHistory
+          document={document}
+          onClose={() => setShowRevisionHistory(false)}
+        />
+      ) : (
+        <div className="ph-default-styles">
+          <div className="inline-flex flex-col gap-10 text-start">
+            {/* Document Toolbar */}
+            <DocumentToolbar
+              document={document}
+              dispatch={dispatch}
+              onHistoryClick={() => setShowRevisionHistory(true)}
+            />
+
+            {/* Edit document name form */}
+
+            <section className="flex justify-between">
+              <h1 className="text-start">{document.header.name}</h1>
+              <div className="flex flex-col space-y-2">
+                <Form
+                  onSubmit={handleSetName}
+                  defaultValues={{ name: document.header.name }}
+                  className="flex flex-col gap-3 pt-2"
+                >
+                  <div className="flex items-end gap-3">
+                    <div>
+                      <FormLabel htmlFor="name">
+                        <b className="mb-1">Change document name</b>
+                      </FormLabel>
+                      <StringField
+                        name="name"
+                        placeholder="Enter document name"
+                        className="mt-1"
+                      />
+                    </div>
+                    <Button type="submit">Edit</Button>
+                  </div>
+                </Form>
+              </div>
+            </section>
+
+            {/* Document metadata */}
+            <section>
+              <ul className="grid grid-cols-2 gap-x-4 gap-y-1 text-gray-700">
+                <li>
+                  <b className="mr-1">Id:</b>
+                  {document.header.id}
+                </li>
+                <li>
+                  <b className="mr-1">Created:</b>
+                  {new Date(document.header.createdAtUtcIso).toLocaleString()}
+                </li>
+                <li>
+                  <b className="mr-1">Type:</b>
+                  {document.header.documentType}
+                </li>
+                <li>
+                  <b className="mr-1">Last Modified:</b>
+                  {new Date(document.header.lastModifiedAtUtcIso).toLocaleString()}
+                </li>
+              </ul>
+            </section>
+
+            {/* Document state */}
+            <section className="inline-block">
+              <h2 className="mb-4">Document state</h2>
+              <textarea
+                rows={10}
+                readOnly
+                value={JSON.stringify(document.state, null, 2)}
+                className="font-mono"
+              ></textarea>
+            </section>
+          </div>
+
+        </div>
+      )}
+
+    </div>
+  );
+}<% } else { %>
+
+import { useSelectedDocument } from "@powerhousedao/reactor-browser";
+import { setName } from "document-model";
+
+export function Editor() {
+  const [document, dispatch] = useSelectedDocument();
+
   if (!document) {
     return null;
   }
-<% } %>
+
   function handleSetName(values: { name: string }) {
     if (values.name) {
       dispatch(setName(values.name));
@@ -28,7 +129,7 @@ export function Editor() {
   return (
     <div className="ph-default-styles py-10 text-center">
       <div className="inline-flex flex-col gap-10 text-start">
-        
+
         {/* Edit document name form */}
         <section className="flex justify-between">
           <h1 className="text-start">{document.header.name}</h1>
@@ -88,6 +189,8 @@ export function Editor() {
           ></textarea>
         </section>
       </div>
+
     </div>
   );
 }
+<% } %>

--- a/packages/codegen/src/codegen/__tests__/generate-editor.expected.ts
+++ b/packages/codegen/src/codegen/__tests__/generate-editor.expected.ts
@@ -10,7 +10,162 @@ export const module: EditorModule = {
     },
 };`;
 
-const EXPECTED_EDITOR_METHOD = `function handleSetName(values: { name: string }) {
+export const EXPECTED_EDITOR_CONTENT = `import {
+  Button,
+  Form,
+  FormLabel,
+  StringField,
+} from "@powerhousedao/document-engineering";
+
+import { setName } from "document-model";
+import { useState } from "react";
+import { useSelectedDocumentModelDocument } from "../hooks/useDocumentModelDocument.js";
+import { DocumentToolbar } from "./components/DocumentToolbar.js";
+import { RevisionHistory } from "./components/RevisionHistory.js";
+
+export function Editor() {
+  const [document, dispatch] = useSelectedDocumentModelDocument();
+  const [showRevisionHistory, setShowRevisionHistory] = useState(false);
+
+  function handleSetName(values: { name: string }) {
+    if (values.name) {
+      dispatch(setName(values.name));
+    }
+  }
+
+  return (
+    <div className="py-10 text-center">
+      {showRevisionHistory ? (
+        <RevisionHistory
+          document={document}
+          onClose={() => setShowRevisionHistory(false)}
+        />
+      ) : (
+        <div className="ph-default-styles">
+          <div className="inline-flex flex-col gap-10 text-start">
+            {/* Document Toolbar */}
+            <DocumentToolbar
+              document={document}
+              dispatch={dispatch}
+              onHistoryClick={() => setShowRevisionHistory(true)}
+            />
+
+            {/* Edit document name form */}
+
+            <section className="flex justify-between">
+              <h1 className="text-start">{document.header.name}</h1>
+              <div className="flex flex-col space-y-2">
+                <Form
+                  onSubmit={handleSetName}
+                  defaultValues={{ name: document.header.name }}
+                  className="flex flex-col gap-3 pt-2"
+                >
+                  <div className="flex items-end gap-3">
+                    <div>
+                      <FormLabel htmlFor="name">
+                        <b className="mb-1">Change document name</b>
+                      </FormLabel>
+                      <StringField
+                        name="name"
+                        placeholder="Enter document name"
+                        className="mt-1"
+                      />
+                    </div>
+                    <Button type="submit">Edit</Button>
+                  </div>
+                </Form>
+              </div>
+            </section>
+
+            {/* Document metadata */}
+            <section>
+              <ul className="grid grid-cols-2 gap-x-4 gap-y-1 text-gray-700">
+                <li>
+                  <b className="mr-1">Id:</b>
+                  {document.header.id}
+                </li>
+                <li>
+                  <b className="mr-1">Created:</b>
+                  {new Date(document.header.createdAtUtcIso).toLocaleString()}
+                </li>
+                <li>
+                  <b className="mr-1">Type:</b>
+                  {document.header.documentType}
+                </li>
+                <li>
+                  <b className="mr-1">Last Modified:</b>
+                  {new Date(document.header.lastModifiedAtUtcIso).toLocaleString()}
+                </li>
+              </ul>
+            </section>
+
+            {/* Document state */}
+            <section className="inline-block">
+              <h2 className="mb-4">Document state</h2>
+              <textarea
+                rows={10}
+                readOnly
+                value={JSON.stringify(document.state, null, 2)}
+                className="font-mono"
+              ></textarea>
+            </section>
+          </div>
+
+        </div>
+      )}
+
+    </div>
+  );
+}`;
+
+export const EXPECTED_MAIN_INDEX_CONTENT = `/**
+* This is a scaffold file meant for customization.
+* Delete the file and run the code generator again to have it reset
+*/
+
+export { module as DocumentModelEditor } from './document-model-editor/index.js';`;
+
+export const EXPECTED_HOOK_CONTENT = `import { useDocumentOfType, useSelectedDocumentOfType } from "@powerhousedao/reactor-browser";
+import type { DocumentModelAction, DocumentModelDocument } from "document-model";
+
+export function useDocumentModelDocument(documentId: string | null | undefined) {
+  return useDocumentOfType<DocumentModelDocument, DocumentModelAction>(documentId, "powerhouse/document-model");
+}
+
+export function useSelectedDocumentModelDocument() {
+  return useSelectedDocumentOfType<DocumentModelDocument, DocumentModelAction>("powerhouse/document-model");
+}`;
+
+export const EXPECTED_INDEX_CONTENT_NO_DOCUMENT_TYPES = `import type { EditorModule } from 'document-model';
+import { Editor } from './editor.js';
+
+export const module: EditorModule = {
+    Component: Editor,
+    documentTypes: ['*'],
+    config: {
+        id: 'test-generic-document-editor',
+        name: 'GenericDocumentEditor',
+    },
+};`;
+
+export const EXPECTED_EDITOR_CONTENT_NO_DOCUMENT_TYPES = `import {
+  Button,
+  Form,
+  FormLabel,
+  StringField,
+} from "@powerhousedao/document-engineering";
+
+import { useSelectedDocument } from "@powerhousedao/reactor-browser";
+import { setName } from "document-model";
+
+export function Editor() {
+  const [document, dispatch] = useSelectedDocument();
+
+  if (!document) {
+    return null;
+  }
+
+  function handleSetName(values: { name: string }) {
     if (values.name) {
       dispatch(setName(values.name));
     }
@@ -19,7 +174,7 @@ const EXPECTED_EDITOR_METHOD = `function handleSetName(values: { name: string })
   return (
     <div className="ph-default-styles py-10 text-center">
       <div className="inline-flex flex-col gap-10 text-start">
-        
+
         {/* Edit document name form */}
         <section className="flex justify-between">
           <h1 className="text-start">{document.header.name}</h1>
@@ -79,72 +234,10 @@ const EXPECTED_EDITOR_METHOD = `function handleSetName(values: { name: string })
           ></textarea>
         </section>
       </div>
+
     </div>
   );
 }`;
-
-export const EXPECTED_EDITOR_CONTENT = `import {
-  Button,
-  Form,
-  FormLabel,
-  StringField,
-} from "@powerhousedao/document-engineering";
-import { useSelectedDocumentModelDocument } from "../hooks/useDocumentModelDocument.js";
-import { setName } from "document-model";
-import { actions } from "document-model";
-
-export function Editor() {
-  const [document, dispatch] = useSelectedDocumentModelDocument();
-
-  ${EXPECTED_EDITOR_METHOD}`;
-
-export const EXPECTED_MAIN_INDEX_CONTENT = `/**
-* This is a scaffold file meant for customization.
-* Delete the file and run the code generator again to have it reset
-*/
-
-export { module as DocumentModelEditor } from './document-model-editor/index.js';`;
-
-export const EXPECTED_HOOK_CONTENT = `import { useDocumentOfType, useSelectedDocumentOfType } from "@powerhousedao/reactor-browser";
-import type { DocumentModelAction, DocumentModelDocument } from "document-model";
-
-export function useDocumentModelDocument(documentId: string | null | undefined) {
-  return useDocumentOfType<DocumentModelDocument, DocumentModelAction>(documentId, "powerhouse/document-model");
-}
-
-export function useSelectedDocumentModelDocument() {
-  return useSelectedDocumentOfType<DocumentModelDocument, DocumentModelAction>("powerhouse/document-model");
-}`;
-
-export const EXPECTED_INDEX_CONTENT_NO_DOCUMENT_TYPES = `import type { EditorModule } from 'document-model';
-import { Editor } from './editor.js';
-
-export const module: EditorModule = {
-    Component: Editor,
-    documentTypes: ['*'],
-    config: {
-        id: 'test-generic-document-editor',
-        name: 'GenericDocumentEditor',
-    },
-};`;
-
-export const EXPECTED_EDITOR_CONTENT_NO_DOCUMENT_TYPES = `import {
-  Button,
-  Form,
-  FormLabel,
-  StringField,
-} from "@powerhousedao/document-engineering";
-import { useSelectedDocument } from "@powerhousedao/reactor-browser";
-import { setName } from "document-model";
-
-export function Editor() {
-  const [document, dispatch] = useSelectedDocument();
-
-  if (!document) {
-    return null;
-  }
-
-  ${EXPECTED_EDITOR_METHOD}`;
 
 export const EXPECTED_MAIN_INDEX_CONTENT_NO_DOCUMENT_TYPES = `/**
 * This is a scaffold file meant for customization.


### PR DESCRIPTION
## Description:

- Added `DocumentToolbar` and `RevisionHistory` components to editor templates 

boilerplate update here: https://github.com/powerhouse-inc/document-model-boilerplate/pull/39

![2025-10-23 17 27 42](https://github.com/user-attachments/assets/5204f2d1-b8a3-4d7e-9521-051e3f8369b3)
