### PR TITLE
Feat/profile min max

### DIFF
--- a/scripts/profiling/docs-create.ts
+++ b/scripts/profiling/docs-create.ts
@@ -154,7 +154,6 @@ interface OperationTiming {
 }
 
 interface OperationsResult {
-  timings: OperationTiming[];
   minOp: OperationTiming | null;
   maxOp: OperationTiming | null;
 }
@@ -167,7 +166,6 @@ async function performOperations(
   totalDocs: number,
   onProgress: (opNum: number, action: object, durationMs: number) => void,
 ): Promise<OperationsResult> {
-  const timings: OperationTiming[] = [];
   let minOp: OperationTiming | null = null;
   let maxOp: OperationTiming | null = null;
 
@@ -181,7 +179,6 @@ async function performOperations(
     const durationMs = Date.now() - opStart;
 
     const timing: OperationTiming = { opIndex: i + 1, durationMs, action };
-    timings.push(timing);
 
     if (minOp === null || durationMs < minOp.durationMs) {
       minOp = timing;
@@ -193,7 +190,7 @@ async function performOperations(
     onProgress(i + 1, action, durationMs);
   }
 
-  return { timings, minOp, maxOp };
+  return { minOp, maxOp };
 }
 
 function parseArgs(args: string[]): {

--- a/scripts/profiling/docs-create.ts
+++ b/scripts/profiling/docs-create.ts
@@ -197,7 +197,6 @@ async function performOperations(
   documentId: string,
   docIndex: number,
   operationCount: number,
-  totalDocs: number,
   onProgress: (opNum: number, action: object, durationMs: number) => void,
 ): Promise<OperationsResult> {
   let minOp: OperationTiming | null = null;
@@ -448,7 +447,6 @@ async function main() {
           docId,
           docNum,
           operations,
-          docCount,
           (opNum, action, durationMs) => {
             if (verbose) {
               console.log(

--- a/scripts/profiling/docs-create.ts
+++ b/scripts/profiling/docs-create.ts
@@ -165,8 +165,13 @@ function calculatePercentiles(durations: number[]): Percentiles | null {
 
   const sorted = [...durations].sort((a, b) => a - b);
   const percentile = (p: number): number => {
-    const index = Math.ceil((p / 100) * sorted.length) - 1;
-    return sorted[Math.max(0, index)];
+    const pos = (p / 100) * (sorted.length - 1);
+    const lower = Math.floor(pos);
+    const upper = Math.ceil(pos);
+    const weight = pos - lower;
+
+    if (lower === upper) return sorted[lower];
+    return Math.round(sorted[lower] * (1 - weight) + sorted[upper] * weight);
   };
 
   return {

--- a/scripts/profiling/docs-create.ts
+++ b/scripts/profiling/docs-create.ts
@@ -259,9 +259,39 @@ Examples:
   tsx docs-create.ts 5 -o 3 --verbose
 `);
       process.exit(0);
-    } else if (!isNaN(Number(arg))) {
+    } else if (!isNaN(Number(arg)) && arg.trim() !== "") {
       count = Number(arg);
+    } else {
+      console.error(`Error: Unrecognized argument: ${arg}`);
+      console.error("Use --help for usage information.");
+      process.exit(1);
     }
+  }
+
+  // Validate numeric inputs
+  if (count < 0) {
+    console.error(`Error: Document count must be a non-negative integer.`);
+    process.exit(1);
+  }
+
+  if (isNaN(operations) || operations < 0) {
+    console.error(
+      `Error: Invalid operations value: must be a non-negative integer.`,
+    );
+    process.exit(1);
+  }
+
+  if (isNaN(opLoops) || opLoops < 1) {
+    console.error(
+      `Error: Invalid op-loops value: must be a positive integer (>= 1).`,
+    );
+    process.exit(1);
+  }
+
+  if (operations === 0 && opLoops > 1) {
+    console.warn(
+      `Warning: --op-loops=${opLoops} has no effect when operations is 0.`,
+    );
   }
 
   return {


### PR DESCRIPTION
## What's changed?                                                                                                          

  - Added min/max operation timing tracking for performance analysis
  - Added `--op-loops/-`l flag to repeat operation sets multiple times
  - Added `--doc-id/-d flag` to use existing documents instead of creating new ones
  - Added `--percentiles/-p` flag to show p50, p90, p95, p99 timing statistics
  - Added input validation for numeric arguments
  - Removed unused timings array to prevent memory bloat

 ## Why make the change?                                                                                                     

  - Enable identification of performance outliers with min/max timing
  - Support stress testing with repeated operation loops
  - Allow profiling operations on existing documents for workflow flexibility
  - Provide percentile statistics for deeper performance distribution analysis
  - Improve error handling with input validation
  - Optimize memory usage during extended profiling sessions

  ## Example Usage

```
# Basic with min/max timing
tsx scripts/profiling/docs-create.ts 10 -o 5

# Operation loops for stress testing
tsx scripts/profiling/docs-create.ts 5 -o 10 -l 3

# Use existing documents
tsx scripts/profiling/docs-create.ts -d abc123 -o 25 -l 100

# With percentile statistics
tsx scripts/profiling/docs-create.ts 5 -o 25 -l 10 -p
```