### PR TITLE
Perf/get doc last

### DIFF
--- a/packages/document-model/src/core/documents.ts
+++ b/packages/document-model/src/core/documents.ts
@@ -344,6 +344,7 @@ export function replayDocument<TState extends PHBaseState = PHBaseState>(
         result = updateHeaderRevision(
           result,
           lastOperation.action.scope,
+          lastOperation.timestampUtcMs,
         ) as PHDocument<TState>;
       }
     }
@@ -1147,13 +1148,15 @@ function getNextRevision(document: PHDocument, scope: string) {
  * Updates the document header with the latest revision number and
  * date of last modification.
  *
- * @param state The current state of the document.
- * @param operation The action being applied to the document.
+ * @param document The current state of the document.
+ * @param scope The scope of the operation.
+ * @param lastModifiedTimestamp Optional timestamp to use directly, avoiding a scan of all operations.
  * @returns The updated document state.
  */
 export function updateHeaderRevision(
   document: PHDocument,
   scope: string,
+  lastModifiedTimestamp?: string,
 ): PHDocument {
   const header: PHDocumentHeader = {
     ...document.header,
@@ -1161,7 +1164,8 @@ export function updateHeaderRevision(
       ...document.header.revision,
       [scope]: getNextRevision(document, scope),
     },
-    lastModifiedAtUtcIso: getDocumentLastModified(document),
+    lastModifiedAtUtcIso:
+      lastModifiedTimestamp ?? getDocumentLastModified(document),
   };
 
   return {

--- a/packages/document-model/src/core/documents.ts
+++ b/packages/document-model/src/core/documents.ts
@@ -1173,7 +1173,8 @@ export function updateHeaderRevision(
       [scope]: getNextRevision(document, scope),
     },
     lastModifiedAtUtcIso:
-      !currentTimestamp || newTimestamp > currentTimestamp
+      !currentTimestamp ||
+      new Date(newTimestamp).getTime() > new Date(currentTimestamp).getTime()
         ? newTimestamp
         : currentTimestamp,
   };

--- a/packages/document-model/src/core/documents.ts
+++ b/packages/document-model/src/core/documents.ts
@@ -1139,9 +1139,13 @@ export function getDocumentLastModified(document: PHDocument) {
  */
 function getNextRevision(document: PHDocument, scope: string) {
   const scopeOperations = document.operations[scope];
-  const latestOperationIndex = scopeOperations?.at(-1)?.index ?? -1;
-
-  return (latestOperationIndex ?? -1) + 1;
+  let maxIndex = -1;
+  if (scopeOperations) {
+    for (const op of scopeOperations) {
+      if (op.index > maxIndex) maxIndex = op.index;
+    }
+  }
+  return maxIndex + 1;
 }
 
 /**

--- a/packages/document-model/src/core/documents.ts
+++ b/packages/document-model/src/core/documents.ts
@@ -1158,6 +1158,10 @@ export function updateHeaderRevision(
   scope: string,
   lastModifiedTimestamp?: string,
 ): PHDocument {
+  const newTimestamp =
+    lastModifiedTimestamp ?? getDocumentLastModified(document);
+  const currentTimestamp = document.header.lastModifiedAtUtcIso;
+
   const header: PHDocumentHeader = {
     ...document.header,
     revision: {
@@ -1165,7 +1169,9 @@ export function updateHeaderRevision(
       [scope]: getNextRevision(document, scope),
     },
     lastModifiedAtUtcIso:
-      lastModifiedTimestamp ?? getDocumentLastModified(document),
+      !currentTimestamp || newTimestamp > currentTimestamp
+        ? newTimestamp
+        : currentTimestamp,
   };
 
   return {

--- a/packages/document-model/src/core/reducer.ts
+++ b/packages/document-model/src/core/reducer.ts
@@ -206,7 +206,7 @@ export function updateDocument<TDocument extends PHDocument>(
     ) as TDocument;
   }
 
-  newDocument = updateHeaderRevision(newDocument, action.scope) as TDocument;
+  newDocument = updateHeaderRevision(newDocument, action.scope, action.timestampUtcMs) as TDocument;
   return newDocument;
 }
 

--- a/packages/document-model/test/document-helpers/headerRevision.test.ts
+++ b/packages/document-model/test/document-helpers/headerRevision.test.ts
@@ -1,0 +1,313 @@
+import type { Operation } from "document-model";
+import {
+  baseCreateDocument,
+  getDocumentLastModified,
+  updateHeaderRevision,
+} from "document-model/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultPHDocumentCreateState, fakeOperation } from "../helpers.js";
+
+function createTestDocument() {
+  return baseCreateDocument(defaultPHDocumentCreateState);
+}
+
+describe("getDocumentLastModified", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns header timestamp when no operations exist", () => {
+    const doc = createTestDocument();
+    doc.operations = { global: [], local: [] };
+
+    const result = getDocumentLastModified(doc);
+
+    expect(result).toBe(doc.header.lastModifiedAtUtcIso);
+  });
+
+  it("returns latest operation timestamp by index", () => {
+    const doc = createTestDocument();
+
+    vi.setSystemTime(new Date("2024-01-15T13:00:00.000Z"));
+    const op0 = fakeOperation(0, 0, "global");
+
+    vi.setSystemTime(new Date("2024-01-15T14:00:00.000Z"));
+    const op1 = fakeOperation(1, 0, "global");
+
+    doc.operations = { global: [op0, op1], local: [] };
+
+    const result = getDocumentLastModified(doc);
+
+    expect(result).toBe(op1.timestampUtcMs);
+  });
+
+  it("uses skip as tiebreaker when index is equal", () => {
+    const doc = createTestDocument();
+
+    vi.setSystemTime(new Date("2024-01-15T13:00:00.000Z"));
+    const opSkip0 = fakeOperation(0, 0, "global");
+
+    vi.setSystemTime(new Date("2024-01-15T14:00:00.000Z"));
+    const opSkip1 = fakeOperation(0, 1, "global");
+
+    doc.operations = { global: [opSkip0, opSkip1], local: [] };
+
+    const result = getDocumentLastModified(doc);
+
+    expect(result).toBe(opSkip1.timestampUtcMs);
+  });
+
+  it("finds latest across multiple scopes", () => {
+    const doc = createTestDocument();
+
+    vi.setSystemTime(new Date("2024-01-15T13:00:00.000Z"));
+    const globalOp = fakeOperation(0, 0, "global");
+
+    vi.setSystemTime(new Date("2024-01-15T14:00:00.000Z"));
+    const localOp = fakeOperation(1, 0, "local");
+
+    doc.operations = { global: [globalOp], local: [localOp] };
+
+    const result = getDocumentLastModified(doc);
+
+    expect(result).toBe(localOp.timestampUtcMs);
+  });
+
+  it("falls back to header timestamp when operations have empty timestampUtcMs", () => {
+    const doc = createTestDocument();
+
+    const op = fakeOperation(0, 0, "global");
+    op.timestampUtcMs = "";
+
+    doc.operations = { global: [op], local: [] };
+
+    const result = getDocumentLastModified(doc);
+
+    expect(result).toBe(doc.header.lastModifiedAtUtcIso);
+  });
+
+  it("falls back to header timestamp when operations have undefined timestampUtcMs", () => {
+    const doc = createTestDocument();
+
+    const op = fakeOperation(0, 0, "global");
+    op.timestampUtcMs = undefined as unknown as string;
+
+    doc.operations = { global: [op], local: [] };
+
+    const result = getDocumentLastModified(doc);
+
+    expect(result).toBe(doc.header.lastModifiedAtUtcIso);
+  });
+
+  it("skips undefined scope arrays in operations", () => {
+    const doc = createTestDocument();
+
+    vi.setSystemTime(new Date("2024-01-15T14:00:00.000Z"));
+    const op = fakeOperation(0, 0, "local");
+
+    doc.operations = {
+      global: undefined as unknown as Operation[],
+      local: [op],
+    };
+
+    const result = getDocumentLastModified(doc);
+
+    expect(result).toBe(op.timestampUtcMs);
+  });
+
+  it("selects by index not by timestamp", () => {
+    const doc = createTestDocument();
+
+    // Higher-index op gets an OLDER timestamp
+    vi.setSystemTime(new Date("2024-01-15T15:00:00.000Z"));
+    const op0 = fakeOperation(0, 0, "global");
+
+    vi.setSystemTime(new Date("2024-01-15T13:00:00.000Z"));
+    const op1 = fakeOperation(1, 0, "global");
+
+    doc.operations = { global: [op0, op1], local: [] };
+
+    const result = getDocumentLastModified(doc);
+
+    // Should return op1's (older) timestamp because it has the higher index
+    expect(result).toBe(op1.timestampUtcMs);
+    expect(result).not.toBe(op0.timestampUtcMs);
+  });
+
+  it("returns operation timestamp even when it is earlier than header timestamp", () => {
+    // Header created at 12:00
+    const doc = createTestDocument();
+    const headerTimestamp = doc.header.lastModifiedAtUtcIso;
+
+    // Operation has a timestamp earlier than the header
+    vi.setSystemTime(new Date("2024-01-15T10:00:00.000Z"));
+    const op = fakeOperation(0, 0, "global");
+    doc.operations = { global: [op], local: [] };
+
+    const result = getDocumentLastModified(doc);
+
+    // Returns the operation's earlier timestamp, not the header's
+    expect(result).toBe(op.timestampUtcMs);
+    expect(result < headerTimestamp).toBe(true);
+  });
+});
+
+describe("updateHeaderRevision", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("updates revision for the given scope", () => {
+    const doc = createTestDocument();
+    const op = fakeOperation(0, 0, "global");
+    doc.operations = { global: [op], local: [] };
+
+    const updated = updateHeaderRevision(doc, "global");
+
+    expect(updated.header.revision.global).toBe(1);
+  });
+
+  it("uses provided timestamp when available", () => {
+    const doc = createTestDocument();
+    const explicitTimestamp = "2024-06-01T00:00:00.000Z";
+
+    const updated = updateHeaderRevision(doc, "global", explicitTimestamp);
+
+    expect(updated.header.lastModifiedAtUtcIso).toBe(explicitTimestamp);
+  });
+
+  it("scans operations when timestamp not provided", () => {
+    const doc = createTestDocument();
+
+    vi.setSystemTime(new Date("2024-06-01T00:00:00.000Z"));
+    const op = fakeOperation(0, 0, "global");
+    doc.operations = { global: [op], local: [] };
+
+    const updated = updateHeaderRevision(doc, "global");
+
+    expect(updated.header.lastModifiedAtUtcIso).toBe(op.timestampUtcMs);
+  });
+
+  it("prevents timestamp regression with explicit timestamp", () => {
+    const futureTimestamp = "2025-01-01T00:00:00.000Z";
+    const doc = createTestDocument();
+    const docWithFutureHeader = {
+      ...doc,
+      header: { ...doc.header, lastModifiedAtUtcIso: futureTimestamp },
+    };
+
+    const olderTimestamp = "2024-06-01T00:00:00.000Z";
+    const updated = updateHeaderRevision(
+      docWithFutureHeader,
+      "global",
+      olderTimestamp,
+    );
+
+    expect(updated.header.lastModifiedAtUtcIso).toBe(futureTimestamp);
+  });
+
+  it("prevents timestamp regression when scanning operations", () => {
+    const doc = createTestDocument();
+    // Set header to a future timestamp
+    const futureTimestamp = "2025-01-01T00:00:00.000Z";
+    doc.header.lastModifiedAtUtcIso = futureTimestamp;
+
+    // Add an operation with a timestamp older than the header
+    vi.setSystemTime(new Date("2024-03-01T00:00:00.000Z"));
+    const op = fakeOperation(0, 0, "global");
+    doc.operations = { global: [op], local: [] };
+
+    // Omit explicit timestamp — forces scan via getDocumentLastModified
+    const updated = updateHeaderRevision(doc, "global");
+
+    expect(updated.header.lastModifiedAtUtcIso).toBe(futureTimestamp);
+  });
+
+  it("advances timestamp when new is later", () => {
+    const doc = createTestDocument();
+    doc.header.lastModifiedAtUtcIso = "2023-01-01T00:00:00.000Z";
+
+    const newerTimestamp = "2024-06-01T00:00:00.000Z";
+    const updated = updateHeaderRevision(doc, "global", newerTimestamp);
+
+    expect(updated.header.lastModifiedAtUtcIso).toBe(newerTimestamp);
+  });
+
+  it("sets timestamp when header has no current timestamp", () => {
+    const doc = createTestDocument();
+    doc.header.lastModifiedAtUtcIso = "";
+
+    const newTimestamp = "2024-06-01T00:00:00.000Z";
+    const updated = updateHeaderRevision(doc, "global", newTimestamp);
+
+    expect(updated.header.lastModifiedAtUtcIso).toBe(newTimestamp);
+  });
+
+  it("preserves revision for other scopes", () => {
+    const doc = createTestDocument();
+    const op = fakeOperation(0, 0, "global");
+    doc.operations = { global: [op], local: [] };
+    doc.header.revision = { global: 5, local: 3 };
+
+    const updated = updateHeaderRevision(
+      doc,
+      "global",
+      "2024-06-01T00:00:00.000Z",
+    );
+
+    expect(updated.header.revision.global).toBe(1);
+    expect(updated.header.revision.local).toBe(3);
+  });
+
+  it("computes revision from last operation index", () => {
+    const doc = createTestDocument();
+    const op0 = fakeOperation(0, 0, "global");
+    const op1 = fakeOperation(1, 0, "global");
+    const op2 = fakeOperation(2, 0, "global");
+    doc.operations = { global: [op0, op1, op2], local: [] };
+
+    const updated = updateHeaderRevision(
+      doc,
+      "global",
+      "2024-06-01T00:00:00.000Z",
+    );
+
+    expect(updated.header.revision.global).toBe(3);
+  });
+
+  it("sets revision to 0 when scope has no operations", () => {
+    const doc = createTestDocument();
+    doc.operations = { global: [], local: [] };
+
+    const updated = updateHeaderRevision(
+      doc,
+      "local",
+      "2024-06-01T00:00:00.000Z",
+    );
+
+    expect(updated.header.revision.local).toBe(0);
+  });
+
+  it("sets revision to 0 when scope is missing from operations", () => {
+    const doc = createTestDocument();
+    doc.operations = { global: [] };
+
+    const updated = updateHeaderRevision(
+      doc,
+      "local",
+      "2024-06-01T00:00:00.000Z",
+    );
+
+    expect(updated.header.revision.local).toBe(0);
+  });
+});

--- a/packages/document-model/test/document-helpers/headerRevision.test.ts
+++ b/packages/document-model/test/document-helpers/headerRevision.test.ts
@@ -233,6 +233,21 @@ describe("updateHeaderRevision", () => {
     expect(updated.header.lastModifiedAtUtcIso).toBe(futureTimestamp);
   });
 
+  it("compares timestamps correctly when precision differs", () => {
+    const doc = createTestDocument();
+    // Header has millisecond precision
+    const currentTimestamp = "2025-01-01T00:00:00.000Z";
+    doc.header.lastModifiedAtUtcIso = currentTimestamp;
+
+    // New timestamp lacks milliseconds — same instant, but lexicographically
+    // "Z" (90) > "." (46) would make string comparison treat it as later
+    const sameInstantNoMs = "2025-01-01T00:00:00Z";
+    const updated = updateHeaderRevision(doc, "global", sameInstantNoMs);
+
+    // Should keep the current timestamp since they represent the same instant
+    expect(updated.header.lastModifiedAtUtcIso).toBe(currentTimestamp);
+  });
+
   it("advances timestamp when new is later", () => {
     const doc = createTestDocument();
     doc.header.lastModifiedAtUtcIso = "2023-01-01T00:00:00.000Z";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8296,35 +8296,20 @@ packages:
       '@powerhousedao/analytics-engine-core': 0.5.0
       '@powerhousedao/analytics-engine-knex': 0.5.1
 
-<<<<<<< HEAD
   '@powerhousedao/builder-tools@6.0.0-dev.33':
     resolution: {integrity: sha512-ecduKiZQyTv+CKHOMoOF+Gq0uWykpCL3HdxEQYwxs/aX/PWS/gcjLl/ToyNUz1XDSu0DdEEPt5qy1sFj3aRsVQ==}
-=======
-  '@powerhousedao/builder-tools@6.0.0-dev.31':
-    resolution: {integrity: sha512-3VQnf0hGOTWvwmy7I2XwOJgez65nn++TUJnEvl3c470BewxRPs0AT+hkKOmtEXbF003AR6SktN2tmkg40lEOkg==}
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     peerDependencies:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
-<<<<<<< HEAD
   '@powerhousedao/common@6.0.0-dev.33':
     resolution: {integrity: sha512-XBVWgA2mKYtVL2GeEk5GDdeaTTD1uzcNcrqlvlLElNOs9r5YymxcZfV5sw9ooRzamrVZV8nABtXUwDyvohs07g==}
-=======
-  '@powerhousedao/common@6.0.0-dev.31':
-    resolution: {integrity: sha512-VylQ4jZ/NaBsKiEADxAQehJmp4UahFiW9H0uRO0oc2Hf9hHYAjU2Nl3SHahpqmTUn6XgOH8K9FuKkV1wG+KKdQ==}
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     peerDependencies:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
-<<<<<<< HEAD
   '@powerhousedao/config@6.0.0-dev.33':
     resolution: {integrity: sha512-R44ZcmZtMjvrBBxzEL0y/O+QY+gXvSnAWPBnr2nzmphLN7JbZP4REg2T8IQIzhGeR3LUExXqOigjcZBy3Wt0Lg==}
-=======
-  '@powerhousedao/config@6.0.0-dev.31':
-    resolution: {integrity: sha512-ZTlTWw0V/uYX8u/NjJMhksL03hf9JC4xXdTh02OcnytzFEfGGtP87UGuWzGdklM3E4d4CT8JhHn5FwxO4lsBhA==}
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
 
   '@powerhousedao/design-system@1.40.2':
     resolution: {integrity: sha512-AnMwstM405qLQcf0oliD7Zt/FTxX/nTnO1aKTtCPROJONT7xnJSeqp7bbqy/3qxAkq5erTDX6LA6aCD4+qwrEA==}
@@ -8332,13 +8317,8 @@ packages:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-<<<<<<< HEAD
   '@powerhousedao/design-system@6.0.0-dev.33':
     resolution: {integrity: sha512-eUm6K+3830aoqy5zt6s6dXek/QIw8ELuIYsFW2HdfMaDSQ8+SFmFnjY7ngkdYwDiUBdFSIBHlehuUux8K51aDA==}
-=======
-  '@powerhousedao/design-system@6.0.0-dev.31':
-    resolution: {integrity: sha512-UqEPfTMJV/SI/ZkxAWMfH1c5VAR6TZErpBYg6ZuNRf42uKCOos26x8PMAT4To74oWl/Es70v4A6PoulrpSiCIQ==}
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     peerDependencies:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
@@ -8355,24 +8335,14 @@ packages:
       react: ^19.2.0
       react-dom: ^19.2.0
 
-<<<<<<< HEAD
   '@powerhousedao/reactor-browser@6.0.0-dev.33':
     resolution: {integrity: sha512-cbLNE6vY+Swhs20kOmldvG8/WqOkt1zJ1I7XPs2+d/AxN/cXuHHPyQZoeeyaxNY/mEY7G02XtqQVVjMKmtmjwA==}
-=======
-  '@powerhousedao/reactor-browser@6.0.0-dev.31':
-    resolution: {integrity: sha512-a3CT78uXcw3XV7ncJBeA13YuNesevKiyrl+I7y4xug3pVsywsRp0jU+Oc67LbM1lDZrxd+Pi/k5zQP+X+V9y7A==}
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     peerDependencies:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
-<<<<<<< HEAD
   '@powerhousedao/reactor@6.0.0-dev.33':
     resolution: {integrity: sha512-eBOFlKOBYks0sgVtqomsExaD13b8Ms4/a5L/zZtzlLalLP6W+4DdU+orheDJGL1DvnuBGlxNOWaELJchr4uIMw==}
-=======
-  '@powerhousedao/reactor@6.0.0-dev.31':
-    resolution: {integrity: sha512-7eF82Bs3tilDe9q1jL3ucekDyFYGso1OOyJ9EeVEJFWjvLFREdjW8ovRnxRIbqu9yvKgmFp4S5Skb7stmP6Irw==}
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
 
   '@powerhousedao/scalars@2.0.1':
     resolution: {integrity: sha512-LKDGuKAg5NJiYO5/2AFwfBeJg2kIRCD4UTUEWqIK/YQeVdXLC5ps92TsW1ga+XcZ+8IYwh8/e3oq3XH4x6N6dg==}
@@ -9074,19 +9044,11 @@ packages:
     resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
     engines: {node: '>=14.0.0'}
 
-<<<<<<< HEAD
   '@renown/sdk@6.0.0-dev.33':
     resolution: {integrity: sha512-L4TwrnFg7bC22xbkx/inKIe0Lyf8r3HuYnMawauOzqVZQA7YSGAa7ipKxxXr2SsYsQc5pnCy6EhJ5VInKMgMGw==}
     peerDependencies:
       '@powerhousedao/reactor': 6.0.0-dev.33
       document-model: 6.0.0-dev.33
-=======
-  '@renown/sdk@6.0.0-dev.31':
-    resolution: {integrity: sha512-qFR73jTVcrVbT5IyQfk24iFv7sMJByGNjzLieRo472bV7s4os1nz3j0bg+biqTl5hvZQI2VTfYLwcJDDvKHTpA==}
-    peerDependencies:
-      '@powerhousedao/reactor': 6.0.0-dev.31
-      document-model: 6.0.0-dev.31
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       react: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       react:
@@ -31183,11 +31145,7 @@ snapshots:
       - supports-color
       - tedious
 
-<<<<<<< HEAD
   '@powerhousedao/builder-tools@6.0.0-dev.33(ab1051dafb0267ca1709a3fed67c64ad)':
-=======
-  '@powerhousedao/builder-tools@6.0.0-dev.31(a78b3c950db1f87d290b16f5e5d20202)':
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/commands': 6.8.1
@@ -31202,17 +31160,10 @@ snapshots:
       '@graphql-tools/schema': 10.0.30(graphql@16.12.0)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
       '@hookform/resolvers': 5.2.2(react-hook-form@7.66.0(react@19.2.0))
-<<<<<<< HEAD
       '@powerhousedao/config': 6.0.0-dev.33(@types/node@24.10.0)
       '@powerhousedao/design-system': 6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@powerhousedao/document-engineering': 1.40.1(@types/express@4.17.25)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@powerhousedao/reactor-browser': 6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-=======
-      '@powerhousedao/config': 6.0.0-dev.31(@types/node@24.10.0)
-      '@powerhousedao/design-system': 6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@powerhousedao/document-engineering': 1.40.1(@types/express@4.17.25)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@powerhousedao/reactor-browser': 6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       '@prettier/sync': 0.5.5(prettier@3.6.2)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-icons': 1.3.2(react@19.2.0)
@@ -31320,19 +31271,11 @@ snapshots:
       - vite
       - ws
 
-<<<<<<< HEAD
   '@powerhousedao/common@6.0.0-dev.33(1239385e61fcf8d9c3ed155e99dc276d)':
     dependencies:
       '@powerhousedao/analytics-engine-core': 0.5.0
       '@powerhousedao/builder-tools': 6.0.0-dev.33(ab1051dafb0267ca1709a3fed67c64ad)
       '@powerhousedao/design-system': 6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-=======
-  '@powerhousedao/common@6.0.0-dev.31(4ec50757caa4e0f4301ba2beb6fae1b6)':
-    dependencies:
-      '@powerhousedao/analytics-engine-core': 0.5.0
-      '@powerhousedao/builder-tools': 6.0.0-dev.31(a78b3c950db1f87d290b16f5e5d20202)
-      '@powerhousedao/design-system': 6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       '@tanstack/react-virtual': 3.13.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/luxon': 3.7.1
       chalk: 5.6.2
@@ -31408,11 +31351,7 @@ snapshots:
       - vite
       - ws
 
-<<<<<<< HEAD
   '@powerhousedao/config@6.0.0-dev.33(@types/node@24.10.0)':
-=======
-  '@powerhousedao/config@6.0.0-dev.31(@types/node@24.10.0)':
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     dependencies:
       '@microsoft/api-extractor': 7.54.0(@types/node@24.10.0)
     transitivePeerDependencies:
@@ -31500,19 +31439,11 @@ snapshots:
       - utf-8-validate
       - ws
 
-<<<<<<< HEAD
   '@powerhousedao/design-system@6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@internationalized/date': 3.10.0
       '@powerhousedao/document-engineering': 1.40.1(@types/express@4.17.25)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@powerhousedao/reactor-browser': 6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-=======
-  '@powerhousedao/design-system@6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@internationalized/date': 3.10.0
-      '@powerhousedao/document-engineering': 1.40.1(@types/express@4.17.25)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@powerhousedao/reactor-browser': 6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -31712,25 +31643,15 @@ snapshots:
       - typescript
       - utf-8-validate
 
-<<<<<<< HEAD
   '@powerhousedao/reactor-browser@6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-=======
-  '@powerhousedao/reactor-browser@6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     dependencies:
       '@electric-sql/pglite': 0.2.17
       '@electric-sql/pglite-react': 0.2.31(@electric-sql/pglite@0.2.17)(react@19.2.0)
       '@powerhousedao/analytics-engine-browser': 0.6.0(@powerhousedao/analytics-engine-core@0.5.0)(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))
       '@powerhousedao/analytics-engine-core': 0.5.0
-<<<<<<< HEAD
       '@powerhousedao/config': 6.0.0-dev.33(@types/node@24.10.0)
       '@powerhousedao/reactor': 6.0.0-dev.33
       '@renown/sdk': 6.0.0-dev.33(@powerhousedao/reactor@6.0.0-dev.33)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-=======
-      '@powerhousedao/config': 6.0.0-dev.31(@types/node@24.10.0)
-      '@powerhousedao/reactor': 6.0.0-dev.31
-      '@renown/sdk': 6.0.0-dev.31(@powerhousedao/reactor@6.0.0-dev.31)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       '@tanstack/react-query': 5.90.7(react@19.2.0)
       change-case: 5.4.4
       did-jwt: 8.0.18
@@ -31764,25 +31685,15 @@ snapshots:
       - utf-8-validate
       - zod
 
-<<<<<<< HEAD
   '@powerhousedao/reactor-browser@6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
-=======
-  '@powerhousedao/reactor-browser@6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     dependencies:
       '@electric-sql/pglite': 0.2.17
       '@electric-sql/pglite-react': 0.2.31(@electric-sql/pglite@0.2.17)(react@19.2.0)
       '@powerhousedao/analytics-engine-browser': 0.6.0(@powerhousedao/analytics-engine-core@0.5.0)(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))
       '@powerhousedao/analytics-engine-core': 0.5.0
-<<<<<<< HEAD
       '@powerhousedao/config': 6.0.0-dev.33(@types/node@24.10.0)
       '@powerhousedao/reactor': 6.0.0-dev.33
       '@renown/sdk': 6.0.0-dev.33(@powerhousedao/reactor@6.0.0-dev.33)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-=======
-      '@powerhousedao/config': 6.0.0-dev.31(@types/node@24.10.0)
-      '@powerhousedao/reactor': 6.0.0-dev.31
-      '@renown/sdk': 6.0.0-dev.31(@powerhousedao/reactor@6.0.0-dev.31)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       '@tanstack/react-query': 5.90.7(react@19.2.0)
       change-case: 5.4.4
       did-jwt: 8.0.18
@@ -31816,11 +31727,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-<<<<<<< HEAD
   '@powerhousedao/reactor@6.0.0-dev.33':
-=======
-  '@powerhousedao/reactor@6.0.0-dev.31':
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     dependencies:
       '@electric-sql/pglite': 0.2.17
       document-drive: link:packages/document-drive
@@ -32558,17 +32465,10 @@ snapshots:
 
   '@remix-run/router@1.23.0': {}
 
-<<<<<<< HEAD
   '@renown/sdk@6.0.0-dev.33(@powerhousedao/reactor@6.0.0-dev.33)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@didtools/key-did': 1.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@powerhousedao/reactor': 6.0.0-dev.33
-=======
-  '@renown/sdk@6.0.0-dev.31(@powerhousedao/reactor@6.0.0-dev.31)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@didtools/key-did': 1.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@powerhousedao/reactor': 6.0.0-dev.31
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       did-jwt: 8.0.18
       did-jwt-vc: 4.0.16
       did-key-creator: 1.2.0
@@ -32584,17 +32484,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-<<<<<<< HEAD
   '@renown/sdk@6.0.0-dev.33(@powerhousedao/reactor@6.0.0-dev.33)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
     dependencies:
       '@didtools/key-did': 1.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@powerhousedao/reactor': 6.0.0-dev.33
-=======
-  '@renown/sdk@6.0.0-dev.31(@powerhousedao/reactor@6.0.0-dev.31)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
-    dependencies:
-      '@didtools/key-did': 1.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@powerhousedao/reactor': 6.0.0-dev.31
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       did-jwt: 8.0.18
       did-jwt-vc: 4.0.16
       did-key-creator: 1.2.0
@@ -33546,17 +33439,10 @@ snapshots:
   '@sky-ph/atlas@2.0.0-canary.1(33ba51ab3c05d97837ef661f40f8ceee)':
     dependencies:
       '@hookform/resolvers': 3.10.0(react-hook-form@7.66.0(react@19.2.0))
-<<<<<<< HEAD
       '@powerhousedao/common': 6.0.0-dev.33(1239385e61fcf8d9c3ed155e99dc276d)
       '@powerhousedao/design-system': 6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@powerhousedao/document-engineering': 1.22.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@powerhousedao/reactor-browser': 6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-=======
-      '@powerhousedao/common': 6.0.0-dev.31(4ec50757caa4e0f4301ba2beb6fae1b6)
-      '@powerhousedao/design-system': 6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@powerhousedao/document-engineering': 1.22.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@powerhousedao/reactor-browser': 6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
->>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-label': 2.1.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2369,6 +2369,9 @@ importers:
         specifier: ^8.14.0
         version: 8.16.3
     devDependencies:
+      '@types/node':
+        specifier: ^22.15.2
+        version: 22.19.0
       '@types/pg':
         specifier: ^8.11.6
         version: 8.15.6
@@ -8293,20 +8296,35 @@ packages:
       '@powerhousedao/analytics-engine-core': 0.5.0
       '@powerhousedao/analytics-engine-knex': 0.5.1
 
+<<<<<<< HEAD
   '@powerhousedao/builder-tools@6.0.0-dev.33':
     resolution: {integrity: sha512-ecduKiZQyTv+CKHOMoOF+Gq0uWykpCL3HdxEQYwxs/aX/PWS/gcjLl/ToyNUz1XDSu0DdEEPt5qy1sFj3aRsVQ==}
+=======
+  '@powerhousedao/builder-tools@6.0.0-dev.31':
+    resolution: {integrity: sha512-3VQnf0hGOTWvwmy7I2XwOJgez65nn++TUJnEvl3c470BewxRPs0AT+hkKOmtEXbF003AR6SktN2tmkg40lEOkg==}
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     peerDependencies:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
+<<<<<<< HEAD
   '@powerhousedao/common@6.0.0-dev.33':
     resolution: {integrity: sha512-XBVWgA2mKYtVL2GeEk5GDdeaTTD1uzcNcrqlvlLElNOs9r5YymxcZfV5sw9ooRzamrVZV8nABtXUwDyvohs07g==}
+=======
+  '@powerhousedao/common@6.0.0-dev.31':
+    resolution: {integrity: sha512-VylQ4jZ/NaBsKiEADxAQehJmp4UahFiW9H0uRO0oc2Hf9hHYAjU2Nl3SHahpqmTUn6XgOH8K9FuKkV1wG+KKdQ==}
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     peerDependencies:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
+<<<<<<< HEAD
   '@powerhousedao/config@6.0.0-dev.33':
     resolution: {integrity: sha512-R44ZcmZtMjvrBBxzEL0y/O+QY+gXvSnAWPBnr2nzmphLN7JbZP4REg2T8IQIzhGeR3LUExXqOigjcZBy3Wt0Lg==}
+=======
+  '@powerhousedao/config@6.0.0-dev.31':
+    resolution: {integrity: sha512-ZTlTWw0V/uYX8u/NjJMhksL03hf9JC4xXdTh02OcnytzFEfGGtP87UGuWzGdklM3E4d4CT8JhHn5FwxO4lsBhA==}
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
 
   '@powerhousedao/design-system@1.40.2':
     resolution: {integrity: sha512-AnMwstM405qLQcf0oliD7Zt/FTxX/nTnO1aKTtCPROJONT7xnJSeqp7bbqy/3qxAkq5erTDX6LA6aCD4+qwrEA==}
@@ -8314,8 +8332,13 @@ packages:
       react: ^18.3.1
       react-dom: ^18.3.1
 
+<<<<<<< HEAD
   '@powerhousedao/design-system@6.0.0-dev.33':
     resolution: {integrity: sha512-eUm6K+3830aoqy5zt6s6dXek/QIw8ELuIYsFW2HdfMaDSQ8+SFmFnjY7ngkdYwDiUBdFSIBHlehuUux8K51aDA==}
+=======
+  '@powerhousedao/design-system@6.0.0-dev.31':
+    resolution: {integrity: sha512-UqEPfTMJV/SI/ZkxAWMfH1c5VAR6TZErpBYg6ZuNRf42uKCOos26x8PMAT4To74oWl/Es70v4A6PoulrpSiCIQ==}
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     peerDependencies:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
@@ -8332,14 +8355,24 @@ packages:
       react: ^19.2.0
       react-dom: ^19.2.0
 
+<<<<<<< HEAD
   '@powerhousedao/reactor-browser@6.0.0-dev.33':
     resolution: {integrity: sha512-cbLNE6vY+Swhs20kOmldvG8/WqOkt1zJ1I7XPs2+d/AxN/cXuHHPyQZoeeyaxNY/mEY7G02XtqQVVjMKmtmjwA==}
+=======
+  '@powerhousedao/reactor-browser@6.0.0-dev.31':
+    resolution: {integrity: sha512-a3CT78uXcw3XV7ncJBeA13YuNesevKiyrl+I7y4xug3pVsywsRp0jU+Oc67LbM1lDZrxd+Pi/k5zQP+X+V9y7A==}
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     peerDependencies:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
+<<<<<<< HEAD
   '@powerhousedao/reactor@6.0.0-dev.33':
     resolution: {integrity: sha512-eBOFlKOBYks0sgVtqomsExaD13b8Ms4/a5L/zZtzlLalLP6W+4DdU+orheDJGL1DvnuBGlxNOWaELJchr4uIMw==}
+=======
+  '@powerhousedao/reactor@6.0.0-dev.31':
+    resolution: {integrity: sha512-7eF82Bs3tilDe9q1jL3ucekDyFYGso1OOyJ9EeVEJFWjvLFREdjW8ovRnxRIbqu9yvKgmFp4S5Skb7stmP6Irw==}
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
 
   '@powerhousedao/scalars@2.0.1':
     resolution: {integrity: sha512-LKDGuKAg5NJiYO5/2AFwfBeJg2kIRCD4UTUEWqIK/YQeVdXLC5ps92TsW1ga+XcZ+8IYwh8/e3oq3XH4x6N6dg==}
@@ -9041,11 +9074,19 @@ packages:
     resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
     engines: {node: '>=14.0.0'}
 
+<<<<<<< HEAD
   '@renown/sdk@6.0.0-dev.33':
     resolution: {integrity: sha512-L4TwrnFg7bC22xbkx/inKIe0Lyf8r3HuYnMawauOzqVZQA7YSGAa7ipKxxXr2SsYsQc5pnCy6EhJ5VInKMgMGw==}
     peerDependencies:
       '@powerhousedao/reactor': 6.0.0-dev.33
       document-model: 6.0.0-dev.33
+=======
+  '@renown/sdk@6.0.0-dev.31':
+    resolution: {integrity: sha512-qFR73jTVcrVbT5IyQfk24iFv7sMJByGNjzLieRo472bV7s4os1nz3j0bg+biqTl5hvZQI2VTfYLwcJDDvKHTpA==}
+    peerDependencies:
+      '@powerhousedao/reactor': 6.0.0-dev.31
+      document-model: 6.0.0-dev.31
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       react: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       react:
@@ -31142,7 +31183,11 @@ snapshots:
       - supports-color
       - tedious
 
+<<<<<<< HEAD
   '@powerhousedao/builder-tools@6.0.0-dev.33(ab1051dafb0267ca1709a3fed67c64ad)':
+=======
+  '@powerhousedao/builder-tools@6.0.0-dev.31(a78b3c950db1f87d290b16f5e5d20202)':
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/commands': 6.8.1
@@ -31157,10 +31202,17 @@ snapshots:
       '@graphql-tools/schema': 10.0.30(graphql@16.12.0)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
       '@hookform/resolvers': 5.2.2(react-hook-form@7.66.0(react@19.2.0))
+<<<<<<< HEAD
       '@powerhousedao/config': 6.0.0-dev.33(@types/node@24.10.0)
       '@powerhousedao/design-system': 6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@powerhousedao/document-engineering': 1.40.1(@types/express@4.17.25)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@powerhousedao/reactor-browser': 6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+=======
+      '@powerhousedao/config': 6.0.0-dev.31(@types/node@24.10.0)
+      '@powerhousedao/design-system': 6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@powerhousedao/document-engineering': 1.40.1(@types/express@4.17.25)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@powerhousedao/reactor-browser': 6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       '@prettier/sync': 0.5.5(prettier@3.6.2)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-icons': 1.3.2(react@19.2.0)
@@ -31268,11 +31320,19 @@ snapshots:
       - vite
       - ws
 
+<<<<<<< HEAD
   '@powerhousedao/common@6.0.0-dev.33(1239385e61fcf8d9c3ed155e99dc276d)':
     dependencies:
       '@powerhousedao/analytics-engine-core': 0.5.0
       '@powerhousedao/builder-tools': 6.0.0-dev.33(ab1051dafb0267ca1709a3fed67c64ad)
       '@powerhousedao/design-system': 6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+=======
+  '@powerhousedao/common@6.0.0-dev.31(4ec50757caa4e0f4301ba2beb6fae1b6)':
+    dependencies:
+      '@powerhousedao/analytics-engine-core': 0.5.0
+      '@powerhousedao/builder-tools': 6.0.0-dev.31(a78b3c950db1f87d290b16f5e5d20202)
+      '@powerhousedao/design-system': 6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       '@tanstack/react-virtual': 3.13.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/luxon': 3.7.1
       chalk: 5.6.2
@@ -31348,7 +31408,11 @@ snapshots:
       - vite
       - ws
 
+<<<<<<< HEAD
   '@powerhousedao/config@6.0.0-dev.33(@types/node@24.10.0)':
+=======
+  '@powerhousedao/config@6.0.0-dev.31(@types/node@24.10.0)':
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     dependencies:
       '@microsoft/api-extractor': 7.54.0(@types/node@24.10.0)
     transitivePeerDependencies:
@@ -31436,11 +31500,19 @@ snapshots:
       - utf-8-validate
       - ws
 
+<<<<<<< HEAD
   '@powerhousedao/design-system@6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@internationalized/date': 3.10.0
       '@powerhousedao/document-engineering': 1.40.1(@types/express@4.17.25)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@powerhousedao/reactor-browser': 6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+=======
+  '@powerhousedao/design-system@6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@internationalized/date': 3.10.0
+      '@powerhousedao/document-engineering': 1.40.1(@types/express@4.17.25)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@powerhousedao/reactor-browser': 6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -31640,15 +31712,25 @@ snapshots:
       - typescript
       - utf-8-validate
 
+<<<<<<< HEAD
   '@powerhousedao/reactor-browser@6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+=======
+  '@powerhousedao/reactor-browser@6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     dependencies:
       '@electric-sql/pglite': 0.2.17
       '@electric-sql/pglite-react': 0.2.31(@electric-sql/pglite@0.2.17)(react@19.2.0)
       '@powerhousedao/analytics-engine-browser': 0.6.0(@powerhousedao/analytics-engine-core@0.5.0)(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))
       '@powerhousedao/analytics-engine-core': 0.5.0
+<<<<<<< HEAD
       '@powerhousedao/config': 6.0.0-dev.33(@types/node@24.10.0)
       '@powerhousedao/reactor': 6.0.0-dev.33
       '@renown/sdk': 6.0.0-dev.33(@powerhousedao/reactor@6.0.0-dev.33)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+=======
+      '@powerhousedao/config': 6.0.0-dev.31(@types/node@24.10.0)
+      '@powerhousedao/reactor': 6.0.0-dev.31
+      '@renown/sdk': 6.0.0-dev.31(@powerhousedao/reactor@6.0.0-dev.31)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       '@tanstack/react-query': 5.90.7(react@19.2.0)
       change-case: 5.4.4
       did-jwt: 8.0.18
@@ -31682,15 +31764,25 @@ snapshots:
       - utf-8-validate
       - zod
 
+<<<<<<< HEAD
   '@powerhousedao/reactor-browser@6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+=======
+  '@powerhousedao/reactor-browser@6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     dependencies:
       '@electric-sql/pglite': 0.2.17
       '@electric-sql/pglite-react': 0.2.31(@electric-sql/pglite@0.2.17)(react@19.2.0)
       '@powerhousedao/analytics-engine-browser': 0.6.0(@powerhousedao/analytics-engine-core@0.5.0)(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))
       '@powerhousedao/analytics-engine-core': 0.5.0
+<<<<<<< HEAD
       '@powerhousedao/config': 6.0.0-dev.33(@types/node@24.10.0)
       '@powerhousedao/reactor': 6.0.0-dev.33
       '@renown/sdk': 6.0.0-dev.33(@powerhousedao/reactor@6.0.0-dev.33)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+=======
+      '@powerhousedao/config': 6.0.0-dev.31(@types/node@24.10.0)
+      '@powerhousedao/reactor': 6.0.0-dev.31
+      '@renown/sdk': 6.0.0-dev.31(@powerhousedao/reactor@6.0.0-dev.31)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       '@tanstack/react-query': 5.90.7(react@19.2.0)
       change-case: 5.4.4
       did-jwt: 8.0.18
@@ -31724,7 +31816,11 @@ snapshots:
       - utf-8-validate
       - zod
 
+<<<<<<< HEAD
   '@powerhousedao/reactor@6.0.0-dev.33':
+=======
+  '@powerhousedao/reactor@6.0.0-dev.31':
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
     dependencies:
       '@electric-sql/pglite': 0.2.17
       document-drive: link:packages/document-drive
@@ -32462,10 +32558,17 @@ snapshots:
 
   '@remix-run/router@1.23.0': {}
 
+<<<<<<< HEAD
   '@renown/sdk@6.0.0-dev.33(@powerhousedao/reactor@6.0.0-dev.33)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@didtools/key-did': 1.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@powerhousedao/reactor': 6.0.0-dev.33
+=======
+  '@renown/sdk@6.0.0-dev.31(@powerhousedao/reactor@6.0.0-dev.31)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+    dependencies:
+      '@didtools/key-did': 1.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@powerhousedao/reactor': 6.0.0-dev.31
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       did-jwt: 8.0.18
       did-jwt-vc: 4.0.16
       did-key-creator: 1.2.0
@@ -32481,10 +32584,17 @@ snapshots:
       - utf-8-validate
       - zod
 
+<<<<<<< HEAD
   '@renown/sdk@6.0.0-dev.33(@powerhousedao/reactor@6.0.0-dev.33)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
     dependencies:
       '@didtools/key-did': 1.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@powerhousedao/reactor': 6.0.0-dev.33
+=======
+  '@renown/sdk@6.0.0-dev.31(@powerhousedao/reactor@6.0.0-dev.31)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+    dependencies:
+      '@didtools/key-did': 1.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@powerhousedao/reactor': 6.0.0-dev.31
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       did-jwt: 8.0.18
       did-jwt-vc: 4.0.16
       did-key-creator: 1.2.0
@@ -33436,10 +33546,17 @@ snapshots:
   '@sky-ph/atlas@2.0.0-canary.1(33ba51ab3c05d97837ef661f40f8ceee)':
     dependencies:
       '@hookform/resolvers': 3.10.0(react-hook-form@7.66.0(react@19.2.0))
+<<<<<<< HEAD
       '@powerhousedao/common': 6.0.0-dev.33(1239385e61fcf8d9c3ed155e99dc276d)
       '@powerhousedao/design-system': 6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@powerhousedao/document-engineering': 1.22.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@powerhousedao/reactor-browser': 6.0.0-dev.33(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+=======
+      '@powerhousedao/common': 6.0.0-dev.31(4ec50757caa4e0f4301ba2beb6fae1b6)
+      '@powerhousedao/design-system': 6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@powerhousedao/document-engineering': 1.22.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@powerhousedao/reactor-browser': 6.0.0-dev.31(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+>>>>>>> perf(document-model): optimize getDocumentLastModified from O(n log n) to O(n)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-label': 2.1.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)

--- a/scripts/profiling/package.json
+++ b/scripts/profiling/package.json
@@ -20,6 +20,7 @@
     "pg": "^8.14.0"
   },
   "devDependencies": {
+    "@types/node": "^22.15.2",
     "@types/pg": "^8.11.6"
   }
 }


### PR DESCRIPTION
## Summary

  - Optimize `getDocumentLastModified` from O(n log n) to O(n) by replacing sorting with a linear scan
  - Further optimize `updateHeaderRevision` hot path from O(n) to O(1) by passing the timestamp directly from call sites
  - Add missing `@types/node` dependency to profiling scripts

## Problem

See https://github.com/powerhouse-inc/powerhouse/pull/2278#issuecomment-3847081667

Pyroscope profiling identified `getDocumentLastModified` as a performance bottleneck. The function was:
1. Creating 3 intermediate arrays (`Object.values`, `flatMap`, `slice`)
2. Sorting all operations twice (O(n log n)) just to get the last one's timestamp
3. Called on every action dispatch via `updateHeaderRevision`

## Solution

**First optimisation:** Replace the sort with a linear scan to find the operation with the highest index/skip:           
  ```typescript                                                                                                            
  // Before: O(n log n) with 3 array allocations                                                                           
  const sortedOperations = sortOperations(                                                                                 
    Object.values(document.operations).flatMap((ops) => ops || []),                                                        
  );                                                                                                                       
  return sortedOperations.at(-1)?.timestampUtcMs;                                                                          
```

  ```ts
  // After: O(n) with zero allocations                                                                                     
  for (const ops of Object.values(document.operations)) {                                                                  
    for (const op of ops) {                                                                                                
      if (!latest || op.index > latest.index || ...) latest = op;                                                          
    }                                                                                                                      
  }                                                                                                                        
  return latest?.timestampUtcMs;       
  ```                                                                                    
                                                                                                                           
Second optimisation: Pass the already-known timestamp from call sites, avoiding the scan entirely in the hot path:
`reducer.ts`: `action.timestampUtcMs` is already available
```ts
updateHeaderRevision(newDocument, action.scope, action.timestampUtcMs);
```

`documents.ts`: `lastOperation.timestampUtcMs` is already available   
```ts                                                   
updateHeaderRevision(result, lastOperation.action.scope, lastOperation.timestampUtcMs);
```

---

Pyroscope shows no hotspots coming from `getDocumentLastModified()`

<img width="2820" height="1034" alt="image" src="https://github.com/user-attachments/assets/44eaabf9-796c-4e59-832e-c9b23035c355" />
<img width="1404" height="607" alt="Screenshot 2026-02-05 at 13 23 27" src="https://github.com/user-attachments/assets/c39a3bd5-8596-4d99-977e-807393bb2d57" />
