### PR TITLE
feat(reactor-browser): add folder hooks

### DIFF
--- a/apps/connect/package.copy.json
+++ b/apps/connect/package.copy.json
@@ -1,7 +1,7 @@
 {
   "name": "@powerhousedao/connect",
   "productName": "Powerhouse-Connect",
-  "version": "4.1.0-dev.89",
+  "version": "4.1.0-dev.91",
   "description": "Powerhouse Connect",
   "main": "./dist/index.html",
   "type": "module",

--- a/packages/reactor-browser/src/hooks/index.ts
+++ b/packages/reactor-browser/src/hooks/index.ts
@@ -49,6 +49,12 @@ export {
   useNodesInSelectedDrive,
 } from "./items-in-selected-drive.js";
 export {
+  useDocumentsInSelectedFolder,
+  useFileNodesInSelectedFolder,
+  useFolderNodesInSelectedFolder,
+  useNodesInSelectedFolder,
+} from "./items-in-selected-folder.js";
+export {
   closePHModal,
   setPHModal,
   showCreateDocumentModal,

--- a/packages/reactor-browser/src/hooks/items-in-selected-folder.ts
+++ b/packages/reactor-browser/src/hooks/items-in-selected-folder.ts
@@ -1,0 +1,39 @@
+import type { FileNode, FolderNode, Node } from "document-drive";
+import type { PHDocument } from "document-model";
+import { isFileNodeKind, isFolderNodeKind } from "../utils/nodes.js";
+import {
+  useDocumentsInSelectedDrive,
+  useNodesInSelectedDrive,
+} from "./items-in-selected-drive.js";
+import { useSelectedFolder } from "./selected-folder.js";
+
+/** Returns the nodes in the selected folder. */
+export function useNodesInSelectedFolder(): Node[] | undefined {
+  const selectedFolder = useSelectedFolder();
+  const nodes = useNodesInSelectedDrive();
+  if (!selectedFolder || !nodes) return undefined;
+
+  return nodes.filter((n) => n.parentFolder === selectedFolder.id);
+}
+
+/** Returns the file nodes in the selected folder. */
+export function useFileNodesInSelectedFolder(): FileNode[] | undefined {
+  const nodes = useNodesInSelectedFolder();
+  if (!nodes) return undefined;
+  return nodes.filter((n) => isFileNodeKind(n));
+}
+
+/** Returns the folder nodes in the selected folder. */
+export function useFolderNodesInSelectedFolder(): FolderNode[] | undefined {
+  const nodes = useNodesInSelectedFolder();
+  if (!nodes) return undefined;
+  return nodes.filter((n) => isFolderNodeKind(n));
+}
+
+/** Returns the documents in the selected folder. */
+export function useDocumentsInSelectedFolder(): PHDocument[] | undefined {
+  const documents = useDocumentsInSelectedDrive();
+  const fileNodes = useFileNodesInSelectedFolder();
+  const fileNodeIds = fileNodes?.map((node) => node.id);
+  return documents?.filter((d) => fileNodeIds?.includes(d.header.id));
+}


### PR DESCRIPTION
add convenience hooks for getting nodes in a folder as opposed to a drive