### PR TITLE
Add batch mode to reactor-direct profiling script

### DIFF
--- a/scripts/profiling/reactor-direct.ts
+++ b/scripts/profiling/reactor-direct.ts
@@ -15,23 +15,27 @@
  *   - Start Pyroscope: docker compose -f scripts/profiling/docker-compose.yml up pyroscope
  *   - Enable profiling: --pyroscope [server-address]
  *   - View results: http://localhost:4040
+ *
+ * Batch mode:
+ *   - Use --batch-size <N> to send N operations per execute call
+ *   - Default is 1 (each operation in its own call)
+ *   - Use this to measure per-call overhead vs batched execution
  */
 
-import { documentModelDocumentModelModule } from "document-model";
-import {
-  ReactorBuilder,
-  JobStatus,
-  runMigrations,
-  REACTOR_SCHEMA,
-  type IReactor,
-  type Database,
-} from "@powerhousedao/reactor";
-import { Kysely } from "kysely";
 import { PGlite } from "@electric-sql/pglite";
+import {
+  JobStatus,
+  REACTOR_SCHEMA,
+  ReactorBuilder,
+  runMigrations,
+  type Database,
+  type IReactor,
+} from "@powerhousedao/reactor";
+import Pyroscope from "@pyroscope/nodejs";
+import { documentModelDocumentModelModule } from "document-model";
+import { Kysely, PostgresDialect } from "kysely";
 import { PGliteDialect } from "kysely-pglite-dialect";
 import { Pool } from "pg";
-import { PostgresDialect } from "kysely";
-import Pyroscope from "@pyroscope/nodejs";
 
 interface MemoryStats {
   heapUsed: number;
@@ -189,37 +193,62 @@ async function performOperations(
   documentId: string,
   docIndex: number,
   operationCount: number,
-  onProgress: (opNum: number, durationMs: number) => void,
+  batchSize: number,
+  onProgress: (opNum: number, durationMs: number, batchCount: number) => void,
 ): Promise<OperationsResult> {
   let minOp: OperationTiming | null = null;
   let maxOp: OperationTiming | null = null;
   const durations: number[] = [];
 
-  for (let i = 0; i < operationCount; i++) {
-    const { action, actionType } = createAction(docIndex, i + 1);
+  for (let i = 0; i < operationCount; i += batchSize) {
+    const batchEnd = Math.min(i + batchSize, operationCount);
+    const batchCount = batchEnd - i;
+
+    // Build batch of actions
+    const actions = [];
+    const actionTypes: string[] = [];
+    for (let j = i; j < batchEnd; j++) {
+      const { action, actionType } = createAction(docIndex, j + 1);
+      actions.push(action);
+      actionTypes.push(actionType);
+    }
+
     const opStart = Date.now();
 
-    const jobInfo = await reactor.execute(documentId, "main", [action]);
+    const jobInfo = await reactor.execute(documentId, "main", actions);
     if (!jobInfo?.id) {
       throw new Error(
-        `Execute returned invalid job info for operation ${i + 1}`,
+        `Execute returned invalid job info for operations ${i + 1}-${batchEnd}`,
       );
     }
     await waitForJob(reactor, jobInfo.id);
 
-    const durationMs = Date.now() - opStart;
-    durations.push(durationMs);
+    const batchDurationMs = Date.now() - opStart;
+    // Calculate per-operation duration for consistent min/max tracking
+    const perOpDurationMs = batchDurationMs / batchCount;
 
-    const timing: OperationTiming = { opIndex: i + 1, durationMs, actionType };
+    // Store per-operation durations for percentile calculations
+    for (let j = 0; j < batchCount; j++) {
+      durations.push(perOpDurationMs);
+    }
 
-    if (minOp === null || durationMs < minOp.durationMs) {
+    // For min/max tracking, always use per-operation time
+    const actionType =
+      batchCount === 1 ? actionTypes[0] : `batch(${batchCount})`;
+    const timing: OperationTiming = {
+      opIndex: batchEnd,
+      durationMs: perOpDurationMs,
+      actionType,
+    };
+
+    if (minOp === null || perOpDurationMs < minOp.durationMs) {
       minOp = timing;
     }
-    if (maxOp === null || durationMs > maxOp.durationMs) {
+    if (maxOp === null || perOpDurationMs > maxOp.durationMs) {
       maxOp = timing;
     }
 
-    onProgress(i + 1, durationMs);
+    onProgress(batchEnd, batchDurationMs, batchCount);
   }
 
   return { minOp, maxOp, durations };
@@ -229,6 +258,7 @@ function parseArgs(args: string[]): {
   count: number;
   operations: number;
   opLoops: number;
+  batchSize: number;
   verbose: boolean;
   percentiles: boolean;
   showActionTypes: boolean;
@@ -239,6 +269,7 @@ function parseArgs(args: string[]): {
   let count = 10;
   let operations = 0;
   let opLoops = 1;
+  let batchSize = 1;
   let verbose = false;
   let percentiles = false;
   let showActionTypes = false;
@@ -252,6 +283,8 @@ function parseArgs(args: string[]): {
       operations = Number(args[++i]);
     } else if ((arg === "--op-loops" || arg === "-l") && args[i + 1]) {
       opLoops = Number(args[++i]);
+    } else if ((arg === "--batch-size" || arg === "-b") && args[i + 1]) {
+      batchSize = Number(args[++i]);
     } else if (arg === "--db" && args[i + 1]) {
       dbPath = args[++i];
     } else if ((arg === "--doc-id" || arg === "-d") && args[i + 1]) {
@@ -281,6 +314,8 @@ Arguments:
 Options:
   --operations, -o <M>      Number of operations per loop (default: 0)
   --op-loops, -l <L>        Number of operation loops per document (default: 1)
+  --batch-size, -b <N>      Operations per execute call (default: 1)
+                            Use higher values to measure per-call overhead
   --db <connection>         Database connection (default: in-memory PGlite)
                             PostgreSQL: "postgresql://user:pass@host:port/db"
                             PGlite file: "./data" (persists to filesystem)
@@ -303,6 +338,7 @@ Examples:
   tsx reactor-direct.ts 5 -o 10 -l 3 -p
   tsx reactor-direct.ts 1 -o 25 -l 10 --db "postgresql://postgres:postgres@localhost:5432/reactor"
   tsx reactor-direct.ts -d abc123 -o 10 -l 5 --db "./data"
+  tsx reactor-direct.ts 1 -o 100 -b 10      # 10 ops per execute call (10 calls total)
 `);
       process.exit(0);
     } else if (!isNaN(Number(arg)) && arg.trim() !== "") {
@@ -339,9 +375,22 @@ Examples:
     process.exit(1);
   }
 
+  if (isNaN(batchSize) || batchSize < 1) {
+    console.error(
+      `Error: Invalid batch-size value: must be a positive integer (>= 1).`,
+    );
+    process.exit(1);
+  }
+
   if (operations === 0 && opLoops > 1) {
     console.warn(
       `Warning: --op-loops=${opLoops} has no effect when operations is 0.`,
+    );
+  }
+
+  if (operations === 0 && batchSize > 1) {
+    console.warn(
+      `Warning: --batch-size=${batchSize} has no effect when operations is 0.`,
     );
   }
 
@@ -355,6 +404,7 @@ Examples:
     count,
     operations,
     opLoops,
+    batchSize,
     verbose,
     percentiles,
     showActionTypes,
@@ -396,6 +446,7 @@ async function main() {
     count,
     operations,
     opLoops,
+    batchSize,
     verbose,
     percentiles: showPercentiles,
     showActionTypes,
@@ -490,9 +541,10 @@ async function main() {
   if (operations > 0) {
     const docCount = documentIds.length;
     const loopLabel = opLoops > 1 ? ` x ${opLoops} loops` : "";
+    const batchLabel = batchSize > 1 ? ` (batch size: ${batchSize})` : "";
     const phaseLabel = docId
-      ? `Performing ${operations} operations${loopLabel} on target document...`
-      : `Performing ${operations} operations${loopLabel} on each document...`;
+      ? `Performing ${operations} operations${loopLabel}${batchLabel} on target document...`
+      : `Performing ${operations} operations${loopLabel}${batchLabel} on each document...`;
     console.log(`\nPhase 2: ${phaseLabel}`);
     const opsStartTime = Date.now();
     const totalOps = docCount * operations * opLoops;
@@ -528,9 +580,13 @@ async function main() {
           docId,
           docNum,
           operations,
-          (opNum, durationMs) => {
+          batchSize,
+          (opNum, durationMs, batchCount) => {
+            const batchInfo = batchCount > 1 ? ` (${batchCount} ops)` : "";
             if (verbose) {
-              console.log(`    op ${opNum}/${operations}: ${durationMs}ms`);
+              console.log(
+                `    op ${opNum}/${operations}: ${durationMs}ms${batchInfo}`,
+              );
             } else {
               process.stdout.write(
                 `\r  [${docNum}/${docCount}] ${docId}: ${loopPrefix}${opNum}/${operations} ops`,

--- a/scripts/profiling/reactor-direct.ts
+++ b/scripts/profiling/reactor-direct.ts
@@ -663,6 +663,19 @@ async function main() {
       }
     }
     console.log(`  Memory: ${formatMemory(phase2Memory)}`);
+
+    // Verify operations by checking document revisions
+    console.log(`\nVerification:`);
+    for (const id of documentIds) {
+      const doc = await reactor.get(id);
+      const revisions = Object.entries(doc.header.revision)
+        .map(([scope, rev]) => `${scope}:${rev}`)
+        .join(", ");
+      const opCount = Object.values(doc.operations)
+        .flat()
+        .filter(Boolean).length;
+      console.log(`  ${id}: revision={${revisions}}, operations=${opCount}`);
+    }
   }
 
   // Cleanup


### PR DESCRIPTION
---

# Output

Create 1 document
Run 250 **operations** on the document
**Batch** the operations by 10
**Loop** the operation cycle 100 times (totalling 25000 operations)
```
powerhouse % tsx ./scripts/profiling/reactor-direct.ts 1 -o 250 -b 10 -l 100  --db "postgresql://postgres:postgres@localhost:5432/postgres" --pyroscope http://localhost:4040

Initializing Pyroscope profiler at: http://localhost:4040
  Wall and CPU profiling enabled
Initializing reactor directly (no GraphQL API)...
  Connecting to PostgreSQL: postgresql://postgres:***@localhost:5432/postgres
  Running database migrations...
Reactor initialized in 0.30s

Initial memory: heap: 31.3MB/63.6MB, rss: 157.3MB

Phase 1: Creating 1 documents...
  Progress: 1/1
  Created 1 documents in 0.07s (avg: 65ms/doc)
  Memory: heap: 32.6MB/63.6MB, rss: 157.6MB

Phase 2: Performing 250 operations x 100 loops (batch size: 10) on each document...
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 1/100: 250/250 ops (2.52s, 10ms/op, min: 8.2ms, max: 13.5ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 2/100: 250/250 ops (2.31s, 9ms/op, min: 8.2ms, max: 11.9ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 3/100: 250/250 ops (2.48s, 10ms/op, min: 8.3ms, max: 13.6ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 4/100: 250/250 ops (2.52s, 10ms/op, min: 7.6ms, max: 16ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 5/100: 250/250 ops (2.59s, 10ms/op, min: 8.9ms, max: 13.4ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 6/100: 250/250 ops (2.72s, 11ms/op, min: 8.9ms, max: 29.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 7/100: 250/250 ops (2.75s, 11ms/op, min: 9.2ms, max: 22.4ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 8/100: 250/250 ops (2.75s, 11ms/op, min: 9.2ms, max: 16.3ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 9/100: 250/250 ops (3.04s, 12ms/op, min: 10.3ms, max: 15.9ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 10/100: 250/250 ops (3.02s, 12ms/op, min: 10.1ms, max: 16.2ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 11/100: 250/250 ops (3.20s, 13ms/op, min: 10.7ms, max: 20.5ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 12/100: 250/250 ops (3.43s, 14ms/op, min: 11ms, max: 17.2ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 13/100: 250/250 ops (3.31s, 13ms/op, min: 11ms, max: 18.1ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 14/100: 250/250 ops (4.02s, 16ms/op, min: 10.9ms, max: 35.1ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 15/100: 250/250 ops (4.02s, 16ms/op, min: 12.4ms, max: 26.1ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 16/100: 250/250 ops (4.28s, 17ms/op, min: 13ms, max: 27.4ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 17/100: 250/250 ops (4.42s, 18ms/op, min: 14ms, max: 22.8ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 18/100: 250/250 ops (4.52s, 18ms/op, min: 13.8ms, max: 23.6ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 19/100: 250/250 ops (4.78s, 19ms/op, min: 14.6ms, max: 27.1ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 20/100: 250/250 ops (4.56s, 18ms/op, min: 14.4ms, max: 29.5ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 21/100: 250/250 ops (5.18s, 21ms/op, min: 13.6ms, max: 49.5ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 22/100: 250/250 ops (4.79s, 19ms/op, min: 15ms, max: 26.6ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 23/100: 250/250 ops (4.85s, 19ms/op, min: 15.6ms, max: 25.1ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 24/100: 250/250 ops (5.16s, 21ms/op, min: 16.1ms, max: 28.9ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 25/100: 250/250 ops (5.18s, 21ms/op, min: 15.9ms, max: 26.8ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 26/100: 250/250 ops (5.01s, 20ms/op, min: 15.4ms, max: 24.8ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 27/100: 250/250 ops (5.87s, 23ms/op, min: 15.4ms, max: 61.3ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 28/100: 250/250 ops (5.34s, 21ms/op, min: 15.9ms, max: 30.6ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 29/100: 250/250 ops (5.65s, 23ms/op, min: 16.2ms, max: 38.2ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 30/100: 250/250 ops (5.61s, 22ms/op, min: 18.4ms, max: 31.9ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 31/100: 250/250 ops (5.59s, 22ms/op, min: 17.2ms, max: 37.5ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 32/100: 250/250 ops (6.41s, 26ms/op, min: 16.2ms, max: 57.6ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 33/100: 250/250 ops (6.18s, 25ms/op, min: 16.8ms, max: 37.6ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 34/100: 250/250 ops (5.99s, 24ms/op, min: 16.5ms, max: 45ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 35/100: 250/250 ops (6.20s, 25ms/op, min: 18.3ms, max: 36.5ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 36/100: 250/250 ops (6.37s, 25ms/op, min: 17.9ms, max: 39.2ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 37/100: 250/250 ops (6.37s, 25ms/op, min: 17.3ms, max: 45.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 38/100: 250/250 ops (6.95s, 28ms/op, min: 19.4ms, max: 62.9ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 39/100: 250/250 ops (8.17s, 33ms/op, min: 18.8ms, max: 106ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 40/100: 250/250 ops (7.46s, 30ms/op, min: 19.8ms, max: 53.1ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 41/100: 250/250 ops (7.87s, 31ms/op, min: 17.1ms, max: 60.3ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 42/100: 250/250 ops (7.71s, 31ms/op, min: 19.9ms, max: 56.1ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 43/100: 250/250 ops (8.63s, 35ms/op, min: 18.9ms, max: 100ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 44/100: 250/250 ops (8.84s, 35ms/op, min: 22.7ms, max: 77.5ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 45/100: 250/250 ops (9.37s, 37ms/op, min: 21.9ms, max: 117.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 46/100: 250/250 ops (46.42s, 186ms/op, min: 46ms, max: 783ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 47/100: 250/250 ops (24.35s, 97ms/op, min: 30.8ms, max: 285.1ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 48/100: 250/250 ops (20.23s, 81ms/op, min: 41.9ms, max: 223.6ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 49/100: 250/250 ops (16.62s, 66ms/op, min: 31.7ms, max: 121.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 50/100: 250/250 ops (12.61s, 50ms/op, min: 23.1ms, max: 108.8ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 51/100: 250/250 ops (13.14s, 53ms/op, min: 25.2ms, max: 95ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 52/100: 250/250 ops (10.60s, 42ms/op, min: 24.3ms, max: 81.8ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 53/100: 250/250 ops (10.96s, 44ms/op, min: 22.6ms, max: 87.3ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 54/100: 250/250 ops (11.80s, 47ms/op, min: 24.8ms, max: 126.2ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 55/100: 250/250 ops (11.93s, 48ms/op, min: 26.7ms, max: 114ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 56/100: 250/250 ops (12.08s, 48ms/op, min: 23.1ms, max: 132.4ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 57/100: 250/250 ops (10.82s, 43ms/op, min: 24.5ms, max: 72.3ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 58/100: 250/250 ops (13.14s, 53ms/op, min: 30.5ms, max: 106.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 59/100: 250/250 ops (14.07s, 56ms/op, min: 22.2ms, max: 126.2ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 60/100: 250/250 ops (11.77s, 47ms/op, min: 26.9ms, max: 84.9ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 61/100: 250/250 ops (16.02s, 64ms/op, min: 29.3ms, max: 151.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 62/100: 250/250 ops (12.39s, 50ms/op, min: 28.9ms, max: 79.5ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 63/100: 250/250 ops (13.03s, 52ms/op, min: 28.8ms, max: 87.2ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 64/100: 250/250 ops (18.48s, 74ms/op, min: 28.6ms, max: 237ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 65/100: 250/250 ops (18.59s, 74ms/op, min: 29ms, max: 157.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 66/100: 250/250 ops (17.40s, 70ms/op, min: 30.3ms, max: 198ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 67/100: 250/250 ops (18.81s, 75ms/op, min: 26.4ms, max: 233.1ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 68/100: 250/250 ops (14.54s, 58ms/op, min: 29.4ms, max: 105.3ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 69/100: 250/250 ops (13.53s, 54ms/op, min: 27.5ms, max: 112.1ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 70/100: 250/250 ops (11.07s, 44ms/op, min: 28.7ms, max: 63.3ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 71/100: 250/250 ops (11.75s, 47ms/op, min: 26.5ms, max: 101ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 72/100: 250/250 ops (13.88s, 56ms/op, min: 25.8ms, max: 143.9ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 73/100: 250/250 ops (13.18s, 53ms/op, min: 31.4ms, max: 78.6ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 74/100: 250/250 ops (13.25s, 53ms/op, min: 30.8ms, max: 121.2ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 75/100: 250/250 ops (19.63s, 79ms/op, min: 33.6ms, max: 168.9ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 76/100: 250/250 ops (14.21s, 57ms/op, min: 31.7ms, max: 126.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 77/100: 250/250 ops (16.45s, 66ms/op, min: 30.6ms, max: 153.5ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 78/100: 250/250 ops (17.58s, 70ms/op, min: 27.7ms, max: 164.5ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 79/100: 250/250 ops (11.96s, 48ms/op, min: 31.2ms, max: 63.1ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 80/100: 250/250 ops (15.65s, 63ms/op, min: 31.8ms, max: 124.4ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 81/100: 250/250 ops (21.12s, 84ms/op, min: 34.8ms, max: 342.1ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 82/100: 250/250 ops (17.78s, 71ms/op, min: 38.1ms, max: 142.8ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 83/100: 250/250 ops (19.09s, 76ms/op, min: 34.7ms, max: 205.5ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 84/100: 250/250 ops (25.99s, 104ms/op, min: 37.5ms, max: 273.6ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 85/100: 250/250 ops (26.35s, 105ms/op, min: 38.3ms, max: 298.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 86/100: 250/250 ops (23.72s, 95ms/op, min: 41.4ms, max: 210.1ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 87/100: 250/250 ops (18.03s, 72ms/op, min: 35.7ms, max: 138.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 88/100: 250/250 ops (20.87s, 83ms/op, min: 38.6ms, max: 174.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 89/100: 250/250 ops (17.13s, 69ms/op, min: 35.3ms, max: 140.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 90/100: 250/250 ops (16.22s, 65ms/op, min: 36.7ms, max: 127.4ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 91/100: 250/250 ops (18.77s, 75ms/op, min: 34.8ms, max: 184.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 92/100: 250/250 ops (16.52s, 66ms/op, min: 29.7ms, max: 126ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 93/100: 250/250 ops (21.90s, 88ms/op, min: 33.8ms, max: 241.6ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 94/100: 250/250 ops (17.73s, 71ms/op, min: 36.8ms, max: 145.6ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 95/100: 250/250 ops (19.43s, 78ms/op, min: 39.3ms, max: 222ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 96/100: 250/250 ops (19.11s, 76ms/op, min: 48.8ms, max: 127.3ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 97/100: 250/250 ops (35.92s, 144ms/op, min: 58.5ms, max: 707.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 98/100: 250/250 ops (54.31s, 217ms/op, min: 68.2ms, max: 455.7ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 99/100: 250/250 ops (35.03s, 140ms/op, min: 55.8ms, max: 451.9ms)
  [1/1] 17eee725-e32b-4696-a412-df42d8bd18af: loop 100/100: 250/250 ops (20.36s, 81ms/op, min: 45.6ms, max: 225.9ms)
  Completed 25000 operations in 1235.32s (avg: 49ms/op, min: 7.6ms, max: 783ms)
  Memory: heap: 63.8MB/200.2MB, rss: 217.8MB

Verification:
  17eee725-e32b-4696-a412-df42d8bd18af: revision={document:2, global:25000}, operations=0

Done! Total time: 1237.10s
Memory delta: heap: +36.4MB, rss: -32.9MB
```

Create 1 document
Run 250 **operations** on the document
**Loop** the operation cycle 100 times (totalling 25000 operations)
No **Batching**
```
powerhouse % tsx ./scripts/profiling/reactor-direct.ts 1 -o 250 -l 100  --db "postgresql://postgres:postgres@localhost:5432/postgres" --pyroscope http://localhost:4040 
Initializing Pyroscope profiler at: http://localhost:4040
  Wall and CPU profiling enabled
Initializing reactor directly (no GraphQL API)...
  Connecting to PostgreSQL: postgresql://postgres:***@localhost:5432/postgres
  Running database migrations...
Reactor initialized in 1.18s

Initial memory: heap: 59.2MB/180.3MB, rss: 199.0MB

Phase 1: Creating 1 documents...
  Progress: 1/1
  Created 1 documents in 0.09s (avg: 88ms/doc)
  Memory: heap: 30.8MB/162.6MB, rss: 198.8MB

Phase 2: Performing 250 operations x 100 loops on each document...
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 1/100: 250/250 ops (5.29s, 21ms/op, min: 15ms, max: 456ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 2/100: 250/250 ops (4.76s, 19ms/op, min: 14ms, max: 83ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 3/100: 250/250 ops (5.14s, 21ms/op, min: 14ms, max: 109ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 4/100: 250/250 ops (5.22s, 21ms/op, min: 14ms, max: 54ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 5/100: 250/250 ops (5.23s, 21ms/op, min: 15ms, max: 46ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 6/100: 250/250 ops (5.63s, 23ms/op, min: 15ms, max: 56ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 7/100: 250/250 ops (6.36s, 25ms/op, min: 15ms, max: 63ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 8/100: 250/250 ops (7.02s, 28ms/op, min: 16ms, max: 107ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 9/100: 250/250 ops (7.05s, 28ms/op, min: 16ms, max: 105ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 10/100: 250/250 ops (7.68s, 31ms/op, min: 16ms, max: 141ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 11/100: 250/250 ops (8.41s, 34ms/op, min: 16ms, max: 129ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 12/100: 250/250 ops (8.70s, 35ms/op, min: 16ms, max: 148ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 13/100: 250/250 ops (9.35s, 37ms/op, min: 17ms, max: 121ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 14/100: 250/250 ops (9.70s, 39ms/op, min: 16ms, max: 162ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 15/100: 250/250 ops (10.70s, 43ms/op, min: 16ms, max: 301ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 16/100: 250/250 ops (10.97s, 44ms/op, min: 16ms, max: 182ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 17/100: 250/250 ops (11.32s, 45ms/op, min: 18ms, max: 204ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 18/100: 250/250 ops (11.28s, 45ms/op, min: 16ms, max: 169ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 19/100: 250/250 ops (12.43s, 50ms/op, min: 16ms, max: 146ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 20/100: 250/250 ops (12.53s, 50ms/op, min: 18ms, max: 206ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 21/100: 250/250 ops (12.99s, 52ms/op, min: 17ms, max: 283ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 22/100: 250/250 ops (13.79s, 55ms/op, min: 17ms, max: 197ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 23/100: 250/250 ops (13.60s, 54ms/op, min: 17ms, max: 294ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 24/100: 250/250 ops (14.14s, 57ms/op, min: 16ms, max: 318ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 25/100: 250/250 ops (15.65s, 63ms/op, min: 17ms, max: 258ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 26/100: 250/250 ops (15.13s, 61ms/op, min: 17ms, max: 395ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 27/100: 250/250 ops (15.99s, 64ms/op, min: 17ms, max: 260ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 28/100: 250/250 ops (17.86s, 71ms/op, min: 17ms, max: 303ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 29/100: 250/250 ops (17.09s, 68ms/op, min: 17ms, max: 350ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 30/100: 250/250 ops (18.38s, 74ms/op, min: 18ms, max: 288ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 31/100: 250/250 ops (19.30s, 77ms/op, min: 17ms, max: 481ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 32/100: 250/250 ops (18.02s, 72ms/op, min: 18ms, max: 256ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 33/100: 250/250 ops (18.00s, 72ms/op, min: 17ms, max: 303ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 34/100: 250/250 ops (18.87s, 75ms/op, min: 17ms, max: 342ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 35/100: 250/250 ops (18.23s, 73ms/op, min: 17ms, max: 316ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 36/100: 250/250 ops (19.78s, 79ms/op, min: 18ms, max: 398ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 37/100: 250/250 ops (20.52s, 82ms/op, min: 18ms, max: 386ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 38/100: 250/250 ops (24.95s, 100ms/op, min: 18ms, max: 726ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 39/100: 250/250 ops (21.47s, 86ms/op, min: 18ms, max: 418ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 40/100: 250/250 ops (22.18s, 89ms/op, min: 17ms, max: 343ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 41/100: 250/250 ops (24.98s, 100ms/op, min: 18ms, max: 549ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 42/100: 250/250 ops (24.09s, 96ms/op, min: 18ms, max: 478ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 43/100: 250/250 ops (26.63s, 107ms/op, min: 18ms, max: 584ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 44/100: 250/250 ops (48.02s, 192ms/op, min: 20ms, max: 4897ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 45/100: 250/250 ops (24.70s, 99ms/op, min: 18ms, max: 458ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 46/100: 250/250 ops (26.23s, 105ms/op, min: 18ms, max: 530ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 47/100: 250/250 ops (25.81s, 103ms/op, min: 19ms, max: 421ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 48/100: 250/250 ops (25.28s, 101ms/op, min: 19ms, max: 535ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 49/100: 250/250 ops (26.72s, 107ms/op, min: 19ms, max: 590ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 50/100: 250/250 ops (25.88s, 104ms/op, min: 19ms, max: 532ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 51/100: 250/250 ops (27.32s, 109ms/op, min: 18ms, max: 497ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 52/100: 250/250 ops (29.06s, 116ms/op, min: 19ms, max: 516ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 53/100: 250/250 ops (27.83s, 111ms/op, min: 18ms, max: 534ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 54/100: 250/250 ops (31.82s, 127ms/op, min: 20ms, max: 704ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 55/100: 250/250 ops (29.72s, 119ms/op, min: 20ms, max: 841ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 56/100: 250/250 ops (28.61s, 114ms/op, min: 18ms, max: 668ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 57/100: 250/250 ops (29.39s, 118ms/op, min: 18ms, max: 620ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 58/100: 250/250 ops (30.12s, 120ms/op, min: 20ms, max: 569ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 59/100: 250/250 ops (29.07s, 116ms/op, min: 20ms, max: 601ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 60/100: 250/250 ops (30.88s, 124ms/op, min: 19ms, max: 565ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 61/100: 250/250 ops (31.38s, 126ms/op, min: 19ms, max: 611ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 62/100: 250/250 ops (32.82s, 131ms/op, min: 20ms, max: 1970ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 63/100: 250/250 ops (32.10s, 128ms/op, min: 19ms, max: 895ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 64/100: 250/250 ops (32.53s, 130ms/op, min: 19ms, max: 609ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 65/100: 250/250 ops (32.10s, 128ms/op, min: 19ms, max: 537ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 66/100: 250/250 ops (43.19s, 173ms/op, min: 19ms, max: 1807ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 67/100: 250/250 ops (35.24s, 141ms/op, min: 19ms, max: 756ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 68/100: 250/250 ops (34.83s, 139ms/op, min: 18ms, max: 674ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 69/100: 250/250 ops (33.56s, 134ms/op, min: 19ms, max: 797ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 70/100: 250/250 ops (36.83s, 147ms/op, min: 19ms, max: 939ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 71/100: 250/250 ops (35.64s, 143ms/op, min: 21ms, max: 1025ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 72/100: 250/250 ops (40.04s, 160ms/op, min: 19ms, max: 833ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 73/100: 250/250 ops (37.31s, 149ms/op, min: 18ms, max: 733ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 74/100: 250/250 ops (35.40s, 142ms/op, min: 20ms, max: 716ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 75/100: 250/250 ops (38.23s, 153ms/op, min: 20ms, max: 791ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 76/100: 250/250 ops (36.57s, 146ms/op, min: 20ms, max: 602ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 77/100: 250/250 ops (36.73s, 147ms/op, min: 20ms, max: 1051ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 78/100: 250/250 ops (38.97s, 156ms/op, min: 20ms, max: 765ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 79/100: 250/250 ops (37.72s, 151ms/op, min: 20ms, max: 574ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 80/100: 250/250 ops (41.28s, 165ms/op, min: 20ms, max: 821ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 81/100: 250/250 ops (38.85s, 155ms/op, min: 20ms, max: 671ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 82/100: 250/250 ops (38.46s, 154ms/op, min: 18ms, max: 573ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 83/100: 250/250 ops (39.30s, 157ms/op, min: 22ms, max: 928ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 84/100: 250/250 ops (64.92s, 260ms/op, min: 19ms, max: 8627ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 85/100: 250/250 ops (43.75s, 175ms/op, min: 22ms, max: 1149ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 86/100: 250/250 ops (41.12s, 164ms/op, min: 21ms, max: 923ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 87/100: 250/250 ops (70.97s, 284ms/op, min: 23ms, max: 3293ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 88/100: 250/250 ops (50.67s, 203ms/op, min: 22ms, max: 1547ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 89/100: 250/250 ops (49.59s, 198ms/op, min: 22ms, max: 1259ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 90/100: 250/250 ops (45.10s, 180ms/op, min: 20ms, max: 984ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 91/100: 250/250 ops (44.79s, 179ms/op, min: 21ms, max: 1145ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 92/100: 250/250 ops (46.46s, 186ms/op, min: 22ms, max: 1001ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 93/100: 250/250 ops (58.74s, 235ms/op, min: 22ms, max: 1521ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 94/100: 250/250 ops (45.77s, 183ms/op, min: 21ms, max: 866ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 95/100: 250/250 ops (48.11s, 192ms/op, min: 21ms, max: 1059ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 96/100: 250/250 ops (51.54s, 206ms/op, min: 24ms, max: 931ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 97/100: 250/250 ops (49.22s, 197ms/op, min: 22ms, max: 891ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 98/100: 250/250 ops (53.56s, 214ms/op, min: 20ms, max: 1577ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 99/100: 250/250 ops (53.27s, 213ms/op, min: 21ms, max: 1024ms)
  [1/1] f68e88ee-4277-4986-b298-c2654fa8d43a: loop 100/100: 250/250 ops (50.70s, 203ms/op, min: 24ms, max: 944ms)
  Completed 25000 operations in 2800.22s (avg: 112ms/op, min: 14ms, max: 8627ms)
  Memory: heap: 116.5MB/255.9MB, rss: 190.8MB

Verification:
  f68e88ee-4277-4986-b298-c2654fa8d43a: revision={document:2, global:25000}, operations=0

Done! Total time: 2801.74s
Memory delta: heap: +60.5MB, rss: -14.3MB
```