### PR TITLE
Strip operations and clipboard from keyframes on persist

### DIFF
--- a/packages/reactor/src/cache/kysely-write-cache.ts
+++ b/packages/reactor/src/cache/kysely-write-cache.ts
@@ -222,7 +222,11 @@ export class KyselyWriteCache implements IWriteCache {
 
     if (this.isKeyframeRevision(revision)) {
       this.keyframeStore
-        .putKeyframe(documentId, scope, branch, revision, document)
+        .putKeyframe(documentId, scope, branch, revision, {
+          ...document,
+          operations: {},
+          clipboard: [],
+        })
         .catch((err) => {
           console.error(
             `Failed to persist keyframe ${documentId}@${revision}:`,

--- a/packages/reactor/test/cache/write/kysely-write-cache.test.ts
+++ b/packages/reactor/test/cache/write/kysely-write-cache.test.ts
@@ -266,6 +266,8 @@ describe("KyselyWriteCache", () => {
         expect.objectContaining({
           state: expect.any(Object),
           header: expect.any(Object),
+          operations: {},
+          clipboard: [],
         }),
       );
       expect(keyframeStore.putKeyframe).toHaveBeenNthCalledWith(
@@ -277,6 +279,8 @@ describe("KyselyWriteCache", () => {
         expect.objectContaining({
           state: expect.any(Object),
           header: expect.any(Object),
+          operations: {},
+          clipboard: [],
         }),
       );
     });
@@ -570,7 +574,11 @@ describe("KyselyWriteCache (Partial Integration) - Cold Miss Rebuild", () => {
     });
 
     const doc20 = await cache.getState(docId, "global", "main", 20);
-    await keyframeStore.putKeyframe(docId, "global", "main", 20, doc20);
+    await keyframeStore.putKeyframe(docId, "global", "main", 20, {
+      ...doc20,
+      operations: {},
+      clipboard: [],
+    });
 
     // now delete operations 1 - 20, this will prove that the keyframe is used
     await db


### PR DESCRIPTION
Keyframes should only store document state, not operations or clipboard data, reducing storage overhead.

Related to https://github.com/powerhouse-inc/powerhouse/pull/2323 attempts to resolve the same problem

## Reactor Direct Profiling Summary (2026-02-16)

  ### Test Setup

  - Script: tsx ./scripts/profiling/reactor-direct.ts 1 -o 25 -b 5 -l 1000
  - Workload: 1 doc x 25 ops x 1000 loops = 25,000 ops
  - DB: local PostgreSQL
  - Pyroscope: wall + CPU enabled

  ## Results vs Feb 13 Baseline

  | Metric | 2026-02-16 | 2026-02-13 baseline | Change |
  |:--|--:|--:|--:|
  | Total time | 495.37s | 651.79s | -24.0% |
  | Ops phase time | 494.77s | 651.79s | -24.1% |
  | Avg latency | 20ms/op | 26ms/op | -23.1% |
  | Min latency | 7.4ms | 7.4ms | 0.0ms |
  | Max latency | 112.2ms | 270.6ms | -58.5% |
  | Heap delta | +240.2MB | +251.1MB | -10.9MB |
  | RSS delta | +201.6MB | +49.4MB | +152.2MB |

  ## Results vs Feb 12 Deferred Baseline

  | Metric | 2026-02-16 | 2026-02-12 deferred | Change |
  |:--|--:|--:|--:|
  | Total time | 495.37s | 410s | +85.37s (+20.8%) |
  | Avg latency | 20ms/op | 16ms/op | +4ms/op (+25.0%) |
  | Min latency | 7.4ms | 7.2ms | +0.2ms |
  | Max latency | 112.2ms | 71ms | +41.2ms (+58.0%) |
  | Heap delta | +240.2MB | +86.3MB | +153.9MB (+178.3%) |
  | RSS delta | +201.6MB | +153.1MB | +48.5MB (+31.7%) |

  ## Degradation and Spikes

  - Early loops are low and stable (for example loop 10: 8ms/op).
  - Late loops are slower and noisier (for example loop 800: 40ms/op, loop 980: 53ms/op).
  - Max observed single-op latency: 112.2ms (loop 998).

  ## Pyroscope Highlights

1. `reducer.js:updateOperationsForAction` (9.9%)
2. `reducer.js:(anonymous L#35)` (7.9%)
3. `:Garbage Collection` (3.9%)
4. `:runMicrotasks` (3.5%)
5. `:writev` (3.0%)