### PR TITLE
test(vetra-e2e): remove subgraph expectation from document model test

### DIFF
--- a/test/vetra-e2e/tests/todo-document.spec.ts
+++ b/test/vetra-e2e/tests/todo-document.spec.ts
@@ -95,18 +95,9 @@ async function setupDocument(
     'export { ToDoDocument } from "./to-do-document/module.js"',
   );
 
-  // Verify subgraph folder was created
-  const subgraphsDir = path.join(process.cwd(), "subgraphs");
-  const todoSubgraphDir = path.join(subgraphsDir, "to-do-document");
-  const subgraphsIndex = path.join(subgraphsDir, "index.ts");
-
-  expect(fs.existsSync(todoSubgraphDir)).toBe(true);
-
-  // Verify export was added to subgraphs/index.ts
-  const subgraphsIndexContent = fs.readFileSync(subgraphsIndex, "utf-8");
-  expect(subgraphsIndexContent).toContain(
-    'export * as ToDoDocumentSubgraph from "./to-do-document/index.js"',
-  );
+  // Note: Automatic subgraph generation for document models was disabled
+  // in commit d705e0c5f. Subgraphs are now generated separately via
+  // the powerhouse/subgraph document type.
 
   await closeDocumentFromToolbar(page);
 }


### PR DESCRIPTION
## Summary

Updates the Vetra E2E test to align with the intentional change made in commit d705e0c5f which disabled automatic subgraph generation for document models.

## Problem

The `Create ToDoDocument Model` E2E test was failing because it expected a subgraph to be automatically generated when creating a document model. However, this behavior was intentionally removed on Jan 5, 2026 (commit d705e0c5f: "fix(vetra): do not generate document model subgraph").

The unit tests were updated in commit c65d4a73f, but the E2E test was missed.

## Changes

- Removed subgraph generation expectations from `test/vetra-e2e/tests/todo-document.spec.ts`
- Added a comment explaining why subgraph generation is no longer expected

## Testing

All 7 Vetra E2E tests pass locally:
- ✅ should load Vetra application successfully
- ✅ should verify basic page structure
- ✅ should create document of each supported type in Vetra drive
- ✅ should log console message when attempting to create powerhouse/codegen-processor
- ✅ Create ToDoDocument Model
- ✅ should display Vetra drive automatically on Connect main page
- ✅ should allow clicking on Vetra drive

## Context
Only a test file was modified - no production code was touched.