### PR TITLE
Implemented `totalCount` in pagination results

### DIFF
--- a/packages/reactor-api/src/graphql/reactor/adapters.ts
+++ b/packages/reactor-api/src/graphql/reactor/adapters.ts
@@ -34,7 +34,7 @@ export function toDocumentModelResultPage(
     hasNextPage: !!result.nextCursor,
     hasPreviousPage: !!result.options.cursor,
     items: models.map(toGqlDocumentModelState),
-    totalCount: result.results.length,
+    totalCount: result.totalCount ?? result.results.length,
   };
 }
 
@@ -76,7 +76,7 @@ export function toPhDocumentResultPage(
     hasNextPage: !!result.nextCursor,
     hasPreviousPage: !!result.options.cursor,
     items: result.results.map(toGqlPhDocument),
-    totalCount: result.results.length,
+    totalCount: result.totalCount ?? result.results.length,
   };
 }
 

--- a/packages/reactor/src/core/reactor.ts
+++ b/packages/reactor/src/core/reactor.ts
@@ -170,6 +170,7 @@ export class Reactor implements IReactor {
       results: pagedModels,
       options: paging || { cursor: "0", limit: filteredModels.length },
       nextCursor,
+      totalCount: filteredModels.length,
       next: hasMore
         ? () =>
             this.getDocumentModels(
@@ -1134,6 +1135,7 @@ export class Reactor implements IReactor {
         results: pagedDocuments,
         options: paging || { cursor: "0", limit: documents.length },
         nextCursor,
+        totalCount: documents.length,
         next: hasMore
           ? () =>
               this.findByIds(
@@ -1185,6 +1187,7 @@ export class Reactor implements IReactor {
         results: pagedDocuments,
         options: paging || { cursor: "0", limit: documents.length },
         nextCursor,
+        totalCount: documents.length,
         next: hasMore
           ? () =>
               this.findByIds(
@@ -1282,6 +1285,7 @@ export class Reactor implements IReactor {
         results: pagedDocuments,
         options: paging || { cursor: "0", limit: documents.length },
         nextCursor,
+        totalCount: documents.length,
         next: hasMore
           ? () =>
               this.findBySlugs(
@@ -1352,6 +1356,7 @@ export class Reactor implements IReactor {
         results: pagedDocuments,
         options: paging || { cursor: "0", limit: documents.length },
         nextCursor,
+        totalCount: documents.length,
         next: hasMore
           ? () =>
               this.findBySlugs(
@@ -1442,6 +1447,7 @@ export class Reactor implements IReactor {
       results: pagedDocuments,
       options: paging || { cursor: "0", limit: documents.length },
       nextCursor,
+      totalCount: relationships.length,
       next: hasMore
         ? () =>
             this.findByParentId(
@@ -1527,10 +1533,13 @@ export class Reactor implements IReactor {
       }
 
       // Results are already paged from the storage layer
+      // Note: totalCount is not available from legacy storage, so we use documents.length
+      // which represents the count of successfully fetched documents on this page
       return {
         results: documents,
         options: paging || { cursor: cursor || "0", limit },
         nextCursor,
+        totalCount: documents.length, // Legacy storage doesn't provide total count
         next: nextCursor
           ? async () =>
               this.findByType(
@@ -1558,10 +1567,13 @@ export class Reactor implements IReactor {
       const cursor = paging?.cursor;
       const limit = paging?.limit || 100;
 
+      // documentView.findByType returns storage/interfaces.PagedResults (with 'items')
+      // Convert to shared/types.PagedResults (with 'results')
       return {
         results: result.items,
         options: paging || { cursor: cursor || "0", limit },
         nextCursor: result.nextCursor,
+        totalCount: result.totalCount,
         next: result.nextCursor
           ? async () =>
               this.findByType(

--- a/packages/reactor/src/core/reactor.ts
+++ b/packages/reactor/src/core/reactor.ts
@@ -1552,11 +1552,14 @@ export class Reactor implements IReactor {
       }
 
       // Results are already paged from the storage layer
+      // Legacy storage doesn't provide total count, so we use the current page size
+      // as a fallback. The adapter will use this value, which represents the number
+      // of documents on this page, not the total across all pages.
       return {
         results: documents,
         options: paging || { cursor: cursor || "0", limit },
         nextCursor,
-        totalCount: undefined, // Legacy storage doesn't provide total count
+        totalCount: documents.length, // Legacy storage fallback: current page size (not total)
         next: nextCursor
           ? async () =>
               this.findByType(

--- a/packages/reactor/src/core/reactor.ts
+++ b/packages/reactor/src/core/reactor.ts
@@ -1131,6 +1131,7 @@ export class Reactor implements IReactor {
       const hasMore = startIndex + limit < documents.length;
       const nextCursor = hasMore ? String(startIndex + limit) : undefined;
 
+      // totalCount reflects successfully fetched documents, not input array size
       return {
         results: pagedDocuments,
         options: paging || { cursor: "0", limit: documents.length },
@@ -1183,6 +1184,7 @@ export class Reactor implements IReactor {
       const hasMore = startIndex + limit < documents.length;
       const nextCursor = hasMore ? String(startIndex + limit) : undefined;
 
+      // totalCount reflects successfully fetched documents, not input array size
       return {
         results: pagedDocuments,
         options: paging || { cursor: "0", limit: documents.length },
@@ -1281,6 +1283,7 @@ export class Reactor implements IReactor {
       const hasMore = startIndex + limit < documents.length;
       const nextCursor = hasMore ? String(startIndex + limit) : undefined;
 
+      // totalCount reflects successfully fetched documents, not input array size
       return {
         results: pagedDocuments,
         options: paging || { cursor: "0", limit: documents.length },
@@ -1352,6 +1355,7 @@ export class Reactor implements IReactor {
       const hasMore = startIndex + limit < documents.length;
       const nextCursor = hasMore ? String(startIndex + limit) : undefined;
 
+      // totalCount reflects successfully fetched documents, not input array size
       return {
         results: pagedDocuments,
         options: paging || { cursor: "0", limit: documents.length },
@@ -1447,7 +1451,7 @@ export class Reactor implements IReactor {
       results: pagedDocuments,
       options: paging || { cursor: "0", limit: documents.length },
       nextCursor,
-      totalCount: relationships.length,
+      totalCount: documents.length,
       next: hasMore
         ? () =>
             this.findByParentId(
@@ -1533,13 +1537,11 @@ export class Reactor implements IReactor {
       }
 
       // Results are already paged from the storage layer
-      // Note: totalCount is not available from legacy storage, so we use documents.length
-      // which represents the count of successfully fetched documents on this page
       return {
         results: documents,
         options: paging || { cursor: cursor || "0", limit },
         nextCursor,
-        totalCount: documents.length, // Legacy storage doesn't provide total count
+        totalCount: undefined, // Legacy storage doesn't provide total count
         next: nextCursor
           ? async () =>
               this.findByType(

--- a/packages/reactor/src/core/utils.ts
+++ b/packages/reactor/src/core/utils.ts
@@ -156,10 +156,12 @@ export function filterByType(
 
   // Create new paged results with filtered documents
   // Note: This maintains the same paging structure but with filtered results
+  // totalCount is not preserved as filtering changes the total count
   return {
     results: filteredDocuments,
     options: results.options,
     nextCursor: results.nextCursor,
+    totalCount: undefined, // Cannot determine total count after filtering without iterating all pages
     next: results.next
       ? async () => {
           // If there's a next function, apply the same filter to the next page

--- a/packages/reactor/src/core/utils.ts
+++ b/packages/reactor/src/core/utils.ts
@@ -156,12 +156,13 @@ export function filterByType(
 
   // Create new paged results with filtered documents
   // Note: This maintains the same paging structure but with filtered results
-  // totalCount is not preserved as filtering changes the total count
+  // totalCount cannot be accurately determined after filtering without iterating all pages,
+  // so we use the filtered documents length as a fallback (represents current page, not total)
   return {
     results: filteredDocuments,
     options: results.options,
     nextCursor: results.nextCursor,
-    totalCount: undefined, // Cannot determine total count after filtering without iterating all pages
+    totalCount: filteredDocuments.length, // Fallback: current page size (not total across all pages)
     next: results.next
       ? async () => {
           // If there's a next function, apply the same filter to the next page

--- a/packages/reactor/src/core/utils.ts
+++ b/packages/reactor/src/core/utils.ts
@@ -156,13 +156,14 @@ export function filterByType(
 
   // Create new paged results with filtered documents
   // Note: This maintains the same paging structure but with filtered results
-  // totalCount cannot be accurately determined after filtering without iterating all pages,
-  // so we use the filtered documents length as a fallback (represents current page, not total)
+  // totalCount is set to undefined because the total count after filtering cannot
+  // be determined without iterating all pages. Using the current page size would
+  // be misleading and break pagination UIs (totalCount would change on each page).
   return {
     results: filteredDocuments,
     options: results.options,
     nextCursor: results.nextCursor,
-    totalCount: filteredDocuments.length, // Fallback: current page size (not total across all pages)
+    totalCount: undefined, // Cannot determine total after filtering without iterating all pages
     next: results.next
       ? async () => {
           // If there's a next function, apply the same filter to the next page

--- a/packages/reactor/src/read-models/document-view.ts
+++ b/packages/reactor/src/read-models/document-view.ts
@@ -487,6 +487,7 @@ export class KyselyDocumentView extends BaseReadModel implements IDocumentView {
       items: documents,
       nextCursor,
       hasMore,
+      totalCount: allDocumentIds.length,
     };
   }
 

--- a/packages/reactor/src/shared/types.ts
+++ b/packages/reactor/src/shared/types.ts
@@ -122,6 +122,11 @@ export type PagedResults<T> = {
 
   next?: () => Promise<PagedResults<T>>;
   nextCursor?: string;
+  /**
+   * Total count of all matching items across all pages.
+   * Optional because it may not always be available or efficient to calculate.
+   */
+  totalCount?: number;
 };
 
 /**

--- a/packages/reactor/src/shared/types.ts
+++ b/packages/reactor/src/shared/types.ts
@@ -131,7 +131,7 @@ export type PagedResults<T> = {
    * - `findByIds`: Input IDs array size (not successfully fetched count)
    * - `findBySlugs`: Input slugs array size (not successfully fetched count)
    * - `findByParentId`: Relationships array size (not successfully fetched count)
-   * - `filterByType`: Filtered current page size (fallback, not total)
+   * - `filterByType`: `undefined` (cannot determine total after filtering)
    *
    * For lookup methods, this represents the input array size, not the count of
    * successfully fetched documents. This is a performance trade-off to avoid

--- a/packages/reactor/src/shared/types.ts
+++ b/packages/reactor/src/shared/types.ts
@@ -123,7 +123,22 @@ export type PagedResults<T> = {
   next?: () => Promise<PagedResults<T>>;
   nextCursor?: string;
   /**
-   * Total count of all matching items across all pages.
+   * Count of items for pagination purposes.
+   *
+   * **⚠️ Inconsistent semantics**: The meaning of `totalCount` varies by method:
+   * - `findByType` (new storage): Actual total count from storage (accurate)
+   * - `findByType` (legacy storage): Current page size (fallback, not total)
+   * - `findByIds`: Input IDs array size (not successfully fetched count)
+   * - `findBySlugs`: Input slugs array size (not successfully fetched count)
+   * - `findByParentId`: Relationships array size (not successfully fetched count)
+   * - `filterByType`: Filtered current page size (fallback, not total)
+   *
+   * For lookup methods, this represents the input array size, not the count of
+   * successfully fetched documents. This is a performance trade-off to avoid
+   * fetching all documents. Only use `totalCount` for accurate pagination UI
+   * with `findByType` (new storage). For other methods, use `nextCursor`/`next`
+   * for pagination logic.
+   *
    * Optional because it may not always be available or efficient to calculate.
    */
   totalCount?: number;

--- a/packages/reactor/src/storage/interfaces.ts
+++ b/packages/reactor/src/storage/interfaces.ts
@@ -161,6 +161,7 @@ export interface PagedResults<T> {
   items: T[];
   nextCursor?: string;
   hasMore: boolean;
+  totalCount?: number;
 }
 
 export interface DocumentSnapshot {

--- a/packages/reactor/src/storage/interfaces.ts
+++ b/packages/reactor/src/storage/interfaces.ts
@@ -161,6 +161,15 @@ export interface PagedResults<T> {
   items: T[];
   nextCursor?: string;
   hasMore: boolean;
+  /**
+   * Count of items for pagination purposes.
+   *
+   * **⚠️ Inconsistent semantics**: Meaning varies by method - see `shared/types.ts`
+   * for detailed breakdown. Only accurate for `findByType` (new storage). For lookup
+   * methods, represents input array size, not successfully fetched count.
+   *
+   * Optional because it may not always be available or efficient to calculate.
+   */
   totalCount?: number;
 }
 


### PR DESCRIPTION
## What's Changed?

- Add `totalCount?: number` to `PagedResults<T>` in both `shared/types.ts` and `storage/interfaces.ts`
- Update all find methods (`getDocumentModels`, `findByType`, `findByIds`, `findBySlugs`, `findByParentId`) to calculate and return `totalCount`
- Update `document-view.findByType` to include `totalCount` from `allDocumentIds.length`
- Update GraphQL adapters to use `result.totalCount` with fallback to `result.results.length`
- Set `totalCount` to `undefined` in `filterByType` (cannot determine after filtering without iterating all pages)