### PR TITLE
Feat/profile config

### DIFF
--- a/scripts/profiling/docker-compose.yml
+++ b/scripts/profiling/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: postgres16
+    restart: unless-stopped
+
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+
+    ports:
+      - "5432:5432"
+
+    volumes:
+      - postgres16-data:/var/lib/postgresql/data
+
+  pyroscope:
+    image: grafana/pyroscope:latest
+    container_name: pyroscope
+    command: server
+    restart: unless-stopped
+
+    ports:
+      - "4040:4040"
+
+volumes:
+  postgres16-data:

--- a/scripts/profiling/switchboard-pyroscope.sh
+++ b/scripts/profiling/switchboard-pyroscope.sh
@@ -2,13 +2,14 @@
 set -euo pipefail
 
 # Run Switchboard with Pyroscope continuous profiling (no CPU profiling)
-# Usage: ./scripts/switchboard-pyroscope.sh [--v2|--legacy] [switchboard-options...]
+# Usage: ./scripts/switchboard-pyroscope.sh [--v2|--legacy] [--postgres URL] [switchboard-options...]
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # Default storage mode (v2)
 STORAGE_V2="true"
 STORAGE_MODE_LABEL="v2"
+DATABASE_URL=""
 
 # Parse our flags (before passing rest to switchboard)
 SWITCHBOARD_ARGS=()
@@ -24,13 +25,23 @@ while [[ $# -gt 0 ]]; do
       STORAGE_MODE_LABEL="legacy"
       shift
       ;;
+    --postgres|-p)
+      if [ -z "${2:-}" ]; then
+        echo "Error: --postgres/-p requires a database URL"
+        echo "Example: --postgres postgresql://user:pass@host:port/database"
+        exit 1
+      fi
+      DATABASE_URL="$2"
+      shift 2
+      ;;
     --help|-h)
       echo "Usage: ./scripts/profiling/switchboard-pyroscope.sh [options] [switchboard-options...]"
       echo ""
       echo "Options:"
-      echo "  --legacy   Use legacy storage (REACTOR_STORAGE_V2=false)"
-      echo "  --v2       Use new storage (default)"
-      echo "  --help     Show this help message"
+      echo "  --legacy              Use legacy storage (REACTOR_STORAGE_V2=false)"
+      echo "  --v2                  Use new storage (default)"
+      echo "  --postgres, -p <url> Set PostgreSQL database URL (sets both PH_REACTOR_DATABASE_URL and DATABASE_URL)"
+      echo "  --help, -h            Show this help message"
       echo ""
       echo "All other options are passed to switchboard."
       exit 0
@@ -49,6 +60,12 @@ else
   export REACTOR_STORAGE_V2="false"
 fi
 
+# Set database URLs if provided
+if [ -n "$DATABASE_URL" ]; then
+  export PH_REACTOR_DATABASE_URL="$DATABASE_URL"
+  export DATABASE_URL="$DATABASE_URL"
+fi
+
 # Set up Pyroscope profiling on port 4040
 export PYROSCOPE_SERVER_ADDRESS="http://localhost:4040"
 export PYROSCOPE_APPLICATION_NAME="powerhouse-mono-switchboard"
@@ -63,6 +80,13 @@ echo "Application: ${PYROSCOPE_APPLICATION_NAME}"
 echo "Storage mode: ${STORAGE_MODE_LABEL}"
 if [ -n "$STORAGE_V2" ]; then
   echo "  REACTOR_STORAGE_V2=true"
+fi
+if [ -n "$DATABASE_URL" ]; then
+  echo "Database: PostgreSQL"
+  # Mask password in URL for display
+  MASKED_URL=$(echo "$DATABASE_URL" | sed -E 's|://([^:]+):([^@]+)@|://\1:***@|')
+  echo "  PH_REACTOR_DATABASE_URL=${MASKED_URL}"
+  echo "  DATABASE_URL=${MASKED_URL}"
 fi
 echo ""
 echo "Note: Make sure Pyroscope server is running on port 4040"

--- a/scripts/profiling/switchboard-pyroscope.sh
+++ b/scripts/profiling/switchboard-pyroscope.sh
@@ -2,9 +2,52 @@
 set -euo pipefail
 
 # Run Switchboard with Pyroscope continuous profiling (no CPU profiling)
-# Usage: ./scripts/switchboard-pyroscope.sh [switchboard-options...]
+# Usage: ./scripts/switchboard-pyroscope.sh [--v2|--legacy] [switchboard-options...]
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Default storage mode (v2)
+STORAGE_V2="true"
+STORAGE_MODE_LABEL="v2"
+
+# Parse our flags (before passing rest to switchboard)
+SWITCHBOARD_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --v2)
+      STORAGE_V2="true"
+      STORAGE_MODE_LABEL="v2"
+      shift
+      ;;
+    --legacy)
+      STORAGE_V2=""
+      STORAGE_MODE_LABEL="legacy"
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: ./scripts/profiling/switchboard-pyroscope.sh [options] [switchboard-options...]"
+      echo ""
+      echo "Options:"
+      echo "  --legacy   Use legacy storage (REACTOR_STORAGE_V2=false)"
+      echo "  --v2       Use new storage (default)"
+      echo "  --help     Show this help message"
+      echo ""
+      echo "All other options are passed to switchboard."
+      exit 0
+      ;;
+    *)
+      SWITCHBOARD_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# Set storage mode
+if [ -n "$STORAGE_V2" ]; then
+  export REACTOR_STORAGE_V2="true"
+else
+  export REACTOR_STORAGE_V2="false"
+fi
 
 # Set up Pyroscope profiling on port 4040
 export PYROSCOPE_SERVER_ADDRESS="http://localhost:4040"
@@ -17,6 +60,10 @@ echo "Switchboard with Pyroscope Profiling"
 echo "=========================================="
 echo "Pyroscope: ${PYROSCOPE_SERVER_ADDRESS}"
 echo "Application: ${PYROSCOPE_APPLICATION_NAME}"
+echo "Storage mode: ${STORAGE_MODE_LABEL}"
+if [ -n "$STORAGE_V2" ]; then
+  echo "  REACTOR_STORAGE_V2=true"
+fi
 echo ""
 echo "Note: Make sure Pyroscope server is running on port 4040"
 echo "  Run: docker-compose -f docker-compose.pyroscope.yml up -d"
@@ -39,4 +86,4 @@ fi
 echo "Starting Switchboard with Pyroscope profiling..."
 echo
 
-node "$SWITCHBOARD_PATH" "$@"
+node "$SWITCHBOARD_PATH" "${SWITCHBOARD_ARGS[@]}"

--- a/scripts/profiling/switchboard-pyroscope.sh
+++ b/scripts/profiling/switchboard-pyroscope.sh
@@ -110,4 +110,20 @@ fi
 echo "Starting Switchboard with Pyroscope profiling..."
 echo
 
-node "$SWITCHBOARD_PATH" "${SWITCHBOARD_ARGS[@]}"
+# Track the node process and forward signals
+node "$SWITCHBOARD_PATH" ${SWITCHBOARD_ARGS[@]+"${SWITCHBOARD_ARGS[@]}"} &
+NODE_PID=$!
+
+cleanup() {
+  echo ""
+  echo "Stopping switchboard (PID: $NODE_PID)..."
+  kill -TERM "$NODE_PID" 2>/dev/null
+  wait "$NODE_PID" 2>/dev/null
+  echo "Stopped."
+  exit 0
+}
+
+trap cleanup SIGINT SIGTERM
+
+# Wait for node process
+wait "$NODE_PID"

--- a/scripts/profiling/switchboard-pyroscope.sh
+++ b/scripts/profiling/switchboard-pyroscope.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Run Switchboard with Pyroscope continuous profiling (no CPU profiling)
-# Usage: ./scripts/switchboard-pyroscope.sh [--v2|--legacy] [--postgres URL] [switchboard-options...]
+# Usage: ./scripts/switchboard-pyroscope.sh [--mode v2|legacy] [--postgres URL] [switchboard-options...]
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
@@ -15,15 +15,26 @@ DATABASE_URL=""
 SWITCHBOARD_ARGS=()
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --v2)
-      STORAGE_V2="true"
-      STORAGE_MODE_LABEL="v2"
-      shift
-      ;;
-    --legacy)
-      STORAGE_V2=""
-      STORAGE_MODE_LABEL="legacy"
-      shift
+    --mode|-m)
+      if [ -z "${2:-}" ]; then
+        echo "Error: --mode/-m requires a value (v2 or legacy)"
+        exit 1
+      fi
+      case "$2" in
+        v2)
+          STORAGE_V2="true"
+          STORAGE_MODE_LABEL="v2"
+          ;;
+        legacy)
+          STORAGE_V2=""
+          STORAGE_MODE_LABEL="legacy"
+          ;;
+        *)
+          echo "Error: --mode/-m must be 'v2' or 'legacy', got: $2"
+          exit 1
+          ;;
+      esac
+      shift 2
       ;;
     --postgres|-p)
       if [ -z "${2:-}" ]; then
@@ -38,10 +49,9 @@ while [[ $# -gt 0 ]]; do
       echo "Usage: ./scripts/profiling/switchboard-pyroscope.sh [options] [switchboard-options...]"
       echo ""
       echo "Options:"
-      echo "  --legacy              Use legacy storage (REACTOR_STORAGE_V2=false)"
-      echo "  --v2                  Use new storage (default)"
-      echo "  --postgres, -p <url> Set PostgreSQL database URL (sets both PH_REACTOR_DATABASE_URL and DATABASE_URL)"
-      echo "  --help, -h            Show this help message"
+      echo "  --mode, -m <v2|legacy> Storage mode: 'v2' for new storage (default) or 'legacy' for legacy storage"
+      echo "  --postgres, -p <url>   Set PostgreSQL database URL (sets both PH_REACTOR_DATABASE_URL and DATABASE_URL)"
+      echo "  --help, -h              Show this help message"
       echo ""
       echo "All other options are passed to switchboard."
       exit 0


### PR DESCRIPTION

**Shorter version with examples:**

## What's changed?

- Added `--mode/-m` and `--postgres/-p` flags to `switchboard-pyroscope.sh` for storage mode and database configuration
- Added graceful shutdown handling with signal forwarding
- Added `docker-compose.yml` for PostgreSQL and Pyroscope services

## Why make the change?

- Enable easy performance comparison between v2 and legacy storage implementations
- Support PostgreSQL-backed profiling for more realistic production scenarios
- Simplify profiling workflow with unified configuration flags and Docker Compose setup
- Ensure proper cleanup with graceful shutdown handling

## Example Usage

```bash
# Start services
docker compose -f scripts/profiling/docker-compose.yml up -d  --wait

# Run with v2 storage (default)
./scripts/profiling/switchboard-pyroscope.sh

# Run with legacy storage
./scripts/profiling/switchboard-pyroscope.sh -m legacy

# Run with PostgreSQL
./scripts/profiling/switchboard-pyroscope.sh -p postgresql://postgres:postgres@localhost:5432/postgres

# Combine options
./scripts/profiling/switchboard-pyroscope.sh -m v2 -p postgresql://postgres:postgres@localhost:5432/postgres

# Teardown
docker compose -f scripts/profiling/docker-compose.yml down -v
```

View profiling data at http://localhost:4040