### PR TITLE
feat(codegen): remove redundant run generated tests command

### DIFF
--- a/packages/codegen/src/codegen/__tests__/generate-doc-model.test.ts
+++ b/packages/codegen/src/codegen/__tests__/generate-doc-model.test.ts
@@ -68,8 +68,7 @@ async function runDocumentModelTests(args: {
     force: true,
   });
   await loadDocumentModelsInDir(documentModelsInDir, outDir, useVersioning);
-  await $`bun run --cwd ${outDir} tsc`;
-  await $`bun run --cwd ${outDir} vitest --run --silent passed-only`;
+  await $`bun run --cwd ${outDir} tsc --noEmit`;
   return outDir;
 }
 


### PR DESCRIPTION
Currently we run the generated tests when we run the generate-doc-model tests. This makes the tests themselves take significantly longer, and these tests are ultimately redundant. If we already know that the tests work, and we aren't changing the test templates, then there is no need to run them over and above checking that they conform with tsc.