### PR TITLE
Pre-stringify JSONB params to bypass pg prepareObject

### DIFF
--- a/packages/reactor/bench/write-cache.bench.ts
+++ b/packages/reactor/bench/write-cache.bench.ts
@@ -85,6 +85,9 @@ async function setupCacheWithData(
   config: WriteCacheConfig = {
     maxDocuments: 100,
     ringBufferSize: 10,
+    hotThresholdMs: 5000,
+    hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+    coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
   },
 ): Promise<{
   cache: KyselyWriteCache;
@@ -180,6 +183,9 @@ describe("Write Cache Cold Miss Performance", () => {
       const { cache } = await setupCacheWithData(100, {
         maxDocuments: 100,
         ringBufferSize: 10,
+        hotThresholdMs: 5000,
+        hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+        coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
       });
 
       const doc50 = await cache.getState(DOCUMENT_ID, SCOPE, BRANCH, 50);
@@ -279,6 +285,9 @@ describe("Write Cache LRU Eviction Performance", () => {
       const cache = new KyselyWriteCache(keyframeStore, store, registry, {
         maxDocuments: 10,
         ringBufferSize: 5,
+        hotThresholdMs: 5000,
+        hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+        coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
       });
       await cache.startup();
 
@@ -333,6 +342,9 @@ describe("Write Cache LRU Eviction Performance", () => {
       const cache = new KyselyWriteCache(keyframeStore, store, registry, {
         maxDocuments: 5,
         ringBufferSize: 5,
+        hotThresholdMs: 5000,
+        hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+        coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
       });
       await cache.startup();
 
@@ -562,6 +574,9 @@ describe("Write Cache Keyframe Performance", () => {
       const { cache } = await setupCacheWithData(0, {
         maxDocuments: 100,
         ringBufferSize: 10,
+        hotThresholdMs: 5000,
+        hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+        coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
       });
 
       const baseDoc = driveDocumentModelModule.utils.createDocument();
@@ -581,6 +596,9 @@ describe("Write Cache Keyframe Performance", () => {
       const { cache } = await setupCacheWithData(0, {
         maxDocuments: 100,
         ringBufferSize: 10,
+        hotThresholdMs: 5000,
+        hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+        coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
       });
 
       const baseDoc = driveDocumentModelModule.utils.createDocument();

--- a/packages/reactor/bench/write-cache.bench.ts
+++ b/packages/reactor/bench/write-cache.bench.ts
@@ -85,7 +85,6 @@ async function setupCacheWithData(
   config: WriteCacheConfig = {
     maxDocuments: 100,
     ringBufferSize: 10,
-    keyframeInterval: 10,
   },
 ): Promise<{
   cache: KyselyWriteCache;
@@ -181,7 +180,6 @@ describe("Write Cache Cold Miss Performance", () => {
       const { cache } = await setupCacheWithData(100, {
         maxDocuments: 100,
         ringBufferSize: 10,
-        keyframeInterval: 50,
       });
 
       const doc50 = await cache.getState(DOCUMENT_ID, SCOPE, BRANCH, 50);
@@ -281,7 +279,6 @@ describe("Write Cache LRU Eviction Performance", () => {
       const cache = new KyselyWriteCache(keyframeStore, store, registry, {
         maxDocuments: 10,
         ringBufferSize: 5,
-        keyframeInterval: 10,
       });
       await cache.startup();
 
@@ -336,7 +333,6 @@ describe("Write Cache LRU Eviction Performance", () => {
       const cache = new KyselyWriteCache(keyframeStore, store, registry, {
         maxDocuments: 5,
         ringBufferSize: 5,
-        keyframeInterval: 10,
       });
       await cache.startup();
 
@@ -566,7 +562,6 @@ describe("Write Cache Keyframe Performance", () => {
       const { cache } = await setupCacheWithData(0, {
         maxDocuments: 100,
         ringBufferSize: 10,
-        keyframeInterval: 10,
       });
 
       const baseDoc = driveDocumentModelModule.utils.createDocument();
@@ -586,7 +581,6 @@ describe("Write Cache Keyframe Performance", () => {
       const { cache } = await setupCacheWithData(0, {
         maxDocuments: 100,
         ringBufferSize: 10,
-        keyframeInterval: 1000000,
       });
 
       const baseDoc = driveDocumentModelModule.utils.createDocument();

--- a/packages/reactor/src/cache/buffer/ring-buffer.ts
+++ b/packages/reactor/src/cache/buffer/ring-buffer.ts
@@ -66,6 +66,16 @@ export class RingBuffer<T> {
   }
 
   /**
+   * Returns the newest (most recently pushed) item without allocating an array.
+   * O(1) time complexity.
+   */
+  peekNewest(): T | undefined {
+    if (this.size === 0) return undefined;
+    const index = (this.head + this.size - 1) % this.capacity;
+    return this.buffer[index];
+  }
+
+  /**
    * Gets the current number of items in the buffer.
    */
   get length(): number {

--- a/packages/reactor/src/cache/kysely-operation-index.ts
+++ b/packages/reactor/src/cache/kysely-operation-index.ts
@@ -137,7 +137,7 @@ export class KyselyOperationIndex implements IOperationIndex {
             index: op.index,
             skip: op.skip,
             hash: op.hash,
-            action: op.action as unknown,
+            action: JSON.stringify(op.action),
           }));
 
         const insertedOps = await trx

--- a/packages/reactor/src/cache/write-cache-types.ts
+++ b/packages/reactor/src/cache/write-cache-types.ts
@@ -9,6 +9,15 @@ export type WriteCacheConfig = {
 
   /** Number of snapshots to keep in each document's ring buffer. Default: 10 */
   ringBufferSize: number;
+
+  /** Time gap in ms below which a stream is considered "hot". Default: 5000 */
+  hotThresholdMs: number;
+
+  /** Revisions between keyframes for hot streams. Default: 1000 */
+  hotKeyframeInterval: number;
+
+  /** Revisions between keyframes for cold streams. Default: 10 */
+  coldKeyframeInterval: number;
 };
 
 /**

--- a/packages/reactor/src/cache/write-cache-types.ts
+++ b/packages/reactor/src/cache/write-cache-types.ts
@@ -9,9 +9,6 @@ export type WriteCacheConfig = {
 
   /** Number of snapshots to keep in each document's ring buffer. Default: 10 */
   ringBufferSize: number;
-
-  /** Persist a keyframe snapshot every N revisions. Default: 10 */
-  keyframeInterval: number;
 };
 
 /**

--- a/packages/reactor/src/core/reactor-builder.ts
+++ b/packages/reactor/src/core/reactor-builder.ts
@@ -221,6 +221,9 @@ export class ReactorBuilder {
     const cacheConfig: WriteCacheConfig = {
       maxDocuments: this.writeCacheConfig?.maxDocuments ?? 100,
       ringBufferSize: this.writeCacheConfig?.ringBufferSize ?? 10,
+      hotThresholdMs: this.writeCacheConfig?.hotThresholdMs ?? 5000,
+      hotKeyframeInterval: this.writeCacheConfig?.hotKeyframeInterval ?? 1000,
+      coldKeyframeInterval: this.writeCacheConfig?.coldKeyframeInterval ?? 10,
     };
 
     const writeCache = new KyselyWriteCache(

--- a/packages/reactor/src/core/reactor-builder.ts
+++ b/packages/reactor/src/core/reactor-builder.ts
@@ -221,7 +221,6 @@ export class ReactorBuilder {
     const cacheConfig: WriteCacheConfig = {
       maxDocuments: this.writeCacheConfig?.maxDocuments ?? 100,
       ringBufferSize: this.writeCacheConfig?.ringBufferSize ?? 10,
-      keyframeInterval: this.writeCacheConfig?.keyframeInterval ?? 10,
     };
 
     const writeCache = new KyselyWriteCache(

--- a/packages/reactor/src/read-models/document-view.ts
+++ b/packages/reactor/src/read-models/document-view.ts
@@ -176,7 +176,7 @@ export class KyselyDocumentView extends BaseReadModel implements IDocumentView {
                 lastOperationHash: hash,
                 lastUpdatedAt: new Date(),
                 snapshotVersion: existingSnapshot.snapshotVersion + 1,
-                content: newState,
+                content: JSON.stringify(newState),
                 slug,
                 name,
               })
@@ -192,7 +192,7 @@ export class KyselyDocumentView extends BaseReadModel implements IDocumentView {
               name,
               scope: scopeName,
               branch,
-              content: newState,
+              content: JSON.stringify(newState),
               documentType,
               lastOperationIndex: index,
               lastOperationHash: hash,

--- a/packages/reactor/src/storage/kysely/document-indexer.ts
+++ b/packages/reactor/src/storage/kysely/document-indexer.ts
@@ -604,7 +604,7 @@ export class KyselyDocumentIndexer implements IDocumentIndexer {
         sourceId: input.sourceId,
         targetId: input.targetId,
         relationshipType: input.relationshipType,
-        metadata: input.metadata || null,
+        metadata: input.metadata ? JSON.stringify(input.metadata) : null,
       };
 
       await trx

--- a/packages/reactor/src/storage/kysely/keyframe-store.ts
+++ b/packages/reactor/src/storage/kysely/keyframe-store.ts
@@ -26,12 +26,12 @@ export class KyselyKeyframeStore implements IKeyframeStore {
         scope,
         branch,
         revision,
-        document,
+        document: JSON.stringify(document),
       })
       .onConflict((oc) =>
         oc
           .columns(["documentId", "scope", "branch", "revision"])
-          .doUpdateSet({ document }),
+          .doUpdateSet({ document: JSON.stringify(document) }),
       )
       .execute();
   }

--- a/packages/reactor/src/storage/kysely/sampling-keyframe-store.ts
+++ b/packages/reactor/src/storage/kysely/sampling-keyframe-store.ts
@@ -1,0 +1,71 @@
+import { appendFile } from "node:fs/promises";
+import type { PHDocument } from "document-model";
+import type { IKeyframeStore } from "../interfaces.js";
+
+export class SamplingKeyframeStore implements IKeyframeStore {
+  private callCount = 0;
+
+  constructor(
+    private inner: IKeyframeStore,
+    private outputPath: string,
+    private sampleInterval: number = 1,
+  ) {}
+
+  async putKeyframe(
+    documentId: string,
+    scope: string,
+    branch: string,
+    revision: number,
+    document: PHDocument,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const shouldSample = this.callCount++ % this.sampleInterval === 0;
+
+    if (shouldSample) {
+      const entry = {
+        timestamp: new Date().toISOString(),
+        callCount: this.callCount,
+        documentId,
+        scope,
+        branch,
+        revision,
+        document,
+      };
+      appendFile(this.outputPath, JSON.stringify(entry) + "\n").catch(() => {});
+    }
+
+    return this.inner.putKeyframe(
+      documentId,
+      scope,
+      branch,
+      revision,
+      document,
+      signal,
+    );
+  }
+
+  findNearestKeyframe(
+    documentId: string,
+    scope: string,
+    branch: string,
+    targetRevision: number,
+    signal?: AbortSignal,
+  ): Promise<{ revision: number; document: PHDocument } | undefined> {
+    return this.inner.findNearestKeyframe(
+      documentId,
+      scope,
+      branch,
+      targetRevision,
+      signal,
+    );
+  }
+
+  deleteKeyframes(
+    documentId: string,
+    scope?: string,
+    branch?: string,
+    signal?: AbortSignal,
+  ): Promise<number> {
+    return this.inner.deleteKeyframes(documentId, scope, branch, signal);
+  }
+}

--- a/packages/reactor/src/storage/kysely/sync-remote-storage.ts
+++ b/packages/reactor/src/storage/kysely/sync-remote-storage.ts
@@ -51,10 +51,15 @@ function remoteRecordToRow(remote: RemoteRecord): InsertableSyncRemote {
     channel_type: remote.channelConfig.type,
     channel_id: remote.id,
     remote_name: remote.name,
-    channel_parameters: remote.channelConfig.parameters,
+    channel_parameters: JSON.stringify(remote.channelConfig.parameters),
     filter_document_ids:
-      remote.filter.documentId.length > 0 ? remote.filter.documentId : null,
-    filter_scopes: remote.filter.scope.length > 0 ? remote.filter.scope : null,
+      remote.filter.documentId.length > 0
+        ? JSON.stringify(remote.filter.documentId)
+        : null,
+    filter_scopes:
+      remote.filter.scope.length > 0
+        ? JSON.stringify(remote.filter.scope)
+        : null,
     filter_branch: remote.filter.branch,
     push_state: remote.status.push.state,
     push_last_success_utc_ms: remote.status.push.lastSuccessUtcMs

--- a/packages/reactor/test/atlas/test/recorded-operations.test.ts
+++ b/packages/reactor/test/atlas/test/recorded-operations.test.ts
@@ -99,6 +99,9 @@ async function createReactorSetup(): Promise<ReactorTestSetup> {
   const writeCacheConfig: WriteCacheConfig = {
     maxDocuments: 100,
     ringBufferSize: 10,
+    hotThresholdMs: 5000,
+    hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+    coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
   };
 
   const writeCache = new KyselyWriteCache(

--- a/packages/reactor/test/atlas/test/recorded-operations.test.ts
+++ b/packages/reactor/test/atlas/test/recorded-operations.test.ts
@@ -99,7 +99,6 @@ async function createReactorSetup(): Promise<ReactorTestSetup> {
   const writeCacheConfig: WriteCacheConfig = {
     maxDocuments: 100,
     ringBufferSize: 10,
-    keyframeInterval: 10,
   };
 
   const writeCache = new KyselyWriteCache(

--- a/packages/reactor/test/cache/integration.test.ts
+++ b/packages/reactor/test/cache/integration.test.ts
@@ -52,6 +52,9 @@ describe("KyselyWriteCache Integration Tests", () => {
     config = {
       maxDocuments: 10,
       ringBufferSize: 5,
+      hotThresholdMs: 5000,
+      hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+      coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
     };
 
     cache = new KyselyWriteCache(
@@ -281,6 +284,9 @@ describe("KyselyWriteCache Integration Tests", () => {
         {
           maxDocuments: 3,
           ringBufferSize: 5,
+          hotThresholdMs: 5000,
+          hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+          coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
         },
       );
       await limitedCache.startup();

--- a/packages/reactor/test/cache/v2-undo-rebuild.integration.test.ts
+++ b/packages/reactor/test/cache/v2-undo-rebuild.integration.test.ts
@@ -145,7 +145,6 @@ describe("V2 UNDO Cache Rebuild Integration Tests", () => {
     const config: WriteCacheConfig = {
       maxDocuments: 10,
       ringBufferSize: 5,
-      keyframeInterval: 100,
     };
 
     writeCache = new KyselyWriteCache(

--- a/packages/reactor/test/cache/v2-undo-rebuild.integration.test.ts
+++ b/packages/reactor/test/cache/v2-undo-rebuild.integration.test.ts
@@ -145,6 +145,9 @@ describe("V2 UNDO Cache Rebuild Integration Tests", () => {
     const config: WriteCacheConfig = {
       maxDocuments: 10,
       ringBufferSize: 5,
+      hotThresholdMs: 5000,
+      hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+      coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
     };
 
     writeCache = new KyselyWriteCache(

--- a/packages/reactor/test/cache/write/document-scope-staleness.test.ts
+++ b/packages/reactor/test/cache/write/document-scope-staleness.test.ts
@@ -76,6 +76,9 @@ describe("Document Scope Cross-Scope Dependency Issue", () => {
     config = {
       maxDocuments: 10,
       ringBufferSize: 5,
+      hotThresholdMs: 5000,
+      hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+      coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
     };
 
     cache = new KyselyWriteCache(

--- a/packages/reactor/test/cache/write/kysely-write-cache-errors.test.ts
+++ b/packages/reactor/test/cache/write/kysely-write-cache-errors.test.ts
@@ -81,6 +81,9 @@ describe("KyselyWriteCache - Error Handling", () => {
     config = {
       maxDocuments: 10,
       ringBufferSize: 5,
+      hotThresholdMs: 5000,
+      hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+      coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
     };
     cache = new KyselyWriteCache(
       keyframeStore,
@@ -764,6 +767,9 @@ describe("KyselyWriteCache - Error Handling", () => {
       const smallConfig: WriteCacheConfig = {
         maxDocuments: 2,
         ringBufferSize: 5,
+        hotThresholdMs: 5000,
+        hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+        coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
       };
 
       const testCache = new KyselyWriteCache(
@@ -785,7 +791,7 @@ describe("KyselyWriteCache - Error Handling", () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to persist keyframe on eviction"),
+        expect.stringContaining("Failed to persist keyframe"),
         expect.any(Error),
       );
 
@@ -801,6 +807,9 @@ describe("KyselyWriteCache - Error Handling", () => {
       const smallConfig: WriteCacheConfig = {
         maxDocuments: 2,
         ringBufferSize: 5,
+        hotThresholdMs: 5000,
+        hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+        coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
       };
 
       const testCache = new KyselyWriteCache(
@@ -1342,6 +1351,9 @@ describe("KyselyWriteCache - Error Handling (Integration)", () => {
     config = {
       maxDocuments: 10,
       ringBufferSize: 5,
+      hotThresholdMs: 5000,
+      hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+      coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
     };
     cache = new KyselyWriteCache(
       keyframeStore,

--- a/packages/reactor/test/executor/integration.test.ts
+++ b/packages/reactor/test/executor/integration.test.ts
@@ -138,6 +138,9 @@ describe("SimpleJobExecutor Integration (Modern Storage)", () => {
     const config: WriteCacheConfig = {
       maxDocuments: 10,
       ringBufferSize: 5,
+      hotThresholdMs: 5000,
+      hotKeyframeInterval: Number.MAX_SAFE_INTEGER,
+      coldKeyframeInterval: Number.MAX_SAFE_INTEGER,
     };
 
     writeCache = new KyselyWriteCache(

--- a/packages/reactor/test/executor/integration.test.ts
+++ b/packages/reactor/test/executor/integration.test.ts
@@ -138,7 +138,6 @@ describe("SimpleJobExecutor Integration (Modern Storage)", () => {
     const config: WriteCacheConfig = {
       maxDocuments: 10,
       ringBufferSize: 5,
-      keyframeInterval: 10,
     };
 
     writeCache = new KyselyWriteCache(

--- a/scripts/profiling/docker-compose.yml
+++ b/scripts/profiling/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     image: postgres:16-alpine
     container_name: postgres16
     restart: unless-stopped
+    mem_limit: 1g
 
     environment:
       POSTGRES_USER: postgres
@@ -20,6 +21,7 @@ services:
     container_name: pyroscope
     command: server
     restart: unless-stopped
+    mem_limit: 512m
 
     ports:
       - "4040:4040"


### PR DESCRIPTION
## Key Takeaways

1. **`prepareObject` is eliminated**, pre-stringify appear to work, `safe-stable-stringify` cost is negligible (0.1%)
2. **`keyframe-store.js` is the new `#1` bottleneck** at 28.6%, writing full document state to PostgreSQL every 10 ops
3. **`reducer.js` functions** are `#2` at 18.1%, document model reduction logic
4. **GC** is `#3` at 8.9%, memory pressure possibly from large object churn
5. **The cause of the non-linear scaling is not yet identified**, the flamegraph shows aggregate time, not which function's cost grows with operation count. Candidates: growing state in `putKeyframe`, growing heap/GC pressure, or PostgreSQL-side effects

## Pyroscope Comparison Across Runs

| Function | [[2026-02-09-pyroscope-flamegraph-25ops\|Original]] | Run 1 (stale build) | **Run 2 (pre-stringify active)** |
|:---------|:----:|:--------:|:--------:|
| `prepareObject` | 34.5% | 34.6% | **0% (gone)** |
| `keyframe-store.js` (combined) | - | - | **28.6%** |
| `reducer (anonymous L#35)` | 9.9% | 10.4% | 12.7% |
| GC | 9.0% | 8.1% | **8.9%** |
| `buffer:_copyActual` | 8.4% | 6.4% | 6.4% |
| `updateOperationsForAction` (self) | 3.9%* | 3.9% | 3.7% |
| `safe-stable-stringify` | 0% | 0% | 0.1% |

> [!TIP]
> Pre-stringify appears to work
> `prepareObject` (previously 34.5% of wall time) is **completely eliminated**. The cost of `JSON.stringify` via `safe-stable-stringify` is negligible at 0.1%. `prepareValue` remains at 0.05%, it now just passes the pre-stringified string through.

> [!CAUTION]
> New dominant bottleneck: `keyframe-store.js`
> `putKeyframe` + its anonymous callback account for **28.6% of active wall time**, this was previously hidden behind `prepareObject`. This is the keyframe write path that serialises the state to PostgreSQL. Combined with `reducer.js` functions (18.1%), the document model + persistence layer now accounts for **46.7%** of active wall time.

> [!NOTE]
> 50% idle, half the wall time is waiting on I/O
> The samples-count profile (`wall:samples:count`) reveals the process is **50.2% idle** (75,723 of 150,913 samples). The percentages in the table above are of **active time only** (excluding idle). Optimising CPU-side work can only address half the total wall time; the other half requires reducing I/O round-trips or batching database operations.

---

## Test Setup

- 1 document, 25 ops/loop, batch size 5, 1000 loops = 25,000 total operations
- Database: PostgreSQL (local)
- Profiler: Pyroscope (wall + CPU)
- Change under test: `JSON.stringify()` applied to all JSONB bind parameters before passing to Kysely/pg

## Run 2: Clean DB, rebuilt dist (latest)

| Metric | Run 2 | Run 1 (stale build, dirty DB) | Original baseline |
|:-------|:-----:|:-----------------------------:|:-----------------:|
| Total time | **4,747s (~79.1 min)** | 2,644s (~44.1 min) | 1,716s (~28.6 min) |
| Avg ms/op | **190ms** | 106ms | 69ms |
| Min ms/op | 7.6ms | 8.2ms | 8.5ms |
| Max ms/op | **12,445.8ms** | 3,316.8ms | 4,540ms |
| Heap start | 31.5MB | 244.5MB | ~31–59MB |
| Heap end | 167.3MB | 82.0MB | - |
| RSS end | 374.5MB | - | - |

> [!CAUTION]
> 2.76x slower than original baseline on a clean database
> This run started with a **clean database** (heap 31.5MB) and used Pyroscope wall+CPU profiling. Despite the pre-stringify optimisation being active (dist rebuilt), total time is **2.76x worse** than the original 1,716s baseline. The degradation in the final 40 loops is catastrophic, single operations exceeding 12 seconds.

### Degradation Pattern: Run 2

| Loop range | Ops accumulated | Approx avg ms/op | Trend |
|:-----------|:----------------|:-----------------:|:------|
| 1–50 | 0–1,250 | ~12–15ms | Stable, fast |
| 50–94 | 1,250–2,350 | ~10–15ms | JIT warmup, slightly faster |
| 95–100 | 2,375–2,500 | **70–207ms** | **First major spike cluster** |
| 100–200 | 2,500–5,000 | ~25–90ms | Rising with periodic spikes |
| 200–300 | 5,000–7,500 | ~25–130ms | Linear growth, spikes to 200ms |
| 300–400 | 7,500–10,000 | ~30–150ms | Spikes to 320ms |
| 400–500 | 10,000–12,500 | ~40–440ms | Severe spikes, 911ms avg at loop 444 |
| 500–600 | 12,500–15,000 | ~60–740ms | Regular spikes to 600ms+ |
| 600–700 | 15,000–17,500 | ~50–640ms | Persistent high latency |
| 700–800 | 17,500–20,000 | ~60–840ms | Spikes to 2,600ms |
| 800–900 | 20,000–22,500 | ~80–1,660ms | Spikes to 3,480ms |
| 900–960 | 22,500–24,000 | ~60–1,050ms | Variable but elevated |
| **960–976** | **24,000–24,400** | **2,400–5,400ms** | **Catastrophic collapse** |
| 977–1000 | 24,400–25,000 | ~70–1,200ms | Partial recovery, still elevated |

> [!CAUTION]
> Catastrophic collapse at ~24k ops
> Loops 965–972 show sustained average op times of **2,400–5,400ms** with single operations hitting **12,446ms**. This is qualitatively different from the gradual degradation seen earlier, it suggests a threshold where some internal data structure or database query plan collapses completely.

### Notable Spikes: Run 2

| Loop | ms/op avg | Max single op | Ops accumulated |
|:-----|:---------:|:-------------:|:----------------|
| 96 | 207ms | 383ms | ~2,400 |
| 444 | **911ms** | 1,821ms | ~11,100 |
| 527 | 768ms | 1,953ms | ~13,175 |
| 566–567 | 566–591ms | 1,179ms | ~14,150–14,175 |
| 689 | 848ms | 2,522ms | ~17,225 |
| 732 | 834ms | 2,619ms | ~18,300 |
| 749 | 838ms | 1,735ms | ~18,725 |
| 787–791 | 650–1,492ms | 2,914ms | ~19,675–19,775 |
| 834–835 | **1,632–1,657ms** | 3,259ms | ~20,850–20,875 |
| 871 | 1,616ms | 2,894ms | ~21,775 |
| 877 | 1,321ms | 3,481ms | ~21,925 |
| 880 | 1,228ms | 3,278ms | ~22,000 |
| 936–939 | 621–1,049ms | 2,597ms | ~23,400–23,475 |
| **965** | **2,380ms** | 4,498ms | ~24,125 |
| **966** | **3,790ms** | 7,136ms | ~24,150 |
| **967** | **3,570ms**| 5,868ms | ~24,175 |
| **968** | **3,712ms** | 6,882ms | ~24,200 |
| **971** | **5,424ms** | **12,446ms** | ~24,275 |
| **972** | **5,022ms** | 12,258ms | ~24,300 |
| 976 | 3,835ms | 8,186ms | ~24,400 |

### Pyroscope Flamegraph: Run 2

- **Total sampled wall time:** ~1,496s (~25 min)
- **Idle time: 50.2%**, the process spent half its wall time waiting (PostgreSQL I/O, event loop idle)
- **`prepareObject` is <ins>completely gone</ins>**, not even present in the function names

#### Top Functions by Self Time

| Self Time | % of Total | Function |
| --------: | :--------: | -------- |
| 232.1s | 15.5% | `keyframe-store.js:putKeyframe` |
| 196.2s | 13.1% | `keyframe-store.js:(anonymous L#20)` |
| 189.5s | 12.7% | `reducer.js:(anonymous L#35)` |
| 133.3s | 8.9% | `:Garbage Collection` |
| 101.3s | 6.8% | `:(anonymous)` |
| 95.0s | 6.4% | `node:buffer:_copyActual` |
| 55.1s | 3.7% | `reducer.js:updateOperationsForAction` |
| 24.8s | 1.7% | `reducer.js:baseReducer` |
| 18.1s | 1.2% | `:writev` |
| 16.4s | 1.1% | `node:internal/buffer:createUnsafeBuffer` |
| 14.7s | 1.0% | `:runMicrotasks` |
| 9.3s | 0.6% | `zod` (schema validation) |
| 7.7s | 0.5% | `@datadog/pprof:serialize` |
| 1.7s | 0.1% | `safe-stable-stringify` (pre-stringify cost) |
| 0.7s | 0.05% | `pg/lib/utils.js:prepareValue` (residual) |

#### CPU Profile: `wall:cpu:nanoseconds`

The CPU-time profile measures actual CPU consumption (excluding I/O wait), revealing which bottlenecks are **compute-bound** vs **I/O-bound**.

- **Total CPU time:** 462.5s
- **Non-JS threads (libuv I/O, native):** 248.5s (53.7%)
- **JS idle:** 54.1s (11.7%)
- **Active JS execution:** **160.0s (34.6%)**

| Function | Wall % (active) | CPU % (active JS) | Ratio | Classification |
|:---------|:---------------:|:-----------------:|:-----:|:---------------|
| `putKeyframe` | 15.5% | **20.7%** | 1.33x | **CPU-bound** |
| `keyframe-store (anon L#20)` | 13.1% | **18.1%** | 1.38x | **CPU-bound** |
| `reducer (anon L#35)` | 12.7% | 10.0% | 0.79x | I/O-bound |
| GC | 8.9% | 7.0% | 0.79x | I/O-bound |
| `(anonymous)` | 6.8% | 9.5% | 1.39x | **CPU-bound** |
| `buffer:_copyActual` | 6.4% | 7.1% | 1.11x | ~equal |
| `updateOperationsForAction` | 3.7% | 2.8% | 0.76x | I/O-bound |
| `baseReducer` | 1.7% | 1.2% | 0.68x | I/O-bound (orchestration) |

> [!IMPORTANT]
> `keyframe-store.js` is CPU-bound, not I/O-bound
> `putKeyframe` + its anonymous callback account for **38.8% of active JS CPU time** (62s of 160s). These functions are <ins>more prominent</ins> in the CPU profile than the wall profile (1.33–1.38x ratio), meaning they are burning CPU cycles on **serialisation/object manipulation**, not waiting on PostgreSQL. Optimising the serialisation within `putKeyframe` (e.g. reducing object size, avoiding deep copies) would directly reduce CPU time.

> [!NOTE]
> Reducer functions are I/O-bound
> `reducer (anon L#35)`, `updateOperationsForAction`, and `baseReducer` are all **less prominent** in the CPU profile (0.68–0.79x ratio), meaning they spend significant time waiting, likely on async database queries or promise resolution. The 53.7% non-JS thread time confirms heavy libuv I/O activity.

### Memory: Run 2

- **Start:** heap 31.5MB / 64.1MB, RSS 168.3MB (clean DB confirmed)
- **End:** heap 167.3MB / 297.2MB, RSS 374.5MB
- **Delta:** heap +135.8MB, RSS +206.2MB (RSS delta reported as -154.9MB likely due to pre-creation allocation being released)

Memory growth of ~136MB across 25k ops indicates significant retained state, likely the in-memory operation index or document cache growing with each operation.

---

## Run 1: Stale dist build, dirty DB

> [!NOTE]
> Pre-stringify was NOT active in this run
> The Pyroscope flamegraph confirms `prepareObject` was **at 34.6% of wall time**. The `dist/` output was not rebuilt after the source changes. This run is effectively a baseline re-run without the optimisation. Additionally, the initial heap was **244.5MB**, suggesting the database was not clean.

### Degradation Pattern: Run 1

| Loop range | Ops accumulated | Approx avg ms/op | Trend |
|:-----------|:----------------|:-----------------:|:------|
| 1–50 | 0–1,250 | ~15–20ms | Stable, fast |
| 50–100 | 1,250–2,500 | ~13–15ms | Dip, possibly JIT warmup |
| 100–200 | 2,500–5,000 | ~16–22ms | Slow rise |
| 200–300 | 5,000–7,500 | ~22–30ms | Linear growth |
| 300–400 | 7,500–10,000 | ~28–50ms | Accelerating, spikes appear |
| 400–500 | 10,000–12,500 | ~40–80ms | Spikes to 370ms |
| 500–600 | 12,500–15,000 | ~60–120ms | Spikes to 810ms |
| 600–700 | 15,000–17,500 | ~70–180ms | Spikes to 2,000ms |
| 700–800 | 17,500–20,000 | ~80–400ms | Severe spikes to 2,800ms |
| 800–900 | 20,000–22,500 | ~80–500ms | Spikes to 1,760ms |
| 900–1000 | 22,500–25,000 | ~80–1,300ms | Worst spike: 3,316ms |

### Pyroscope Flamegraph: Run 1

- **Total sampled wall time:** 815s
- **Profile confirms pre-stringify was NOT active**, `prepareObject` still dominates

#### Top Functions by Self Time

| Self Time | % of Total | Function                                  |
| --------: | :--------: | ----------------------------------------- |
|    281.6s |   34.6%    | `pg/lib/utils.js:prepareObject`           |
|     85.1s |   10.4%    | `reducer.js:(anonymous:L#35)`             |
|     66.0s |    8.1%    | `:Garbage Collection`                     |
|     58.9s |    7.2%    | `:(anonymous)`                            |
|     52.4s |    6.4%    | `node:buffer:_copyActual`                 |
|     31.7s |    3.9%    | `reducer.js:updateOperationsForAction`    |
|     15.0s |    1.8%    | `:writev`                                 |
|     13.5s |    1.7%    | `node:internal/buffer:createUnsafeBuffer` |
|     12.0s |    1.5%    | `reducer.js:getNextRevision`              |

#### Comparison with Previous Flamegraph

| Function | [[2026-02-09-pyroscope-flamegraph-25ops\|Previous]] (25 ops/loop) | Run 1 (25 ops/loop) |
|:---------|:----:|:--------:|
| `prepareObject` | 34.5% | 34.6% |
| `reducer (anonymous)` | 9.9% | 10.4% |
| GC | 9.0% | 8.1% |
| `buffer:_copyActual` | 8.4% | 6.4% |
| `updateOperationsForAction` (total) | 13.6% | 14.6% |

---

## Analysis

### Pre-stringify is confirmed working: `prepareObject` eliminated

The Pyroscope flamegraph proves `prepareObject` is **completely gone** from the profile. The cost of pre-stringifying via `safe-stable-stringify` is negligible (0.1% self time / 1.7s). This validates the optimisation approach.

### New dominant bottleneck: `keyframe-store.js` (28.6%)

With `prepareObject` removed, `putKeyframe` and its callback in `keyframe-store.js` are now the **largest single bottleneck** at 28.6% combined self time. This is the path that writes the full document state (keyframe) to PostgreSQL, it runs every 10 operations and serialises the entire `PHDocument` object.

This was previously masked by `prepareObject` (which was called on the same path but dominated the profile). Now that `prepareObject` is gone, the remaining cost is:
- The keyframe serialisation logic itself
- The database write (INSERT ... ON CONFLICT UPDATE with the full document JSONB)

### `reducer.js` functions are the second bottleneck (18.1%)

| Function | Self time | % |
|:---------|:---------:|:--:|
| `(anonymous L#35)`, likely `operationReducer` | 189.5s | 12.7% |
| `updateOperationsForAction` | 55.1s | 3.7% |
| `baseReducer` | 24.8s | 1.7% |
| **Combined** | **269.4s** | **18.1%** |

`updateOperationsForAction` at 3.7% self time is lower than initially expected. The cause of the non-linear degradation has not been conclusively identified from the flamegraph alone, the flamegraph shows aggregate time, not how cost scales with operation count.

### GC pressure is worse than before (8.9% vs 8.1%)

Garbage collection increased from 8.1% (Run 1) to 8.9% (Run 2). This is unexpected, pre-stringify should reduce GC by eliminating intermediate objects from `prepareObject`. Possible explanations:
- The keyframe serialisation path (now exposed as the top bottleneck) creates significant garbage
- The accumulated in-memory state (heap grew 31.5MB → 167.3MB) increases GC work over time
- Profiler overhead (`@datadog/pprof` appears at 0.5%) may contribute

### Run 2 is 2.76x slower than original baseline:

Run 2 took **4,747s** vs the original **1,716s** baseline. However:
- `prepareObject` was 34.5% of the original profile, removing it should save ~590s, not add 3,031s
- Run 2 had Pyroscope wall+CPU profiling active with `@datadog/pprof`

### Catastrophic collapse at ~24k ops

The step-function collapse at ~24k operations (5,400ms/op avg at loops 965–972) is consistent with:
- **`putKeyframe` writing increasingly large JSONB**, if the document state grows with each operation, each keyframe write becomes more expensive
- **PostgreSQL autovacuum or checkpoint pressure**, 25k write transactions with large JSONB payloads
- **Growing in-memory state**, heap grew 31.5MB → 167.3MB, suggesting some data structure accumulates with operation count

> [!CAUTION]
> Root cause of scaling not yet identified
> The non-linear degradation is clearly visible in the data, but the specific code path responsible has not been confirmed. The flamegraph shows aggregate time, not per-operation scaling. Need to investigate which specific function's cost grows with accumulated operation count, could be `putKeyframe` (growing document size), GC (growing heap), or something else entirely.