### PR TITLE
fix: update e2e test fixtures for document version type changes

### DIFF
--- a/clis/ph-cli/src/cli.ts
+++ b/clis/ph-cli/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { Command } from "commander";
-import { registerCommands } from "@powerhousedao/ph-cli";
+import { registerCommands } from "./index.js";
 
 function ensureNodeVersion(minVersion = "22") {
   const version = process.versions.node;

--- a/packages/reactor-browser/src/renown/utils.ts
+++ b/packages/reactor-browser/src/renown/utils.ts
@@ -1,7 +1,4 @@
-import {
-  setLoginStatus,
-  setUser,
-} from "@powerhousedao/reactor-browser/connect";
+import { setLoginStatus, setUser } from "../connect.js";
 import type { IConnectCrypto, IRenown, User } from "@renown/sdk";
 import { logger, type IDocumentDriveServer } from "document-drive";
 import { RENOWN_CHAIN_ID, RENOWN_NETWORK_ID, RENOWN_URL } from "./constants.js";

--- a/test/connect-e2e/tests/expected-zip-content/current-state.json
+++ b/test/connect-e2e/tests/expected-zip-content/current-state.json
@@ -1,7 +1,7 @@
 {
   "auth": {},
   "document": {
-    "version": "1.0.0"
+    "version": 0
   },
   "global": {
     "id": "powerhouse/todo",

--- a/test/connect-e2e/tests/expected-zip-content/operations.json
+++ b/test/connect-e2e/tests/expected-zip-content/operations.json
@@ -8,7 +8,7 @@
         "scope": "document",
         "input": {
           "model": "powerhouse/document-model",
-          "version": "0.0.0"
+          "version": 0
         }
       }
     },
@@ -20,11 +20,11 @@
         "scope": "document",
         "input": {
           "model": "powerhouse/document-model",
-          "fromVersion": "0.0.0",
-          "toVersion": "0.1.0",
+          "fromVersion": 0,
+          "toVersion": 1,
           "initialState": {
             "document": {
-              "version": "1.0.0"
+              "version": 0
             },
             "global": {
               "name": "",

--- a/test/connect-e2e/tests/expected-zip-content/state.json
+++ b/test/connect-e2e/tests/expected-zip-content/state.json
@@ -1,7 +1,7 @@
 {
   "auth": {},
   "document": {
-    "version": "1.0.0"
+    "version": 0
   },
   "global": {
     "id": "",

--- a/test/connect-e2e/tests/todo-document.spec.ts
+++ b/test/connect-e2e/tests/todo-document.spec.ts
@@ -131,7 +131,8 @@ test("Create ToDoDocument Model", async ({ page }) => {
 test("Create a TodoList", async ({ page }) => {
   await goToConnectDrive(page, "My Local Drive");
   await createDocument(page, "ToDoDocument", "MyTodoList");
-  await page.getByText("Edit Name").waitFor({ state: "visible" });
+  // Wait for the editor to load - look for the "Edit" button in the generated editor
+  await page.getByRole("button", { name: "Edit" }).waitFor({ state: "visible" });
 });
 
 // Helper Functions


### PR DESCRIPTION
## Summary

Fixes failing Connect E2E tests caused by document version type changes (from strings to numbers).

## Changes

### Test Fixtures Updates
Updated expected test files to match the new document version format:

| File | Change |
|------|--------|
| `state.json` | `"version": "1.0.0"` → `"version": 0` |
| `current-state.json` | `"version": "1.0.0"` → `"version": 0` |
| `operations.json` | Version strings → numbers (`"0.0.0"` → `0`, `"0.1.0"` → `1`, etc.) |

### Test Selector Update
- Updated `todo-document.spec.ts` to use `getByRole("button", { name: "Edit" })` instead of `getByText("Edit Name")` to match the updated editor template

### Import Path Fixes
Fixed self-reference import issues that prevented local development:

- **`clis/ph-cli/src/cli.ts`**: Changed `@powerhousedao/ph-cli` → `./index.js`
- **`packages/reactor-browser/src/renown/utils.ts`**: Changed `@powerhousedao/reactor-browser/connect` → `../connect.js`

## Testing

- ✅ All 10 Connect E2E tests pass locally

## Production Code Changes (Potential Impact)

**1. clis/ph-cli/src/cli.ts**
- import { registerCommands } from "@powerhousedao/ph-cli";+ import { registerCommands } from "./index.js";
Risk Assessment: ⚠️ Low risk, but worth noting
- Why changed: Package couldn't resolve its own name (@powerhousedao/ph-cli) - self-reference issue with pnpm workspace
- Impact: None for published package. The relative import is equivalent and arguably cleaner for internal imports within the same package.
- Alternative fix: Could configure pnpm to support self-referencing packages, or add the package as its own dependency

**2. packages/reactor-browser/src/renown/utils.ts**
- import { setLoginStatus, setUser } from "@powerhousedao/reactor-browser/connect";+ import { setLoginStatus, setUser } from "../connect.js";
- Risk Assessment: ⚠️ Low risk, but worth noting
- Why changed: Same self-reference issue - package importing from its own exports path
- Impact: None for published package. Relative imports work identically.
- Alternative fix: Same as above - fix the workspace/package configuration to support self-references


## Notes for Reviewers

The import path changes are functionally equivalent - relative imports work the same as package self-references. This is a workaround for pnpm workspace self-reference resolution issues. A proper long-term fix would be to configure the workspace to support package self-references.