### PR TITLE
fix(connect): update sideEffects in package.json to include main.js

### DIFF
--- a/apps/connect/package.json
+++ b/apps/connect/package.json
@@ -95,7 +95,7 @@
     "./assets/*.avif": "./assets/*.avif",
     "./public/icon.ico": "./public/icon.ico"
   },
-  "sideEffects": false,
+  "sideEffects": ["lib/src/main.js"],
   "license": "AGPL-3.0-only",
   "author": "powerhouse.inc",
   "repository": {


### PR DESCRIPTION
## Description

`ph connect build` is currently broken (connect code isn't included in the bundled files)
the problem is that package.json has `"sideEffects": false` which tells bundlers like vite/rollup that all files in the package are pure and can be tree-shaken away if not used.
but `lib/src/main.js` actually has side effects, it executes this code on import:
```js
createRoot(document.getElementById("root")).render(_jsx(AppLoader, {}));
```

We will need to push this fix to staging too