### PR TITLE
feat: integrate doc model versioning in reactor

### DIFF
--- a/packages/codegen/src/ts-morph-utils/templates/document-model/module.ts
+++ b/packages/codegen/src/ts-morph-utils/templates/document-model/module.ts
@@ -4,11 +4,13 @@ type DocumentModelModuleFileTemplateArgs = {
   phStateName: string;
   versionedDocumentModelPackageImportPath: string;
   pascalCaseDocumentType: string;
+  version: number;
 };
 export function documentModelModuleFileTemplate({
   phStateName,
   versionedDocumentModelPackageImportPath,
   pascalCaseDocumentType,
+  version,
 }: DocumentModelModuleFileTemplateArgs) {
   const template = ts`
   import type { DocumentModelModule } from "document-model";
@@ -24,6 +26,7 @@ export function documentModelModuleFileTemplate({
 
   /** Document model module for the Todo List document type */
   export const ${pascalCaseDocumentType}: DocumentModelModule<${phStateName}> = {
+    version: ${version},
     reducer,
     actions,
     utils,

--- a/packages/reactor/src/cache/document-meta-cache.ts
+++ b/packages/reactor/src/cache/document-meta-cache.ts
@@ -190,10 +190,11 @@ export class DocumentMetaCache implements IDocumentMetaCache {
       documentScopeRevision = op.index;
 
       if (op.action.type === "UPGRADE_DOCUMENT") {
-        document = applyUpgradeDocumentAction(
-          document,
-          op.action as UpgradeDocumentAction,
-        );
+        const upgradeAction = op.action as UpgradeDocumentAction;
+        const result = applyUpgradeDocumentAction(document, upgradeAction);
+        if (result !== null) {
+          document = result;
+        }
       } else if (op.action.type === "DELETE_DOCUMENT") {
         document = applyDeleteDocumentAction(
           document,

--- a/packages/reactor/src/cache/document-meta-cache.ts
+++ b/packages/reactor/src/cache/document-meta-cache.ts
@@ -191,10 +191,7 @@ export class DocumentMetaCache implements IDocumentMetaCache {
 
       if (op.action.type === "UPGRADE_DOCUMENT") {
         const upgradeAction = op.action as UpgradeDocumentAction;
-        const result = applyUpgradeDocumentAction(document, upgradeAction);
-        if (result !== null) {
-          document = result;
-        }
+        document = applyUpgradeDocumentAction(document, upgradeAction);
       } else if (op.action.type === "DELETE_DOCUMENT") {
         document = applyDeleteDocumentAction(
           document,

--- a/packages/reactor/src/cache/kysely-write-cache.ts
+++ b/packages/reactor/src/cache/kysely-write-cache.ts
@@ -1,4 +1,8 @@
-import type { CreateDocumentAction, PHDocument } from "document-model";
+import type {
+  CreateDocumentAction,
+  PHDocument,
+  UpgradeDocumentAction,
+} from "document-model";
 import {
   applyDeleteDocumentAction,
   applyUpgradeDocumentAction,
@@ -390,7 +394,11 @@ export class KyselyWriteCache implements IWriteCache {
         }
 
         if (operation.action.type === "UPGRADE_DOCUMENT") {
-          applyUpgradeDocumentAction(document, operation.action as never);
+          const upgradeAction = operation.action as UpgradeDocumentAction;
+          const result = applyUpgradeDocumentAction(document, upgradeAction);
+          if (result !== null) {
+            document = result;
+          }
         } else if (operation.action.type === "DELETE_DOCUMENT") {
           applyDeleteDocumentAction(document, operation.action as never);
         } else {

--- a/packages/reactor/src/cache/kysely-write-cache.ts
+++ b/packages/reactor/src/cache/kysely-write-cache.ts
@@ -395,10 +395,7 @@ export class KyselyWriteCache implements IWriteCache {
 
         if (operation.action.type === "UPGRADE_DOCUMENT") {
           const upgradeAction = operation.action as UpgradeDocumentAction;
-          const result = applyUpgradeDocumentAction(document, upgradeAction);
-          if (result !== null) {
-            document = result;
-          }
+          document = applyUpgradeDocumentAction(document, upgradeAction);
         } else if (operation.action.type === "DELETE_DOCUMENT") {
           applyDeleteDocumentAction(document, operation.action as never);
         } else {

--- a/packages/reactor/src/core/reactor-builder.ts
+++ b/packages/reactor/src/core/reactor-builder.ts
@@ -7,7 +7,7 @@ import {
   ReactorBuilder as DriveReactorBuilder,
   MemoryStorage,
 } from "document-drive";
-import type { DocumentModelModule } from "document-model";
+import type { DocumentModelModule, UpgradeManifest } from "document-model";
 import { DocumentMetaCache } from "../cache/document-meta-cache.js";
 import { KyselyOperationIndex } from "../cache/kysely-operation-index.js";
 import { KyselyWriteCache } from "../cache/kysely-write-cache.js";
@@ -56,6 +56,7 @@ export type IReadModelCoordinatorFactory = (
 
 export class ReactorBuilder {
   private documentModels: DocumentModelModule[] = [];
+  private upgradeManifests: UpgradeManifest<readonly number[]>[] = [];
   private storage?: IDocumentStorage & IDocumentOperationStorage;
   private features: ReactorFeatures = { legacyStorageEnabled: true };
   private readModels: IReadModel[] = [];
@@ -72,6 +73,11 @@ export class ReactorBuilder {
 
   withDocumentModels(models: DocumentModelModule[]): this {
     this.documentModels = models;
+    return this;
+  }
+
+  withUpgradeManifests(manifests: UpgradeManifest<readonly number[]>[]): this {
+    this.upgradeManifests = manifests;
     return this;
   }
 
@@ -146,6 +152,9 @@ export class ReactorBuilder {
     const storage = this.storage || new MemoryStorage();
 
     const documentModelRegistry = new DocumentModelRegistry();
+    if (this.upgradeManifests.length > 0) {
+      documentModelRegistry.registerUpgradeManifests(...this.upgradeManifests);
+    }
     if (this.documentModels.length > 0) {
       documentModelRegistry.registerModules(...this.documentModels);
     }

--- a/packages/reactor/src/executor/simple-job-executor.ts
+++ b/packages/reactor/src/executor/simple-job-executor.ts
@@ -655,9 +655,18 @@ export class SimpleJobExecutor implements IJobExecutor {
       }
     }
 
-    let upgradedDocument: PHDocument | null;
+    if (fromVersion === toVersion && fromVersion > 0) {
+      return {
+        job,
+        success: true,
+        operations: [],
+        operationsWithContext: [],
+        duration: Date.now() - startTime,
+      };
+    }
+
     try {
-      upgradedDocument = applyUpgradeDocumentAction(
+      document = applyUpgradeDocumentAction(
         document,
         action as UpgradeDocumentAction,
         upgradePath,
@@ -669,18 +678,6 @@ export class SimpleJobExecutor implements IJobExecutor {
         startTime,
       );
     }
-
-    if (upgradedDocument === null) {
-      return {
-        job,
-        success: true,
-        operations: [],
-        operationsWithContext: [],
-        duration: Date.now() - startTime,
-      };
-    }
-
-    document = upgradedDocument;
 
     const operation = this.createOperation(action, nextIndex, skip);
 

--- a/packages/reactor/src/registry/implementation.ts
+++ b/packages/reactor/src/registry/implementation.ts
@@ -1,12 +1,20 @@
-import type { DocumentModelModule } from "document-model";
+import type {
+  DocumentModelModule,
+  UpgradeManifest,
+  UpgradeReducer,
+  UpgradeTransition,
+} from "document-model";
 import type { IDocumentModelRegistry } from "./interfaces.js";
 
 /**
  * Error thrown when a document model module is not found in the registry.
  */
 export class ModuleNotFoundError extends Error {
-  constructor(documentType: string) {
-    super(`Document model module not found for type: ${documentType}`);
+  constructor(documentType: string, version?: number) {
+    const versionSuffix = version !== undefined ? ` version ${version}` : "";
+    super(
+      `Document model module not found for type: ${documentType}${versionSuffix}`,
+    );
     this.name = "ModuleNotFoundError";
   }
 }
@@ -15,8 +23,11 @@ export class ModuleNotFoundError extends Error {
  * Error thrown when attempting to register a module that already exists.
  */
 export class DuplicateModuleError extends Error {
-  constructor(documentType: string) {
-    super(`Document model module already registered for type: ${documentType}`);
+  constructor(documentType: string, version?: number) {
+    const versionSuffix = version !== undefined ? ` (version ${version})` : "";
+    super(
+      `Document model module already registered for type: ${documentType}${versionSuffix}`,
+    );
     this.name = "DuplicateModuleError";
   }
 }
@@ -32,81 +43,269 @@ export class InvalidModuleError extends Error {
 }
 
 /**
+ * Error thrown when attempting to register an upgrade manifest that already exists.
+ */
+export class DuplicateManifestError extends Error {
+  constructor(documentType: string) {
+    super(`Upgrade manifest already registered for type: ${documentType}`);
+    this.name = "DuplicateManifestError";
+  }
+}
+
+/**
+ * Error thrown when an upgrade manifest is not found.
+ */
+export class ManifestNotFoundError extends Error {
+  constructor(documentType: string) {
+    super(`Upgrade manifest not found for type: ${documentType}`);
+    this.name = "ManifestNotFoundError";
+  }
+}
+
+/**
+ * Error thrown when attempting a downgrade operation.
+ */
+export class DowngradeNotSupportedError extends Error {
+  constructor(documentType: string, fromVersion: number, toVersion: number) {
+    super(
+      `Downgrade not supported for ${documentType}: cannot go from version ${fromVersion} to ${toVersion}`,
+    );
+    this.name = "DowngradeNotSupportedError";
+  }
+}
+
+/**
+ * Error thrown when a required upgrade transition is missing from the manifest.
+ */
+export class MissingUpgradeTransitionError extends Error {
+  constructor(documentType: string, fromVersion: number, toVersion: number) {
+    super(
+      `Missing upgrade transition for ${documentType}: v${fromVersion} to v${toVersion}`,
+    );
+    this.name = "MissingUpgradeTransitionError";
+  }
+}
+
+/**
+ * Error thrown when getUpgradeReducer is called with a non-single-step version increment.
+ */
+export class InvalidUpgradeStepError extends Error {
+  constructor(documentType: string, fromVersion: number, toVersion: number) {
+    super(
+      `Invalid upgrade step for ${documentType}: must be single version increment, got v${fromVersion} to v${toVersion}`,
+    );
+    this.name = "InvalidUpgradeStepError";
+  }
+}
+
+/**
  * In-memory implementation of the IDocumentModelRegistry interface.
- * Manages document model modules and provides centralized access to their reducers, utils, and specifications.
+ * Manages document model modules with version-aware storage and upgrade manifest support.
  */
 export class DocumentModelRegistry implements IDocumentModelRegistry {
-  private modules = new Map<string, DocumentModelModule<any>>();
+  private modules: DocumentModelModule<any>[] = [];
+  private manifests: UpgradeManifest<readonly number[]>[] = [];
 
-  /**
-   * Register multiple modules at once.
-   *
-   * @param modules Document model modules to register
-   * @throws DuplicateModuleError if a module with the same document type is already registered
-   * @throws InvalidModuleError if a module is malformed
-   */
   registerModules(...modules: DocumentModelModule<any>[]): void {
     for (const module of modules) {
       const documentType = module.documentModel.global.id;
+      const version = module.version ?? 1;
 
-      if (this.modules.has(documentType)) {
-        throw new DuplicateModuleError(documentType);
+      for (let i = 0; i < this.modules.length; i++) {
+        const existing = this.modules[i];
+        const existingType = existing.documentModel.global.id;
+        const existingVersion = existing.version ?? 1;
+
+        if (existingType === documentType && existingVersion === version) {
+          throw new DuplicateModuleError(documentType, version);
+        }
       }
 
-      this.modules.set(documentType, module);
+      this.modules.push(module);
     }
   }
 
-  /**
-   * Unregister multiple document model modules at once.
-   *
-   * @param documentTypes The document types to unregister
-   * @returns true if all modules were unregistered, false if any were not found
-   */
   unregisterModules(...documentTypes: string[]): boolean {
     let allFound = true;
 
     for (const documentType of documentTypes) {
-      const wasDeleted = this.modules.delete(documentType);
-      if (!wasDeleted) {
+      const hasModule = this.modules.some(
+        (m) => m.documentModel.global.id === documentType,
+      );
+
+      if (!hasModule) {
         allFound = false;
       }
+
+      this.modules = this.modules.filter(
+        (m) => m.documentModel.global.id !== documentType,
+      );
     }
 
     return allFound;
   }
 
-  /**
-   * Get a specific document model module by document type.
-   *
-   * @param documentType The document type identifier
-   * @returns The document model module
-   * @throws ModuleNotFoundError if the document type is not registered
-   */
-  getModule(documentType: string): DocumentModelModule<any> {
-    const module = this.modules.get(documentType);
+  getModule(documentType: string, version?: number): DocumentModelModule<any> {
+    let latestModule: DocumentModelModule<any> | undefined;
+    let latestVersion = -1;
 
-    if (module) {
-      return module;
+    for (let i = 0; i < this.modules.length; i++) {
+      const module = this.modules[i];
+      const moduleType = module.documentModel.global.id;
+      const moduleVersion = module.version ?? 1;
+
+      if (moduleType === documentType) {
+        if (version !== undefined && moduleVersion === version) {
+          return module;
+        }
+
+        if (moduleVersion > latestVersion) {
+          latestModule = module;
+          latestVersion = moduleVersion;
+        }
+      }
     }
 
-    throw new ModuleNotFoundError(documentType);
+    if (version === undefined && latestModule !== undefined) {
+      return latestModule;
+    }
+
+    throw new ModuleNotFoundError(documentType, version);
   }
 
-  /**
-   * Get all registered document model modules.
-   * Note: This only returns loaded modules, not lazy-loaded ones.
-   *
-   * @returns Array of all registered modules
-   */
   getAllModules(): DocumentModelModule<any>[] {
-    return Array.from(this.modules.values());
+    return [...this.modules];
   }
 
-  /**
-   * Clear all registered modules
-   */
   clear(): void {
-    this.modules.clear();
+    this.modules = [];
+    this.manifests = [];
+  }
+
+  getSupportedVersions(documentType: string): number[] {
+    const versions: number[] = [];
+
+    for (const module of this.modules) {
+      if (module.documentModel.global.id === documentType) {
+        versions.push(module.version ?? 1);
+      }
+    }
+
+    if (versions.length === 0) {
+      throw new ModuleNotFoundError(documentType);
+    }
+
+    return versions.sort((a, b) => a - b);
+  }
+
+  getLatestVersion(documentType: string): number {
+    let latest = -1;
+    let found = false;
+
+    for (const module of this.modules) {
+      if (module.documentModel.global.id === documentType) {
+        found = true;
+        const version = module.version ?? 1;
+        if (version > latest) {
+          latest = version;
+        }
+      }
+    }
+
+    if (!found) {
+      throw new ModuleNotFoundError(documentType);
+    }
+
+    return latest;
+  }
+
+  registerUpgradeManifests(
+    ...manifests: UpgradeManifest<readonly number[]>[]
+  ): void {
+    for (const manifest of manifests) {
+      for (let i = 0; i < this.manifests.length; i++) {
+        if (this.manifests[i].documentType === manifest.documentType) {
+          throw new DuplicateManifestError(manifest.documentType);
+        }
+      }
+      this.manifests.push(manifest);
+    }
+  }
+
+  getUpgradeManifest(
+    documentType: string,
+  ): UpgradeManifest<readonly number[]> | undefined {
+    for (let i = 0; i < this.manifests.length; i++) {
+      if (this.manifests[i].documentType === documentType) {
+        return this.manifests[i];
+      }
+    }
+    return undefined;
+  }
+
+  computeUpgradePath(
+    documentType: string,
+    fromVersion: number,
+    toVersion: number,
+  ): UpgradeTransition[] {
+    if (fromVersion === toVersion) {
+      return [];
+    }
+
+    if (toVersion < fromVersion) {
+      throw new DowngradeNotSupportedError(
+        documentType,
+        fromVersion,
+        toVersion,
+      );
+    }
+
+    const manifest = this.getUpgradeManifest(documentType);
+    if (manifest === undefined) {
+      throw new ManifestNotFoundError(documentType);
+    }
+
+    const path: UpgradeTransition[] = [];
+    for (let v = fromVersion + 1; v <= toVersion; v++) {
+      const key = `v${v}`;
+
+      if (!(key in manifest.upgrades)) {
+        throw new MissingUpgradeTransitionError(documentType, v - 1, v);
+      }
+
+      const transition =
+        manifest.upgrades[key as keyof typeof manifest.upgrades];
+      path.push(transition);
+    }
+
+    return path;
+  }
+
+  getUpgradeReducer(
+    documentType: string,
+    fromVersion: number,
+    toVersion: number,
+  ): UpgradeReducer<any, any> {
+    if (toVersion !== fromVersion + 1) {
+      throw new InvalidUpgradeStepError(documentType, fromVersion, toVersion);
+    }
+
+    const manifest = this.getUpgradeManifest(documentType);
+    if (manifest === undefined) {
+      throw new ManifestNotFoundError(documentType);
+    }
+
+    const key = `v${toVersion}`;
+
+    if (!(key in manifest.upgrades)) {
+      throw new MissingUpgradeTransitionError(
+        documentType,
+        fromVersion,
+        toVersion,
+      );
+    }
+
+    const transition = manifest.upgrades[key as keyof typeof manifest.upgrades];
+    return transition.upgradeReducer;
   }
 }

--- a/packages/reactor/src/registry/implementation.ts
+++ b/packages/reactor/src/registry/implementation.ts
@@ -232,15 +232,13 @@ export class DocumentModelRegistry implements IDocumentModelRegistry {
     }
   }
 
-  getUpgradeManifest(
-    documentType: string,
-  ): UpgradeManifest<readonly number[]> | undefined {
+  getUpgradeManifest(documentType: string): UpgradeManifest<readonly number[]> {
     for (let i = 0; i < this.manifests.length; i++) {
       if (this.manifests[i].documentType === documentType) {
         return this.manifests[i];
       }
     }
-    return undefined;
+    throw new ManifestNotFoundError(documentType);
   }
 
   computeUpgradePath(
@@ -261,9 +259,6 @@ export class DocumentModelRegistry implements IDocumentModelRegistry {
     }
 
     const manifest = this.getUpgradeManifest(documentType);
-    if (manifest === undefined) {
-      throw new ManifestNotFoundError(documentType);
-    }
 
     const path: UpgradeTransition[] = [];
     for (let v = fromVersion + 1; v <= toVersion; v++) {
@@ -291,9 +286,6 @@ export class DocumentModelRegistry implements IDocumentModelRegistry {
     }
 
     const manifest = this.getUpgradeManifest(documentType);
-    if (manifest === undefined) {
-      throw new ManifestNotFoundError(documentType);
-    }
 
     const key = `v${toVersion}`;
 

--- a/packages/reactor/src/registry/interfaces.ts
+++ b/packages/reactor/src/registry/interfaces.ts
@@ -1,20 +1,27 @@
-import type { DocumentModelModule } from "document-model";
+import type {
+  DocumentModelModule,
+  UpgradeManifest,
+  UpgradeReducer,
+  UpgradeTransition,
+} from "document-model";
 
 /**
  * Registry for managing document model modules.
  * Provides centralized access to document models' reducers, utils, and specifications.
+ * Supports version-aware module storage and upgrade manifest management.
  */
 export interface IDocumentModelRegistry {
   /**
    * Register multiple modules at once.
+   * Modules without a version field default to version 1.
    *
    * @param modules Document model modules to register
-   * @throws Error if a module with the same document type is already registered
+   * @throws DuplicateModuleError if a module with the same document type and version is already registered
    */
   registerModules(...modules: DocumentModelModule<any>[]): void;
 
   /**
-   * Unregister multiple document model modules at once.
+   * Unregister all versions of the specified document types.
    *
    * @param documentTypes The document types to unregister
    * @returns true if all modules were unregistered, false if any were not found
@@ -22,22 +29,98 @@ export interface IDocumentModelRegistry {
   unregisterModules(...documentTypes: string[]): boolean;
 
   /**
-   * Get a specific document model module by document type.
+   * Get a specific document model module by document type and optional version.
+   * If version is not specified, returns the latest version.
    *
    * @param documentType The document type identifier
+   * @param version Optional version number to retrieve
    * @returns The document model module
-   * @throws Error if the document type is not registered
+   * @throws ModuleNotFoundError if the document type or version is not registered
    */
-  getModule(documentType: string): DocumentModelModule<any>;
+  getModule(documentType: string, version?: number): DocumentModelModule<any>;
 
   /**
-   * Get all registered document model modules
+   * Get all registered document model modules.
+   *
    * @returns Array of all registered modules
    */
   getAllModules(): DocumentModelModule<any>[];
 
   /**
-   * Clear all registered modules
+   * Clear all registered modules and upgrade manifests.
    */
   clear(): void;
+
+  /**
+   * Get all supported versions for a document type, sorted in ascending order.
+   *
+   * @param documentType The document type identifier
+   * @returns Array of version numbers sorted ascending
+   * @throws ModuleNotFoundError if no modules are registered for the document type
+   */
+  getSupportedVersions(documentType: string): number[];
+
+  /**
+   * Get the latest (highest) version number for a document type.
+   *
+   * @param documentType The document type identifier
+   * @returns The highest version number registered for this document type
+   * @throws ModuleNotFoundError if no modules are registered for the document type
+   */
+  getLatestVersion(documentType: string): number;
+
+  /**
+   * Register upgrade manifests that define upgrade paths between versions.
+   *
+   * @param manifests Upgrade manifests to register
+   * @throws DuplicateManifestError if a manifest for the same document type is already registered
+   */
+  registerUpgradeManifests(
+    ...manifests: UpgradeManifest<readonly number[]>[]
+  ): void;
+
+  /**
+   * Get the upgrade manifest for a document type.
+   *
+   * @param documentType The document type identifier
+   * @returns The upgrade manifest, or undefined if not found
+   */
+  getUpgradeManifest(
+    documentType: string,
+  ): UpgradeManifest<readonly number[]> | undefined;
+
+  /**
+   * Compute the upgrade path from one version to another.
+   * Returns the sequence of upgrade transitions needed.
+   *
+   * @param documentType The document type identifier
+   * @param fromVersion The starting version
+   * @param toVersion The target version
+   * @returns Array of upgrade transitions in order
+   * @throws DowngradeNotSupportedError if toVersion is less than fromVersion
+   * @throws ManifestNotFoundError if no upgrade manifest is registered
+   * @throws MissingUpgradeTransitionError if any transition in the path is missing
+   */
+  computeUpgradePath(
+    documentType: string,
+    fromVersion: number,
+    toVersion: number,
+  ): UpgradeTransition[];
+
+  /**
+   * Get the upgrade reducer for a single-step version transition.
+   *
+   * @param documentType The document type identifier
+   * @param fromVersion The starting version
+   * @param toVersion The target version (must be fromVersion + 1)
+   * @returns The upgrade reducer function
+   * @throws InvalidUpgradeStepError if toVersion is not fromVersion + 1
+   * @throws ManifestNotFoundError if no upgrade manifest is registered
+   * @throws MissingUpgradeTransitionError if the transition is not found
+   */
+  getUpgradeReducer(
+    documentType: string,
+    fromVersion: number,
+    toVersion: number,
+  ): UpgradeReducer<any, any>;
 }

--- a/packages/reactor/src/registry/interfaces.ts
+++ b/packages/reactor/src/registry/interfaces.ts
@@ -83,11 +83,10 @@ export interface IDocumentModelRegistry {
    * Get the upgrade manifest for a document type.
    *
    * @param documentType The document type identifier
-   * @returns The upgrade manifest, or undefined if not found
+   * @returns The upgrade manifest
+   * @throws ManifestNotFoundError if no manifest is registered for the document type
    */
-  getUpgradeManifest(
-    documentType: string,
-  ): UpgradeManifest<readonly number[]> | undefined;
+  getUpgradeManifest(documentType: string): UpgradeManifest<readonly number[]>;
 
   /**
    * Compute the upgrade path from one version to another.

--- a/packages/reactor/src/shared/errors.ts
+++ b/packages/reactor/src/shared/errors.ts
@@ -54,3 +54,39 @@ export class InvalidSignatureError extends Error {
     Error.captureStackTrace(this, InvalidSignatureError);
   }
 }
+
+/**
+ * Error thrown when attempting to downgrade a document version.
+ */
+export class DowngradeNotSupportedError extends Error {
+  public readonly documentType: string;
+  public readonly fromVersion: number;
+  public readonly toVersion: number;
+
+  constructor(documentType: string, fromVersion: number, toVersion: number) {
+    super(
+      `Downgrade not supported for ${documentType}: cannot upgrade from version ${fromVersion} to ${toVersion}`,
+    );
+    this.name = "DowngradeNotSupportedError";
+    this.documentType = documentType;
+    this.fromVersion = fromVersion;
+    this.toVersion = toVersion;
+
+    Error.captureStackTrace(this, DowngradeNotSupportedError);
+  }
+}
+
+/**
+ * Error thrown when an upgrade manifest is required but not registered.
+ */
+export class UpgradeManifestNotFoundError extends Error {
+  public readonly documentType: string;
+
+  constructor(documentType: string) {
+    super(`No upgrade manifest registered for document type: ${documentType}`);
+    this.name = "UpgradeManifestNotFoundError";
+    this.documentType = documentType;
+
+    Error.captureStackTrace(this, UpgradeManifestNotFoundError);
+  }
+}

--- a/packages/reactor/test/cache/document-meta-cache.test.ts
+++ b/packages/reactor/test/cache/document-meta-cache.test.ts
@@ -59,6 +59,8 @@ function createUpgradeDocumentOperation(
       timestampUtcMs: `2024-01-01T00:0${index}:00.000Z`,
       input: {
         documentId,
+        fromVersion: version > 0 ? version - 1 : 0,
+        toVersion: version,
         initialState: {
           document: {
             version,

--- a/packages/reactor/test/cache/integration.test.ts
+++ b/packages/reactor/test/cache/integration.test.ts
@@ -502,10 +502,16 @@ describe("KyselyWriteCache Integration Tests", () => {
         nextIndex,
         (txn) => {
           txn.addOperations(
-            createUpgradeDocumentOperation(docId, nextIndex, {
-              global: { test: "state" },
-              local: {},
-            }),
+            createUpgradeDocumentOperation(
+              docId,
+              0,
+              1,
+              {
+                global: { test: "state" },
+                local: {},
+              },
+              { index: nextIndex },
+            ),
           );
         },
       );

--- a/packages/reactor/test/cache/write/document-scope-staleness.test.ts
+++ b/packages/reactor/test/cache/write/document-scope-staleness.test.ts
@@ -2,8 +2,8 @@ import type { Action, Operation } from "document-model";
 import { documentModelDocumentModelModule } from "document-model";
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { DocumentMetaCache } from "../../../src/cache/document-meta-cache.js";
 import type { IDocumentMetaCache } from "../../../src/cache/document-meta-cache-types.js";
+import { DocumentMetaCache } from "../../../src/cache/document-meta-cache.js";
 import { KyselyWriteCache } from "../../../src/cache/kysely-write-cache.js";
 import type { WriteCacheConfig } from "../../../src/cache/write-cache-types.js";
 import { DocumentModelRegistry } from "../../../src/registry/implementation.js";
@@ -124,7 +124,7 @@ describe("Document Scope Cross-Scope Dependency Issue", () => {
         1,
         (txn) => {
           txn.addOperations(
-            createUpgradeDocumentOperation(docId, 1, {
+            createUpgradeDocumentOperation(docId, 0, 1, {
               document: {
                 version: 1,
                 hash: { algorithm: "sha256", encoding: "base64" },
@@ -169,14 +169,20 @@ describe("Document Scope Cross-Scope Dependency Issue", () => {
         2,
         (txn) => {
           txn.addOperations(
-            createUpgradeDocumentOperation(docId, 2, {
-              document: {
-                version: 2,
-                hash: { algorithm: "sha256", encoding: "base64" },
+            createUpgradeDocumentOperation(
+              docId,
+              1,
+              2,
+              {
+                document: {
+                  version: 2,
+                  hash: { algorithm: "sha256", encoding: "base64" },
+                },
+                global: {},
+                local: {},
               },
-              global: {},
-              local: {},
-            }),
+              { index: 2 },
+            ),
           );
         },
       );
@@ -226,7 +232,7 @@ describe("Document Scope Cross-Scope Dependency Issue", () => {
         1,
         (txn) => {
           txn.addOperations(
-            createUpgradeDocumentOperation(docId, 1, {
+            createUpgradeDocumentOperation(docId, 0, 1, {
               document: {
                 version: 1,
                 hash: { algorithm: "sha256", encoding: "base64" },
@@ -311,7 +317,7 @@ describe("Document Scope Cross-Scope Dependency Issue", () => {
         1,
         (txn) => {
           txn.addOperations(
-            createUpgradeDocumentOperation(docId, 1, {
+            createUpgradeDocumentOperation(docId, 0, 1, {
               document: {
                 version: 1,
                 hash: { algorithm: "sha256", encoding: "base64" },
@@ -332,14 +338,20 @@ describe("Document Scope Cross-Scope Dependency Issue", () => {
         2,
         (txn) => {
           txn.addOperations(
-            createUpgradeDocumentOperation(docId, 2, {
-              document: {
-                version: 2,
-                hash: { algorithm: "sha256", encoding: "base64" },
+            createUpgradeDocumentOperation(
+              docId,
+              1,
+              2,
+              {
+                document: {
+                  version: 2,
+                  hash: { algorithm: "sha256", encoding: "base64" },
+                },
+                global: {},
+                local: {},
               },
-              global: {},
-              local: {},
-            }),
+              { index: 2 },
+            ),
           );
         },
       );
@@ -353,14 +365,20 @@ describe("Document Scope Cross-Scope Dependency Issue", () => {
         3,
         (txn) => {
           txn.addOperations(
-            createUpgradeDocumentOperation(docId, 3, {
-              document: {
-                version: 3,
-                hash: { algorithm: "sha256", encoding: "base64" },
+            createUpgradeDocumentOperation(
+              docId,
+              2,
+              3,
+              {
+                document: {
+                  version: 3,
+                  hash: { algorithm: "sha256", encoding: "base64" },
+                },
+                global: {},
+                local: {},
               },
-              global: {},
-              local: {},
-            }),
+              { index: 3 },
+            ),
           );
         },
       );

--- a/packages/reactor/test/cache/write/kysely-write-cache-errors.test.ts
+++ b/packages/reactor/test/cache/write/kysely-write-cache-errors.test.ts
@@ -41,6 +41,12 @@ function createMockRegistry(): IDocumentModelRegistry {
     getModule: vi.fn(),
     getAllModules: vi.fn(),
     clear: vi.fn(),
+    getSupportedVersions: vi.fn(),
+    getLatestVersion: vi.fn(),
+    registerUpgradeManifests: vi.fn(),
+    getUpgradeManifest: vi.fn(),
+    computeUpgradePath: vi.fn(),
+    getUpgradeReducer: vi.fn(),
   };
 }
 
@@ -1270,6 +1276,12 @@ describe("KyselyWriteCache - Error Handling (Integration)", () => {
       }),
       getAllModules: vi.fn(),
       clear: vi.fn(),
+      getSupportedVersions: vi.fn(),
+      getLatestVersion: vi.fn(),
+      registerUpgradeManifests: vi.fn(),
+      getUpgradeManifest: vi.fn(),
+      computeUpgradePath: vi.fn(),
+      getUpgradeReducer: vi.fn(),
     };
 
     registry = mockRegistry;

--- a/packages/reactor/test/cache/write/kysely-write-cache.test.ts
+++ b/packages/reactor/test/cache/write/kysely-write-cache.test.ts
@@ -38,6 +38,12 @@ function createMockRegistry(): IDocumentModelRegistry {
     getModule: vi.fn(),
     getAllModules: vi.fn(),
     clear: vi.fn(),
+    getSupportedVersions: vi.fn(),
+    getLatestVersion: vi.fn(),
+    registerUpgradeManifests: vi.fn(),
+    getUpgradeManifest: vi.fn(),
+    computeUpgradePath: vi.fn(),
+    getUpgradeReducer: vi.fn(),
   };
 }
 
@@ -429,6 +435,12 @@ describe("KyselyWriteCache (Partial Integration) - Cold Miss Rebuild", () => {
       }),
       getAllModules: vi.fn(),
       clear: vi.fn(),
+      getSupportedVersions: vi.fn(),
+      getLatestVersion: vi.fn(),
+      registerUpgradeManifests: vi.fn(),
+      getUpgradeManifest: vi.fn(),
+      computeUpgradePath: vi.fn(),
+      getUpgradeReducer: vi.fn(),
     };
 
     registry = mockRegistry;
@@ -658,6 +670,12 @@ describe("KyselyWriteCache - Warm Miss Rebuild", () => {
       }),
       getAllModules: vi.fn(),
       clear: vi.fn(),
+      getSupportedVersions: vi.fn(),
+      getLatestVersion: vi.fn(),
+      registerUpgradeManifests: vi.fn(),
+      getUpgradeManifest: vi.fn(),
+      computeUpgradePath: vi.fn(),
+      getUpgradeReducer: vi.fn(),
     };
 
     registry = mockRegistry;

--- a/packages/reactor/test/executor/util/unit.test.ts
+++ b/packages/reactor/test/executor/util/unit.test.ts
@@ -319,7 +319,7 @@ describe("applyUpgradeDocumentAction", () => {
     expect(result!.state).toEqual(expectedState);
   });
 
-  it("should return null for same version (no-op)", () => {
+  it("should return unchanged document for same version (no-op)", () => {
     const document = createDocumentFromAction({
       id: "action-1",
       type: "CREATE_DOCUMENT",
@@ -348,7 +348,8 @@ describe("applyUpgradeDocumentAction", () => {
 
     const result = applyUpgradeDocumentAction(document, upgradeAction as never);
 
-    expect(result).toBeNull();
+    expect(result).toBe(document);
+    expect(result.state.document.version).toBe(1);
   });
 
   it("should throw DowngradeNotSupportedError for downgrade attempt", () => {

--- a/packages/reactor/test/factories.ts
+++ b/packages/reactor/test/factories.ts
@@ -204,10 +204,12 @@ export function createCreateDocumentOperation(
 
 export function createUpgradeDocumentOperation(
   documentId: string,
-  index: number,
-  initialState: Record<string, any> = {},
+  fromVersion: number,
+  toVersion: number,
+  initialState: Record<string, unknown> = {},
   overrides: Partial<Operation> = {},
 ): Operation {
+  const index = overrides.index ?? 1;
   return {
     id: overrides.id || `${documentId}-upgrade-${index}`,
     index,
@@ -221,12 +223,14 @@ export function createUpgradeDocumentOperation(
       timestampUtcMs: overrides.timestampUtcMs || new Date().toISOString(),
       input: {
         documentId,
+        fromVersion,
+        toVersion,
         initialState,
       },
     } as Action,
     resultingState:
       overrides.resultingState ||
-      JSON.stringify({ document: { id: documentId, index } }),
+      JSON.stringify({ document: { id: documentId, version: toVersion } }),
     ...overrides,
   };
 }

--- a/packages/reactor/test/fixtures/versioned-test-doc/index.ts
+++ b/packages/reactor/test/fixtures/versioned-test-doc/index.ts
@@ -1,0 +1,48 @@
+import type { DocumentModelModule, UpgradeManifest } from "document-model";
+
+export const VERSIONED_DOC_TYPE = "test/versioned-doc";
+
+function createMockModule(version: number): DocumentModelModule {
+  return {
+    version,
+    reducer: (document: unknown) => document,
+    actions: {},
+    utils: {
+      createDocument: () => ({}),
+      createState: () => ({}),
+    },
+    documentModel: {
+      global: {
+        id: VERSIONED_DOC_TYPE,
+        name: "Versioned Test Doc",
+        description: "Test document for versioning",
+        extension: "vtd",
+        author: { name: "Test", website: "" },
+        specifications: [],
+      },
+      local: {},
+    },
+  } as unknown as DocumentModelModule;
+}
+
+export const testDocV1Module = createMockModule(1);
+export const testDocV2Module = createMockModule(2);
+export const testDocV3Module = createMockModule(3);
+
+export const testDocUpgradeManifest = {
+  documentType: VERSIONED_DOC_TYPE,
+  latestVersion: 3,
+  supportedVersions: [1, 2, 3] as const,
+  upgrades: {
+    v2: {
+      toVersion: 2,
+      upgradeReducer: (doc: unknown) => doc,
+      description: "Add description field",
+    },
+    v3: {
+      toVersion: 3,
+      upgradeReducer: (doc: unknown) => doc,
+      description: "Add tags field",
+    },
+  },
+} as unknown as UpgradeManifest<readonly [1, 2, 3]>;

--- a/packages/reactor/test/registry/versioned.test.ts
+++ b/packages/reactor/test/registry/versioned.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DocumentModelRegistry,
+  DowngradeNotSupportedError,
+  DuplicateManifestError,
+  DuplicateModuleError,
+  InvalidUpgradeStepError,
+  ManifestNotFoundError,
+  MissingUpgradeTransitionError,
+  ModuleNotFoundError,
+} from "../../src/registry/implementation.js";
+import {
+  testDocUpgradeManifest,
+  testDocV1Module,
+  testDocV2Module,
+  testDocV3Module,
+  VERSIONED_DOC_TYPE,
+} from "../fixtures/versioned-test-doc/index.js";
+
+describe("DocumentModelRegistry - Versioning", () => {
+  let registry: DocumentModelRegistry;
+
+  beforeEach(() => {
+    registry = new DocumentModelRegistry();
+  });
+
+  describe("registerModules with versions", () => {
+    it("should register multiple versions of the same document type", () => {
+      registry.registerModules(
+        testDocV1Module,
+        testDocV2Module,
+        testDocV3Module,
+      );
+      expect(registry.getAllModules()).toHaveLength(3);
+    });
+
+    it("should throw DuplicateModuleError when registering same type+version", () => {
+      registry.registerModules(testDocV1Module);
+      expect(() => registry.registerModules(testDocV1Module)).toThrow(
+        DuplicateModuleError,
+      );
+      expect(() => registry.registerModules(testDocV1Module)).toThrow(
+        `Document model module already registered for type: ${VERSIONED_DOC_TYPE} (version 1)`,
+      );
+    });
+
+    it("should default version to 1 when module has no version field", () => {
+      const moduleWithoutVersion = { ...testDocV1Module, version: undefined };
+      registry.registerModules(moduleWithoutVersion);
+      expect(registry.getLatestVersion(VERSIONED_DOC_TYPE)).toBe(1);
+    });
+  });
+
+  describe("getModule with version", () => {
+    beforeEach(() => {
+      registry.registerModules(
+        testDocV1Module,
+        testDocV2Module,
+        testDocV3Module,
+      );
+    });
+
+    it("should return correct module for specific version", () => {
+      expect(registry.getModule(VERSIONED_DOC_TYPE, 1)).toBe(testDocV1Module);
+      expect(registry.getModule(VERSIONED_DOC_TYPE, 2)).toBe(testDocV2Module);
+      expect(registry.getModule(VERSIONED_DOC_TYPE, 3)).toBe(testDocV3Module);
+    });
+
+    it("should return latest version when version not specified", () => {
+      expect(registry.getModule(VERSIONED_DOC_TYPE)).toBe(testDocV3Module);
+    });
+
+    it("should throw ModuleNotFoundError for non-existent version", () => {
+      expect(() => registry.getModule(VERSIONED_DOC_TYPE, 99)).toThrow(
+        ModuleNotFoundError,
+      );
+      expect(() => registry.getModule(VERSIONED_DOC_TYPE, 99)).toThrow(
+        `Document model module not found for type: ${VERSIONED_DOC_TYPE} version 99`,
+      );
+    });
+
+    it("should throw ModuleNotFoundError for unknown document type", () => {
+      expect(() => registry.getModule("unknown/type")).toThrow(
+        ModuleNotFoundError,
+      );
+    });
+  });
+
+  describe("getSupportedVersions", () => {
+    it("should return sorted array of versions", () => {
+      registry.registerModules(
+        testDocV3Module,
+        testDocV1Module,
+        testDocV2Module,
+      );
+      expect(registry.getSupportedVersions(VERSIONED_DOC_TYPE)).toEqual([
+        1, 2, 3,
+      ]);
+    });
+
+    it("should throw ModuleNotFoundError for unknown document type", () => {
+      expect(() => registry.getSupportedVersions("unknown/type")).toThrow(
+        ModuleNotFoundError,
+      );
+    });
+  });
+
+  describe("getLatestVersion", () => {
+    it("should return highest version number", () => {
+      registry.registerModules(testDocV1Module, testDocV3Module);
+      expect(registry.getLatestVersion(VERSIONED_DOC_TYPE)).toBe(3);
+    });
+
+    it("should throw ModuleNotFoundError for unknown document type", () => {
+      expect(() => registry.getLatestVersion("unknown/type")).toThrow(
+        ModuleNotFoundError,
+      );
+    });
+  });
+
+  describe("registerUpgradeManifests", () => {
+    it("should register upgrade manifest", () => {
+      registry.registerUpgradeManifests(testDocUpgradeManifest);
+      expect(registry.getUpgradeManifest(VERSIONED_DOC_TYPE)).toBe(
+        testDocUpgradeManifest,
+      );
+    });
+
+    it("should throw DuplicateManifestError for duplicate", () => {
+      registry.registerUpgradeManifests(testDocUpgradeManifest);
+      expect(() =>
+        registry.registerUpgradeManifests(testDocUpgradeManifest),
+      ).toThrow(DuplicateManifestError);
+    });
+  });
+
+  describe("getUpgradeManifest", () => {
+    it("should return manifest for document type", () => {
+      registry.registerUpgradeManifests(testDocUpgradeManifest);
+      expect(registry.getUpgradeManifest(VERSIONED_DOC_TYPE)).toBe(
+        testDocUpgradeManifest,
+      );
+    });
+
+    it("should return undefined for unknown document type", () => {
+      expect(registry.getUpgradeManifest("unknown/type")).toBeUndefined();
+    });
+  });
+
+  describe("computeUpgradePath", () => {
+    beforeEach(() => {
+      registry.registerUpgradeManifests(testDocUpgradeManifest);
+    });
+
+    it("should return empty array for same version", () => {
+      expect(registry.computeUpgradePath(VERSIONED_DOC_TYPE, 1, 1)).toEqual([]);
+    });
+
+    it("should return single transition for v1 to v2", () => {
+      const path = registry.computeUpgradePath(VERSIONED_DOC_TYPE, 1, 2);
+      expect(path).toHaveLength(1);
+      expect(path[0].toVersion).toBe(2);
+    });
+
+    it("should return multiple transitions for v1 to v3", () => {
+      const path = registry.computeUpgradePath(VERSIONED_DOC_TYPE, 1, 3);
+      expect(path).toHaveLength(2);
+      expect(path[0].toVersion).toBe(2);
+      expect(path[1].toVersion).toBe(3);
+    });
+
+    it("should throw DowngradeNotSupportedError for downgrade", () => {
+      expect(() =>
+        registry.computeUpgradePath(VERSIONED_DOC_TYPE, 3, 1),
+      ).toThrow(DowngradeNotSupportedError);
+    });
+
+    it("should throw ManifestNotFoundError for unknown type", () => {
+      expect(() => registry.computeUpgradePath("unknown/type", 1, 2)).toThrow(
+        ManifestNotFoundError,
+      );
+    });
+
+    it("should throw MissingUpgradeTransitionError for missing transition", () => {
+      const incompleteManifest = {
+        ...testDocUpgradeManifest,
+        upgrades: { v2: testDocUpgradeManifest.upgrades.v2 },
+      };
+      registry.clear();
+      registry.registerUpgradeManifests(
+        incompleteManifest as typeof testDocUpgradeManifest,
+      );
+      expect(() =>
+        registry.computeUpgradePath(VERSIONED_DOC_TYPE, 1, 3),
+      ).toThrow(MissingUpgradeTransitionError);
+    });
+  });
+
+  describe("getUpgradeReducer", () => {
+    beforeEach(() => {
+      registry.registerUpgradeManifests(testDocUpgradeManifest);
+    });
+
+    it("should return upgrade reducer for valid transition", () => {
+      const reducer = registry.getUpgradeReducer(VERSIONED_DOC_TYPE, 1, 2);
+      expect(reducer).toBe(testDocUpgradeManifest.upgrades.v2.upgradeReducer);
+    });
+
+    it("should throw InvalidUpgradeStepError for non-single-step", () => {
+      expect(() =>
+        registry.getUpgradeReducer(VERSIONED_DOC_TYPE, 1, 3),
+      ).toThrow(InvalidUpgradeStepError);
+    });
+
+    it("should throw ManifestNotFoundError for unknown type", () => {
+      expect(() => registry.getUpgradeReducer("unknown/type", 1, 2)).toThrow(
+        ManifestNotFoundError,
+      );
+    });
+  });
+
+  describe("backward compatibility", () => {
+    it("should work with modules without version field (defaults to 1)", () => {
+      const moduleWithoutVersion = { ...testDocV1Module, version: undefined };
+      registry.registerModules(moduleWithoutVersion);
+
+      const retrieved = registry.getModule(VERSIONED_DOC_TYPE);
+      expect(retrieved).toBe(moduleWithoutVersion);
+      expect(registry.getLatestVersion(VERSIONED_DOC_TYPE)).toBe(1);
+    });
+
+    it("should return latest when getModule called without version", () => {
+      registry.registerModules(testDocV1Module, testDocV2Module);
+      expect(registry.getModule(VERSIONED_DOC_TYPE)).toBe(testDocV2Module);
+    });
+  });
+
+  describe("clear with manifests", () => {
+    it("should clear both modules and manifests", () => {
+      registry.registerModules(testDocV1Module);
+      registry.registerUpgradeManifests(testDocUpgradeManifest);
+
+      registry.clear();
+
+      expect(registry.getAllModules()).toHaveLength(0);
+      expect(registry.getUpgradeManifest(VERSIONED_DOC_TYPE)).toBeUndefined();
+    });
+  });
+
+  describe("unregisterModules with versions", () => {
+    it("should unregister all versions of a document type", () => {
+      registry.registerModules(
+        testDocV1Module,
+        testDocV2Module,
+        testDocV3Module,
+      );
+      expect(registry.getAllModules()).toHaveLength(3);
+
+      registry.unregisterModules(VERSIONED_DOC_TYPE);
+
+      expect(registry.getAllModules()).toHaveLength(0);
+    });
+  });
+});

--- a/packages/reactor/test/registry/versioned.test.ts
+++ b/packages/reactor/test/registry/versioned.test.ts
@@ -142,8 +142,10 @@ describe("DocumentModelRegistry - Versioning", () => {
       );
     });
 
-    it("should return undefined for unknown document type", () => {
-      expect(registry.getUpgradeManifest("unknown/type")).toBeUndefined();
+    it("should throw ManifestNotFoundError for unknown document type", () => {
+      expect(() => registry.getUpgradeManifest("unknown/type")).toThrow(
+        "Upgrade manifest not found for type: unknown/type",
+      );
     });
   });
 
@@ -243,7 +245,9 @@ describe("DocumentModelRegistry - Versioning", () => {
       registry.clear();
 
       expect(registry.getAllModules()).toHaveLength(0);
-      expect(registry.getUpgradeManifest(VERSIONED_DOC_TYPE)).toBeUndefined();
+      expect(() => registry.getUpgradeManifest(VERSIONED_DOC_TYPE)).toThrow(
+        `Upgrade manifest not found for type: ${VERSIONED_DOC_TYPE}`,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

This PR implements document model versioning support in the reactor, enabling documents to be upgraded from one version to another via `UPGRADE_DOCUMENT` operations.

### Key Changes

**Codegen**
- Set `version` field on generated `DocumentModelModule` objects

**Registry**
- Changed storage from `Map<string, Module>` to flat array for version-aware lookup
- Added `getModule(documentType, version?)` - returns specific version or latest
- Added `getSupportedVersions()`, `getLatestVersion()` methods
- Added upgrade manifest support: `registerUpgradeManifests()`, `getUpgradeManifest()`, `computeUpgradePath()`, `getUpgradeReducer()`
- New error classes: `DuplicateModuleError`, `ModuleNotFoundError`, `DuplicateManifestError`, `ManifestNotFoundError`, `MissingUpgradeTransitionError`

**Executor**
- Version-aware module selection using `docMeta.state.version` from DocumentMetaCache
- When `version === 0`: uses latest module (document not yet upgraded)
- When `version >= 1`: uses specific version module
- Upgrade chain execution: computes upgrade path via registry, applies reducers sequentially

**Utilities (util.ts)**
- `parseVersionNumber(versionString)`: Parses version strings to integers
- `getUpgradeTargetVersion(action)`: Extracts toVersion from action with fallback
- Refactored `applyUpgradeDocumentAction()`:
  - Returns `null` for no-op (same version)
  - Throws `DowngradeNotSupportedError` for downgrade attempts
  - Accepts optional `upgradePath` for multi-step upgrades
  - Always applies `initialState` from action after transitions

**ReactorBuilder**
- Added `withUpgradeManifests(manifests)` method

### Tests
- 28 new registry versioning tests (`versioned.test.ts`)
- Unit tests for `applyUpgradeDocumentAction` scenarios
- Test fixtures with mock v1, v2, v3 modules and upgrade manifest

## Test Plan

- [x] Registry unit tests pass (28 tests)
- [x] Executor util unit tests pass
- [x] Existing tests pass (backward compatibility)
- [ ] Executor integration tests
- [ ] E2E tests
