### PR TITLE
feat: trigger powerhouse-demo after monorepo release

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -108,3 +108,67 @@ jobs:
     needs: build-and-publish
     uses: "./.github/workflows/publish-docker-images.yml"
     secrets: inherit
+
+  determine-downstream-params:
+    name: Determine Downstream Parameters
+    needs: [build-and-publish, publish-docker]
+    if: ${{ inputs.dry-run != true }}
+    runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.params.outputs.channel }}
+      version: ${{ steps.params.outputs.version }}
+      skip: ${{ steps.params.outputs.skip }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine channel and version
+        id: params
+        run: |
+          # Determine channel based on branch
+          # main = dev, release/staging/* = staging, release/production/* = latest
+          BRANCH="${{ github.ref_name }}"
+          if [[ "$BRANCH" == "main" ]]; then
+            CHANNEL="dev"
+          elif [[ "$BRANCH" == release/staging/* ]]; then
+            CHANNEL="staging"
+          elif [[ "$BRANCH" == release/production/* ]]; then
+            CHANNEL="latest"
+          else
+            echo "Unknown branch pattern: $BRANCH, skipping downstream trigger"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Get the latest version tag for this channel
+          if [[ "$CHANNEL" == "dev" ]]; then
+            VERSION=$(git tag --sort=-v:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+-dev\.[0-9]+$" | head -1)
+          elif [[ "$CHANNEL" == "staging" ]]; then
+            VERSION=$(git tag --sort=-v:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+-staging\.[0-9]+$" | head -1)
+          else
+            VERSION=$(git tag --sort=-v:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | head -1)
+          fi
+
+          if [[ -z "$VERSION" ]]; then
+            echo "Could not determine version for channel $CHANNEL"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+          echo "Triggering downstream with channel=$CHANNEL version=$VERSION"
+
+  trigger-downstream:
+    name: Trigger Downstream Packages
+    needs: determine-downstream-params
+    if: ${{ needs.determine-downstream-params.outputs.skip != 'true' }}
+    uses: ./.github/workflows/trigger-downstream-packages.yml
+    with:
+      version: ${{ needs.determine-downstream-params.outputs.version }}
+      channel: ${{ needs.determine-downstream-params.outputs.channel }}
+      dry-run: false
+    secrets: inherit

--- a/.github/workflows/trigger-downstream-packages.yml
+++ b/.github/workflows/trigger-downstream-packages.yml
@@ -48,9 +48,8 @@ jobs:
         package:
           - repo: powerhouse-inc/renown-package
             name: renown-package
-          # Add more packages as needed:
-          # - repo: powerhouse-inc/other-package
-          #   name: other-package
+          - repo: powerhouse-inc/powerhouse-demo
+            name: powerhouse-demo
     steps:
       - name: Trigger ${{ matrix.package.name }}
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
## Summary
- Adds `powerhouse-demo` to the downstream packages that get triggered after a monorepo release
- Adds a new job to `release-branch.yml` that triggers downstream packages after Docker images are published

## Channel Mapping
- `main` branch → `dev` channel
- `release/staging/*` branches → `staging` channel  
- `release/production/*` branches → `latest` channel

## Changes
1. **trigger-downstream-packages.yml**: Added `powerhouse-inc/powerhouse-demo` to the matrix
2. **release-branch.yml**: Added `determine-downstream-params` and `trigger-downstream` jobs

## Test Plan
- [ ] Run release on `main` branch and verify powerhouse-demo workflow is triggered with `dev` channel
- [ ] Run release on `release/staging/*` branch and verify powerhouse-demo workflow is triggered with `staging` channel