### PR TITLE
feat(monorepo): add shared package

### DIFF
--- a/clis/ph-cli/package.json
+++ b/clis/ph-cli/package.json
@@ -49,6 +49,7 @@
     "copyfiles": "^2.4.1",
     "document-drive": "workspace:*",
     "document-model": "workspace:*",
+    "shared": "workspace:*",
     "nodemon": "^3.1.9",
     "vitest": "^3.2.4"
   },

--- a/clis/ph-cli/src/services/legacy/generate.old.ts
+++ b/clis/ph-cli/src/services/legacy/generate.old.ts
@@ -8,7 +8,7 @@ import {
   generateProcessor,
   generateSubgraph,
 } from "@powerhousedao/codegen";
-import { PROCESSOR_APPS } from "@powerhousedao/common/clis";
+import { PROCESSOR_APPS } from "shared";
 import { getConfig } from "@powerhousedao/config/node";
 import path from "path";
 

--- a/clis/ph-cli/tsconfig.json
+++ b/clis/ph-cli/tsconfig.json
@@ -40,6 +40,9 @@
     },
     {
       "path": "../../packages/reactor"
+    },
+    {
+      "path": "../../shared"
     }
   ]
 }

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -84,6 +84,7 @@
   "devDependencies": {
     "@powerhousedao/analytics-engine-core": "^0.5.0",
     "@powerhousedao/reactor": "workspace:*",
+    "shared": "workspace:*",
     "@types/bun": "^1.3.7",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",

--- a/packages/codegen/src/codegen/__tests__/generate-processor.test.ts
+++ b/packages/codegen/src/codegen/__tests__/generate-processor.test.ts
@@ -1,4 +1,4 @@
-import type { ProcessorApps } from "@powerhousedao/common/clis";
+import type { ProcessorApps } from "shared";
 import { $ } from "bun";
 import { describe, it } from "bun:test";
 import { cp } from "node:fs/promises";

--- a/packages/codegen/src/codegen/generate.ts
+++ b/packages/codegen/src/codegen/generate.ts
@@ -6,7 +6,7 @@ import {
   tsMorphGenerateDriveEditor,
 } from "@powerhousedao/codegen/file-builders";
 import { buildTsMorphProject } from "@powerhousedao/codegen/utils";
-import { fileExists, type ProcessorApps } from "@powerhousedao/common/clis";
+import { fileExists } from "@powerhousedao/common/clis";
 import type {
   PartialPowerhouseManifest,
   PowerhouseConfig,
@@ -19,6 +19,7 @@ import { readdir } from "node:fs/promises";
 import path, { join } from "node:path";
 import { readPackage, type NormalizedPackageJson } from "read-pkg";
 import semver from "semver";
+import type { ProcessorApps } from "shared";
 import { tsMorphGenerateProcessor } from "../file-builders/processors/processor.js";
 import { TSMorphCodeGenerator } from "../ts-morph-generator/core/TSMorphCodeGenerator.js";
 import { generateDocumentModelZodSchemas, generateSchemas } from "./graphql.js";

--- a/packages/codegen/src/file-builders/processors/processor.ts
+++ b/packages/codegen/src/file-builders/processors/processor.ts
@@ -8,9 +8,9 @@ import {
   formatSourceFileWithPrettier,
   getOrCreateSourceFile,
 } from "@powerhousedao/codegen/utils";
-import type { ProcessorApp, ProcessorApps } from "@powerhousedao/common/clis";
 import { camelCase, paramCase, pascalCase } from "change-case";
 import path from "path";
+import type { ProcessorApp, ProcessorApps } from "shared";
 import { ts, type Project } from "ts-morph";
 import { tsMorphGenerateAnalyticsProcessor } from "./analytics.js";
 import { tsMorphGenerateRelationalDbProcessor } from "./relational-db.js";

--- a/packages/codegen/tsconfig.json
+++ b/packages/codegen/tsconfig.json
@@ -19,6 +19,7 @@
     { "path": "../design-system" },
     { "path": "../common" },
     { "path": "../config" },
-    { "path": "../reactor" }
+    { "path": "../reactor" },
+    { "path": "../../shared" }
   ]
 }

--- a/packages/common/clis/args/generate.ts
+++ b/packages/common/clis/args/generate.ts
@@ -10,8 +10,8 @@ import {
   positional,
   string,
 } from "cmd-ts";
-import { PROCESSOR_APPS } from "../constants.js";
-import type { ProcessorApp, ProcessorApps } from "../types.js";
+import type { ProcessorApp, ProcessorApps } from "shared";
+import { PROCESSOR_APPS } from "shared";
 import { debugArgs, useHygen } from "./common.js";
 
 const ProcessorAppType: Type<string[], ProcessorApps> = {

--- a/packages/common/clis/constants.ts
+++ b/packages/common/clis/constants.ts
@@ -66,5 +66,3 @@ export const VERSIONED_DEV_DEPENDENCIES = [
   "@powerhousedao/connect",
   "document-drive",
 ];
-
-export const PROCESSOR_APPS = ["connect", "switchboard"] as const;

--- a/packages/common/clis/types.ts
+++ b/packages/common/clis/types.ts
@@ -3,7 +3,6 @@ import type { getPackageManagerCommand } from "./args/common.js";
 import type {
   DRIVES_PRESERVE_STRATEGIES,
   LOG_LEVELS,
-  PROCESSOR_APPS,
   SERVICE_ACTIONS,
 } from "./constants.js";
 
@@ -20,6 +19,3 @@ export type PackageManagerArgs = ParsedCmdResult<
 >;
 
 export type PathValidation = (dir: string) => boolean;
-export type ProcessorApp = (typeof PROCESSOR_APPS)[number];
-
-export type ProcessorApps = readonly ProcessorApp[];

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -1,4 +1,5 @@
 export type * from "./clis/types.js";
 export * from "./editors/index.js";
 export * from "./hooks/index.js";
+export type * from "./types.js";
 export * from "./utils/index.js";

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -69,6 +69,7 @@
   "devDependencies": {
     "@powerhousedao/config": "workspace:*",
     "@powerhousedao/reactor-browser": "workspace:*",
+    "shared": "workspace:*",
     "@storybook/addon-actions": "^8.6.7",
     "@storybook/addon-docs": "^8.6.3",
     "@storybook/addon-essentials": "^8.6.7",

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -39,6 +39,9 @@
     },
     {
       "path": "../config"
+    },
+    {
+      "path": "../../shared"
     }
   ]
 }

--- a/packages/common/types.ts
+++ b/packages/common/types.ts
@@ -1,0 +1,1 @@
+export type { ProcessorApp } from "shared";

--- a/packages/document-drive/package.json
+++ b/packages/document-drive/package.json
@@ -95,6 +95,7 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
+    "shared": "workspace:*",
     "@anatine/zod-mock": "^3.14.0",
     "@types/node": "^24.6.1",
     "@types/uuid": "^9.0.8",

--- a/packages/document-drive/src/processors/types.ts
+++ b/packages/document-drive/src/processors/types.ts
@@ -6,7 +6,7 @@ import type {
 } from "document-drive";
 import type { PHDocumentHeader } from "document-model";
 import type { Kysely, QueryCreator } from "kysely";
-
+import type { ProcessorApp } from "shared";
 export type IRelationalQueryMethods =
   | "selectFrom"
   | "selectNoFrom"
@@ -39,13 +39,10 @@ export type IRelationalDbLegacy<Schema = unknown> =
     ): IRelationalQueryBuilderLegacy<NamespaceSchema>;
   };
 
-export type ProcessorAppsLegacy = ("connect" | "switchboard")[];
-export type ProcessorAppLegacy = ProcessorAppsLegacy[number];
-
 export interface IProcessorHostModuleLegacy {
   analyticsStore: IAnalyticsStore;
   relationalDb: IRelationalDbLegacy;
-  processorApp: ProcessorAppLegacy;
+  processorApp: ProcessorApp;
   config?: Map<string, unknown>;
 }
 
@@ -83,7 +80,7 @@ export type ProcessorRecordLegacy = {
  */
 export type ProcessorFactoryLegacy = (
   driveHeader: PHDocumentHeader,
-  processorApp?: ProcessorAppLegacy,
+  processorApp?: ProcessorApp,
 ) => ProcessorRecordLegacy[] | Promise<ProcessorRecordLegacy[]>;
 
 /**

--- a/packages/document-drive/tsconfig.json
+++ b/packages/document-drive/tsconfig.json
@@ -15,6 +15,9 @@
     },
     {
       "path": "../config"
+    },
+    {
+      "path": "../../shared"
     }
   ]
 }

--- a/packages/reactor-api/package.json
+++ b/packages/reactor-api/package.json
@@ -98,6 +98,7 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
+    "shared": "workspace:*",
     "@graphql-codegen/cli": "^5.0.0",
     "@graphql-codegen/client-preset": "^4.1.0",
     "@graphql-codegen/typed-document-node": "^5.0.1",

--- a/packages/reactor-api/src/server.ts
+++ b/packages/reactor-api/src/server.ts
@@ -18,7 +18,6 @@ import type {
   IProcessorHostModuleLegacy,
   IProcessorManagerLegacy,
   IRelationalDbLegacy,
-  ProcessorAppLegacy,
   ProcessorFactoryLegacy,
 } from "document-drive";
 import {
@@ -38,6 +37,7 @@ import type { TlsOptions } from "node:tls";
 import type { Pool } from "pg";
 import { WebSocketServer } from "ws";
 // Import tracing - initializes OpenTelemetry and provides stub functions for backwards compatibility
+import type { ProcessorApp } from "shared";
 import { config, DefaultCoreSubgraphs } from "./config.js";
 import { AuthSubgraph } from "./graphql/auth/subgraph.js";
 import { GraphQLManager } from "./graphql/graphql-manager.js";
@@ -488,7 +488,7 @@ async function _setupAPI(
     freeEntry: boolean;
   },
   legacyReactor: boolean,
-  processorApp: ProcessorAppLegacy,
+  processorApp: ProcessorApp,
   reactorProcessorManager?: IReactorProcessorManager,
 ): Promise<API> {
   const module: IProcessorHostModuleLegacy = {
@@ -693,7 +693,7 @@ export async function startAPI(
   registry: IDocumentModelRegistry,
   syncManager: ISyncManager,
   options: Options,
-  processorApp: ProcessorAppLegacy,
+  processorApp: ProcessorApp,
 ): Promise<API> {
   const {
     port,
@@ -769,7 +769,7 @@ export async function initializeAndStartAPI(
     documentModels: DocumentModelModule[],
   ) => Promise<ReactorClientModule>,
   options: Options,
-  processorApp: ProcessorAppLegacy,
+  processorApp: ProcessorApp,
 ): Promise<
   API & {
     driveServer: IDocumentDriveServer;

--- a/packages/reactor-api/tsconfig.json
+++ b/packages/reactor-api/tsconfig.json
@@ -23,6 +23,9 @@
     },
     {
       "path": "../config"
+    },
+    {
+      "path": "../../shared"
     }
   ]
 }

--- a/packages/vetra/package.json
+++ b/packages/vetra/package.json
@@ -96,6 +96,7 @@
     "@powerhousedao/reactor-browser": "workspace:*",
     "@powerhousedao/reactor-local": "workspace:*",
     "@powerhousedao/switchboard": "workspace:*",
+    "shared": "workspace:*",
     "@tailwindcss/cli": "^4.1.14",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",

--- a/packages/vetra/processors/codegen/document-handlers/generators/constants.ts
+++ b/packages/vetra/processors/codegen/document-handlers/generators/constants.ts
@@ -1,6 +1,5 @@
+import { PROCESSOR_APPS } from "shared";
+
 export const USE_TS_MORPH = true;
 export const USE_VERSIONING = false;
-export const TEMP_HARDCODED_PROCESSOR_APPS = [
-  "connect",
-  "switchboard",
-] as const;
+export const TEMP_HARDCODED_PROCESSOR_APPS = PROCESSOR_APPS;

--- a/packages/vetra/tsconfig.json
+++ b/packages/vetra/tsconfig.json
@@ -64,6 +64,9 @@
     },
     {
       "path": "../reactor"
+    },
+    {
+      "path": "../../shared"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2491,6 +2491,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
+      shared:
+        specifier: workspace:*
+        version: link:../../shared
       tailwindcss:
         specifier: ^4.0.15
         version: 4.1.16
@@ -2515,6 +2518,9 @@ importers:
       '@powerhousedao/config':
         specifier: workspace:*
         version: link:../../packages/config
+      shared:
+        specifier: workspace:*
+        version: link:../../shared
 
   test/test-client:
     dependencies:
@@ -2531,6 +2537,9 @@ importers:
       '@types/node':
         specifier: ^24.6.1
         version: 24.10.0
+      shared:
+        specifier: workspace:*
+        version: link:../../shared
       tsx:
         specifier: ^4.20.3
         version: 4.21.0
@@ -2573,6 +2582,9 @@ importers:
       kysely:
         specifier: ^0.28.7
         version: 0.28.8
+      shared:
+        specifier: workspace:*
+        version: link:../../shared
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -2794,6 +2806,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
+      shared:
+        specifier: workspace:*
+        version: link:../../shared
       storybook:
         specifier: ^8.6.14
         version: 8.6.14(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -513,6 +513,9 @@ importers:
       nodemon:
         specifier: ^3.1.9
         version: 3.1.10
+      shared:
+        specifier: workspace:*
+        version: link:../../shared
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.0)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(jiti@2.6.1)(jsdom@24.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.12.0(@types/node@24.10.0)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
@@ -944,6 +947,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
+      shared:
+        specifier: workspace:*
+        version: link:../../shared
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.0)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(jiti@2.6.1)(jsdom@24.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.12.0(@types/node@24.10.0)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
@@ -1086,6 +1092,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
+      shared:
+        specifier: workspace:*
+        version: link:../../shared
       storybook:
         specifier: ^8.6.14
         version: 8.6.14(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)
@@ -1484,6 +1493,9 @@ importers:
       msw:
         specifier: ^2.3.1
         version: 2.12.0(@types/node@24.10.0)(typescript@5.9.3)
+      shared:
+        specifier: workspace:*
+        version: link:../../shared
       vite:
         specifier: ^7.2.6
         version: 7.2.6(@types/node@24.10.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
@@ -1842,6 +1854,9 @@ importers:
       msw:
         specifier: ^2.7.3
         version: 2.12.0(@types/node@24.10.0)(typescript@5.9.3)
+      shared:
+        specifier: workspace:*
+        version: link:../../shared
       tinybench:
         specifier: ^3.1.1
         version: 3.1.1
@@ -2350,6 +2365,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
+      shared:
+        specifier: workspace:*
+        version: link:../../shared
       tailwindcss:
         specifier: ^4.1.14
         version: 4.1.16
@@ -2396,6 +2414,8 @@ importers:
       '@types/pg':
         specifier: ^8.11.6
         version: 8.15.6
+
+  shared: {}
 
   test/connect-e2e:
     devDependencies:
@@ -8317,20 +8337,20 @@ packages:
       '@powerhousedao/analytics-engine-core': 0.5.0
       '@powerhousedao/analytics-engine-knex': 0.5.1
 
-  '@powerhousedao/builder-tools@6.0.0-dev.38':
-    resolution: {integrity: sha512-uHgSdVfah6BTRCedW6ftmLiF37uDfTWRGbytO8LzCbhTfY0UMBJMvE/IyUvd7orl2IFm07GW0ZLsEiArspW2gA==}
+  '@powerhousedao/builder-tools@6.0.0-dev.39':
+    resolution: {integrity: sha512-GhxUmB8TmTy6GG5BzGRgO1bKRRmi68D1qLVkXd18U5wgfV/XKdTq3QdJEOcPkwawaRapY+PcomMWLdZp/NSAlg==}
     peerDependencies:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
-  '@powerhousedao/common@6.0.0-dev.38':
-    resolution: {integrity: sha512-nyxYua00BlVn2/8VW3HLQWNsZf5v8wPeImW7mWCwr5HxIKw/4x1VS9XKn9NM52Gw2QaeeH7ck3tae82/iP1Iog==}
+  '@powerhousedao/common@6.0.0-dev.39':
+    resolution: {integrity: sha512-bb/sPBwVWRSarsK+dsTJq5JoaRfX79iRAIW0RRvmyEMYBPCZpeaaMh2p+kKGJ1CGoLCRNTtz7X7vx3FLEqQI5w==}
     peerDependencies:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
-  '@powerhousedao/config@6.0.0-dev.38':
-    resolution: {integrity: sha512-Z+3FIWapnXLMcOPMjgeccJYs1SAOQ95wdgy0LbhCtriL2sBWr9D7zJeJtOe9AN2nOWTUxj5z0FLkxjISG58xtA==}
+  '@powerhousedao/config@6.0.0-dev.39':
+    resolution: {integrity: sha512-mB1LVHkFCFjM+4bEPWM37LaypyA33rwIwOufgTiC9rodhd6Q3pgzbO/aGMT62MZzzDzN6kOyzsdi3J2LI/KKVg==}
 
   '@powerhousedao/design-system@1.40.2':
     resolution: {integrity: sha512-AnMwstM405qLQcf0oliD7Zt/FTxX/nTnO1aKTtCPROJONT7xnJSeqp7bbqy/3qxAkq5erTDX6LA6aCD4+qwrEA==}
@@ -8338,8 +8358,8 @@ packages:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@powerhousedao/design-system@6.0.0-dev.38':
-    resolution: {integrity: sha512-f+SF5DIy4yMSGhk55pmoJtaXFoYyRkjc6a6AP2j1ubZ95/G7+6yVCvcVzOh1MWNUb0+ACmCVDnf+KPTBj0/nXg==}
+  '@powerhousedao/design-system@6.0.0-dev.39':
+    resolution: {integrity: sha512-1DLFATTkPvt5cqpQyHeepGmmjCqsHFPIf4s05Fxan6tynkC/kmVO6Werknle1IsTfF/OAbnx7/X0wMpxpVuP0A==}
     peerDependencies:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
@@ -8356,14 +8376,14 @@ packages:
       react: ^19.2.0
       react-dom: ^19.2.0
 
-  '@powerhousedao/reactor-browser@6.0.0-dev.38':
-    resolution: {integrity: sha512-qzY8f5IQDbyAj6lGCP/a2lbKt/hb4rfeilDfm/VYdrtqtA+R/1I2IWkMNWGHZ0Ik4ooeO8idXpmPQ+U+pKUn3g==}
+  '@powerhousedao/reactor-browser@6.0.0-dev.39':
+    resolution: {integrity: sha512-8Tq53icD+gbV+WLeS4uhWLRBT9NilepbYVRvj0IkdRDyI+egi4hYyWnveYTqbj66RyRKoSroae9kexz6eeOERg==}
     peerDependencies:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
-  '@powerhousedao/reactor@6.0.0-dev.38':
-    resolution: {integrity: sha512-jlwt80w/L1QMCsYjsmuxkS+aH/spKHfNPPKgB9KHeikAx7fgbH8jppDEukCVKzU7yBujcYzA6YhBSrLEPm8kKg==}
+  '@powerhousedao/reactor@6.0.0-dev.39':
+    resolution: {integrity: sha512-7Zl9Iqus8EFf4+HYr9KPwW3lcMT0g6SgGGRQGcGUe86iRjA626rmnmlDxKKOHMjIG1vUO0hxldDpV2Ad1cALiQ==}
 
   '@powerhousedao/scalars@2.0.1':
     resolution: {integrity: sha512-LKDGuKAg5NJiYO5/2AFwfBeJg2kIRCD4UTUEWqIK/YQeVdXLC5ps92TsW1ga+XcZ+8IYwh8/e3oq3XH4x6N6dg==}
@@ -9065,11 +9085,11 @@ packages:
     resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
     engines: {node: '>=14.0.0'}
 
-  '@renown/sdk@6.0.0-dev.38':
-    resolution: {integrity: sha512-mB1Ap77EdJs5xB9lP//VncLm3A0QTCo6jYcj26suogEzXWrruPzygKHX+zKqiK8tIJZxT59jY6fUm8Tzauy0wA==}
+  '@renown/sdk@6.0.0-dev.39':
+    resolution: {integrity: sha512-Hc9BHCUxBI+60V7+Q+J8a/9UGatSzsAiAnGtggUxqnh5xYYWEU3I+L2xJCX1QLeKLT7Tqv8XPCNN59NTviaVPw==}
     peerDependencies:
-      '@powerhousedao/reactor': 6.0.0-dev.38
-      document-model: 6.0.0-dev.38
+      '@powerhousedao/reactor': 6.0.0-dev.39
+      document-model: 6.0.0-dev.39
       react: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       react:
@@ -31166,7 +31186,7 @@ snapshots:
       - supports-color
       - tedious
 
-  '@powerhousedao/builder-tools@6.0.0-dev.38(ab1051dafb0267ca1709a3fed67c64ad)':
+  '@powerhousedao/builder-tools@6.0.0-dev.39(ab1051dafb0267ca1709a3fed67c64ad)':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/commands': 6.8.1
@@ -31181,10 +31201,10 @@ snapshots:
       '@graphql-tools/schema': 10.0.30(graphql@16.12.0)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
       '@hookform/resolvers': 5.2.2(react-hook-form@7.66.0(react@19.2.0))
-      '@powerhousedao/config': 6.0.0-dev.38(@types/node@24.10.0)
-      '@powerhousedao/design-system': 6.0.0-dev.38(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@powerhousedao/config': 6.0.0-dev.39(@types/node@24.10.0)
+      '@powerhousedao/design-system': 6.0.0-dev.39(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@powerhousedao/document-engineering': 1.40.1(@types/express@4.17.25)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@powerhousedao/reactor-browser': 6.0.0-dev.38(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@powerhousedao/reactor-browser': 6.0.0-dev.39(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@prettier/sync': 0.5.5(prettier@3.6.2)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-icons': 1.3.2(react@19.2.0)
@@ -31292,11 +31312,11 @@ snapshots:
       - vite
       - ws
 
-  '@powerhousedao/common@6.0.0-dev.38(235e465aafa4640a523a9620942ff4cd)':
+  '@powerhousedao/common@6.0.0-dev.39(235e465aafa4640a523a9620942ff4cd)':
     dependencies:
       '@powerhousedao/analytics-engine-core': 0.5.0
-      '@powerhousedao/builder-tools': 6.0.0-dev.38(ab1051dafb0267ca1709a3fed67c64ad)
-      '@powerhousedao/design-system': 6.0.0-dev.38(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@powerhousedao/builder-tools': 6.0.0-dev.39(ab1051dafb0267ca1709a3fed67c64ad)
+      '@powerhousedao/design-system': 6.0.0-dev.39(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@tanstack/react-virtual': 3.13.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/luxon': 3.7.1
       chalk: 5.6.2
@@ -31374,7 +31394,7 @@ snapshots:
       - ws
       - zod
 
-  '@powerhousedao/config@6.0.0-dev.38(@types/node@24.10.0)':
+  '@powerhousedao/config@6.0.0-dev.39(@types/node@24.10.0)':
     dependencies:
       '@microsoft/api-extractor': 7.54.0(@types/node@24.10.0)
     transitivePeerDependencies:
@@ -31462,11 +31482,11 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@powerhousedao/design-system@6.0.0-dev.38(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@powerhousedao/design-system@6.0.0-dev.39(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@internationalized/date': 3.10.0
       '@powerhousedao/document-engineering': 1.40.1(@types/express@4.17.25)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@powerhousedao/reactor-browser': 6.0.0-dev.38(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@powerhousedao/reactor-browser': 6.0.0-dev.39(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -31666,15 +31686,15 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@powerhousedao/reactor-browser@6.0.0-dev.38(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@powerhousedao/reactor-browser@6.0.0-dev.39(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@electric-sql/pglite': 0.2.17
       '@electric-sql/pglite-react': 0.2.31(@electric-sql/pglite@0.2.17)(react@19.2.0)
       '@powerhousedao/analytics-engine-browser': 0.6.0(@powerhousedao/analytics-engine-core@0.5.0)(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))
       '@powerhousedao/analytics-engine-core': 0.5.0
-      '@powerhousedao/config': 6.0.0-dev.38(@types/node@24.10.0)
-      '@powerhousedao/reactor': 6.0.0-dev.38
-      '@renown/sdk': 6.0.0-dev.38(@powerhousedao/reactor@6.0.0-dev.38)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@powerhousedao/config': 6.0.0-dev.39(@types/node@24.10.0)
+      '@powerhousedao/reactor': 6.0.0-dev.39
+      '@renown/sdk': 6.0.0-dev.39(@powerhousedao/reactor@6.0.0-dev.39)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@tanstack/react-query': 5.90.7(react@19.2.0)
       change-case: 5.4.4
       did-jwt: 8.0.18
@@ -31708,15 +31728,15 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@powerhousedao/reactor-browser@6.0.0-dev.38(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@powerhousedao/reactor-browser@6.0.0-dev.39(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
     dependencies:
       '@electric-sql/pglite': 0.2.17
       '@electric-sql/pglite-react': 0.2.31(@electric-sql/pglite@0.2.17)(react@19.2.0)
       '@powerhousedao/analytics-engine-browser': 0.6.0(@powerhousedao/analytics-engine-core@0.5.0)(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))
       '@powerhousedao/analytics-engine-core': 0.5.0
-      '@powerhousedao/config': 6.0.0-dev.38(@types/node@24.10.0)
-      '@powerhousedao/reactor': 6.0.0-dev.38
-      '@renown/sdk': 6.0.0-dev.38(@powerhousedao/reactor@6.0.0-dev.38)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      '@powerhousedao/config': 6.0.0-dev.39(@types/node@24.10.0)
+      '@powerhousedao/reactor': 6.0.0-dev.39
+      '@renown/sdk': 6.0.0-dev.39(@powerhousedao/reactor@6.0.0-dev.39)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@tanstack/react-query': 5.90.7(react@19.2.0)
       change-case: 5.4.4
       did-jwt: 8.0.18
@@ -31750,9 +31770,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@powerhousedao/reactor@6.0.0-dev.38':
+  '@powerhousedao/reactor@6.0.0-dev.39':
     dependencies:
       '@electric-sql/pglite': 0.2.17
+      '@sindresorhus/fnv1a': 3.1.0
       document-drive: link:packages/document-drive
       document-model: link:packages/document-model
       kysely: 0.28.8
@@ -32488,10 +32509,10 @@ snapshots:
 
   '@remix-run/router@1.23.0': {}
 
-  '@renown/sdk@6.0.0-dev.38(@powerhousedao/reactor@6.0.0-dev.38)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@renown/sdk@6.0.0-dev.39(@powerhousedao/reactor@6.0.0-dev.39)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@didtools/key-did': 1.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@powerhousedao/reactor': 6.0.0-dev.38
+      '@powerhousedao/reactor': 6.0.0-dev.39
       did-jwt: 8.0.18
       did-jwt-vc: 4.0.16
       did-key-creator: 1.2.0
@@ -32507,10 +32528,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@renown/sdk@6.0.0-dev.38(@powerhousedao/reactor@6.0.0-dev.38)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@renown/sdk@6.0.0-dev.39(@powerhousedao/reactor@6.0.0-dev.39)(bufferutil@4.0.9)(document-model@packages+document-model)(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
     dependencies:
       '@didtools/key-did': 1.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      '@powerhousedao/reactor': 6.0.0-dev.38
+      '@powerhousedao/reactor': 6.0.0-dev.39
       did-jwt: 8.0.18
       did-jwt-vc: 4.0.16
       did-key-creator: 1.2.0
@@ -33462,10 +33483,10 @@ snapshots:
   '@sky-ph/atlas@2.0.0-canary.1(33ba51ab3c05d97837ef661f40f8ceee)':
     dependencies:
       '@hookform/resolvers': 3.10.0(react-hook-form@7.66.0(react@19.2.0))
-      '@powerhousedao/common': 6.0.0-dev.38(235e465aafa4640a523a9620942ff4cd)
-      '@powerhousedao/design-system': 6.0.0-dev.38(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@powerhousedao/common': 6.0.0-dev.39(235e465aafa4640a523a9620942ff4cd)
+      '@powerhousedao/design-system': 6.0.0-dev.39(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/express@4.17.25)(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@powerhousedao/document-engineering': 1.22.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@powerhousedao/reactor-browser': 6.0.0-dev.38(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@powerhousedao/reactor-browser': 6.0.0-dev.39(@powerhousedao/analytics-engine-knex@0.6.0(@powerhousedao/analytics-engine-core@0.5.0))(@types/node@24.10.0)(bufferutil@4.0.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-label': 2.1.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - "test/*"
   - "packages/reactor/test/atlas"
   - "scripts/*"
+  - "shared"
   - "!releases"
 
 catalog:

--- a/shared/README.md
+++ b/shared/README.md
@@ -4,7 +4,7 @@ This directory is an npm package which is intended for sharing code across packa
 
 This package is excluded from the release workflow and is never intended to be published ("private": true) in package.json.
 
-The only exports is for the `index.ts` file because we never intend to publish this package directory. It also doesn't define anything in the "files" field of the `package.json` for the same reason.
+It also doesn't define anything in the "files" field of the `package.json` for the same reason.
 
 This package should **never depend on any other package in this monorepo**. We want to be able to use the code kept here in any of the other monorepo packages without circular imports.
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,15 @@
+# Shared code for the Powerhouse monorepo
+
+This directory is an npm package which is intended for sharing code across packages in the monorepo.
+
+This package is excluded from the release workflow and is never intended to be published ("private": true) in package.json.
+
+The only exports is for the `index.ts` file because we never intend to publish this package directory. It also doesn't define anything in the "files" field of the `package.json` for the same reason.
+
+This package should **never depend on any other package in this monorepo**. We want to be able to use the code kept here in any of the other monorepo packages without circular imports.
+
+This is a great place to put your:
+
+- simple constants you want to be able to use anywhere
+- base types you want to share easily (**not** derived types that require imports from elsewhere)
+- simple utility functions that **do not depend on code from elsewhere in the monorepo**

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,0 +1,2 @@
+export * from "./processors/constants.js";
+export * from "./processors/types.js";

--- a/shared/package.json
+++ b/shared/package.json
@@ -7,6 +7,9 @@
     "access": "restricted"
   },
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "shared",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "publishConfig": {
+    "access": "restricted"
+  },
+  "exports": {
+    ".": "./index.ts"
+  }
+}

--- a/shared/processors/constants.ts
+++ b/shared/processors/constants.ts
@@ -1,0 +1,1 @@
+export const PROCESSOR_APPS = ["connect", "switchboard"] as const;

--- a/shared/processors/types.ts
+++ b/shared/processors/types.ts
@@ -1,0 +1,5 @@
+import type { PROCESSOR_APPS } from "./constants.js";
+
+export type ProcessorApp = (typeof PROCESSOR_APPS)[number];
+
+export type ProcessorApps = readonly ProcessorApp[];

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  // extend our monorepo's base tsconfig
+  "extends": "../tsconfig.options.json",
+  "compilerOptions": {
+    // output transpiled code in the dist file relative to this package's root
+    "outDir": "./dist"
+  },
+  // include all files in this package's root
+  "include": ["**/*"],
+  // add monorepo package paths here
+  // whenever you add "workspace:*" to this package's package.json, also add the path here
+  "references": []
+}

--- a/test/connect-e2e/package.json
+++ b/test/connect-e2e/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@electric-sql/pglite": "0.2.17",
     "@playwright/test": "^1.41.2",
+    "shared": "workspace:*",
     "@powerhousedao/builder-tools": "workspace:*",
     "@powerhousedao/codegen": "workspace:*",
     "@powerhousedao/config": "workspace:*",

--- a/test/connect-e2e/tsconfig.json
+++ b/test/connect-e2e/tsconfig.json
@@ -37,6 +37,9 @@
     },
     {
       "path": "../../packages/document-model"
+    },
+    {
+      "path": "../../shared"
     }
   ],
   "include": ["**/*", "powerhouse.manifest.json"]

--- a/test/e2e-utils/package.json
+++ b/test/e2e-utils/package.json
@@ -35,6 +35,7 @@
     "@playwright/test": "^1.41.2"
   },
   "devDependencies": {
+    "shared": "workspace:*",
     "@playwright/test": "^1.41.2",
     "@powerhousedao/config": "workspace:*"
   }

--- a/test/e2e-utils/tsconfig.json
+++ b/test/e2e-utils/tsconfig.json
@@ -5,5 +5,12 @@
     "types": ["node"]
   },
   "include": ["**/*"],
-  "references": [{ "path": "../../packages/config" }]
+  "references": [
+    {
+      "path": "../../packages/config"
+    },
+    {
+      "path": "../../shared"
+    }
+  ]
 }

--- a/test/test-client/package.json
+++ b/test/test-client/package.json
@@ -25,6 +25,7 @@
     "document-model": "workspace:*"
   },
   "devDependencies": {
+    "shared": "workspace:*",
     "@types/node": "^24.6.1",
     "tsx": "^4.20.3",
     "vitest": "^3.2.4"

--- a/test/test-client/tsconfig.json
+++ b/test/test-client/tsconfig.json
@@ -13,6 +13,9 @@
   "references": [
     {
       "path": "../../packages/document-model"
+    },
+    {
+      "path": "../../shared"
     }
   ]
 }

--- a/test/versioned-documents/package.json
+++ b/test/versioned-documents/package.json
@@ -72,6 +72,7 @@
     "service-unstartup": "bash ./node_modules/@powerhousedao/ph-cli/dist/scripts/service-unstartup.sh"
   },
   "dependencies": {
+    "shared": "workspace:*",
     "@powerhousedao/builder-tools": "workspace:*",
     "@powerhousedao/common": "workspace:*",
     "@powerhousedao/config": "workspace:*",

--- a/test/versioned-documents/tsconfig.json
+++ b/test/versioned-documents/tsconfig.json
@@ -47,6 +47,9 @@
     },
     {
       "path": "../../apps/switchboard"
+    },
+    {
+      "path": "../../shared"
     }
   ]
 }

--- a/test/vetra-e2e/package.json
+++ b/test/vetra-e2e/package.json
@@ -72,6 +72,7 @@
     "@eslint/js": "^9.37.0",
     "@openfeature/core": "^1.9.1",
     "@playwright/test": "^1.55.0",
+    "shared": "workspace:*",
     "@powerhousedao/analytics-engine-core": "^0.5.0",
     "@powerhousedao/codegen": "workspace:*",
     "@powerhousedao/config": "workspace:*",

--- a/test/vetra-e2e/tsconfig.json
+++ b/test/vetra-e2e/tsconfig.json
@@ -49,6 +49,9 @@
     },
     {
       "path": "../../packages/document-drive"
+    },
+    {
+      "path": "../../shared"
     }
   ],
   "include": ["**/*", "powerhouse.manifest.json"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -75,6 +75,9 @@
     },
     {
       "path": "./scripts"
+    },
+    {
+      "path": "./shared"
     }
   ],
   "files": []


### PR DESCRIPTION
# Shared code for the Powerhouse monorepo

This directory is an npm package which is intended for sharing code across packages in the monorepo.

This package is excluded from the release workflow and is never intended to be published ("private": true) in package.json.

It also doesn't define anything in the "files" field of the `package.json` for the same reason.

This package should **never depend on any other package in this monorepo**. We want to be able to use the code kept here in any of the other monorepo packages without circular imports.

This is a great place to put your:

- simple constants you want to be able to use anywhere
- base types you want to share easily (**not** derived types that require imports from elsewhere)
- simple utility functions that **do not depend on code from elsewhere in the monorepo**