### PR TITLE
Profiler to file

### DIFF
--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -72,8 +72,11 @@ tsx reactor-direct.ts 10 --db "./data"
 # Enable Pyroscope continuous profiling
 tsx reactor-direct.ts 1 -o 100 -l 10 --pyroscope
 
-# Save output to a file (also prints to stdout)
-tsx reactor-direct.ts 5 -o 20 -l 10 -p --output results.txt
+# Save output to a timestamped file (e.g. 2026-02-18T12-00-00-000Z-reactor-direct.txt)
+tsx reactor-direct.ts 5 -o 20 -l 10 -p --file
+
+# Save output to a specific file
+tsx reactor-direct.ts 5 -o 20 -l 10 -p -O results.txt
 
 # Show percentiles and verbose output
 tsx reactor-direct.ts 5 -o 20 --percentiles --verbose --show-action-types
@@ -88,7 +91,8 @@ tsx reactor-direct.ts 5 -o 20 --percentiles --verbose --show-action-types
 | `--db`                |       | Database connection string or PGlite path                                                                                |
 | `--doc-id`            | `-d`  | Use an existing document (skips creation)                                                                                |
 | `--pyroscope`         |       | Enable Pyroscope profiling (optionally pass server address). Automatically runs `pyroscope-analyse.ts` after completion. |
-| `--output`            | `-O`  | Write output to a file (in addition to stdout)                                                                           |
+| `--file`              |       | Write output to a timestamped file (default name: `reactor-direct.txt`)                                                  |
+| `--output`            | `-O`  | Write output to a specific file (no timestamp prefix)                                                                    |
 | `--verbose`           | `-v`  | Show per-operation timings                                                                                               |
 | `--percentiles`       | `-p`  | Show p50/p90/p95/p99 stats                                                                                               |
 | `--show-action-types` | `-a`  | Show action names in min/max timings                                                                                     |

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -72,6 +72,9 @@ tsx reactor-direct.ts 10 --db "./data"
 # Enable Pyroscope continuous profiling
 tsx reactor-direct.ts 1 -o 100 -l 10 --pyroscope
 
+# Save output to a file (also prints to stdout)
+tsx reactor-direct.ts 5 -o 20 -l 10 -p --output results.txt
+
 # Show percentiles and verbose output
 tsx reactor-direct.ts 5 -o 20 --percentiles --verbose --show-action-types
 ```
@@ -85,6 +88,7 @@ tsx reactor-direct.ts 5 -o 20 --percentiles --verbose --show-action-types
 | `--db`                |       | Database connection string or PGlite path                                                                                |
 | `--doc-id`            | `-d`  | Use an existing document (skips creation)                                                                                |
 | `--pyroscope`         |       | Enable Pyroscope profiling (optionally pass server address). Automatically runs `pyroscope-analyse.ts` after completion. |
+| `--output`            | `-O`  | Write output to a file (in addition to stdout)                                                                           |
 | `--verbose`           | `-v`  | Show per-operation timings                                                                                               |
 | `--percentiles`       | `-p`  | Show p50/p90/p95/p99 stats                                                                                               |
 | `--show-action-types` | `-a`  | Show action names in min/max timings                                                                                     |

--- a/scripts/profiling/reactor-direct.ts
+++ b/scripts/profiling/reactor-direct.ts
@@ -516,6 +516,10 @@ async function main() {
     console.log(`Writing output to: ${outputPath}`);
   }
 
+  console.log(
+    `Command: tsx reactor-direct.ts ${process.argv.slice(2).join(" ")}`,
+  );
+
   // Initialize Pyroscope profiling if enabled
   if (pyroscopeServer) {
     console.log(`Initializing Pyroscope profiler at: ${pyroscopeServer}`);


### PR DESCRIPTION
  Summary     
                                                                                                   
  - Add `--output / -O <file>` option to `reactor-direct.ts` that tees all output to a file while still
   printing to the terminal
  - Output file names are automatically prefixed with an ISO 8601 timestamp (e.g.
  `2026-02-17T10-56-44-123Z-results.txt`)
  - Pyroscope analysis output files now use the same ISO 8601 timestamp format instead of epoch
  seconds
  - Carriage return progress lines are handled correctly in the file, only the final version of
  each line is written, matching terminal output
  - Command arguments are printed at the start of output so the parameters are recorded for future
  reference