### PR TITLE
Feat/handle reducer reserved names

### DIFF
--- a/apps/connect/src/store/reactor.ts
+++ b/apps/connect/src/store/reactor.ts
@@ -18,9 +18,11 @@ import {
   refreshReactorData,
   refreshReactorDataClient,
   setFeatures,
+  setPHToast,
   setSelectedDrive,
   setSelectedNode,
   setVetraPackages,
+  type PHToastFn,
   type VetraPackage,
 } from "@powerhousedao/reactor-browser";
 import {
@@ -39,6 +41,7 @@ import {
   setRenown,
   setSync,
 } from "@powerhousedao/reactor-browser/connect";
+import { toast } from "@powerhousedao/connect/services";
 import { initRenown } from "@renown/sdk";
 import type {
   DocumentDriveDocument,
@@ -135,6 +138,9 @@ export async function createReactor() {
 
   // add window event handlers for updates
   addPHEventHandlers();
+
+  // register toast function for use in editor components
+  setPHToast(toast as PHToastFn);
 
   // initialize feature flags
   const features = await initFeatureFlags();

--- a/packages/builder-tools/document-model-editor/editor.tsx
+++ b/packages/builder-tools/document-model-editor/editor.tsx
@@ -1,5 +1,8 @@
 import { DocumentToolbar } from "@powerhousedao/design-system/connect";
-import { useSetPHDocumentEditorConfig } from "@powerhousedao/reactor-browser";
+import {
+  usePHToast,
+  useSetPHDocumentEditorConfig,
+} from "@powerhousedao/reactor-browser";
 import { pascalCase } from "change-case";
 import {
   addModule,
@@ -41,6 +44,7 @@ const StateSchemas = lazy(() => import("./components/state-schemas.js"));
 
 export default function Editor() {
   useSetPHDocumentEditorConfig(editorConfig);
+  const toast = usePHToast();
   const [document, dispatch] = useSelectedDocumentModelDocument();
   const [scope, setScope] = useState<Scope>("global");
   const documentNodeName = document.header.name;
@@ -167,45 +171,26 @@ export default function Editor() {
     name: string,
   ): Promise<string | undefined> => {
     return new Promise((resolve) => {
-      try {
-        const moduleOperationNames =
-          modules
-            .find((module) => module.id === moduleId)
-            ?.operations.map((operation) => operation.name)
-            .filter(Boolean) ?? [];
-        if (
-          moduleOperationNames.some((opName) =>
-            compareStringsWithoutWhitespace(opName, name),
-          )
-        ) {
+      const id = generateId();
+      dispatch(addOperation({ id, moduleId, name, scope }), (errors) => {
+        if (errors.length > 0) {
+          if (toast) {
+            toast(errors[0].message, { type: "connect-warning" });
+          }
           resolve(undefined);
-          return;
+        } else {
+          resolve(id);
         }
-        const id = generateId();
-        dispatch(addOperation({ id, moduleId, name, scope }));
-        resolve(id);
-      } catch (error) {
-        console.error("Failed to add operation:", error);
-        resolve(undefined);
-      }
+      });
     });
   };
 
   const handleSetOperationName = (id: string, name: string) => {
-    const operationModule = modules.find((module) =>
-      module.operations.some((operation) => operation.id === id),
-    );
-    const operationNames =
-      operationModule?.operations
-        .map((operation) => operation.name)
-        .filter(Boolean) ?? [];
-    if (
-      operationNames.some((opName) =>
-        compareStringsWithoutWhitespace(opName, name),
-      )
-    )
-      return;
-    dispatch(setOperationName({ id, name }));
+    dispatch(setOperationName({ id, name }), (errors) => {
+      if (errors.length > 0 && toast) {
+        toast(errors[0].message, { type: "connect-warning" });
+      }
+    });
   };
 
   const handleSetOperationSchema = (id: string, newSchema: string) => {

--- a/packages/document-model/src/document-model/reducers.ts
+++ b/packages/document-model/src/document-model/reducers.ts
@@ -99,6 +99,7 @@ import {
   UpdateOperationExampleInputSchema,
   UpdateStateExampleInputSchema,
 } from "./schemas.js";
+import { validateOperationName } from "./validation.js";
 
 function sorter<TItem extends { id: string }>(
   order: string[],
@@ -376,6 +377,8 @@ export const documentModelOperationExampleReducer: DocumentModelOperationExample
   };
 export const documentModelOperationReducer: DocumentModelOperationOperations = {
   addOperationOperation(state, action) {
+    validateOperationName(action.input.name, state);
+
     const latestSpec = state.specifications[state.specifications.length - 1];
     for (let i = 0; i < latestSpec.modules.length; i++) {
       if (latestSpec.modules[i].id == action.input.moduleId) {
@@ -395,6 +398,10 @@ export const documentModelOperationReducer: DocumentModelOperationOperations = {
   },
 
   setOperationNameOperation(state, action) {
+    if (action.input.name) {
+      validateOperationName(action.input.name, state, action.input.id);
+    }
+
     const latestSpec = state.specifications[state.specifications.length - 1];
     for (let i = 0; i < latestSpec.modules.length; i++) {
       for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {

--- a/packages/document-model/src/document-model/validation.ts
+++ b/packages/document-model/src/document-model/validation.ts
@@ -4,6 +4,83 @@ import type {
   OperationSpecification,
   ValidationError,
 } from "document-model";
+import type { DocumentModelGlobalState } from "./types.js";
+
+/**
+ * Reserved operation names from base reducer (core/actions.ts).
+ * These names cannot be used for custom operations.
+ */
+export const RESERVED_OPERATION_NAMES = [
+  "UNDO",
+  "REDO",
+  "PRUNE",
+  "LOAD_STATE",
+  "SET_NAME",
+  "NOOP",
+] as const;
+
+export type ReservedOperationName = (typeof RESERVED_OPERATION_NAMES)[number];
+
+/**
+ * Check if name conflicts with base reducer actions (case-insensitive).
+ */
+export function isReservedOperationName(name: string): boolean {
+  return RESERVED_OPERATION_NAMES.includes(
+    name.toUpperCase() as ReservedOperationName,
+  );
+}
+
+/**
+ * Get all operation names from all modules in the latest specification.
+ * Returns names in uppercase for case-insensitive comparison.
+ */
+export function getAllOperationNames(
+  state: DocumentModelGlobalState,
+  excludeOperationId?: string,
+): string[] {
+  const latestSpec = state.specifications[state.specifications.length - 1];
+  if (!latestSpec) return [];
+
+  const names: string[] = [];
+  for (const module of latestSpec.modules) {
+    for (const operation of module.operations) {
+      if (excludeOperationId && operation.id === excludeOperationId) continue;
+      if (operation.name) names.push(operation.name.toUpperCase());
+    }
+  }
+  return names;
+}
+
+/**
+ * Validate operation name is not reserved or duplicate. Throws on failure.
+ *
+ * @param name - The operation name to validate
+ * @param state - The document model global state
+ * @param excludeOperationId - Optional operation ID to exclude (for rename validation)
+ * @throws Error if the name is reserved or a duplicate
+ */
+export function validateOperationName(
+  name: string,
+  state: DocumentModelGlobalState,
+  excludeOperationId?: string,
+): void {
+  if (!name) return; // Empty names handled by existing validation
+
+  const upperName = name.toUpperCase();
+
+  if (isReservedOperationName(name)) {
+    throw new Error(
+      `Operation name "${name}" is reserved. Please use a different name.`,
+    );
+  }
+
+  const existingNames = getAllOperationNames(state, excludeOperationId);
+  if (existingNames.includes(upperName)) {
+    throw new Error(
+      `Operation name "${name}" is already used by another operation. Operation names must be unique across all modules.`,
+    );
+  }
+}
 
 export function validateInitialState(
   initialState: string,

--- a/packages/document-model/test/document-model/validation.test.ts
+++ b/packages/document-model/test/document-model/validation.test.ts
@@ -5,13 +5,20 @@ import type {
   ValidationError,
 } from "document-model";
 import {
+  addModule,
+  addOperation,
   documentModelCreateDocument,
   documentModelReducer,
+  getAllOperationNames,
+  isReservedOperationName,
+  RESERVED_OPERATION_NAMES,
+  setOperationName,
   setStateSchema,
   validateInitialState,
   validateModule,
   validateModuleOperation,
   validateModules,
+  validateOperationName,
   validateStateSchemaName,
 } from "document-model";
 
@@ -376,6 +383,342 @@ describe("DocumentModel Validation Error", () => {
       ]);
 
       expect(errors.length).toBe(0);
+    });
+  });
+
+  describe("operation name validation", () => {
+    describe("isReservedOperationName", () => {
+      it("should return true for all reserved names (exact case)", () => {
+        for (const name of RESERVED_OPERATION_NAMES) {
+          expect(isReservedOperationName(name)).toBe(true);
+        }
+      });
+
+      it("should return true for reserved names (lowercase)", () => {
+        expect(isReservedOperationName("undo")).toBe(true);
+        expect(isReservedOperationName("redo")).toBe(true);
+        expect(isReservedOperationName("prune")).toBe(true);
+        expect(isReservedOperationName("load_state")).toBe(true);
+        expect(isReservedOperationName("set_name")).toBe(true);
+        expect(isReservedOperationName("noop")).toBe(true);
+      });
+
+      it("should return true for reserved names (mixed case)", () => {
+        expect(isReservedOperationName("Undo")).toBe(true);
+        expect(isReservedOperationName("Set_Name")).toBe(true);
+        expect(isReservedOperationName("Load_State")).toBe(true);
+      });
+
+      it("should return false for non-reserved names", () => {
+        expect(isReservedOperationName("CREATE_USER")).toBe(false);
+        expect(isReservedOperationName("UPDATE")).toBe(false);
+        expect(isReservedOperationName("MY_UNDO")).toBe(false);
+        expect(isReservedOperationName("UNDO_ACTION")).toBe(false);
+      });
+    });
+
+    describe("getAllOperationNames", () => {
+      it("should return empty array when no specifications exist", () => {
+        const state = {
+          ...doc.state.global,
+          specifications: [],
+        };
+        const names = getAllOperationNames(state);
+        expect(names).toEqual([]);
+      });
+
+      it("should return all operation names in uppercase", () => {
+        let testDoc = documentModelReducer(
+          doc,
+          addModule({ id: "mod-1", name: "TestModule" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-1", moduleId: "mod-1", name: "CREATE_USER" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-2", moduleId: "mod-1", name: "update_user" }),
+        );
+
+        const names = getAllOperationNames(testDoc.state.global);
+        expect(names).toContain("CREATE_USER");
+        expect(names).toContain("UPDATE_USER");
+        expect(names.length).toBe(2);
+      });
+
+      it("should exclude operation by id", () => {
+        let testDoc = documentModelReducer(
+          doc,
+          addModule({ id: "mod-1", name: "TestModule" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-1", moduleId: "mod-1", name: "CREATE_USER" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-2", moduleId: "mod-1", name: "UPDATE_USER" }),
+        );
+
+        const names = getAllOperationNames(testDoc.state.global, "op-1");
+        expect(names).not.toContain("CREATE_USER");
+        expect(names).toContain("UPDATE_USER");
+        expect(names.length).toBe(1);
+      });
+    });
+
+    describe("validateOperationName", () => {
+      it("should throw error for reserved names", () => {
+        expect(() => validateOperationName("UNDO", doc.state.global)).toThrow(
+          /reserved/,
+        );
+        expect(() =>
+          validateOperationName("set_name", doc.state.global),
+        ).toThrow(/reserved/);
+        expect(() =>
+          validateOperationName("Load_State", doc.state.global),
+        ).toThrow(/reserved/);
+      });
+
+      it("should throw error for duplicate names (same case)", () => {
+        let testDoc = documentModelReducer(
+          doc,
+          addModule({ id: "mod-1", name: "TestModule" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-1", moduleId: "mod-1", name: "CREATE_USER" }),
+        );
+
+        expect(() =>
+          validateOperationName("CREATE_USER", testDoc.state.global),
+        ).toThrow(/already used/);
+      });
+
+      it("should throw error for duplicate names (different case)", () => {
+        let testDoc = documentModelReducer(
+          doc,
+          addModule({ id: "mod-1", name: "TestModule" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-1", moduleId: "mod-1", name: "CREATE_USER" }),
+        );
+
+        expect(() =>
+          validateOperationName("create_user", testDoc.state.global),
+        ).toThrow(/already used/);
+        expect(() =>
+          validateOperationName("Create_User", testDoc.state.global),
+        ).toThrow(/already used/);
+      });
+
+      it("should not throw for valid unique names", () => {
+        let testDoc = documentModelReducer(
+          doc,
+          addModule({ id: "mod-1", name: "TestModule" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-1", moduleId: "mod-1", name: "CREATE_USER" }),
+        );
+
+        expect(() =>
+          validateOperationName("UPDATE_USER", testDoc.state.global),
+        ).not.toThrow();
+        expect(() =>
+          validateOperationName("DELETE_USER", testDoc.state.global),
+        ).not.toThrow();
+      });
+
+      it("should allow renaming to same name (exclude current operation)", () => {
+        let testDoc = documentModelReducer(
+          doc,
+          addModule({ id: "mod-1", name: "TestModule" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-1", moduleId: "mod-1", name: "CREATE_USER" }),
+        );
+
+        expect(() =>
+          validateOperationName("CREATE_USER", testDoc.state.global, "op-1"),
+        ).not.toThrow();
+      });
+
+      it("should not throw for empty names", () => {
+        expect(() => validateOperationName("", doc.state.global)).not.toThrow();
+      });
+    });
+
+    describe("addOperation reducer validation", () => {
+      // Helper to get the last operation's error
+      function getLastOperationError(
+        document: ReturnType<typeof documentModelReducer>,
+      ): string | undefined {
+        const ops = document.operations.global;
+        return ops[ops.length - 1]?.error;
+      }
+
+      it("should record error when adding operation with reserved name", () => {
+        const testDoc = documentModelReducer(
+          doc,
+          addModule({ id: "mod-1", name: "TestModule" }),
+        );
+
+        const result1 = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-1", moduleId: "mod-1", name: "UNDO" }),
+        );
+        expect(getLastOperationError(result1)).toMatch(/reserved/);
+
+        const result2 = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-2", moduleId: "mod-1", name: "set_name" }),
+        );
+        expect(getLastOperationError(result2)).toMatch(/reserved/);
+      });
+
+      it("should record error when adding operation with duplicate name", () => {
+        let testDoc = documentModelReducer(
+          doc,
+          addModule({ id: "mod-1", name: "Module1" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addModule({ id: "mod-2", name: "Module2" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-1", moduleId: "mod-1", name: "CREATE_USER" }),
+        );
+
+        // Duplicate in same module should fail
+        const result1 = documentModelReducer(
+          testDoc,
+          addOperation({
+            id: "op-2",
+            moduleId: "mod-1",
+            name: "CREATE_USER",
+          }),
+        );
+        expect(getLastOperationError(result1)).toMatch(/already used/);
+
+        // Duplicate in different module should also fail
+        const result2 = documentModelReducer(
+          testDoc,
+          addOperation({
+            id: "op-3",
+            moduleId: "mod-2",
+            name: "CREATE_USER",
+          }),
+        );
+        expect(getLastOperationError(result2)).toMatch(/already used/);
+      });
+
+      it("should allow adding operation with valid unique name", () => {
+        let testDoc = documentModelReducer(
+          doc,
+          addModule({ id: "mod-1", name: "TestModule" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-1", moduleId: "mod-1", name: "CREATE_USER" }),
+        );
+
+        const result = documentModelReducer(
+          testDoc,
+          addOperation({
+            id: "op-2",
+            moduleId: "mod-1",
+            name: "UPDATE_USER",
+          }),
+        );
+        expect(getLastOperationError(result)).toBeUndefined();
+      });
+    });
+
+    describe("setOperationName reducer validation", () => {
+      // Helper to get the last operation's error
+      function getLastOperationError(
+        document: ReturnType<typeof documentModelReducer>,
+      ): string | undefined {
+        const ops = document.operations.global;
+        return ops[ops.length - 1]?.error;
+      }
+
+      it("should record error when renaming to reserved name", () => {
+        let testDoc = documentModelReducer(
+          doc,
+          addModule({ id: "mod-1", name: "TestModule" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-1", moduleId: "mod-1", name: "VALID_NAME" }),
+        );
+
+        const result = documentModelReducer(
+          testDoc,
+          setOperationName({ id: "op-1", name: "SET_NAME" }),
+        );
+        expect(getLastOperationError(result)).toMatch(/reserved/);
+      });
+
+      it("should record error when renaming to duplicate name", () => {
+        let testDoc = documentModelReducer(
+          doc,
+          addModule({ id: "mod-1", name: "TestModule" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-1", moduleId: "mod-1", name: "OP_ONE" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-2", moduleId: "mod-1", name: "OP_TWO" }),
+        );
+
+        const result = documentModelReducer(
+          testDoc,
+          setOperationName({ id: "op-2", name: "OP_ONE" }),
+        );
+        expect(getLastOperationError(result)).toMatch(/already used/);
+      });
+
+      it("should allow renaming operation to its current name", () => {
+        let testDoc = documentModelReducer(
+          doc,
+          addModule({ id: "mod-1", name: "TestModule" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-1", moduleId: "mod-1", name: "MY_OPERATION" }),
+        );
+
+        const result = documentModelReducer(
+          testDoc,
+          setOperationName({ id: "op-1", name: "MY_OPERATION" }),
+        );
+        expect(getLastOperationError(result)).toBeUndefined();
+      });
+
+      it("should allow renaming to valid unique name", () => {
+        let testDoc = documentModelReducer(
+          doc,
+          addModule({ id: "mod-1", name: "TestModule" }),
+        );
+        testDoc = documentModelReducer(
+          testDoc,
+          addOperation({ id: "op-1", moduleId: "mod-1", name: "OLD_NAME" }),
+        );
+
+        const result = documentModelReducer(
+          testDoc,
+          setOperationName({ id: "op-1", name: "NEW_NAME" }),
+        );
+        expect(getLastOperationError(result)).toBeUndefined();
+      });
     });
   });
 });

--- a/packages/reactor-browser/src/hooks/add-ph-event-handlers.ts
+++ b/packages/reactor-browser/src/hooks/add-ph-event-handlers.ts
@@ -83,6 +83,7 @@ import {
 } from "./selected-node.js";
 import { addSelectedTimelineItemEventHandler } from "./selected-timeline-item.js";
 import { addSelectedTimelineRevisionEventHandler } from "./timeline-revision.js";
+import { addToastEventHandler } from "./toast.js";
 import { addUserEventHandler } from "./user.js";
 import { addVetraPackagesEventHandler } from "./vetra-packages.js";
 
@@ -170,6 +171,7 @@ const phGlobalEventHandlerRegisterFunctions: PHGlobalEventHandlerAdders = {
   isSentryTracingEnabled: addIsSentryTracingEnabledEventHandler,
   isExternalProcessorsEnabled: addIsExternalProcessorsEnabledEventHandler,
   isExternalPackagesEnabled: addIsExternalPackagesEnabledEventHandler,
+  toast: addToastEventHandler,
 };
 export function addPHEventHandlers() {
   for (const fn of Object.values(phGlobalEventHandlerRegisterFunctions)) {

--- a/packages/reactor-browser/src/hooks/index.ts
+++ b/packages/reactor-browser/src/hooks/index.ts
@@ -121,6 +121,7 @@ export {
   setSelectedTimelineRevision,
   useSelectedTimelineRevision,
 } from "./timeline-revision.js";
+export { setPHToast, usePHToast } from "./toast.js";
 export { useGetSwitchboardLink } from "./use-get-switchboard-link.js";
 export { useOnDropFile } from "./use-on-drop-file.js";
 export { useUserPermissions } from "./user-permissions.js";

--- a/packages/reactor-browser/src/hooks/toast.ts
+++ b/packages/reactor-browser/src/hooks/toast.ts
@@ -1,0 +1,12 @@
+import { makePHEventFunctions } from "./make-ph-event-functions.js";
+
+const toastEventFunctions = makePHEventFunctions("toast");
+
+/** Returns the toast function */
+export const usePHToast = toastEventFunctions.useValue;
+
+/** Sets the toast function */
+export const setPHToast = toastEventFunctions.setValue;
+
+/** Adds an event handler for the toast */
+export const addToastEventHandler = toastEventFunctions.addEventHandler;

--- a/packages/reactor-browser/src/types/global.ts
+++ b/packages/reactor-browser/src/types/global.ts
@@ -16,6 +16,7 @@ import type { PHGlobalConfig } from "./config.js";
 import type { IDocumentCache } from "./documents.js";
 import type { PHModal } from "./modals.js";
 import type { TimelineItem } from "./timeline.js";
+import type { PHToastFn } from "./toast.js";
 import type { VetraPackage } from "./vetra.js";
 
 export type BrowserReactorClientModule = ReactorClientModule & {
@@ -46,6 +47,7 @@ export type PHGlobal = PHGlobalConfig & {
   revisionHistoryVisible?: boolean;
   selectedTimelineItem?: TimelineItem | null;
   features?: Map<string, boolean>;
+  toast?: PHToastFn;
 };
 
 export type PHGlobalKey = keyof PHGlobal;

--- a/packages/reactor-browser/src/types/index.ts
+++ b/packages/reactor-browser/src/types/index.ts
@@ -4,5 +4,6 @@ export type * from "./global.js";
 export type * from "./modals.js";
 export type * from "./reactor.js";
 export type * from "./timeline.js";
+export type * from "./toast.js";
 export type * from "./upload.js";
 export type * from "./vetra.js";

--- a/packages/reactor-browser/src/types/toast.ts
+++ b/packages/reactor-browser/src/types/toast.ts
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+export type PHToastType =
+  | "default"
+  | "success"
+  | "error"
+  | "warning"
+  | "info"
+  | "connect-success"
+  | "connect-warning"
+  | "connect-loading"
+  | "connect-deleted";
+
+export type PHToastOptions = {
+  type?: PHToastType;
+  autoClose?: number | false;
+  containerId?: string;
+};
+
+export type PHToastFn = (
+  content: ReactNode | string,
+  options?: PHToastOptions,
+) => void;


### PR DESCRIPTION
## Description:

- handle reserved operation names in document model reducer
- handle duplicated operation names in document model reducer
- enable toast acces in reactor browser hooks
- display error toast in document model editor

![2025-12-30 13 54 25](https://github.com/user-attachments/assets/ab6ad3eb-890f-4077-95b9-27c5a9289781)
