### PR TITLE
feat: add support for operations with no inputs

### DIFF
--- a/packages/builder-tools/document-model-editor/components/module.tsx
+++ b/packages/builder-tools/document-model-editor/components/module.tsx
@@ -27,6 +27,7 @@ type Props = {
     errorId: string,
     name: string,
   ) => void;
+  toggleNoInputRequired: (id: string, noInputRequired: boolean) => void;
 };
 export function Module(props: Props) {
   const {
@@ -45,6 +46,7 @@ export function Module(props: Props) {
     addOperationError,
     deleteOperationError,
     setOperationErrorName,
+    toggleNoInputRequired,
   } = props;
   return (
     <div className="relative rounded-3xl bg-gray-100 p-6">
@@ -87,6 +89,7 @@ export function Module(props: Props) {
           addOperationError={addOperationError}
           deleteOperationError={deleteOperationError}
           setOperationErrorName={setOperationErrorName}
+          toggleNoInputRequired={toggleNoInputRequired}
         />
       )}
     </div>

--- a/packages/builder-tools/document-model-editor/components/modules.tsx
+++ b/packages/builder-tools/document-model-editor/components/modules.tsx
@@ -26,6 +26,7 @@ type Props = {
     errorId: string,
     name: string,
   ) => void;
+  toggleNoInputRequired: (id: string, noInputRequired: boolean) => void;
 };
 export default function Modules({
   modules,
@@ -41,6 +42,7 @@ export default function Modules({
   addOperationError,
   deleteOperationError,
   setOperationErrorName,
+  toggleNoInputRequired,
 }: Props) {
   const [lastCreatedModuleId, setLastCreatedModuleId] = useState<string | null>(
     null,
@@ -79,6 +81,7 @@ export default function Modules({
           addOperationError={addOperationError}
           deleteOperationError={deleteOperationError}
           setOperationErrorName={setOperationErrorName}
+          toggleNoInputRequired={toggleNoInputRequired}
         />
       ))}
       <Module
@@ -97,6 +100,7 @@ export default function Modules({
         addOperationError={addOperationError}
         deleteOperationError={deleteOperationError}
         setOperationErrorName={setOperationErrorName}
+        toggleNoInputRequired={toggleNoInputRequired}
       />
       {/* Focus trap to prevent tabbing out of the editor */}
       <div

--- a/packages/builder-tools/document-model-editor/components/operation.tsx
+++ b/packages/builder-tools/document-model-editor/components/operation.tsx
@@ -1,6 +1,7 @@
 import type { ModuleSpecification } from "document-model";
 import { lazy, useCallback } from "react";
 import type { DocumentActionHandlers } from "../types/documents.js";
+import { isEmptyOperationSchema } from "../utils/helpers.js";
 import { ensureValidOperationSchemaInputName } from "../utils/linting.js";
 import { OperationDescriptionForm } from "./operation-description-form.js";
 import { OperationErrors } from "./operation-errors.js";
@@ -35,6 +36,7 @@ type Props = {
     errorId: string,
     name: string,
   ) => void;
+  toggleNoInputRequired: (id: string, noInputRequired: boolean) => void;
 };
 export function Operation(props: Props) {
   const {
@@ -50,7 +52,15 @@ export function Operation(props: Props) {
     addOperationError,
     deleteOperationError,
     setOperationErrorName,
+    toggleNoInputRequired,
   } = props;
+
+  const noInputRequired = isEmptyOperationSchema(operation.schema);
+
+  const handleToggleNoInput = useCallback(
+    (checked: boolean) => toggleNoInputRequired(operation.id, checked),
+    [operation.id, toggleNoInputRequired],
+  );
 
   const handleUpdateDocument = useCallback(
     (newDoc: string) => updateOperationSchema(operation.id, newDoc),
@@ -93,11 +103,22 @@ export function Operation(props: Props) {
       </div>
 
       <div className="relative top-8" style={{ gridArea: "editor" }}>
-        <GraphqlEditor
-          doc={operation.schema ?? ""}
-          updateDocumentInModel={handleUpdateDocument}
-          customLinter={customLinter}
-        />
+        <label className="mb-2 flex cursor-pointer items-center gap-2">
+          <input
+            type="checkbox"
+            checked={noInputRequired}
+            onChange={(e) => handleToggleNoInput(e.target.checked)}
+            className="h-4 w-4 rounded border-gray-300"
+          />
+          <span className="text-sm text-gray-700">Operation with no inputs</span>
+        </label>
+        {!noInputRequired && (
+          <GraphqlEditor
+            doc={operation.schema ?? ""}
+            updateDocumentInModel={handleUpdateDocument}
+            customLinter={customLinter}
+          />
+        )}
       </div>
 
       <div style={{ gridArea: "errors" }}>

--- a/packages/builder-tools/document-model-editor/components/operations.tsx
+++ b/packages/builder-tools/document-model-editor/components/operations.tsx
@@ -25,6 +25,7 @@ type Props = {
     errorId: string,
     name: string,
   ) => void;
+  toggleNoInputRequired: (id: string, noInputRequired: boolean) => void;
 };
 export function Operations({
   module,
@@ -38,6 +39,7 @@ export function Operations({
   setOperationErrorName,
   updateOperationSchema,
   setOperationDescription,
+  toggleNoInputRequired,
 }: Props) {
   const [lastCreatedOperationId, setLastCreatedOperationId] = useState<
     string | null
@@ -75,6 +77,7 @@ export function Operations({
             deleteOperation={deleteOperation}
             updateOperationSchema={updateOperationSchema}
             setOperationDescription={setOperationDescription}
+            toggleNoInputRequired={toggleNoInputRequired}
           />
         </div>
       ))}

--- a/packages/builder-tools/document-model-editor/editor.tsx
+++ b/packages/builder-tools/document-model-editor/editor.tsx
@@ -32,6 +32,7 @@ import type { Scope } from "./types/documents.js";
 import {
   compareStringsWithoutWhitespace,
   initializeModelSchema,
+  makeEmptyOperationSchema,
   makeOperationInitialDoc,
 } from "./utils/helpers.js";
 import ModelMetadata from "./components/model-metadata-form.js";
@@ -217,6 +218,24 @@ export default function Editor() {
     dispatch(setOperationSchema({ id, schema: newSchema }));
   };
 
+  const handleToggleNoInputRequired = (
+    id: string,
+    noInputRequired: boolean,
+  ) => {
+    const operation = operations.find((op) => op.id === id);
+    if (!operation?.name) return;
+
+    if (noInputRequired) {
+      dispatch(
+        setOperationSchema({ id, schema: makeEmptyOperationSchema(operation.name) }),
+      );
+    } else {
+      dispatch(
+        setOperationSchema({ id, schema: makeOperationInitialDoc(operation.name) }),
+      );
+    }
+  };
+
   const handleSetOperationDescription = (
     id: string,
     newDescription: string,
@@ -365,6 +384,7 @@ export default function Editor() {
               deleteOperationError={handleDeleteOperationError}
               setOperationErrorName={handleSetOperationErrorName}
               addOperationAndInitialSchema={addOperationAndInitialSchema}
+              toggleNoInputRequired={handleToggleNoInputRequired}
             />
           </div>
         </div>

--- a/packages/builder-tools/document-model-editor/utils/helpers.ts
+++ b/packages/builder-tools/document-model-editor/utils/helpers.ts
@@ -55,6 +55,22 @@ export function makeOperationInitialDoc(name: string) {
   return inputSdl;
 }
 
+export function makeEmptyOperationSchema(operationName: string): string {
+  const pascalName = pascalCase(operationName);
+  return `input ${pascalName}Input {\n  _empty: Boolean\n}`;
+}
+
+export function isEmptyOperationSchema(
+  schema: string | null | undefined,
+): boolean {
+  if (!schema) return false;
+  // Check if schema only contains _empty: Boolean field
+  return (
+    /_empty:\s*Boolean/.test(schema) &&
+    !schema.replace(/_empty:\s*Boolean/, "").match(/\w+:\s*\w+/)
+  );
+}
+
 export function safeParseJsonRecord(json: string) {
   try {
     return JSON.parse(json) as Record<string, Serializable>;

--- a/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-document-model-module/creators.esm.t
+++ b/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-document-model-module/creators.esm.t
@@ -20,7 +20,7 @@ import type {
 } from './actions.js';
 
 <% actions.filter(a => a.hasInput).forEach(action => { _%>
-export const <%= h.changeCase.camel(action.name) %> = (input: <%= h.changeCase.pascal(action.name) %>Input<%if(action.hasAttachment){ %>, attachments: AttachmentInput[] <% } %>) =>
+export const <%= h.changeCase.camel(action.name) %> = (input<% if(action.isEmptyInput) { %>: <%= h.changeCase.pascal(action.name) %>Input = {}<% } else { %>: <%= h.changeCase.pascal(action.name) %>Input<% } %><%if(action.hasAttachment){ %>, attachments: AttachmentInput[] <% } %>) =>
     createAction<<%= h.changeCase.pascal(action.name) %>Action>(
         '<%= h.changeCase.constantCase(action.name) %>',
         {...input},

--- a/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-document-model-module/index.js
+++ b/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-document-model-module/index.js
@@ -15,6 +15,9 @@ module.exports = {
         ? filteredModules[0].operations.map((a) => ({
             name: a.name,
             hasInput: a.schema !== null,
+            isEmptyInput:
+              a.schema?.includes("_empty") &&
+              !a.schema.replace(/_empty:\s*Boolean/, "").match(/\w+:\s*\w+/),
             hasAttachment: a.schema?.includes(": Attachment"),
             scope: a.scope || "global",
             state: a.scope === "global" ? "" : a.scope, // the state this action affects

--- a/packages/codegen/src/ts-morph-utils/name-builders/get-variable-names.ts
+++ b/packages/codegen/src/ts-morph-utils/name-builders/get-variable-names.ts
@@ -173,12 +173,17 @@ function getActionFromOperation(
     throw new Error("Operation name is required");
   }
   const hasInput = schema !== null;
+  const isEmptyInput =
+    hasInput &&
+    schema.includes("_empty") &&
+    !schema.replace(/_empty:\s*Boolean/, "").match(/\w+:\s*\w+/);
   const hasAttachment = hasInput && schema.includes(": Attachment");
   const state = scope === "global" ? "" : scope;
 
   return {
     name,
     hasInput,
+    isEmptyInput,
     hasAttachment,
     scope,
     state,

--- a/packages/codegen/src/ts-morph-utils/name-builders/types.ts
+++ b/packages/codegen/src/ts-morph-utils/name-builders/types.ts
@@ -27,6 +27,7 @@ export type DocumentModelTemplateInputsWithModule = {
 export type ActionFromOperation = {
   name: string;
   hasInput: boolean;
+  isEmptyInput: boolean;
   hasAttachment: boolean;
   scope: string;
   state: string;

--- a/packages/codegen/src/ts-morph-utils/templates/document-model/gen/modules/creators.ts
+++ b/packages/codegen/src/ts-morph-utils/templates/document-model/gen/modules/creators.ts
@@ -50,7 +50,10 @@ function makeActionCreatorWithInput(actionWithInput: ActionFromOperation) {
   const actionTypeName = makeActionTypeName(actionWithInput);
   const inputSchemaName = makeActionInputSchemaName(actionWithInput)!;
   const inputTypeName = makeActionInputTypeName(actionWithInput)!;
-  const argsArray = [`input: ${inputTypeName}`];
+  const inputArg = actionWithInput.isEmptyInput
+    ? `input: ${inputTypeName} = {}`
+    : `input: ${inputTypeName}`;
+  const argsArray = [inputArg];
   if (actionWithInput.hasAttachment) {
     argsArray.push(`attachments: AttachmentInput[]`);
   }


### PR DESCRIPTION
This PR adds support for empty operation inputs.

Since GraphQL does not allow empty input types (e.g. `input MyInput {}`), I added a checkbox in the document model editor that enables creating empty operation inputs. Under the hood, this generates an input with an optional `_empty` field:

```graphql
input MyInput {
  _empty: Boolean
}
```

This approach prevents breaking the `schema.graphql` file and the codegen pipeline.

During code generation, empty operations default to an empty object in the action creator:

```ts
export const setMyDocEmptyOperation = (
  input: SetMyDocEmptyOperation = {}
) => {
  ...
}
```

This allows the action creator to be called without arguments:
```ts
actions.setMyDocEmptyOperation()
```

![2025-12-15 16 37 56](https://github.com/user-attachments/assets/bdcfaf9d-f6d6-4b0b-803e-57bcbefdaf27)
