### PR TITLE
feat: per-document protection auth model

### DIFF
--- a/packages/config/src/powerhouse.ts
+++ b/packages/config/src/powerhouse.ts
@@ -51,10 +51,8 @@ export type PowerhouseConfig = {
   };
   auth?: {
     enabled?: boolean;
-    guests: string[];
-    users: string[];
     admins: string[];
-    freeEntry?: boolean;
+    defaultProtection?: boolean;
   };
   switchboard?: {
     database?: {
@@ -93,8 +91,6 @@ export const DEFAULT_CONFIG: PowerhouseConfig = {
   logLevel: DEFAULT_LOG_LEVEL,
   auth: {
     enabled: false,
-    guests: [],
-    users: [],
     admins: [],
   },
 };

--- a/packages/reactor-api/src/custom.d.ts
+++ b/packages/reactor-api/src/custom.d.ts
@@ -7,7 +7,5 @@ declare namespace Express {
     };
     auth_enabled?: boolean;
     admins?: string[];
-    users?: string[];
-    guests?: string[];
   }
 }

--- a/packages/reactor-api/src/graphql/auth/resolvers.ts
+++ b/packages/reactor-api/src/graphql/auth/resolvers.ts
@@ -567,7 +567,14 @@ export async function transferDocumentOwnership(
     }
   }
 
+  // Revoke old owner's explicit ADMIN grant before transferring
+  const previousOwner = await service.getDocumentOwner(args.documentId);
+  if (previousOwner) {
+    await service.revokePermission(args.documentId, previousOwner);
+  }
+
   await service.setDocumentOwner(args.documentId, args.newOwnerAddress);
+
   // Grant ADMIN to new owner
   await service.grantPermission(
     args.documentId,
@@ -575,5 +582,6 @@ export async function transferDocumentOwnership(
     "ADMIN",
     userAddress,
   );
+
   return service.getDocumentProtection(args.documentId);
 }

--- a/packages/reactor-api/src/graphql/auth/resolvers.ts
+++ b/packages/reactor-api/src/graphql/auth/resolvers.ts
@@ -1,4 +1,5 @@
 import { GraphQLError } from "graphql";
+import type { AuthorizationService } from "../../services/authorization.service.js";
 import type {
   DocumentPermissionService,
   GetParentIdsFn,
@@ -471,4 +472,108 @@ export async function revokeGroupOperationPermission(
     args.groupId,
   );
   return true;
+}
+
+// ============================================
+// Document Protection Resolvers
+// ============================================
+
+export type DocumentProtectionInfo = {
+  documentId: string;
+  protected: boolean;
+  ownerAddress: string | null;
+};
+
+export async function documentProtection(
+  service: DocumentPermissionService,
+  args: { documentId: string },
+): Promise<DocumentProtectionInfo> {
+  return service.getDocumentProtection(args.documentId);
+}
+
+export async function setDocumentProtection(
+  service: DocumentPermissionService,
+  authorizationService: AuthorizationService | undefined,
+  args: { documentId: string; protected: boolean },
+  userAddress: string | undefined,
+  isGlobalAdmin: boolean,
+): Promise<DocumentProtectionInfo> {
+  if (!userAddress) {
+    throw new GraphQLError("Authentication required");
+  }
+
+  // Check manage permission
+  if (!isGlobalAdmin) {
+    if (authorizationService) {
+      const canManage = await authorizationService.canManage(
+        args.documentId,
+        userAddress,
+      );
+      if (!canManage) {
+        throw new GraphQLError(
+          "Forbidden: You must be an admin of this document to change protection",
+        );
+      }
+    } else {
+      const canManage = await service.canManageDocument(
+        args.documentId,
+        userAddress,
+      );
+      if (!canManage) {
+        throw new GraphQLError(
+          "Forbidden: You must be an admin of this document to change protection",
+        );
+      }
+    }
+  }
+
+  await service.setDocumentProtection(args.documentId, args.protected);
+  return service.getDocumentProtection(args.documentId);
+}
+
+export async function transferDocumentOwnership(
+  service: DocumentPermissionService,
+  authorizationService: AuthorizationService | undefined,
+  args: { documentId: string; newOwnerAddress: string },
+  userAddress: string | undefined,
+  isGlobalAdmin: boolean,
+): Promise<DocumentProtectionInfo> {
+  if (!userAddress) {
+    throw new GraphQLError("Authentication required");
+  }
+
+  // Check manage permission
+  if (!isGlobalAdmin) {
+    if (authorizationService) {
+      const canManage = await authorizationService.canManage(
+        args.documentId,
+        userAddress,
+      );
+      if (!canManage) {
+        throw new GraphQLError(
+          "Forbidden: You must be an admin of this document to transfer ownership",
+        );
+      }
+    } else {
+      const canManage = await service.canManageDocument(
+        args.documentId,
+        userAddress,
+      );
+      if (!canManage) {
+        throw new GraphQLError(
+          "Forbidden: You must be an admin of this document to transfer ownership",
+        );
+      }
+    }
+  }
+
+  await service.setDocumentOwner(args.documentId, args.newOwnerAddress);
+  // Grant ADMIN to new owner
+  await service.grantPermission(
+    args.documentId,
+    args.newOwnerAddress,
+    "ADMIN",
+    userAddress,
+  );
+  return service.getDocumentProtection(args.documentId);
 }

--- a/packages/reactor-api/src/graphql/auth/schema.graphql
+++ b/packages/reactor-api/src/graphql/auth/schema.graphql
@@ -78,9 +78,19 @@ type OperationPermissionsInfo {
   groupPermissions: [OperationGroupPermission!]!
 }
 
+# Document protection info
+type DocumentProtectionInfo {
+  documentId: String!
+  protected: Boolean!
+  ownerAddress: String
+}
+
 type Query {
   # Get permissions for a document
   documentAccess(documentId: String!): DocumentAccessInfo!
+
+  # Get protection status for a document
+  documentProtection(documentId: String!): DocumentProtectionInfo!
 
   # Get all documents the current user has explicit access to
   userDocumentPermissions: [DocumentPermissionEntry!]!
@@ -95,13 +105,28 @@ type Query {
   userGroups(userAddress: String!): [Group!]!
 
   # Get operation permissions for a document and operation type
-  operationPermissions(documentId: String!, operationType: String!): OperationPermissionsInfo!
+  operationPermissions(
+    documentId: String!
+    operationType: String!
+  ): OperationPermissionsInfo!
 
   # Check if the current user can execute a specific operation on a document
   canExecuteOperation(documentId: String!, operationType: String!): Boolean!
 }
 
 type Mutation {
+  # Set document protection status (requires ADMIN permission or global admin)
+  setDocumentProtection(
+    documentId: String!
+    protected: Boolean!
+  ): DocumentProtectionInfo!
+
+  # Transfer document ownership (requires ADMIN permission or global admin)
+  transferDocumentOwnership(
+    documentId: String!
+    newOwnerAddress: String!
+  ): DocumentProtectionInfo!
+
   # Grant a user permission on a document (requires ADMIN permission or global admin)
   grantDocumentPermission(
     documentId: String!
@@ -110,10 +135,7 @@ type Mutation {
   ): DocumentPermissionEntry!
 
   # Revoke a user's permission on a document (requires ADMIN permission or global admin)
-  revokeDocumentPermission(
-    documentId: String!
-    userAddress: String!
-  ): Boolean!
+  revokeDocumentPermission(documentId: String!, userAddress: String!): Boolean!
 
   # --- Group Management ---
 

--- a/packages/reactor-api/src/graphql/auth/subgraph.ts
+++ b/packages/reactor-api/src/graphql/auth/subgraph.ts
@@ -164,9 +164,82 @@ export class AuthSubgraph extends BaseSubgraph {
           throw error;
         }
       },
+
+      documentProtection: async (
+        _parent: unknown,
+        args: { documentId: string },
+      ) => {
+        this.logger.debug("documentProtection", args);
+        if (!this.documentPermissionService) {
+          throw new GraphQLError("DocumentPermissionService not available");
+        }
+        try {
+          return await resolvers.documentProtection(
+            this.documentPermissionService,
+            args,
+          );
+        } catch (error) {
+          this.logger.error("Error in documentProtection:", error);
+          throw error;
+        }
+      },
     },
 
     Mutation: {
+      setDocumentProtection: async (
+        _parent: unknown,
+        args: { documentId: string; protected: boolean },
+        ctx: {
+          user?: { address: string };
+          isAdmin?: (address: string) => boolean;
+        },
+      ) => {
+        this.logger.debug("setDocumentProtection", args);
+        if (!this.documentPermissionService) {
+          throw new GraphQLError("DocumentPermissionService not available");
+        }
+        try {
+          const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "") ?? false;
+          return await resolvers.setDocumentProtection(
+            this.documentPermissionService,
+            this.authorizationService,
+            args,
+            ctx.user?.address,
+            isGlobalAdmin,
+          );
+        } catch (error) {
+          this.logger.error("Error in setDocumentProtection:", error);
+          throw error;
+        }
+      },
+
+      transferDocumentOwnership: async (
+        _parent: unknown,
+        args: { documentId: string; newOwnerAddress: string },
+        ctx: {
+          user?: { address: string };
+          isAdmin?: (address: string) => boolean;
+        },
+      ) => {
+        this.logger.debug("transferDocumentOwnership", args);
+        if (!this.documentPermissionService) {
+          throw new GraphQLError("DocumentPermissionService not available");
+        }
+        try {
+          const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "") ?? false;
+          return await resolvers.transferDocumentOwnership(
+            this.documentPermissionService,
+            this.authorizationService,
+            args,
+            ctx.user?.address,
+            isGlobalAdmin,
+          );
+        } catch (error) {
+          this.logger.error("Error in transferDocumentOwnership:", error);
+          throw error;
+        }
+      },
+
       grantDocumentPermission: async (
         _parent: unknown,
         args: { documentId: string; userAddress: string; permission: string },

--- a/packages/reactor-api/src/graphql/auth/subgraph.ts
+++ b/packages/reactor-api/src/graphql/auth/subgraph.ts
@@ -168,10 +168,18 @@ export class AuthSubgraph extends BaseSubgraph {
       documentProtection: async (
         _parent: unknown,
         args: { documentId: string },
+        ctx: {
+          user?: { address: string };
+        },
       ) => {
         this.logger.debug("documentProtection", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
+        }
+        if (!ctx.user?.address) {
+          throw new GraphQLError(
+            "Authentication required to view document protection info",
+          );
         }
         try {
           return await resolvers.documentProtection(

--- a/packages/reactor-api/src/graphql/base-subgraph.ts
+++ b/packages/reactor-api/src/graphql/base-subgraph.ts
@@ -7,6 +7,7 @@ import type {
 import type { IDocumentDriveServer, IRelationalDbLegacy } from "document-drive";
 import type { DocumentNode } from "graphql";
 import { gql } from "graphql-tag";
+import type { AuthorizationService } from "../services/authorization.service.js";
 import type { DocumentPermissionService } from "../services/document-permission.service.js";
 
 export class BaseSubgraph implements ISubgraph {
@@ -28,6 +29,7 @@ export class BaseSubgraph implements ISubgraph {
   relationalDb: IRelationalDbLegacy;
   syncManager: ISyncManager;
   documentPermissionService?: DocumentPermissionService;
+  authorizationService?: AuthorizationService;
 
   constructor(args: SubgraphArgs) {
     this.reactor = args.reactor;
@@ -36,6 +38,7 @@ export class BaseSubgraph implements ISubgraph {
     this.relationalDb = args.relationalDb;
     this.syncManager = args.syncManager;
     this.documentPermissionService = args.documentPermissionService;
+    this.authorizationService = args.authorizationService;
     this.path = args.path ?? "";
   }
 

--- a/packages/reactor-api/src/graphql/base-subgraph.ts
+++ b/packages/reactor-api/src/graphql/base-subgraph.ts
@@ -6,9 +6,14 @@ import type {
 } from "@powerhousedao/reactor-api";
 import type { IDocumentDriveServer, IRelationalDbLegacy } from "document-drive";
 import type { DocumentNode } from "graphql";
+import { GraphQLError } from "graphql";
 import { gql } from "graphql-tag";
 import type { AuthorizationService } from "../services/authorization.service.js";
-import type { DocumentPermissionService } from "../services/document-permission.service.js";
+import type {
+  DocumentPermissionService,
+  GetParentIdsFn,
+} from "../services/document-permission.service.js";
+import type { Context } from "./types.js";
 
 export class BaseSubgraph implements ISubgraph {
   name = "example";
@@ -44,5 +49,164 @@ export class BaseSubgraph implements ISubgraph {
 
   async onSetup() {
     // noop
+  }
+
+  // ============================================
+  // Shared permission helpers
+  // ============================================
+
+  protected getParentIdsFn(): GetParentIdsFn {
+    return async (documentId: string): Promise<string[]> => {
+      try {
+        const result = await this.reactorClient.getParents(documentId);
+        return result.results.map((doc) => doc.header.id);
+      } catch {
+        return [];
+      }
+    };
+  }
+
+  protected hasGlobalAdminAccess(ctx: Context): boolean {
+    return !!ctx.isAdmin?.(ctx.user?.address ?? "");
+  }
+
+  protected async canReadDocument(
+    documentId: string,
+    ctx: Context,
+  ): Promise<boolean> {
+    if (this.authorizationService) {
+      return this.authorizationService.canRead(
+        documentId,
+        ctx.user?.address,
+        this.getParentIdsFn(),
+      );
+    }
+    if (this.hasGlobalAdminAccess(ctx)) return true;
+    if (this.documentPermissionService) {
+      return this.documentPermissionService.canRead(
+        documentId,
+        ctx.user?.address,
+        this.getParentIdsFn(),
+      );
+    }
+    return false;
+  }
+
+  protected async assertCanRead(
+    documentId: string,
+    ctx: Context,
+  ): Promise<void> {
+    if (this.authorizationService) {
+      const canRead = await this.authorizationService.canRead(
+        documentId,
+        ctx.user?.address,
+        this.getParentIdsFn(),
+      );
+      if (!canRead) {
+        throw new GraphQLError(
+          "Forbidden: insufficient permissions to read this document",
+        );
+      }
+      return;
+    }
+    // Legacy fallback
+    if (!this.hasGlobalAdminAccess(ctx)) {
+      if (this.documentPermissionService) {
+        const canRead = await this.documentPermissionService.canRead(
+          documentId,
+          ctx.user?.address,
+          this.getParentIdsFn(),
+        );
+        if (!canRead) {
+          throw new GraphQLError(
+            "Forbidden: insufficient permissions to read this document",
+          );
+        }
+      } else {
+        throw new GraphQLError(
+          "Forbidden: insufficient permissions to read this document",
+        );
+      }
+    }
+  }
+
+  protected async assertCanWrite(
+    documentId: string,
+    ctx: Context,
+  ): Promise<void> {
+    if (this.authorizationService) {
+      const canWrite = await this.authorizationService.canWrite(
+        documentId,
+        ctx.user?.address,
+        this.getParentIdsFn(),
+      );
+      if (!canWrite) {
+        throw new GraphQLError(
+          "Forbidden: insufficient permissions to write to this document",
+        );
+      }
+      return;
+    }
+    // Legacy fallback
+    if (!this.hasGlobalAdminAccess(ctx)) {
+      if (this.documentPermissionService) {
+        const canWrite = await this.documentPermissionService.canWrite(
+          documentId,
+          ctx.user?.address,
+          this.getParentIdsFn(),
+        );
+        if (!canWrite) {
+          throw new GraphQLError(
+            "Forbidden: insufficient permissions to write to this document",
+          );
+        }
+      } else {
+        throw new GraphQLError(
+          "Forbidden: insufficient permissions to write to this document",
+        );
+      }
+    }
+  }
+
+  protected async assertCanExecuteOperation(
+    documentId: string,
+    operationType: string,
+    ctx: Context,
+  ): Promise<void> {
+    if (this.authorizationService) {
+      const canMutate = await this.authorizationService.canMutate(
+        documentId,
+        operationType,
+        ctx.user?.address,
+        this.getParentIdsFn(),
+      );
+      if (!canMutate) {
+        throw new GraphQLError(
+          `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
+        );
+      }
+      return;
+    }
+    // Legacy fallback
+    if (!this.documentPermissionService) return;
+    if (ctx.isAdmin?.(ctx.user?.address ?? "")) return;
+    const isRestricted =
+      await this.documentPermissionService.isOperationRestricted(
+        documentId,
+        operationType,
+      );
+    if (isRestricted) {
+      const canExecute =
+        await this.documentPermissionService.canExecuteOperation(
+          documentId,
+          operationType,
+          ctx.user?.address,
+        );
+      if (!canExecute) {
+        throw new GraphQLError(
+          `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
+        );
+      }
+    }
   }
 }

--- a/packages/reactor-api/src/graphql/document-model-subgraph.ts
+++ b/packages/reactor-api/src/graphql/document-model-subgraph.ts
@@ -38,46 +38,26 @@ export class DocumentModelSubgraph extends BaseSubgraph {
     this.resolvers = this.generateResolvers();
   }
 
-  /**
-   * Check if user has global read access (admin, user, or guest)
-   */
-  private hasGlobalReadAccess(ctx: Context): boolean {
-    const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "");
-    const isGlobalUser = ctx.isUser?.(ctx.user?.address ?? "");
-    const isGlobalGuest =
-      ctx.isGuest?.(ctx.user?.address ?? "") ||
-      process.env.FREE_ENTRY === "true";
-    return !!(isGlobalAdmin || isGlobalUser || isGlobalGuest);
-  }
-
-  /**
-   * Check if user has global write access (admin or user, not guest)
-   */
-  private hasGlobalWriteAccess(ctx: Context): boolean {
-    const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "");
-    const isGlobalUser = ctx.isUser?.(ctx.user?.address ?? "");
-    return !!(isGlobalAdmin || isGlobalUser);
-  }
-
-  /**
-   * Get the parent IDs function for hierarchical permission checks.
-   * Uses the shared createGetParentIdsFn from reactor/resolvers.
-   */
   private getParentIdsFn(): GetParentIdsFn {
     return createGetParentIdsFn(this.reactorClient);
   }
 
-  /**
-   * Check if user can read a document (with hierarchy)
-   */
+  private hasGlobalAdminAccess(ctx: Context): boolean {
+    return !!ctx.isAdmin?.(ctx.user?.address ?? "");
+  }
+
   private async canReadDocument(
     documentId: string,
     ctx: Context,
   ): Promise<boolean> {
-    if (this.hasGlobalReadAccess(ctx)) {
-      return true;
+    if (this.authorizationService) {
+      return this.authorizationService.canRead(
+        documentId,
+        ctx.user?.address,
+        this.getParentIdsFn(),
+      );
     }
-
+    if (this.hasGlobalAdminAccess(ctx)) return true;
     if (this.documentPermissionService) {
       return this.documentPermissionService.canRead(
         documentId,
@@ -85,35 +65,9 @@ export class DocumentModelSubgraph extends BaseSubgraph {
         this.getParentIdsFn(),
       );
     }
-
     return false;
   }
 
-  /**
-   * Check if user can write to a document (with hierarchy)
-   */
-  private async canWriteDocument(
-    documentId: string,
-    ctx: Context,
-  ): Promise<boolean> {
-    if (this.hasGlobalWriteAccess(ctx)) {
-      return true;
-    }
-
-    if (this.documentPermissionService) {
-      return this.documentPermissionService.canWrite(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-    }
-
-    return false;
-  }
-
-  /**
-   * Throw an error if user cannot read the document
-   */
   private async assertCanRead(documentId: string, ctx: Context): Promise<void> {
     const canRead = await this.canReadDocument(documentId, ctx);
     if (!canRead) {
@@ -123,44 +77,70 @@ export class DocumentModelSubgraph extends BaseSubgraph {
     }
   }
 
-  /**
-   * Throw an error if user cannot write to the document
-   */
   private async assertCanWrite(
     documentId: string,
     ctx: Context,
   ): Promise<void> {
-    const canWrite = await this.canWriteDocument(documentId, ctx);
-    if (!canWrite) {
-      throw new GraphQLError(
-        "Forbidden: insufficient permissions to write to this document",
+    if (this.authorizationService) {
+      const canWrite = await this.authorizationService.canWrite(
+        documentId,
+        ctx.user?.address,
+        this.getParentIdsFn(),
       );
+      if (!canWrite) {
+        throw new GraphQLError(
+          "Forbidden: insufficient permissions to write to this document",
+        );
+      }
+      return;
+    }
+    if (!this.hasGlobalAdminAccess(ctx)) {
+      if (this.documentPermissionService) {
+        const canWrite = await this.documentPermissionService.canWrite(
+          documentId,
+          ctx.user?.address,
+          this.getParentIdsFn(),
+        );
+        if (!canWrite) {
+          throw new GraphQLError(
+            "Forbidden: insufficient permissions to write to this document",
+          );
+        }
+      } else {
+        throw new GraphQLError(
+          "Forbidden: insufficient permissions to write to this document",
+        );
+      }
     }
   }
 
-  /**
-   * Check if user can execute a specific operation on a document.
-   * Throws an error if the operation is restricted and user lacks permission.
-   */
   private async assertCanExecuteOperation(
     documentId: string,
     operationType: string,
     ctx: Context,
   ): Promise<void> {
-    if (!this.documentPermissionService) {
+    if (this.authorizationService) {
+      const canMutate = await this.authorizationService.canMutate(
+        documentId,
+        operationType,
+        ctx.user?.address,
+        this.getParentIdsFn(),
+      );
+      if (!canMutate) {
+        throw new GraphQLError(
+          `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
+        );
+      }
       return;
     }
-
-    if (ctx.isAdmin?.(ctx.user?.address ?? "")) {
-      return;
-    }
-
+    // Legacy fallback
+    if (!this.documentPermissionService) return;
+    if (ctx.isAdmin?.(ctx.user?.address ?? "")) return;
     const isRestricted =
       await this.documentPermissionService.isOperationRestricted(
         documentId,
         operationType,
       );
-
     if (isRestricted) {
       const canExecute =
         await this.documentPermissionService.canExecuteOperation(
@@ -168,7 +148,6 @@ export class DocumentModelSubgraph extends BaseSubgraph {
           operationType,
           ctx.user?.address,
         );
-
       if (!canExecute) {
         throw new GraphQLError(
           `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
@@ -333,7 +312,7 @@ export class DocumentModelSubgraph extends BaseSubgraph {
 
           // Filter by permission if needed
           if (
-            !this.hasGlobalReadAccess(ctx) &&
+            !this.hasGlobalAdminAccess(ctx) &&
             this.documentPermissionService
           ) {
             const filteredItems = [];
@@ -422,7 +401,7 @@ export class DocumentModelSubgraph extends BaseSubgraph {
 
           if (parentIdentifier) {
             await this.assertCanWrite(parentIdentifier, ctx);
-          } else if (!this.hasGlobalWriteAccess(ctx)) {
+          } else if (!this.hasGlobalAdminAccess(ctx)) {
             throw new GraphQLError(
               "Forbidden: insufficient permissions to create documents",
             );
@@ -460,7 +439,7 @@ export class DocumentModelSubgraph extends BaseSubgraph {
 
           if (parentIdentifier) {
             await this.assertCanWrite(parentIdentifier, ctx);
-          } else if (!this.hasGlobalWriteAccess(ctx)) {
+          } else if (!this.hasGlobalAdminAccess(ctx)) {
             throw new GraphQLError(
               "Forbidden: insufficient permissions to create documents",
             );
@@ -581,54 +560,26 @@ export class DocumentModelSubgraphLegacy extends BaseSubgraph {
     this.resolvers = this.generateResolvers();
   }
 
-  /**
-   * Check if user has global read access (admin, user, or guest)
-   */
-  private hasGlobalReadAccess(ctx: Context): boolean {
-    const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "");
-    const isGlobalUser = ctx.isUser?.(ctx.user?.address ?? "");
-    const isGlobalGuest =
-      ctx.isGuest?.(ctx.user?.address ?? "") ||
-      process.env.FREE_ENTRY === "true";
-    return !!(isGlobalAdmin || isGlobalUser || isGlobalGuest);
-  }
-
-  /**
-   * Check if user has global write access (admin or user, not guest)
-   */
-  private hasGlobalWriteAccess(ctx: Context): boolean {
-    const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "");
-    const isGlobalUser = ctx.isUser?.(ctx.user?.address ?? "");
-    return !!(isGlobalAdmin || isGlobalUser);
-  }
-
-  /**
-   * Get the parent IDs function for hierarchical permission checks
-   */
   private getParentIdsFn(): GetParentIdsFn {
-    return async (documentId: string): Promise<string[]> => {
-      try {
-        const result = await this.reactorClient.getParents(documentId);
-        return result.results.map((doc) => doc.header.id);
-      } catch {
-        return [];
-      }
-    };
+    return createGetParentIdsFn(this.reactorClient);
   }
 
-  /**
-   * Check if user can read a document (with hierarchy)
-   */
+  private hasGlobalAdminAccess(ctx: Context): boolean {
+    return !!ctx.isAdmin?.(ctx.user?.address ?? "");
+  }
+
   private async canReadDocument(
     documentId: string,
     ctx: Context,
   ): Promise<boolean> {
-    // Global access allows reading
-    if (this.hasGlobalReadAccess(ctx)) {
-      return true;
+    if (this.authorizationService) {
+      return this.authorizationService.canRead(
+        documentId,
+        ctx.user?.address,
+        this.getParentIdsFn(),
+      );
     }
-
-    // Check document-level permissions with hierarchy
+    if (this.hasGlobalAdminAccess(ctx)) return true;
     if (this.documentPermissionService) {
       return this.documentPermissionService.canRead(
         documentId,
@@ -636,37 +587,9 @@ export class DocumentModelSubgraphLegacy extends BaseSubgraph {
         this.getParentIdsFn(),
       );
     }
-
     return false;
   }
 
-  /**
-   * Check if user can write to a document (with hierarchy)
-   */
-  private async canWriteDocument(
-    documentId: string,
-    ctx: Context,
-  ): Promise<boolean> {
-    // Global write access allows writing
-    if (this.hasGlobalWriteAccess(ctx)) {
-      return true;
-    }
-
-    // Check document-level permissions with hierarchy
-    if (this.documentPermissionService) {
-      return this.documentPermissionService.canWrite(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-    }
-
-    return false;
-  }
-
-  /**
-   * Throw an error if user cannot read the document
-   */
   private async assertCanRead(documentId: string, ctx: Context): Promise<void> {
     const canRead = await this.canReadDocument(documentId, ctx);
     if (!canRead) {
@@ -676,56 +599,76 @@ export class DocumentModelSubgraphLegacy extends BaseSubgraph {
     }
   }
 
-  /**
-   * Throw an error if user cannot write to the document
-   */
   private async assertCanWrite(
     documentId: string,
     ctx: Context,
   ): Promise<void> {
-    const canWrite = await this.canWriteDocument(documentId, ctx);
-    if (!canWrite) {
-      throw new GraphQLError(
-        "Forbidden: insufficient permissions to write to this document",
+    if (this.authorizationService) {
+      const canWrite = await this.authorizationService.canWrite(
+        documentId,
+        ctx.user?.address,
+        this.getParentIdsFn(),
       );
+      if (!canWrite) {
+        throw new GraphQLError(
+          "Forbidden: insufficient permissions to write to this document",
+        );
+      }
+      return;
+    }
+    if (!this.hasGlobalAdminAccess(ctx)) {
+      if (this.documentPermissionService) {
+        const canWrite = await this.documentPermissionService.canWrite(
+          documentId,
+          ctx.user?.address,
+          this.getParentIdsFn(),
+        );
+        if (!canWrite) {
+          throw new GraphQLError(
+            "Forbidden: insufficient permissions to write to this document",
+          );
+        }
+      } else {
+        throw new GraphQLError(
+          "Forbidden: insufficient permissions to write to this document",
+        );
+      }
     }
   }
 
-  /**
-   * Check if user can execute a specific operation on a document.
-   * Throws an error if the operation is restricted and user lacks permission.
-   */
   private async assertCanExecuteOperation(
     documentId: string,
     operationType: string,
     ctx: Context,
   ): Promise<void> {
-    // Skip if no permission service
-    if (!this.documentPermissionService) {
+    if (this.authorizationService) {
+      const canMutate = await this.authorizationService.canMutate(
+        documentId,
+        operationType,
+        ctx.user?.address,
+        this.getParentIdsFn(),
+      );
+      if (!canMutate) {
+        throw new GraphQLError(
+          `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
+        );
+      }
       return;
     }
-
-    // Global admins bypass operation-level restrictions
-    if (ctx.isAdmin?.(ctx.user?.address ?? "")) {
-      return;
-    }
-
-    // Check if this operation has any restrictions set
+    if (!this.documentPermissionService) return;
+    if (ctx.isAdmin?.(ctx.user?.address ?? "")) return;
     const isRestricted =
       await this.documentPermissionService.isOperationRestricted(
         documentId,
         operationType,
       );
-
     if (isRestricted) {
-      // Operation is restricted, check if user has permission
       const canExecute =
         await this.documentPermissionService.canExecuteOperation(
           documentId,
           operationType,
           ctx.user?.address,
         );
-
       if (!canExecute) {
         throw new GraphQLError(
           `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
@@ -807,7 +750,7 @@ export class DocumentModelSubgraphLegacy extends BaseSubgraph {
 
               // If user doesn't have global read access, filter by document-level permissions
               if (
-                !this.hasGlobalReadAccess(ctx) &&
+                !this.hasGlobalAdminAccess(ctx) &&
                 this.documentPermissionService
               ) {
                 const filteredDocs = [];
@@ -836,7 +779,7 @@ export class DocumentModelSubgraphLegacy extends BaseSubgraph {
           // If creating under a drive, check write permission on drive
           if (driveId) {
             await this.assertCanWrite(driveId, ctx);
-          } else if (!this.hasGlobalWriteAccess(ctx)) {
+          } else if (!this.hasGlobalAdminAccess(ctx)) {
             throw new GraphQLError(
               "Forbidden: insufficient permissions to create documents",
             );

--- a/packages/reactor-api/src/graphql/document-model-subgraph.ts
+++ b/packages/reactor-api/src/graphql/document-model-subgraph.ts
@@ -2,7 +2,6 @@ import { camelCase, kebabCase } from "change-case";
 import { addFile } from "document-drive";
 import { setName, type DocumentModelModule } from "document-model";
 import { GraphQLError, Kind, parse } from "graphql";
-import type { GetParentIdsFn } from "../services/document-permission.service.js";
 import {
   generateDocumentModelSchema,
   getDocumentModelSchemaName,
@@ -11,7 +10,6 @@ import { BaseSubgraph } from "./base-subgraph.js";
 import { toGqlPhDocument } from "./reactor/adapters.js";
 import {
   createEmptyDocument as createEmptyDocumentResolver,
-  createGetParentIdsFn,
   documentChildren as documentChildrenResolver,
   documentParents as documentParentsResolver,
   document as documentResolver,
@@ -36,124 +34,6 @@ export class DocumentModelSubgraph extends BaseSubgraph {
       { useNewApi: true },
     );
     this.resolvers = this.generateResolvers();
-  }
-
-  private getParentIdsFn(): GetParentIdsFn {
-    return createGetParentIdsFn(this.reactorClient);
-  }
-
-  private hasGlobalAdminAccess(ctx: Context): boolean {
-    return !!ctx.isAdmin?.(ctx.user?.address ?? "");
-  }
-
-  private async canReadDocument(
-    documentId: string,
-    ctx: Context,
-  ): Promise<boolean> {
-    if (this.authorizationService) {
-      return this.authorizationService.canRead(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-    }
-    if (this.hasGlobalAdminAccess(ctx)) return true;
-    if (this.documentPermissionService) {
-      return this.documentPermissionService.canRead(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-    }
-    return false;
-  }
-
-  private async assertCanRead(documentId: string, ctx: Context): Promise<void> {
-    const canRead = await this.canReadDocument(documentId, ctx);
-    if (!canRead) {
-      throw new GraphQLError(
-        "Forbidden: insufficient permissions to read this document",
-      );
-    }
-  }
-
-  private async assertCanWrite(
-    documentId: string,
-    ctx: Context,
-  ): Promise<void> {
-    if (this.authorizationService) {
-      const canWrite = await this.authorizationService.canWrite(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-      if (!canWrite) {
-        throw new GraphQLError(
-          "Forbidden: insufficient permissions to write to this document",
-        );
-      }
-      return;
-    }
-    if (!this.hasGlobalAdminAccess(ctx)) {
-      if (this.documentPermissionService) {
-        const canWrite = await this.documentPermissionService.canWrite(
-          documentId,
-          ctx.user?.address,
-          this.getParentIdsFn(),
-        );
-        if (!canWrite) {
-          throw new GraphQLError(
-            "Forbidden: insufficient permissions to write to this document",
-          );
-        }
-      } else {
-        throw new GraphQLError(
-          "Forbidden: insufficient permissions to write to this document",
-        );
-      }
-    }
-  }
-
-  private async assertCanExecuteOperation(
-    documentId: string,
-    operationType: string,
-    ctx: Context,
-  ): Promise<void> {
-    if (this.authorizationService) {
-      const canMutate = await this.authorizationService.canMutate(
-        documentId,
-        operationType,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-      if (!canMutate) {
-        throw new GraphQLError(
-          `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
-        );
-      }
-      return;
-    }
-    // Legacy fallback
-    if (!this.documentPermissionService) return;
-    if (ctx.isAdmin?.(ctx.user?.address ?? "")) return;
-    const isRestricted =
-      await this.documentPermissionService.isOperationRestricted(
-        documentId,
-        operationType,
-      );
-    if (isRestricted) {
-      const canExecute =
-        await this.documentPermissionService.canExecuteOperation(
-          documentId,
-          operationType,
-          ctx.user?.address,
-        );
-      if (!canExecute) {
-        throw new GraphQLError(
-          `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
-        );
-      }
-    }
   }
 
   /**
@@ -401,6 +281,12 @@ export class DocumentModelSubgraph extends BaseSubgraph {
 
           if (parentIdentifier) {
             await this.assertCanWrite(parentIdentifier, ctx);
+          } else if (this.authorizationService) {
+            if (!ctx.user?.address) {
+              throw new GraphQLError(
+                "Forbidden: authentication required to create documents",
+              );
+            }
           } else if (!this.hasGlobalAdminAccess(ctx)) {
             throw new GraphQLError(
               "Forbidden: insufficient permissions to create documents",
@@ -415,6 +301,19 @@ export class DocumentModelSubgraph extends BaseSubgraph {
               parentIdentifier,
             },
           );
+
+          // Auto-ownership: set creator as document owner
+          if (
+            this.authorizationService &&
+            ctx.user?.address &&
+            createdDoc?.id
+          ) {
+            await this.documentPermissionService?.initializeDocumentProtection(
+              createdDoc.id,
+              ctx.user.address,
+              this.authorizationService.config.defaultProtection,
+            );
+          }
 
           if (name) {
             const updatedDoc = await this.reactorClient.execute(
@@ -439,6 +338,12 @@ export class DocumentModelSubgraph extends BaseSubgraph {
 
           if (parentIdentifier) {
             await this.assertCanWrite(parentIdentifier, ctx);
+          } else if (this.authorizationService) {
+            if (!ctx.user?.address) {
+              throw new GraphQLError(
+                "Forbidden: authentication required to create documents",
+              );
+            }
           } else if (!this.hasGlobalAdminAccess(ctx)) {
             throw new GraphQLError(
               "Forbidden: insufficient permissions to create documents",
@@ -446,10 +351,21 @@ export class DocumentModelSubgraph extends BaseSubgraph {
           }
 
           // Use shared resolver function - returns PHDocument format directly
-          return createEmptyDocumentResolver(this.reactorClient, {
+          const result = await createEmptyDocumentResolver(this.reactorClient, {
             documentType,
             parentIdentifier,
           });
+
+          // Auto-ownership: set creator as document owner
+          if (this.authorizationService && ctx.user?.address && result?.id) {
+            await this.documentPermissionService?.initializeDocumentProtection(
+              result.id,
+              ctx.user.address,
+              this.authorizationService.config.defaultProtection,
+            );
+          }
+
+          return result;
         },
         // Generate sync and async mutations for each operation
         ...operations.reduce(
@@ -462,7 +378,11 @@ export class DocumentModelSubgraph extends BaseSubgraph {
             ) => {
               const { docId, input } = args;
 
-              await this.assertCanWrite(docId, ctx);
+              // assertCanExecuteOperation uses canMutate (write + operation) when
+              // authorizationService is available. Legacy fallback needs separate write check.
+              if (!this.authorizationService) {
+                await this.assertCanWrite(docId, ctx);
+              }
               await this.assertCanExecuteOperation(docId, op.name!, ctx);
 
               const doc = await this.reactorClient.get(docId);
@@ -502,7 +422,9 @@ export class DocumentModelSubgraph extends BaseSubgraph {
             ) => {
               const { docId, input } = args;
 
-              await this.assertCanWrite(docId, ctx);
+              if (!this.authorizationService) {
+                await this.assertCanWrite(docId, ctx);
+              }
               await this.assertCanExecuteOperation(docId, op.name!, ctx);
 
               const doc = await this.reactorClient.get(docId);
@@ -558,123 +480,6 @@ export class DocumentModelSubgraphLegacy extends BaseSubgraph {
       this.documentModel.documentModel.global,
     );
     this.resolvers = this.generateResolvers();
-  }
-
-  private getParentIdsFn(): GetParentIdsFn {
-    return createGetParentIdsFn(this.reactorClient);
-  }
-
-  private hasGlobalAdminAccess(ctx: Context): boolean {
-    return !!ctx.isAdmin?.(ctx.user?.address ?? "");
-  }
-
-  private async canReadDocument(
-    documentId: string,
-    ctx: Context,
-  ): Promise<boolean> {
-    if (this.authorizationService) {
-      return this.authorizationService.canRead(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-    }
-    if (this.hasGlobalAdminAccess(ctx)) return true;
-    if (this.documentPermissionService) {
-      return this.documentPermissionService.canRead(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-    }
-    return false;
-  }
-
-  private async assertCanRead(documentId: string, ctx: Context): Promise<void> {
-    const canRead = await this.canReadDocument(documentId, ctx);
-    if (!canRead) {
-      throw new GraphQLError(
-        "Forbidden: insufficient permissions to read this document",
-      );
-    }
-  }
-
-  private async assertCanWrite(
-    documentId: string,
-    ctx: Context,
-  ): Promise<void> {
-    if (this.authorizationService) {
-      const canWrite = await this.authorizationService.canWrite(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-      if (!canWrite) {
-        throw new GraphQLError(
-          "Forbidden: insufficient permissions to write to this document",
-        );
-      }
-      return;
-    }
-    if (!this.hasGlobalAdminAccess(ctx)) {
-      if (this.documentPermissionService) {
-        const canWrite = await this.documentPermissionService.canWrite(
-          documentId,
-          ctx.user?.address,
-          this.getParentIdsFn(),
-        );
-        if (!canWrite) {
-          throw new GraphQLError(
-            "Forbidden: insufficient permissions to write to this document",
-          );
-        }
-      } else {
-        throw new GraphQLError(
-          "Forbidden: insufficient permissions to write to this document",
-        );
-      }
-    }
-  }
-
-  private async assertCanExecuteOperation(
-    documentId: string,
-    operationType: string,
-    ctx: Context,
-  ): Promise<void> {
-    if (this.authorizationService) {
-      const canMutate = await this.authorizationService.canMutate(
-        documentId,
-        operationType,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-      if (!canMutate) {
-        throw new GraphQLError(
-          `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
-        );
-      }
-      return;
-    }
-    if (!this.documentPermissionService) return;
-    if (ctx.isAdmin?.(ctx.user?.address ?? "")) return;
-    const isRestricted =
-      await this.documentPermissionService.isOperationRestricted(
-        documentId,
-        operationType,
-      );
-    if (isRestricted) {
-      const canExecute =
-        await this.documentPermissionService.canExecuteOperation(
-          documentId,
-          operationType,
-          ctx.user?.address,
-        );
-      if (!canExecute) {
-        throw new GraphQLError(
-          `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
-        );
-      }
-    }
   }
 
   /**
@@ -779,6 +584,12 @@ export class DocumentModelSubgraphLegacy extends BaseSubgraph {
           // If creating under a drive, check write permission on drive
           if (driveId) {
             await this.assertCanWrite(driveId, ctx);
+          } else if (this.authorizationService) {
+            if (!ctx.user?.address) {
+              throw new GraphQLError(
+                "Forbidden: authentication required to create documents",
+              );
+            }
           } else if (!this.hasGlobalAdminAccess(ctx)) {
             throw new GraphQLError(
               "Forbidden: insufficient permissions to create documents",
@@ -802,6 +613,15 @@ export class DocumentModelSubgraphLegacy extends BaseSubgraph {
             await this.reactor.addAction(document.header.id, setName(name));
           }
 
+          // Auto-ownership: set creator as document owner
+          if (this.authorizationService && ctx.user?.address) {
+            await this.documentPermissionService?.initializeDocumentProtection(
+              document.header.id,
+              ctx.user.address,
+              this.authorizationService.config.defaultProtection,
+            );
+          }
+
           return document.header.id;
         },
         ...operations.reduce(
@@ -813,10 +633,11 @@ export class DocumentModelSubgraphLegacy extends BaseSubgraph {
             ) => {
               const { docId, input } = args;
 
-              // Check write permission before mutating document
-              await this.assertCanWrite(docId, ctx);
-
-              // Check operation-level permissions
+              // assertCanExecuteOperation uses canMutate (write + operation) when
+              // authorizationService is available. Legacy fallback needs separate write check.
+              if (!this.authorizationService) {
+                await this.assertCanWrite(docId, ctx);
+              }
               await this.assertCanExecuteOperation(docId, op.name!, ctx);
 
               const doc = await this.reactor.getDocument(docId);

--- a/packages/reactor-api/src/graphql/drive-subgraph.ts
+++ b/packages/reactor-api/src/graphql/drive-subgraph.ts
@@ -372,23 +372,12 @@ export class DriveSubgraph extends BaseSubgraph {
         }
         const reactorDriveId = await this.getDriveIdBySlugOrId(ctx.driveId);
 
-        // Check global roles first
-        const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "");
-        const isGlobalUser = ctx.isUser?.(ctx.user?.address ?? "");
-        const isGlobalGuest =
-          ctx.isGuest?.(ctx.user?.address ?? "") ||
-          process.env.FREE_ENTRY === "true";
-
-        // If user has a global role, allow access
-        const hasGlobalAccess = isGlobalAdmin || isGlobalUser || isGlobalGuest;
-
-        // If no global access, check document-level permissions
-        if (!hasGlobalAccess && this.documentPermissionService) {
-          const canRead = await this.documentPermissionService.canReadDocument(
+        // Check read permission
+        if (this.authorizationService) {
+          const canRead = await this.authorizationService.canRead(
             reactorDriveId,
             ctx.user?.address,
           );
-
           if (!canRead) {
             this.logger.warn(
               `registerPullResponderListener rejected: user ${ctx.user?.address ?? "anonymous"} lacks read permission for drive ${reactorDriveId}`,
@@ -397,8 +386,23 @@ export class DriveSubgraph extends BaseSubgraph {
               "Forbidden: insufficient permissions to read from this drive",
             );
           }
-        } else if (!hasGlobalAccess) {
-          throw new GraphQLError("Forbidden");
+        } else {
+          // Legacy fallback
+          const isGlobalAdmin = !!ctx.isAdmin?.(ctx.user?.address ?? "");
+          if (!isGlobalAdmin && this.documentPermissionService) {
+            const canRead =
+              await this.documentPermissionService.canReadDocument(
+                reactorDriveId,
+                ctx.user?.address,
+              );
+            if (!canRead) {
+              throw new GraphQLError(
+                "Forbidden: insufficient permissions to read from this drive",
+              );
+            }
+          } else if (!isGlobalAdmin) {
+            throw new GraphQLError("Forbidden");
+          }
         }
         const driveId = await this.getDriveIdBySlugOrId(ctx.driveId);
 
@@ -457,21 +461,12 @@ export class DriveSubgraph extends BaseSubgraph {
           strandsGql,
         );
 
-        // Check global roles first (write requires admin or user, not guest)
-        const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "");
-        const isGlobalUser = ctx.isUser?.(ctx.user?.address ?? "");
-
-        // If user has global write access, allow
-        const hasGlobalWriteAccess = isGlobalAdmin || isGlobalUser;
-
-        // If no global write access, check document-level permissions
-        if (!hasGlobalWriteAccess && this.documentPermissionService) {
-          const canWrite =
-            await this.documentPermissionService.canWriteDocument(
-              driveId,
-              ctx.user?.address,
-            );
-
+        // Check write permission
+        if (this.authorizationService) {
+          const canWrite = await this.authorizationService.canWrite(
+            driveId,
+            ctx.user?.address,
+          );
           if (!canWrite) {
             this.logger.warn(
               `pushUpdates rejected: user ${ctx.user?.address ?? "anonymous"} lacks write permission for drive ${driveId}`,
@@ -480,8 +475,23 @@ export class DriveSubgraph extends BaseSubgraph {
               "Forbidden: insufficient permissions to write to this drive",
             );
           }
-        } else if (!hasGlobalWriteAccess) {
-          throw new GraphQLError("Forbidden");
+        } else {
+          // Legacy fallback
+          const isGlobalAdmin = !!ctx.isAdmin?.(ctx.user?.address ?? "");
+          if (!isGlobalAdmin && this.documentPermissionService) {
+            const canWrite =
+              await this.documentPermissionService.canWriteDocument(
+                driveId,
+                ctx.user?.address,
+              );
+            if (!canWrite) {
+              throw new GraphQLError(
+                "Forbidden: insufficient permissions to write to this drive",
+              );
+            }
+          } else if (!isGlobalAdmin) {
+            throw new GraphQLError("Forbidden");
+          }
         }
 
         // translate data types
@@ -571,31 +581,33 @@ export class DriveSubgraph extends BaseSubgraph {
           `strands(drive: ${ctx.driveId}/${driveId}, listenerId: ${listenerId}, since:${since})`,
         );
 
-        // Check global roles first
-        const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "");
-        const isGlobalUser = ctx.isUser?.(ctx.user?.address ?? "");
-        const isGlobalGuest =
-          ctx.isGuest?.(ctx.user?.address ?? "") ||
-          process.env.FREE_ENTRY === "true";
-
-        // If user has a global role, allow access
-        const hasGlobalAccess = isGlobalAdmin || isGlobalUser || isGlobalGuest;
-
-        // If no global access, check document-level permissions
-        if (!hasGlobalAccess && this.documentPermissionService) {
-          const canRead = await this.documentPermissionService.canReadDocument(
+        // Check read permission
+        if (this.authorizationService) {
+          const canRead = await this.authorizationService.canRead(
             driveId,
             ctx.user?.address,
           );
-
           if (!canRead) {
             this.logger.warn(
               `strands filtered: user ${ctx.user?.address ?? "anonymous"} lacks read permission for drive ${driveId}`,
             );
-            return []; // Return empty for drives without permission
+            return [];
           }
-        } else if (!hasGlobalAccess) {
-          return []; // Return empty if no access
+        } else {
+          // Legacy fallback
+          const isGlobalAdmin = !!ctx.isAdmin?.(ctx.user?.address ?? "");
+          if (!isGlobalAdmin && this.documentPermissionService) {
+            const canRead =
+              await this.documentPermissionService.canReadDocument(
+                driveId,
+                ctx.user?.address,
+              );
+            if (!canRead) {
+              return [];
+            }
+          } else if (!isGlobalAdmin) {
+            return [];
+          }
         }
 
         // get the requested strand updates

--- a/packages/reactor-api/src/graphql/graphql-manager.ts
+++ b/packages/reactor-api/src/graphql/graphql-manager.ts
@@ -43,6 +43,7 @@ import { match, type MatchFunction, type ParamData } from "path-to-regexp";
 import type { WebSocketServer } from "ws";
 import type { AuthConfig } from "../services/auth.service.js";
 import { AuthService } from "../services/auth.service.js";
+import type { AuthorizationService } from "../services/authorization.service.js";
 import type { DocumentPermissionService } from "../services/document-permission.service.js";
 import {
   buildSubgraphSchemaModule,
@@ -174,6 +175,7 @@ export class GraphQLManager {
     private readonly documentPermissionService?: DocumentPermissionService,
     private readonly featureFlags: GraphqlManagerFeatureFlags = DefaultFeatureFlags,
     private readonly port: number = 4001,
+    private readonly authorizationService?: AuthorizationService,
   ) {
     if (this.authConfig) {
       this.authService = new AuthService(this.authConfig);
@@ -216,18 +218,6 @@ export class GraphQLManager {
           !req.auth_enabled
             ? true
             : (req.admins
-                ?.map((a) => a.toLowerCase())
-                .includes(address.toLowerCase() ?? "") ?? false),
-        isUser: (address: string) =>
-          !req.auth_enabled
-            ? true
-            : (req.users
-                ?.map((a) => a.toLowerCase())
-                .includes(address.toLowerCase() ?? "") ?? false),
-        isGuest: (address: string) =>
-          !req.auth_enabled
-            ? true
-            : (req.guests
                 ?.map((a) => a.toLowerCase())
                 .includes(address.toLowerCase() ?? "") ?? false),
       });
@@ -314,6 +304,7 @@ export class GraphQLManager {
           syncManager: this.syncManager,
           path: this.path,
           documentPermissionService: this.documentPermissionService,
+          authorizationService: this.authorizationService,
         });
 
         await this.#addSubgraphInstance(subgraphInstance, supergraph, false);
@@ -377,6 +368,7 @@ export class GraphQLManager {
       syncManager: this.syncManager,
       path: this.path,
       documentPermissionService: this.documentPermissionService,
+      authorizationService: this.authorizationService,
     });
 
     return this.#addSubgraphInstance(subgraphInstance, supergraph, core);

--- a/packages/reactor-api/src/graphql/reactor/subgraph.ts
+++ b/packages/reactor-api/src/graphql/reactor/subgraph.ts
@@ -39,27 +39,6 @@ export class ReactorSubgraph extends BaseSubgraph {
   hasSubscriptions = true;
 
   /**
-   * Check if user has global read access (admin, user, or guest)
-   */
-  private hasGlobalReadAccess(ctx: Context): boolean {
-    const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "");
-    const isGlobalUser = ctx.isUser?.(ctx.user?.address ?? "");
-    const isGlobalGuest =
-      ctx.isGuest?.(ctx.user?.address ?? "") ||
-      process.env.FREE_ENTRY === "true";
-    return !!(isGlobalAdmin || isGlobalUser || isGlobalGuest);
-  }
-
-  /**
-   * Check if user has global write access (admin or user, not guest)
-   */
-  private hasGlobalWriteAccess(ctx: Context): boolean {
-    const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "");
-    const isGlobalUser = ctx.isUser?.(ctx.user?.address ?? "");
-    return !!(isGlobalAdmin || isGlobalUser);
-  }
-
-  /**
    * Get the parent IDs function for hierarchical permission checks
    */
   private getParentIdsFn() {
@@ -67,18 +46,67 @@ export class ReactorSubgraph extends BaseSubgraph {
   }
 
   /**
-   * Check if user can read a document (with hierarchy)
+   * Check if user has global admin access.
+   * Used as legacy fallback when authorizationService is not available.
+   */
+  private hasGlobalAdminAccess(ctx: Context): boolean {
+    return !!ctx.isAdmin?.(ctx.user?.address ?? "");
+  }
+
+  /**
+   * Throw an error if user cannot read the document
+   */
+  private async assertCanRead(documentId: string, ctx: Context): Promise<void> {
+    if (this.authorizationService) {
+      const canRead = await this.authorizationService.canRead(
+        documentId,
+        ctx.user?.address,
+        this.getParentIdsFn(),
+      );
+      if (!canRead) {
+        throw new GraphQLError(
+          "Forbidden: insufficient permissions to read this document",
+        );
+      }
+      return;
+    }
+    // Legacy fallback
+    if (!this.hasGlobalAdminAccess(ctx)) {
+      if (this.documentPermissionService) {
+        const canRead = await this.documentPermissionService.canRead(
+          documentId,
+          ctx.user?.address,
+          this.getParentIdsFn(),
+        );
+        if (!canRead) {
+          throw new GraphQLError(
+            "Forbidden: insufficient permissions to read this document",
+          );
+        }
+      } else {
+        throw new GraphQLError(
+          "Forbidden: insufficient permissions to read this document",
+        );
+      }
+    }
+  }
+
+  /**
+   * Check if user can read a document (returns boolean, for filtering)
    */
   private async canReadDocument(
     documentId: string,
     ctx: Context,
   ): Promise<boolean> {
-    // Global access allows reading
-    if (this.hasGlobalReadAccess(ctx)) {
-      return true;
+    if (this.authorizationService) {
+      return this.authorizationService.canRead(
+        documentId,
+        ctx.user?.address,
+        this.getParentIdsFn(),
+      );
     }
-
-    // Check document-level permissions with hierarchy
+    // Legacy fallback
+    if (this.hasGlobalAdminAccess(ctx)) return true;
     if (this.documentPermissionService) {
       return this.documentPermissionService.canRead(
         documentId,
@@ -86,44 +114,7 @@ export class ReactorSubgraph extends BaseSubgraph {
         this.getParentIdsFn(),
       );
     }
-
     return false;
-  }
-
-  /**
-   * Check if user can write to a document (with hierarchy)
-   */
-  private async canWriteDocument(
-    documentId: string,
-    ctx: Context,
-  ): Promise<boolean> {
-    // Global write access allows writing
-    if (this.hasGlobalWriteAccess(ctx)) {
-      return true;
-    }
-
-    // Check document-level permissions with hierarchy
-    if (this.documentPermissionService) {
-      return this.documentPermissionService.canWrite(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-    }
-
-    return false;
-  }
-
-  /**
-   * Throw an error if user cannot read the document
-   */
-  private async assertCanRead(documentId: string, ctx: Context): Promise<void> {
-    const canRead = await this.canReadDocument(documentId, ctx);
-    if (!canRead) {
-      throw new GraphQLError(
-        "Forbidden: insufficient permissions to read this document",
-      );
-    }
   }
 
   /**
@@ -133,62 +124,94 @@ export class ReactorSubgraph extends BaseSubgraph {
     documentId: string,
     ctx: Context,
   ): Promise<void> {
-    const canWrite = await this.canWriteDocument(documentId, ctx);
-    if (!canWrite) {
-      throw new GraphQLError(
-        "Forbidden: insufficient permissions to write to this document",
+    if (this.authorizationService) {
+      const canWrite = await this.authorizationService.canWrite(
+        documentId,
+        ctx.user?.address,
+        this.getParentIdsFn(),
       );
+      if (!canWrite) {
+        throw new GraphQLError(
+          "Forbidden: insufficient permissions to write to this document",
+        );
+      }
+      return;
+    }
+    // Legacy fallback
+    if (!this.hasGlobalAdminAccess(ctx)) {
+      if (this.documentPermissionService) {
+        const canWrite = await this.documentPermissionService.canWrite(
+          documentId,
+          ctx.user?.address,
+          this.getParentIdsFn(),
+        );
+        if (!canWrite) {
+          throw new GraphQLError(
+            "Forbidden: insufficient permissions to write to this document",
+          );
+        }
+      } else {
+        throw new GraphQLError(
+          "Forbidden: insufficient permissions to write to this document",
+        );
+      }
     }
   }
 
   /**
    * Check if user can execute specific operations on a document.
-   * Only checks operations that have restrictions set.
-   * Throws an error if any operation is restricted and user lacks permission.
+   * Uses AuthorizationService.canMutate when available, which supports
+   * READ-only users with operation grants.
    */
   private async assertCanExecuteOperations(
     documentId: string,
     actions: readonly unknown[],
     ctx: Context,
   ): Promise<void> {
-    // Skip if no permission service
-    if (!this.documentPermissionService) {
+    if (this.authorizationService) {
+      for (const action of actions) {
+        if (!action || typeof action !== "object") continue;
+        const actionObj = action as Record<string, unknown>;
+        const operationType = actionObj.type;
+        if (typeof operationType !== "string") continue;
+
+        const canMutate = await this.authorizationService.canMutate(
+          documentId,
+          operationType,
+          ctx.user?.address,
+          this.getParentIdsFn(),
+        );
+        if (!canMutate) {
+          throw new GraphQLError(
+            `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
+          );
+        }
+      }
       return;
     }
 
-    // Global admins bypass operation-level restrictions
-    if (ctx.isAdmin?.(ctx.user?.address ?? "")) {
-      return;
-    }
+    // Legacy fallback
+    if (!this.documentPermissionService) return;
+    if (ctx.isAdmin?.(ctx.user?.address ?? "")) return;
 
     for (const action of actions) {
-      if (!action || typeof action !== "object") {
-        continue;
-      }
-
+      if (!action || typeof action !== "object") continue;
       const actionObj = action as Record<string, unknown>;
       const operationType = actionObj.type;
+      if (typeof operationType !== "string") continue;
 
-      if (typeof operationType !== "string") {
-        continue;
-      }
-
-      // Check if this operation has any restrictions set
       const isRestricted =
         await this.documentPermissionService.isOperationRestricted(
           documentId,
           operationType,
         );
-
       if (isRestricted) {
-        // Operation is restricted, check if user has permission
         const canExecute =
           await this.documentPermissionService.canExecuteOperation(
             documentId,
             operationType,
             ctx.user?.address,
           );
-
         if (!canExecute) {
           throw new GraphQLError(
             `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
@@ -281,7 +304,7 @@ export class ReactorSubgraph extends BaseSubgraph {
           );
           // Filter results to only include documents the user can read
           if (
-            !this.hasGlobalReadAccess(ctx) &&
+            !this.hasGlobalAdminAccess(ctx) &&
             this.documentPermissionService
           ) {
             const filteredItems = [];
@@ -314,7 +337,7 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           // Filter results to only include documents the user can read
           if (
-            !this.hasGlobalReadAccess(ctx) &&
+            !this.hasGlobalAdminAccess(ctx) &&
             this.documentPermissionService
           ) {
             const filteredItems = [];
@@ -390,12 +413,32 @@ export class ReactorSubgraph extends BaseSubgraph {
             });
 
             await this.assertCanWrite(parent.document.id, ctx);
-          } else if (!this.hasGlobalWriteAccess(ctx)) {
+          } else if (this.authorizationService) {
+            if (!ctx.user?.address) {
+              throw new GraphQLError(
+                "Forbidden: authentication required to create documents",
+              );
+            }
+          } else if (!this.hasGlobalAdminAccess(ctx)) {
             throw new GraphQLError(
               "Forbidden: insufficient permissions to create documents",
             );
           }
-          return await resolvers.createDocument(this.reactorClient, args);
+          const result = await resolvers.createDocument(
+            this.reactorClient,
+            args,
+          );
+
+          // Auto-ownership: set creator as document owner
+          if (this.authorizationService && ctx.user?.address && result?.id) {
+            await this.documentPermissionService?.initializeDocumentProtection(
+              result.id,
+              ctx.user.address,
+              this.authorizationService.config.defaultProtection,
+            );
+          }
+
+          return result;
         } catch (error) {
           this.logger.error("Error in createDocument(@args): @Error", error);
           throw error;
@@ -412,12 +455,32 @@ export class ReactorSubgraph extends BaseSubgraph {
             });
 
             await this.assertCanWrite(parent.document.id, ctx);
-          } else if (!this.hasGlobalWriteAccess(ctx)) {
+          } else if (this.authorizationService) {
+            if (!ctx.user?.address) {
+              throw new GraphQLError(
+                "Forbidden: authentication required to create documents",
+              );
+            }
+          } else if (!this.hasGlobalAdminAccess(ctx)) {
             throw new GraphQLError(
               "Forbidden: insufficient permissions to create documents",
             );
           }
-          return await resolvers.createEmptyDocument(this.reactorClient, args);
+          const result = await resolvers.createEmptyDocument(
+            this.reactorClient,
+            args,
+          );
+
+          // Auto-ownership: set creator as document owner
+          if (this.authorizationService && ctx.user?.address && result?.id) {
+            await this.documentPermissionService?.initializeDocumentProtection(
+              result.id,
+              ctx.user.address,
+              this.authorizationService.config.defaultProtection,
+            );
+          }
+
+          return result;
         } catch (error) {
           this.logger.error(
             "Error in createEmptyDocument(@args): @Error",

--- a/packages/reactor-api/src/graphql/reactor/subgraph.ts
+++ b/packages/reactor-api/src/graphql/reactor/subgraph.ts
@@ -39,185 +39,21 @@ export class ReactorSubgraph extends BaseSubgraph {
   hasSubscriptions = true;
 
   /**
-   * Get the parent IDs function for hierarchical permission checks
-   */
-  private getParentIdsFn() {
-    return resolvers.createGetParentIdsFn(this.reactorClient);
-  }
-
-  /**
-   * Check if user has global admin access.
-   * Used as legacy fallback when authorizationService is not available.
-   */
-  private hasGlobalAdminAccess(ctx: Context): boolean {
-    return !!ctx.isAdmin?.(ctx.user?.address ?? "");
-  }
-
-  /**
-   * Throw an error if user cannot read the document
-   */
-  private async assertCanRead(documentId: string, ctx: Context): Promise<void> {
-    if (this.authorizationService) {
-      const canRead = await this.authorizationService.canRead(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-      if (!canRead) {
-        throw new GraphQLError(
-          "Forbidden: insufficient permissions to read this document",
-        );
-      }
-      return;
-    }
-    // Legacy fallback
-    if (!this.hasGlobalAdminAccess(ctx)) {
-      if (this.documentPermissionService) {
-        const canRead = await this.documentPermissionService.canRead(
-          documentId,
-          ctx.user?.address,
-          this.getParentIdsFn(),
-        );
-        if (!canRead) {
-          throw new GraphQLError(
-            "Forbidden: insufficient permissions to read this document",
-          );
-        }
-      } else {
-        throw new GraphQLError(
-          "Forbidden: insufficient permissions to read this document",
-        );
-      }
-    }
-  }
-
-  /**
-   * Check if user can read a document (returns boolean, for filtering)
-   */
-  private async canReadDocument(
-    documentId: string,
-    ctx: Context,
-  ): Promise<boolean> {
-    if (this.authorizationService) {
-      return this.authorizationService.canRead(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-    }
-    // Legacy fallback
-    if (this.hasGlobalAdminAccess(ctx)) return true;
-    if (this.documentPermissionService) {
-      return this.documentPermissionService.canRead(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-    }
-    return false;
-  }
-
-  /**
-   * Throw an error if user cannot write to the document
-   */
-  private async assertCanWrite(
-    documentId: string,
-    ctx: Context,
-  ): Promise<void> {
-    if (this.authorizationService) {
-      const canWrite = await this.authorizationService.canWrite(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-      if (!canWrite) {
-        throw new GraphQLError(
-          "Forbidden: insufficient permissions to write to this document",
-        );
-      }
-      return;
-    }
-    // Legacy fallback
-    if (!this.hasGlobalAdminAccess(ctx)) {
-      if (this.documentPermissionService) {
-        const canWrite = await this.documentPermissionService.canWrite(
-          documentId,
-          ctx.user?.address,
-          this.getParentIdsFn(),
-        );
-        if (!canWrite) {
-          throw new GraphQLError(
-            "Forbidden: insufficient permissions to write to this document",
-          );
-        }
-      } else {
-        throw new GraphQLError(
-          "Forbidden: insufficient permissions to write to this document",
-        );
-      }
-    }
-  }
-
-  /**
-   * Check if user can execute specific operations on a document.
-   * Uses AuthorizationService.canMutate when available, which supports
-   * READ-only users with operation grants.
+   * Check operation-level permissions for an array of actions.
+   * Delegates to base assertCanExecuteOperation for each action.
    */
   private async assertCanExecuteOperations(
     documentId: string,
     actions: readonly unknown[],
     ctx: Context,
   ): Promise<void> {
-    if (this.authorizationService) {
-      for (const action of actions) {
-        if (!action || typeof action !== "object") continue;
-        const actionObj = action as Record<string, unknown>;
-        const operationType = actionObj.type;
-        if (typeof operationType !== "string") continue;
-
-        const canMutate = await this.authorizationService.canMutate(
-          documentId,
-          operationType,
-          ctx.user?.address,
-          this.getParentIdsFn(),
-        );
-        if (!canMutate) {
-          throw new GraphQLError(
-            `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
-          );
-        }
-      }
-      return;
-    }
-
-    // Legacy fallback
-    if (!this.documentPermissionService) return;
-    if (ctx.isAdmin?.(ctx.user?.address ?? "")) return;
-
     for (const action of actions) {
       if (!action || typeof action !== "object") continue;
       const actionObj = action as Record<string, unknown>;
       const operationType = actionObj.type;
       if (typeof operationType !== "string") continue;
 
-      const isRestricted =
-        await this.documentPermissionService.isOperationRestricted(
-          documentId,
-          operationType,
-        );
-      if (isRestricted) {
-        const canExecute =
-          await this.documentPermissionService.canExecuteOperation(
-            documentId,
-            operationType,
-            ctx.user?.address,
-          );
-        if (!canExecute) {
-          throw new GraphQLError(
-            `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
-          );
-        }
-      }
+      await this.assertCanExecuteOperation(documentId, operationType, ctx);
     }
   }
 
@@ -493,8 +329,11 @@ export class ReactorSubgraph extends BaseSubgraph {
       mutateDocument: async (_parent, args, ctx: Context) => {
         this.logger.debug("mutateDocument(@args)", args);
         try {
-          // Resolve document and check write permission
-          await this.assertCanWrite(args.documentIdentifier, ctx);
+          // assertCanExecuteOperations uses canMutate (which combines write + operation checks)
+          // when authorizationService is available. For legacy fallback, assertCanWrite is needed.
+          if (!this.authorizationService) {
+            await this.assertCanWrite(args.documentIdentifier, ctx);
+          }
 
           // Check operation-level permissions for each action
           await this.assertCanExecuteOperations(
@@ -513,8 +352,9 @@ export class ReactorSubgraph extends BaseSubgraph {
       mutateDocumentAsync: async (_parent, args, ctx: Context) => {
         this.logger.debug("mutateDocumentAsync(@args)", args);
         try {
-          // Resolve document and check write permission
-          await this.assertCanWrite(args.documentIdentifier, ctx);
+          if (!this.authorizationService) {
+            await this.assertCanWrite(args.documentIdentifier, ctx);
+          }
 
           // Check operation-level permissions for each action
           await this.assertCanExecuteOperations(

--- a/packages/reactor-api/src/graphql/types.ts
+++ b/packages/reactor-api/src/graphql/types.ts
@@ -9,6 +9,7 @@ import type {
 import type { PHDocument } from "document-model";
 import type { DocumentNode } from "graphql";
 import type { IncomingHttpHeaders } from "http";
+import type { AuthorizationService } from "../services/authorization.service.js";
 import type { DocumentPermissionService } from "../services/document-permission.service.js";
 import type { BaseSubgraph } from "./base-subgraph.js";
 
@@ -20,8 +21,6 @@ export type Context = {
   document?: PHDocument;
   headers: IncomingHttpHeaders;
   db: unknown;
-  isGuest?: (address: string) => boolean;
-  isUser?: (address: string) => boolean;
   isAdmin?: (address: string) => boolean;
   user?: {
     address: string;
@@ -29,6 +28,7 @@ export type Context = {
     networkId: string;
   };
   documentPermissionService?: DocumentPermissionService;
+  authorizationService?: AuthorizationService;
 };
 
 export type ISubgraph = {
@@ -51,6 +51,7 @@ export type SubgraphArgs = {
   graphqlManager: GraphQLManager;
   syncManager: ISyncManager;
   documentPermissionService?: DocumentPermissionService;
+  authorizationService?: AuthorizationService;
   path?: string;
 };
 

--- a/packages/reactor-api/src/migrations/002_add_document_protection.ts
+++ b/packages/reactor-api/src/migrations/002_add_document_protection.ts
@@ -1,0 +1,25 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS "DocumentProtection" (
+      "documentId" VARCHAR(255) PRIMARY KEY,
+      "protected" BOOLEAN NOT NULL DEFAULT false,
+      "ownerAddress" VARCHAR(255),
+      "createdAt" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updatedAt" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `.execute(db);
+
+  await sql`CREATE INDEX IF NOT EXISTS "documentprotection_owneraddress_index" ON "DocumentProtection" ("ownerAddress")`.execute(
+    db,
+  );
+  await sql`CREATE INDEX IF NOT EXISTS "documentprotection_protected_index" ON "DocumentProtection" ("protected")`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS "DocumentProtection"`.execute(db);
+}

--- a/packages/reactor-api/src/migrations/index.ts
+++ b/packages/reactor-api/src/migrations/index.ts
@@ -5,6 +5,7 @@ import {
   type MigrationProvider,
 } from "kysely";
 import * as migration001 from "./001_create_document_permissions.js";
+import * as migration002 from "./002_add_document_protection.js";
 
 /**
  * Custom migration provider that loads migrations from imported modules
@@ -13,6 +14,7 @@ class StaticMigrationProvider implements MigrationProvider {
   async getMigrations(): Promise<Record<string, Migration>> {
     return {
       "001_create_document_permissions": migration001,
+      "002_add_document_protection": migration002,
     };
   }
 }

--- a/packages/reactor-api/src/server.ts
+++ b/packages/reactor-api/src/server.ts
@@ -360,7 +360,18 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
 
   let defaultProtection = false;
   if (DEFAULT_PROTECTION !== undefined) {
-    defaultProtection = DEFAULT_PROTECTION === "true";
+    defaultProtection = DEFAULT_PROTECTION.toLowerCase() === "true";
+  }
+
+  // Warn about deprecated env vars
+  const { USERS, GUESTS, FREE_ENTRY } = process.env;
+  if (USERS || GUESTS || FREE_ENTRY) {
+    console.warn(
+      "[DEPRECATION WARNING] The USERS, GUESTS, and FREE_ENTRY environment variables are no longer supported. " +
+        "Access control is now managed per-document via the DocumentProtection system. " +
+        "Use DEFAULT_PROTECTION=true for strict mode, or manage protection per document via the GraphQL API. " +
+        "See the auth documentation for migration guidance.",
+    );
   }
 
   let skipCredentialVerification = false;

--- a/packages/reactor-api/src/server.ts
+++ b/packages/reactor-api/src/server.ts
@@ -53,6 +53,7 @@ import {
 } from "./packages/package-manager.js";
 import type { AuthenticatedRequest } from "./services/auth.service.js";
 import { AuthService } from "./services/auth.service.js";
+import { AuthorizationService } from "./services/authorization.service.js";
 import { DocumentPermissionService } from "./services/document-permission.service.js";
 import { initTracing, isTracingEnabled, trace } from "./tracing.js";
 import type { API, IPackageLoader, Processor } from "./types.js";
@@ -73,10 +74,7 @@ type Options = {
   packages?: string[];
   auth?: {
     enabled: boolean;
-    guests: string[];
-    users: string[];
     admins: string[];
-    freeEntry: boolean;
   };
   https?:
     | {
@@ -173,15 +171,13 @@ async function setupGraphQLManager(
   logger: ILogger,
   auth?: {
     enabled: boolean;
-    guests: string[];
-    users: string[];
     admins: string[];
-    freeEntry: boolean;
   },
   documentPermissionService?: DocumentPermissionService,
   enableDocumentModelSubgraphs?: boolean,
   useNewDocumentModelSubgraph?: boolean,
   port?: number,
+  authorizationService?: AuthorizationService,
 ): Promise<GraphQLManager> {
   const graphqlManager = new GraphQLManager(
     config.basePath,
@@ -196,10 +192,7 @@ async function setupGraphQLManager(
     logger,
     {
       enabled: auth?.enabled ?? false,
-      guests: auth?.guests ?? [],
-      users: auth?.users ?? [],
       admins: auth?.admins ?? [],
-      freeEntry: auth?.freeEntry ?? false,
     },
     documentPermissionService,
     {
@@ -207,6 +200,7 @@ async function setupGraphQLManager(
       useNewDocumentModelSubgraph,
     },
     port,
+    authorizationService,
   );
 
   await graphqlManager.init(subgraphs.core);
@@ -323,14 +317,12 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
   app: Express;
   auth: {
     enabled: boolean;
-    guests: string[];
-    users: string[];
     admins: string[];
-    freeEntry: boolean;
   };
   relationalDb: IRelationalDbLegacy;
   analyticsStore: IAnalyticsStore;
   documentPermissionService: DocumentPermissionService | undefined;
+  authorizationService: AuthorizationService | undefined;
   packages: PackageManager;
 }> {
   // Initialize OpenTelemetry tracing
@@ -343,47 +335,32 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
 
   // Setup auth configuration
   let admins: string[] = [];
-  let users: string[] = [];
-  let guests: string[] = [];
   let authEnabled = false;
-  let freeEntry = false;
   if (options.configFile) {
     const config = getConfig(options.configFile);
     admins = config.auth?.admins?.map((a) => a.toLowerCase()) ?? [];
-    users = config.auth?.users?.map((u) => u.toLowerCase()) ?? [];
-    guests = config.auth?.guests?.map((g) => g.toLowerCase()) ?? [];
     authEnabled = config.auth?.enabled ?? false;
-    freeEntry = config.auth?.freeEntry ?? false;
   } else if (options.auth) {
     admins = options.auth?.admins?.map((a) => a.toLowerCase()) ?? [];
-    users = options.auth?.users?.map((u) => u.toLowerCase()) ?? [];
-    guests = options.auth?.guests?.map((g) => g.toLowerCase()) ?? [];
     authEnabled = options.auth?.enabled ?? false;
-    freeEntry = options.auth?.freeEntry ?? false;
   }
   const {
     AUTH_ENABLED,
-    GUESTS,
-    USERS,
     ADMINS,
-    FREE_ENTRY,
+    DEFAULT_PROTECTION,
     DOCUMENT_PERMISSIONS_ENABLED,
     SKIP_CREDENTIAL_VERIFICATION,
   } = process.env;
   if (AUTH_ENABLED !== undefined) {
     authEnabled = AUTH_ENABLED === "true";
   }
-  if (GUESTS !== undefined) {
-    guests = GUESTS.split(",").map((g) => g.toLowerCase());
-  }
-  if (USERS !== undefined) {
-    users = USERS.split(",").map((u) => u.toLowerCase());
-  }
   if (ADMINS !== undefined) {
     admins = ADMINS.split(",").map((a) => a.toLowerCase());
   }
-  if (FREE_ENTRY !== undefined) {
-    freeEntry = FREE_ENTRY === "true";
+
+  let defaultProtection = false;
+  if (DEFAULT_PROTECTION !== undefined) {
+    defaultProtection = DEFAULT_PROTECTION === "true";
   }
 
   let skipCredentialVerification = false;
@@ -403,10 +380,7 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
     logger.info("Setting up Auth middleware");
     const authService = new AuthService({
       enabled: authEnabled,
-      guests,
-      users,
       admins,
-      freeEntry,
       skipCredentialVerification,
     });
 
@@ -436,8 +410,19 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
     logger.info("Document permission migrations completed");
     documentPermissionService = new DocumentPermissionService(
       db as Kysely<DocumentPermissionDatabase>,
+      { defaultProtection },
     );
     logger.info("Document permission service initialized");
+  }
+
+  // Create AuthorizationService when document permission service is available
+  let authorizationService: AuthorizationService | undefined;
+  if (documentPermissionService) {
+    authorizationService = new AuthorizationService(documentPermissionService, {
+      admins,
+      defaultProtection,
+    });
+    logger.info("Authorization service initialized");
   }
 
   // Initialize package manager
@@ -456,14 +441,12 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
     app,
     auth: {
       enabled: authEnabled,
-      guests,
-      users,
       admins,
-      freeEntry,
     },
     relationalDb,
     analyticsStore,
     documentPermissionService,
+    authorizationService,
     packages,
   };
 }
@@ -489,14 +472,12 @@ async function _setupAPI(
   options: Options,
   auth: {
     enabled: boolean;
-    guests: string[];
-    users: string[];
     admins: string[];
-    freeEntry: boolean;
   },
   legacyReactor: boolean,
   processorApp: ProcessorApp,
   reactorProcessorManager?: IReactorProcessorManager,
+  authorizationService?: AuthorizationService,
 ): Promise<API> {
   const module: IProcessorHostModuleLegacy = {
     relationalDb,
@@ -669,6 +650,7 @@ async function _setupAPI(
     options.enableDocumentModelSubgraphs,
     options.useNewDocumentModelSubgraph,
     port,
+    authorizationService,
   );
 
   // Set up event listeners
@@ -717,6 +699,7 @@ export async function startAPI(
     relationalDb,
     analyticsStore,
     documentPermissionService,
+    authorizationService,
     packages,
   } = await trace(
     "reactor-api.setup.infrastructure",
@@ -761,6 +744,7 @@ export async function startAPI(
     legacyReactor,
     processorApp,
     undefined, // no reactorProcessorManager in legacy mode
+    authorizationService,
   );
 }
 
@@ -799,6 +783,7 @@ export async function initializeAndStartAPI(
     relationalDb,
     analyticsStore,
     documentPermissionService,
+    authorizationService,
     packages,
   } = await trace(
     "reactor-api.setup.infrastructure",
@@ -853,6 +838,7 @@ export async function initializeAndStartAPI(
     legacyReactor,
     processorApp,
     reactorProcessorManager,
+    authorizationService,
   );
 
   return {

--- a/packages/reactor-api/src/services/auth.service.ts
+++ b/packages/reactor-api/src/services/auth.service.ts
@@ -11,10 +11,7 @@ import type { NextFunction, Request, Response } from "express";
 
 export interface AuthConfig {
   enabled: boolean;
-  guests: string[];
-  users: string[];
   admins: string[];
-  freeEntry: boolean;
   cacheTtl?: number; // Cache TTL in milliseconds, defaults to 10 seconds
   skipCredentialVerification?: boolean; // Skip Renown API credential verification (useful for testing)
 }
@@ -28,9 +25,6 @@ export interface User {
 export interface AuthenticatedRequest extends Request {
   user?: User;
   admins: string[];
-  users: string[];
-  guests: string[];
-  freeEntry: boolean;
 }
 
 export class AuthService {
@@ -59,13 +53,13 @@ export class AuthService {
 
     // Set auth lists on request
     req.admins = this.config.admins;
-    req.users = this.config.users;
-    req.guests = this.config.guests;
     req.auth_enabled = this.config.enabled;
-    req.freeEntry = this.config.freeEntry;
     const token = req.headers.authorization?.split(" ")[1];
     if (!token) {
-      res.status(400).json({ error: "Missing authorization token" });
+      // Allow through without user — resolver layer enforces permissions
+      // This is critical: GraphQL queries are POST requests, so blocking
+      // unauthenticated POSTs would block all anonymous reads.
+      next();
       return;
     }
 
@@ -190,37 +184,16 @@ export class AuthService {
   }
 
   /**
-   * Check if user address is in allowed lists
-   */
-  private isUserAllowed(address: string): boolean {
-    const all = [
-      ...this.config.admins,
-      ...this.config.users,
-      ...this.config.guests,
-    ];
-    return all.includes(address.toLocaleLowerCase()) || this.config.freeEntry;
-  }
-
-  /**
    * Get additional context fields for GraphQL
    */
   getAdditionalContextFields() {
     if (!this.config.enabled) {
       return {
-        isGuest: () => true,
-        isUser: () => true,
         isAdmin: () => true,
       };
     }
 
     return {
-      isGuest: (address: string) =>
-        this.config.enabled &&
-        (this.config.freeEntry ||
-          this.config.guests?.includes(address.toLowerCase())),
-      isUser: (address: string) =>
-        this.config.enabled &&
-        this.config.users?.includes(address.toLowerCase()),
       isAdmin: (address: string) =>
         this.config.enabled &&
         this.config.admins?.includes(address.toLowerCase()),

--- a/packages/reactor-api/src/services/authorization.service.ts
+++ b/packages/reactor-api/src/services/authorization.service.ts
@@ -95,9 +95,8 @@ export class AuthorizationService {
    * Check if a user can write to a document.
    *
    * - Supreme admin → yes
-   * - Not authenticated → no (anonymous can never write)
-   * - Not protected → any authenticated user can write
-   * - Protected → requires WRITE/ADMIN grant (direct, group, or parent inheritance)
+   * - Not protected → anyone can write (even anonymous)
+   * - Protected → requires authentication + WRITE/ADMIN grant
    * - Owner → yes (implicit ADMIN)
    */
   async canWrite(
@@ -108,9 +107,6 @@ export class AuthorizationService {
     // Supreme admin bypasses all
     if (this.isSupremeAdmin(userAddress)) return true;
 
-    // Anonymous can never write
-    if (!userAddress) return false;
-
     // Check protection status
     const isProtected = getParentIds
       ? await this.documentPermissionService.isProtectedWithAncestors(
@@ -119,8 +115,11 @@ export class AuthorizationService {
         )
       : await this.documentPermissionService.isDocumentProtected(documentId);
 
-    // Unprotected documents are writable by any authenticated user
+    // Unprotected documents are writable by anyone (even anonymous)
     if (!isProtected) return true;
+
+    // Protected document — requires authentication
+    if (!userAddress) return false;
 
     // Owner has implicit ADMIN
     const owner =

--- a/packages/reactor-api/src/services/authorization.service.ts
+++ b/packages/reactor-api/src/services/authorization.service.ts
@@ -60,7 +60,7 @@ export class AuthorizationService {
 
     // Check protection status (walks parent chain if getParentIds provided)
     const isProtected = getParentIds
-      ? await this.documentPermissionService.isProtected(
+      ? await this.documentPermissionService.isProtectedWithAncestors(
           documentId,
           getParentIds,
         )
@@ -113,7 +113,7 @@ export class AuthorizationService {
 
     // Check protection status
     const isProtected = getParentIds
-      ? await this.documentPermissionService.isProtected(
+      ? await this.documentPermissionService.isProtectedWithAncestors(
           documentId,
           getParentIds,
         )
@@ -200,13 +200,15 @@ export class AuthorizationService {
     return this.documentPermissionService.canExecuteOperation(
       documentId,
       operationType,
-      userAddress,
+      userAddress?.toLowerCase(),
     );
   }
 
   /**
    * Combined check for mutations: can the user write + execute the operation?
    * This enables READ-only users with operation grants to execute specific operations.
+   * For restricted operations, only the operation grant is checked (bypasses write check),
+   * allowing READ-only users with an explicit operation grant to execute that operation.
    */
   async canMutate(
     documentId: string,
@@ -230,7 +232,7 @@ export class AuthorizationService {
       return this.documentPermissionService.canExecuteOperation(
         documentId,
         operationType,
-        userAddress,
+        userAddress?.toLowerCase(),
       );
     }
 

--- a/packages/reactor-api/src/services/authorization.service.ts
+++ b/packages/reactor-api/src/services/authorization.service.ts
@@ -1,0 +1,240 @@
+import type {
+  DocumentPermissionService,
+  GetParentIdsFn,
+} from "./document-permission.service.js";
+
+export interface AuthorizationConfig {
+  admins: string[];
+  defaultProtection: boolean;
+}
+
+/**
+ * Central authorization service — single source of truth for all permission checks.
+ *
+ * Authorization model:
+ * 1. Supreme admin (ADMINS env) → ALLOW ALL
+ * 2. Is document protected?
+ *    a. NOT protected:
+ *       - READ: anyone (even anonymous) → ALLOW
+ *       - WRITE: authenticated user → ALLOW
+ *    b. PROTECTED:
+ *       - READ: requires explicit READ/WRITE/ADMIN grant (direct or via group/parent)
+ *       - WRITE: requires explicit WRITE/ADMIN grant (direct or via group/parent)
+ * 3. Operation restricted? → Check OperationUserPermission
+ * 4. Document owner = implicit ADMIN
+ * 5. Drive protected = all children effectively protected
+ */
+export class AuthorizationService {
+  readonly config: AuthorizationConfig;
+
+  constructor(
+    private readonly documentPermissionService: DocumentPermissionService,
+    config: AuthorizationConfig,
+  ) {
+    this.config = config;
+  }
+
+  /**
+   * Check if a user is a supreme admin (from ADMINS env var).
+   */
+  isSupremeAdmin(userAddress?: string): boolean {
+    if (!userAddress) return false;
+    return this.config.admins.includes(userAddress.toLowerCase());
+  }
+
+  /**
+   * Check if a user can read a document.
+   *
+   * - Supreme admin → yes
+   * - Not protected → anyone can read (even anonymous)
+   * - Protected → requires READ/WRITE/ADMIN grant (direct, group, or parent inheritance)
+   * - Owner → yes (implicit ADMIN)
+   */
+  async canRead(
+    documentId: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean> {
+    // Supreme admin bypasses all
+    if (this.isSupremeAdmin(userAddress)) return true;
+
+    // Check protection status (walks parent chain if getParentIds provided)
+    const isProtected = getParentIds
+      ? await this.documentPermissionService.isProtected(
+          documentId,
+          getParentIds,
+        )
+      : await this.documentPermissionService.isDocumentProtected(documentId);
+
+    // Unprotected documents are readable by anyone
+    if (!isProtected) return true;
+
+    // Protected document — requires authentication
+    if (!userAddress) return false;
+
+    // Owner has implicit ADMIN
+    const owner =
+      await this.documentPermissionService.getDocumentOwner(documentId);
+    if (owner && owner === userAddress.toLowerCase()) return true;
+
+    // Check grant (READ/WRITE/ADMIN all allow reading)
+    if (getParentIds) {
+      return this.documentPermissionService.canRead(
+        documentId,
+        userAddress,
+        getParentIds,
+      );
+    }
+    return this.documentPermissionService.canReadDocument(
+      documentId,
+      userAddress,
+    );
+  }
+
+  /**
+   * Check if a user can write to a document.
+   *
+   * - Supreme admin → yes
+   * - Not authenticated → no (anonymous can never write)
+   * - Not protected → any authenticated user can write
+   * - Protected → requires WRITE/ADMIN grant (direct, group, or parent inheritance)
+   * - Owner → yes (implicit ADMIN)
+   */
+  async canWrite(
+    documentId: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean> {
+    // Supreme admin bypasses all
+    if (this.isSupremeAdmin(userAddress)) return true;
+
+    // Anonymous can never write
+    if (!userAddress) return false;
+
+    // Check protection status
+    const isProtected = getParentIds
+      ? await this.documentPermissionService.isProtected(
+          documentId,
+          getParentIds,
+        )
+      : await this.documentPermissionService.isDocumentProtected(documentId);
+
+    // Unprotected documents are writable by any authenticated user
+    if (!isProtected) return true;
+
+    // Owner has implicit ADMIN
+    const owner =
+      await this.documentPermissionService.getDocumentOwner(documentId);
+    if (owner && owner === userAddress.toLowerCase()) return true;
+
+    // Check grant (WRITE/ADMIN allow writing)
+    if (getParentIds) {
+      return this.documentPermissionService.canWrite(
+        documentId,
+        userAddress,
+        getParentIds,
+      );
+    }
+    return this.documentPermissionService.canWriteDocument(
+      documentId,
+      userAddress,
+    );
+  }
+
+  /**
+   * Check if a user can manage a document (change permissions, protection, transfer ownership).
+   *
+   * - Supreme admin → yes
+   * - Owner → yes
+   * - Has ADMIN grant → yes
+   */
+  async canManage(
+    documentId: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean> {
+    // Supreme admin bypasses all
+    if (this.isSupremeAdmin(userAddress)) return true;
+
+    if (!userAddress) return false;
+
+    // Owner has implicit ADMIN
+    const owner =
+      await this.documentPermissionService.getDocumentOwner(documentId);
+    if (owner && owner === userAddress.toLowerCase()) return true;
+
+    // Check ADMIN grant
+    return this.documentPermissionService.canManageDocument(
+      documentId,
+      userAddress,
+    );
+  }
+
+  /**
+   * Check if a user can execute a specific operation.
+   * If the operation is not restricted, falls through to the standard write check.
+   * If the operation is restricted, requires an explicit OperationUserPermission grant.
+   */
+  async canExecuteOperation(
+    documentId: string,
+    operationType: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean> {
+    // Supreme admin bypasses all
+    if (this.isSupremeAdmin(userAddress)) return true;
+
+    // Check if operation is restricted
+    const isRestricted =
+      await this.documentPermissionService.isOperationRestricted(
+        documentId,
+        operationType,
+      );
+
+    if (!isRestricted) {
+      // Operation not restricted — standard write check applies
+      return this.canWrite(documentId, userAddress, getParentIds);
+    }
+
+    // Operation is restricted — user needs explicit operation grant
+    return this.documentPermissionService.canExecuteOperation(
+      documentId,
+      operationType,
+      userAddress,
+    );
+  }
+
+  /**
+   * Combined check for mutations: can the user write + execute the operation?
+   * This enables READ-only users with operation grants to execute specific operations.
+   */
+  async canMutate(
+    documentId: string,
+    operationType: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean> {
+    // Supreme admin bypasses all
+    if (this.isSupremeAdmin(userAddress)) return true;
+
+    // Check if the operation is restricted
+    const isRestricted =
+      await this.documentPermissionService.isOperationRestricted(
+        documentId,
+        operationType,
+      );
+
+    if (isRestricted) {
+      // For restricted operations, only the operation grant matters
+      // This allows READ-only users with operation grants to execute
+      return this.documentPermissionService.canExecuteOperation(
+        documentId,
+        operationType,
+        userAddress,
+      );
+    }
+
+    // For unrestricted operations, standard write check applies
+    return this.canWrite(documentId, userAddress, getParentIds);
+  }
+}

--- a/packages/reactor-api/src/services/document-permission.service.ts
+++ b/packages/reactor-api/src/services/document-permission.service.ts
@@ -54,6 +54,13 @@ export interface OperationGroupPermissionEntry {
 export type GetParentIdsFn = (documentId: string) => Promise<string[]>;
 
 /**
+ * Configuration for the DocumentPermissionService
+ */
+export interface DocumentPermissionConfig {
+  defaultProtection: boolean;
+}
+
+/**
  * Service for managing document-level permissions.
  *
  * Permission levels for documents:
@@ -63,15 +70,16 @@ export type GetParentIdsFn = (documentId: string) => Promise<string[]>;
  *
  * Operation permissions:
  * - Users and groups can be granted permission to execute specific operations
- *
- * Global roles (via environment variables):
- * - AUTH_ENABLED: Enables authorization checks
- * - ADMINS: Comma-separated list of admin addresses (full access)
- * - USERS: Comma-separated list of user addresses (read/write access)
- * - GUESTS: Comma-separated list of guest addresses (read access)
  */
 export class DocumentPermissionService {
-  constructor(private readonly db: Kysely<DocumentPermissionDatabase>) {}
+  readonly config: DocumentPermissionConfig;
+
+  constructor(
+    private readonly db: Kysely<DocumentPermissionDatabase>,
+    config: DocumentPermissionConfig = { defaultProtection: false },
+  ) {
+    this.config = config;
+  }
 
   // ============================================
   // User Permission Operations
@@ -892,5 +900,177 @@ export class DocumentPermissionService {
       .executeTakeFirst();
 
     return groupPermCount !== undefined && Number(groupPermCount.count) > 0;
+  }
+
+  // ============================================
+  // Document Protection
+  // ============================================
+
+  /**
+   * Check if a specific document has a protection row set to true.
+   * Falls back to `config.defaultProtection` if no row exists.
+   */
+  async isDocumentProtected(documentId: string): Promise<boolean> {
+    const row = await this.db
+      .selectFrom("DocumentProtection")
+      .select("protected")
+      .where("documentId", "=", documentId)
+      .executeTakeFirst();
+
+    if (row === undefined) {
+      return this.config.defaultProtection;
+    }
+
+    return row.protected;
+  }
+
+  /**
+   * Walk the parent chain: if the document itself or any ancestor is protected, return true.
+   */
+  async isProtected(
+    documentId: string,
+    getParentIds: GetParentIdsFn,
+  ): Promise<boolean> {
+    if (await this.isDocumentProtected(documentId)) {
+      return true;
+    }
+
+    const parentIds = await getParentIds(documentId);
+    for (const parentId of parentIds) {
+      if (await this.isProtected(parentId, getParentIds)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Upsert protection status for a document.
+   */
+  async setDocumentProtection(
+    documentId: string,
+    isProtected: boolean,
+  ): Promise<void> {
+    const now = new Date();
+
+    await this.db
+      .insertInto("DocumentProtection")
+      .values({
+        documentId,
+        protected: isProtected,
+        ownerAddress: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflict((oc) =>
+        oc.column("documentId").doUpdateSet({
+          protected: isProtected,
+          updatedAt: now,
+        }),
+      )
+      .execute();
+  }
+
+  /**
+   * Get the owner address for a document, or null if not set.
+   */
+  async getDocumentOwner(documentId: string): Promise<string | null> {
+    const row = await this.db
+      .selectFrom("DocumentProtection")
+      .select("ownerAddress")
+      .where("documentId", "=", documentId)
+      .executeTakeFirst();
+
+    return row?.ownerAddress ?? null;
+  }
+
+  /**
+   * Upsert owner address for a document.
+   */
+  async setDocumentOwner(
+    documentId: string,
+    ownerAddress: string,
+  ): Promise<void> {
+    const now = new Date();
+    const normalizedAddress = ownerAddress.toLowerCase();
+
+    await this.db
+      .insertInto("DocumentProtection")
+      .values({
+        documentId,
+        protected: this.config.defaultProtection,
+        ownerAddress: normalizedAddress,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflict((oc) =>
+        oc.column("documentId").doUpdateSet({
+          ownerAddress: normalizedAddress,
+          updatedAt: now,
+        }),
+      )
+      .execute();
+  }
+
+  /**
+   * Initialize protection for a newly created document.
+   * Sets protection status and grants ADMIN to the owner.
+   */
+  async initializeDocumentProtection(
+    documentId: string,
+    ownerAddress: string,
+    defaultProtection?: boolean,
+  ): Promise<void> {
+    const now = new Date();
+    const normalizedAddress = ownerAddress.toLowerCase();
+    const isProtected = defaultProtection ?? this.config.defaultProtection;
+
+    await this.db
+      .insertInto("DocumentProtection")
+      .values({
+        documentId,
+        protected: isProtected,
+        ownerAddress: normalizedAddress,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflict((oc) => oc.column("documentId").doNothing())
+      .execute();
+
+    // Grant ADMIN permission to the owner
+    await this.grantPermission(
+      documentId,
+      normalizedAddress,
+      "ADMIN",
+      normalizedAddress,
+    );
+  }
+
+  /**
+   * Get the full protection info for a document.
+   */
+  async getDocumentProtection(
+    documentId: string,
+  ): Promise<{
+    documentId: string;
+    protected: boolean;
+    ownerAddress: string | null;
+  }> {
+    const row = await this.db
+      .selectFrom("DocumentProtection")
+      .select(["documentId", "protected", "ownerAddress"])
+      .where("documentId", "=", documentId)
+      .executeTakeFirst();
+
+    if (!row) {
+      return {
+        documentId,
+        protected: this.config.defaultProtection,
+        ownerAddress: null,
+      };
+    }
+
+    return row;
   }
 }

--- a/packages/reactor-api/src/services/document-permission.service.ts
+++ b/packages/reactor-api/src/services/document-permission.service.ts
@@ -1050,9 +1050,7 @@ export class DocumentPermissionService {
   /**
    * Get the full protection info for a document.
    */
-  async getDocumentProtection(
-    documentId: string,
-  ): Promise<{
+  async getDocumentProtection(documentId: string): Promise<{
     documentId: string;
     protected: boolean;
     ownerAddress: string | null;

--- a/packages/reactor-api/src/services/document-permission.service.ts
+++ b/packages/reactor-api/src/services/document-permission.service.ts
@@ -926,23 +926,63 @@ export class DocumentPermissionService {
 
   /**
    * Walk the parent chain: if the document itself or any ancestor is protected, return true.
+   * Collects all ancestor IDs first (with cycle detection), then batch-checks protection.
    */
-  async isProtected(
+  async isProtectedWithAncestors(
     documentId: string,
     getParentIds: GetParentIdsFn,
   ): Promise<boolean> {
-    if (await this.isDocumentProtected(documentId)) {
-      return true;
+    // Collect all IDs in the hierarchy (document + all ancestors)
+    const allIds = await this.collectAncestorIds(documentId, getParentIds);
+
+    // Batch-check protection for all IDs at once
+    if (allIds.length === 0) {
+      return this.config.defaultProtection;
     }
 
-    const parentIds = await getParentIds(documentId);
-    for (const parentId of parentIds) {
-      if (await this.isProtected(parentId, getParentIds)) {
+    const rows = await this.db
+      .selectFrom("DocumentProtection")
+      .select(["documentId", "protected"])
+      .where("documentId", "in", allIds)
+      .execute();
+
+    const protectionMap = new Map(rows.map((r) => [r.documentId, r.protected]));
+
+    for (const id of allIds) {
+      const isProtected = protectionMap.get(id);
+      // If no row exists, fall back to defaultProtection
+      if (isProtected ?? this.config.defaultProtection) {
         return true;
       }
     }
 
     return false;
+  }
+
+  /**
+   * Collect all ancestor IDs (including the document itself) with cycle detection.
+   */
+  private async collectAncestorIds(
+    documentId: string,
+    getParentIds: GetParentIdsFn,
+  ): Promise<string[]> {
+    const visited = new Set<string>();
+    const queue = [documentId];
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (visited.has(current)) continue;
+      visited.add(current);
+
+      const parentIds = await getParentIds(current);
+      for (const parentId of parentIds) {
+        if (!visited.has(parentId)) {
+          queue.push(parentId);
+        }
+      }
+    }
+
+    return Array.from(visited);
   }
 
   /**
@@ -1035,7 +1075,12 @@ export class DocumentPermissionService {
         createdAt: now,
         updatedAt: now,
       })
-      .onConflict((oc) => oc.column("documentId").doNothing())
+      .onConflict((oc) =>
+        oc.column("documentId").doUpdateSet({
+          ownerAddress: normalizedAddress,
+          updatedAt: now,
+        }),
+      )
       .execute();
 
     // Grant ADMIN permission to the owner

--- a/packages/reactor-api/src/utils/auth.ts
+++ b/packages/reactor-api/src/utils/auth.ts
@@ -1,26 +1,14 @@
 export { verifyAuthBearerToken } from "@renown/sdk";
 
-export function isAuthEnabledAndUserPartOfGroup(
-  req: Express.Request,
-  group: "admins" | "users" | "guests",
-) {
-  if (req.auth_enabled) {
-    return false;
+export function isAdmin(req: Express.Request): boolean {
+  if (!req.auth_enabled) {
+    return true;
   }
 
   const user = req.user;
-  if (!user) {
+  if (!user?.address) {
     return false;
   }
 
-  if (!user.address) {
-    return false;
-  }
-
-  const groupList = req[group];
-  if (!groupList) {
-    return false;
-  }
-
-  return groupList.includes(user.address);
+  return req.admins?.includes(user.address.toLowerCase()) ?? false;
 }

--- a/packages/reactor-api/src/utils/db.ts
+++ b/packages/reactor-api/src/utils/db.ts
@@ -18,6 +18,14 @@ export type DocumentPermissionLevel = "READ" | "WRITE" | "ADMIN";
 /**
  * Database schema for document permissions
  */
+export interface DocumentProtectionTable {
+  documentId: string;
+  protected: boolean;
+  ownerAddress: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 export interface DocumentPermissionDatabase {
   DocumentPermission: DocumentPermissionTable;
   Group: GroupTable;
@@ -25,6 +33,7 @@ export interface DocumentPermissionDatabase {
   DocumentGroupPermission: DocumentGroupPermissionTable;
   OperationUserPermission: OperationUserPermissionTable;
   OperationGroupPermission: OperationGroupPermissionTable;
+  DocumentProtection: DocumentProtectionTable;
 }
 
 export interface DocumentPermissionTable {

--- a/packages/reactor-api/test/authorization.service.test.ts
+++ b/packages/reactor-api/test/authorization.service.test.ts
@@ -11,7 +11,7 @@ describe("AuthorizationService", () => {
     vi.clearAllMocks();
     mockPermissionService = {
       isDocumentProtected: vi.fn().mockResolvedValue(false),
-      isProtected: vi.fn().mockResolvedValue(false),
+      isProtectedWithAncestors: vi.fn().mockResolvedValue(false),
       getDocumentOwner: vi.fn().mockResolvedValue(null),
       canRead: vi.fn().mockResolvedValue(false),
       canWrite: vi.fn().mockResolvedValue(false),
@@ -118,17 +118,18 @@ describe("AuthorizationService", () => {
     });
 
     it("should use hierarchy check when getParentIds is provided", async () => {
-      vi.mocked(mockPermissionService.isProtected!).mockResolvedValue(true);
+      vi.mocked(
+        mockPermissionService.isProtectedWithAncestors!,
+      ).mockResolvedValue(true);
       vi.mocked(mockPermissionService.getDocumentOwner!).mockResolvedValue(
         null,
       );
       vi.mocked(mockPermissionService.canRead!).mockResolvedValue(true);
       const result = await service.canRead("doc-1", "0xuser", getParentIds);
       expect(result).toBe(true);
-      expect(mockPermissionService.isProtected).toHaveBeenCalledWith(
-        "doc-1",
-        getParentIds,
-      );
+      expect(
+        mockPermissionService.isProtectedWithAncestors,
+      ).toHaveBeenCalledWith("doc-1", getParentIds);
       expect(mockPermissionService.canRead).toHaveBeenCalledWith(
         "doc-1",
         "0xuser",
@@ -352,10 +353,64 @@ describe("AuthorizationService", () => {
     });
   });
 
+  describe("Address normalization", () => {
+    it("should normalize address in canExecuteOperation for restricted ops", async () => {
+      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
+        true,
+      );
+      vi.mocked(mockPermissionService.canExecuteOperation!).mockResolvedValue(
+        true,
+      );
+      await service.canExecuteOperation("doc-1", "SPECIAL_OP", "0xMixedCase");
+      expect(mockPermissionService.canExecuteOperation).toHaveBeenCalledWith(
+        "doc-1",
+        "SPECIAL_OP",
+        "0xmixedcase",
+      );
+    });
+
+    it("should normalize address in canMutate for restricted ops", async () => {
+      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
+        true,
+      );
+      vi.mocked(mockPermissionService.canExecuteOperation!).mockResolvedValue(
+        true,
+      );
+      await service.canMutate("doc-1", "SPECIAL_OP", "0xMixedCase");
+      expect(mockPermissionService.canExecuteOperation).toHaveBeenCalledWith(
+        "doc-1",
+        "SPECIAL_OP",
+        "0xmixedcase",
+      );
+    });
+
+    it("should handle undefined address in canExecuteOperation", async () => {
+      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
+        true,
+      );
+      vi.mocked(mockPermissionService.canExecuteOperation!).mockResolvedValue(
+        false,
+      );
+      const result = await service.canExecuteOperation(
+        "doc-1",
+        "SPECIAL_OP",
+        undefined,
+      );
+      expect(result).toBe(false);
+      expect(mockPermissionService.canExecuteOperation).toHaveBeenCalledWith(
+        "doc-1",
+        "SPECIAL_OP",
+        undefined,
+      );
+    });
+  });
+
   describe("Protection inheritance", () => {
     it("should treat document as protected when parent is protected", async () => {
       // Document itself is not protected, but parent is
-      vi.mocked(mockPermissionService.isProtected!).mockResolvedValue(true);
+      vi.mocked(
+        mockPermissionService.isProtectedWithAncestors!,
+      ).mockResolvedValue(true);
       vi.mocked(mockPermissionService.getDocumentOwner!).mockResolvedValue(
         null,
       );
@@ -363,10 +418,9 @@ describe("AuthorizationService", () => {
 
       const result = await service.canRead("doc-1", "0xuser", getParentIds);
       expect(result).toBe(false);
-      expect(mockPermissionService.isProtected).toHaveBeenCalledWith(
-        "doc-1",
-        getParentIds,
-      );
+      expect(
+        mockPermissionService.isProtectedWithAncestors,
+      ).toHaveBeenCalledWith("doc-1", getParentIds);
     });
   });
 });

--- a/packages/reactor-api/test/authorization.service.test.ts
+++ b/packages/reactor-api/test/authorization.service.test.ts
@@ -1,0 +1,372 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthorizationService } from "../src/services/authorization.service.js";
+import type { DocumentPermissionService } from "../src/services/document-permission.service.js";
+
+describe("AuthorizationService", () => {
+  let service: AuthorizationService;
+  let mockPermissionService: Partial<DocumentPermissionService>;
+  const getParentIds = vi.fn().mockResolvedValue([]);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPermissionService = {
+      isDocumentProtected: vi.fn().mockResolvedValue(false),
+      isProtected: vi.fn().mockResolvedValue(false),
+      getDocumentOwner: vi.fn().mockResolvedValue(null),
+      canRead: vi.fn().mockResolvedValue(false),
+      canWrite: vi.fn().mockResolvedValue(false),
+      canReadDocument: vi.fn().mockResolvedValue(false),
+      canWriteDocument: vi.fn().mockResolvedValue(false),
+      canManageDocument: vi.fn().mockResolvedValue(false),
+      isOperationRestricted: vi.fn().mockResolvedValue(false),
+      canExecuteOperation: vi.fn().mockResolvedValue(false),
+    };
+    service = new AuthorizationService(
+      mockPermissionService as DocumentPermissionService,
+      { admins: ["0xadmin"], defaultProtection: false },
+    );
+  });
+
+  describe("isSupremeAdmin", () => {
+    it("should return true for admin address", () => {
+      expect(service.isSupremeAdmin("0xadmin")).toBe(true);
+    });
+
+    it("should return true case-insensitively", () => {
+      expect(service.isSupremeAdmin("0xADMIN")).toBe(true);
+    });
+
+    it("should return false for non-admin", () => {
+      expect(service.isSupremeAdmin("0xuser")).toBe(false);
+    });
+
+    it("should return false for undefined", () => {
+      expect(service.isSupremeAdmin(undefined)).toBe(false);
+    });
+  });
+
+  describe("canRead", () => {
+    it("should allow supreme admin", async () => {
+      const result = await service.canRead("doc-1", "0xadmin");
+      expect(result).toBe(true);
+      expect(mockPermissionService.isDocumentProtected).not.toHaveBeenCalled();
+    });
+
+    it("should allow anonymous read on unprotected document", async () => {
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        false,
+      );
+      const result = await service.canRead("doc-1", undefined);
+      expect(result).toBe(true);
+    });
+
+    it("should allow authenticated read on unprotected document", async () => {
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        false,
+      );
+      const result = await service.canRead("doc-1", "0xuser");
+      expect(result).toBe(true);
+    });
+
+    it("should deny anonymous read on protected document", async () => {
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        true,
+      );
+      const result = await service.canRead("doc-1", undefined);
+      expect(result).toBe(false);
+    });
+
+    it("should allow owner read on protected document", async () => {
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        true,
+      );
+      vi.mocked(mockPermissionService.getDocumentOwner!).mockResolvedValue(
+        "0xowner",
+      );
+      const result = await service.canRead("doc-1", "0xowner");
+      expect(result).toBe(true);
+    });
+
+    it("should check grants for protected document when user is not owner", async () => {
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        true,
+      );
+      vi.mocked(mockPermissionService.getDocumentOwner!).mockResolvedValue(
+        "0xother",
+      );
+      vi.mocked(mockPermissionService.canReadDocument!).mockResolvedValue(true);
+      const result = await service.canRead("doc-1", "0xuser");
+      expect(result).toBe(true);
+      expect(mockPermissionService.canReadDocument).toHaveBeenCalledWith(
+        "doc-1",
+        "0xuser",
+      );
+    });
+
+    it("should deny read when no grant on protected document", async () => {
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        true,
+      );
+      vi.mocked(mockPermissionService.getDocumentOwner!).mockResolvedValue(
+        null,
+      );
+      vi.mocked(mockPermissionService.canReadDocument!).mockResolvedValue(
+        false,
+      );
+      const result = await service.canRead("doc-1", "0xuser");
+      expect(result).toBe(false);
+    });
+
+    it("should use hierarchy check when getParentIds is provided", async () => {
+      vi.mocked(mockPermissionService.isProtected!).mockResolvedValue(true);
+      vi.mocked(mockPermissionService.getDocumentOwner!).mockResolvedValue(
+        null,
+      );
+      vi.mocked(mockPermissionService.canRead!).mockResolvedValue(true);
+      const result = await service.canRead("doc-1", "0xuser", getParentIds);
+      expect(result).toBe(true);
+      expect(mockPermissionService.isProtected).toHaveBeenCalledWith(
+        "doc-1",
+        getParentIds,
+      );
+      expect(mockPermissionService.canRead).toHaveBeenCalledWith(
+        "doc-1",
+        "0xuser",
+        getParentIds,
+      );
+    });
+  });
+
+  describe("canWrite", () => {
+    it("should allow supreme admin", async () => {
+      const result = await service.canWrite("doc-1", "0xadmin");
+      expect(result).toBe(true);
+    });
+
+    it("should deny anonymous write even on unprotected document", async () => {
+      const result = await service.canWrite("doc-1", undefined);
+      expect(result).toBe(false);
+    });
+
+    it("should allow authenticated write on unprotected document", async () => {
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        false,
+      );
+      const result = await service.canWrite("doc-1", "0xuser");
+      expect(result).toBe(true);
+    });
+
+    it("should deny authenticated write on protected document without grant", async () => {
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        true,
+      );
+      vi.mocked(mockPermissionService.getDocumentOwner!).mockResolvedValue(
+        null,
+      );
+      vi.mocked(mockPermissionService.canWriteDocument!).mockResolvedValue(
+        false,
+      );
+      const result = await service.canWrite("doc-1", "0xuser");
+      expect(result).toBe(false);
+    });
+
+    it("should allow owner write on protected document", async () => {
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        true,
+      );
+      vi.mocked(mockPermissionService.getDocumentOwner!).mockResolvedValue(
+        "0xowner",
+      );
+      const result = await service.canWrite("doc-1", "0xowner");
+      expect(result).toBe(true);
+    });
+
+    it("should allow write with WRITE grant on protected document", async () => {
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        true,
+      );
+      vi.mocked(mockPermissionService.getDocumentOwner!).mockResolvedValue(
+        null,
+      );
+      vi.mocked(mockPermissionService.canWriteDocument!).mockResolvedValue(
+        true,
+      );
+      const result = await service.canWrite("doc-1", "0xuser");
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("canManage", () => {
+    it("should allow supreme admin", async () => {
+      const result = await service.canManage("doc-1", "0xadmin");
+      expect(result).toBe(true);
+    });
+
+    it("should deny unauthenticated", async () => {
+      const result = await service.canManage("doc-1", undefined);
+      expect(result).toBe(false);
+    });
+
+    it("should allow owner", async () => {
+      vi.mocked(mockPermissionService.getDocumentOwner!).mockResolvedValue(
+        "0xowner",
+      );
+      const result = await service.canManage("doc-1", "0xowner");
+      expect(result).toBe(true);
+    });
+
+    it("should allow user with ADMIN grant", async () => {
+      vi.mocked(mockPermissionService.getDocumentOwner!).mockResolvedValue(
+        null,
+      );
+      vi.mocked(mockPermissionService.canManageDocument!).mockResolvedValue(
+        true,
+      );
+      const result = await service.canManage("doc-1", "0xuser");
+      expect(result).toBe(true);
+    });
+
+    it("should deny user without ADMIN grant", async () => {
+      vi.mocked(mockPermissionService.getDocumentOwner!).mockResolvedValue(
+        null,
+      );
+      vi.mocked(mockPermissionService.canManageDocument!).mockResolvedValue(
+        false,
+      );
+      const result = await service.canManage("doc-1", "0xuser");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("canExecuteOperation", () => {
+    it("should allow supreme admin", async () => {
+      const result = await service.canExecuteOperation(
+        "doc-1",
+        "SET_NAME",
+        "0xadmin",
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should fall through to write check for unrestricted operations", async () => {
+      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
+        false,
+      );
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        false,
+      );
+      const result = await service.canExecuteOperation(
+        "doc-1",
+        "SET_NAME",
+        "0xuser",
+      );
+      expect(result).toBe(true); // unprotected + authenticated = write allowed
+    });
+
+    it("should check operation grant for restricted operations", async () => {
+      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
+        true,
+      );
+      vi.mocked(mockPermissionService.canExecuteOperation!).mockResolvedValue(
+        true,
+      );
+      const result = await service.canExecuteOperation(
+        "doc-1",
+        "SPECIAL_OP",
+        "0xuser",
+      );
+      expect(result).toBe(true);
+      expect(mockPermissionService.canExecuteOperation).toHaveBeenCalledWith(
+        "doc-1",
+        "SPECIAL_OP",
+        "0xuser",
+      );
+    });
+
+    it("should deny when restricted and no operation grant", async () => {
+      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
+        true,
+      );
+      vi.mocked(mockPermissionService.canExecuteOperation!).mockResolvedValue(
+        false,
+      );
+      const result = await service.canExecuteOperation(
+        "doc-1",
+        "SPECIAL_OP",
+        "0xuser",
+      );
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("canMutate", () => {
+    it("should allow supreme admin", async () => {
+      const result = await service.canMutate("doc-1", "SET_NAME", "0xadmin");
+      expect(result).toBe(true);
+    });
+
+    it("should allow write for unrestricted operations", async () => {
+      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
+        false,
+      );
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        false,
+      );
+      const result = await service.canMutate("doc-1", "SET_NAME", "0xuser");
+      expect(result).toBe(true);
+    });
+
+    it("should allow READ-only user with operation grant for restricted ops", async () => {
+      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
+        true,
+      );
+      vi.mocked(mockPermissionService.canExecuteOperation!).mockResolvedValue(
+        true,
+      );
+      // Even if user only has READ permission, the operation grant should suffice
+      const result = await service.canMutate(
+        "doc-1",
+        "SPECIAL_OP",
+        "0xreadonly",
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should deny when restricted and no operation grant", async () => {
+      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
+        true,
+      );
+      vi.mocked(mockPermissionService.canExecuteOperation!).mockResolvedValue(
+        false,
+      );
+      const result = await service.canMutate("doc-1", "SPECIAL_OP", "0xuser");
+      expect(result).toBe(false);
+    });
+
+    it("should deny anonymous for unrestricted operations", async () => {
+      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
+        false,
+      );
+      const result = await service.canMutate("doc-1", "SET_NAME", undefined);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("Protection inheritance", () => {
+    it("should treat document as protected when parent is protected", async () => {
+      // Document itself is not protected, but parent is
+      vi.mocked(mockPermissionService.isProtected!).mockResolvedValue(true);
+      vi.mocked(mockPermissionService.getDocumentOwner!).mockResolvedValue(
+        null,
+      );
+      vi.mocked(mockPermissionService.canRead!).mockResolvedValue(false);
+
+      const result = await service.canRead("doc-1", "0xuser", getParentIds);
+      expect(result).toBe(false);
+      expect(mockPermissionService.isProtected).toHaveBeenCalledWith(
+        "doc-1",
+        getParentIds,
+      );
+    });
+  });
+});

--- a/packages/reactor-api/test/authorization.service.test.ts
+++ b/packages/reactor-api/test/authorization.service.test.ts
@@ -144,9 +144,12 @@ describe("AuthorizationService", () => {
       expect(result).toBe(true);
     });
 
-    it("should deny anonymous write even on unprotected document", async () => {
+    it("should allow anonymous write on unprotected document", async () => {
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        false,
+      );
       const result = await service.canWrite("doc-1", undefined);
-      expect(result).toBe(false);
+      expect(result).toBe(true);
     });
 
     it("should allow authenticated write on unprotected document", async () => {
@@ -155,6 +158,14 @@ describe("AuthorizationService", () => {
       );
       const result = await service.canWrite("doc-1", "0xuser");
       expect(result).toBe(true);
+    });
+
+    it("should deny anonymous write on protected document", async () => {
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        true,
+      );
+      const result = await service.canWrite("doc-1", undefined);
+      expect(result).toBe(false);
     });
 
     it("should deny authenticated write on protected document without grant", async () => {
@@ -344,9 +355,23 @@ describe("AuthorizationService", () => {
       expect(result).toBe(false);
     });
 
-    it("should deny anonymous for unrestricted operations", async () => {
+    it("should allow anonymous for unrestricted operations on unprotected doc", async () => {
       vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
         false,
+      );
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        false,
+      );
+      const result = await service.canMutate("doc-1", "SET_NAME", undefined);
+      expect(result).toBe(true);
+    });
+
+    it("should deny anonymous for unrestricted operations on protected doc", async () => {
+      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
+        false,
+      );
+      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
+        true,
       );
       const result = await service.canMutate("doc-1", "SET_NAME", undefined);
       expect(result).toBe(false);

--- a/packages/reactor-api/test/document-model-subgraph-legacy-permissions.test.ts
+++ b/packages/reactor-api/test/document-model-subgraph-legacy-permissions.test.ts
@@ -9,7 +9,7 @@ import type { IReactorClient, PagedResults } from "@powerhousedao/reactor";
 import type { IDocumentDriveServer } from "document-drive";
 import type { DocumentModelModule, PHDocument } from "document-model";
 import { GraphQLError } from "graphql";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DocumentModelSubgraphLegacy } from "../src/graphql/document-model-subgraph.js";
 import type { Context, SubgraphArgs } from "../src/graphql/types.js";
 import type { DocumentPermissionService } from "../src/services/document-permission.service.js";
@@ -86,22 +86,15 @@ describe("DocumentModelSubgraphLegacy Permission Checks", () => {
   // Helper to create context with different permission levels
   const createContext = (options: {
     isAdmin?: boolean;
-    isUser?: boolean;
-    isGuest?: boolean;
     userAddress?: string;
   }): Context =>
     ({
       user: options.userAddress ? { address: options.userAddress } : undefined,
       isAdmin: vi.fn().mockReturnValue(options.isAdmin ?? false),
-      isUser: vi.fn().mockReturnValue(options.isUser ?? false),
-      isGuest: vi.fn().mockReturnValue(options.isGuest ?? false),
     }) as unknown as Context;
 
   beforeEach(() => {
     vi.clearAllMocks();
-
-    // Reset FREE_ENTRY
-    delete process.env.FREE_ENTRY;
 
     // Create mock DocumentPermissionService
     mockDocumentPermissionService = {
@@ -144,10 +137,6 @@ describe("DocumentModelSubgraphLegacy Permission Checks", () => {
     } as SubgraphArgs);
   });
 
-  afterEach(() => {
-    delete process.env.FREE_ENTRY;
-  });
-
   describe("Query: getDocument", () => {
     const callGetDocument = async (
       ctx: Context,
@@ -159,7 +148,7 @@ describe("DocumentModelSubgraphLegacy Permission Checks", () => {
       return queryObject.getDocument({ docId, driveId });
     };
 
-    describe("Global Role Access (hasGlobalReadAccess)", () => {
+    describe("Global Admin Access", () => {
       it("should allow access when user is global admin", async () => {
         const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
 
@@ -167,34 +156,6 @@ describe("DocumentModelSubgraphLegacy Permission Checks", () => {
 
         expect(result).toBeDefined();
         expect(result.id).toBe("doc-123");
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-      });
-
-      it("should allow access when user is global user", async () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = await callGetDocument(ctx, "doc-123");
-
-        expect(result).toBeDefined();
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-      });
-
-      it("should allow access when user is global guest", async () => {
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-        const result = await callGetDocument(ctx, "doc-123");
-
-        expect(result).toBeDefined();
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-      });
-
-      it("should allow access when FREE_ENTRY is true", async () => {
-        process.env.FREE_ENTRY = "true";
-        const ctx = createContext({ userAddress: "0xanyone" });
-
-        const result = await callGetDocument(ctx, "doc-123");
-
-        expect(result).toBeDefined();
         expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
       });
     });
@@ -340,22 +301,6 @@ describe("DocumentModelSubgraphLegacy Permission Checks", () => {
         expect(result).toHaveLength(1);
         expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
       });
-
-      it("should return all documents for user", async () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = await callGetDocuments(ctx, "drive-1");
-
-        expect(result).toHaveLength(1);
-      });
-
-      it("should return all documents for guest", async () => {
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-        const result = await callGetDocuments(ctx, "drive-1");
-
-        expect(result).toHaveLength(1);
-      });
     });
 
     describe("Document Permission Filtering", () => {
@@ -423,7 +368,7 @@ describe("DocumentModelSubgraphLegacy Permission Checks", () => {
       return mutation(null, { name, driveId }, ctx);
     };
 
-    describe("Global Role Access (hasGlobalWriteAccess)", () => {
+    describe("Global Admin Access", () => {
       it("should allow creation when user is global admin", async () => {
         const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
 
@@ -431,22 +376,6 @@ describe("DocumentModelSubgraphLegacy Permission Checks", () => {
 
         expect(result).toBe("doc-123");
         expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
-      });
-
-      it("should allow creation when user is global user", async () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = await callCreateDocument(ctx, "New Doc");
-
-        expect(result).toBe("doc-123");
-      });
-
-      it("should deny creation when user is only global guest", async () => {
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-        await expect(callCreateDocument(ctx, "New Doc")).rejects.toThrow(
-          "Forbidden: insufficient permissions to create documents",
-        );
       });
     });
 
@@ -539,16 +468,6 @@ describe("DocumentModelSubgraphLegacy Permission Checks", () => {
 
         expect(result).toBe(1);
         expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
-      });
-
-      it("should allow operation for global user without permission check", async () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = await callMutation(ctx, "setName", "doc-123", {
-          name: "New Name",
-        });
-
-        expect(result).toBe(1);
       });
     });
 
@@ -659,11 +578,9 @@ describe("DocumentModelSubgraphLegacy Permission Checks", () => {
   });
 
   describe("AUTH_ENABLED=false behavior", () => {
-    it("should allow all read access when all roles return true", async () => {
+    it("should allow all read access when admin role returns true", async () => {
       const ctx = createContext({
         isAdmin: true,
-        isUser: true,
-        isGuest: true,
         userAddress: "0xanyone",
       });
 
@@ -675,11 +592,9 @@ describe("DocumentModelSubgraphLegacy Permission Checks", () => {
       expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
     });
 
-    it("should allow all write access when admin/user roles return true", async () => {
+    it("should allow all write access when admin role returns true", async () => {
       const ctx = createContext({
         isAdmin: true,
-        isUser: true,
-        isGuest: true,
         userAddress: "0xanyone",
       });
 
@@ -750,7 +665,7 @@ describe("DocumentModelSubgraphLegacy Permission Checks", () => {
     });
 
     it("should skip operation restriction check when no permission service", async () => {
-      const ctx = createContext({ isUser: true, userAddress: "0xuser" });
+      const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
 
       const result = await (
         subgraphWithoutPermService.resolvers.Mutation as any
@@ -769,8 +684,6 @@ describe("DocumentModelSubgraphLegacy Permission Checks", () => {
       const ctx = {
         user: { address: "" },
         isAdmin: vi.fn().mockReturnValue(false),
-        isUser: vi.fn().mockReturnValue(false),
-        isGuest: vi.fn().mockReturnValue(false),
       } as unknown as Context;
 
       const queryResolver = (subgraph.resolvers.Query as any)?.TestModel;

--- a/packages/reactor-api/test/document-model-subgraph-permissions.test.ts
+++ b/packages/reactor-api/test/document-model-subgraph-permissions.test.ts
@@ -9,7 +9,7 @@ import type { IReactorClient, PagedResults } from "@powerhousedao/reactor";
 import type { IDocumentDriveServer } from "document-drive";
 import type { DocumentModelModule, PHDocument } from "document-model";
 import { GraphQLError } from "graphql";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DocumentModelSubgraph } from "../src/graphql/document-model-subgraph.js";
 import type { Context, SubgraphArgs } from "../src/graphql/types.js";
 import type { DocumentPermissionService } from "../src/services/document-permission.service.js";
@@ -83,21 +83,15 @@ describe("DocumentModelSubgraph Permission Checks", () => {
 
   const createContext = (options: {
     isAdmin?: boolean;
-    isUser?: boolean;
-    isGuest?: boolean;
     userAddress?: string;
   }): Context =>
     ({
       user: options.userAddress ? { address: options.userAddress } : undefined,
       isAdmin: vi.fn().mockReturnValue(options.isAdmin ?? false),
-      isUser: vi.fn().mockReturnValue(options.isUser ?? false),
-      isGuest: vi.fn().mockReturnValue(options.isGuest ?? false),
     }) as unknown as Context;
 
   beforeEach(() => {
     vi.clearAllMocks();
-
-    delete process.env.FREE_ENTRY;
 
     mockDocumentPermissionService = {
       canRead: vi.fn().mockResolvedValue(false),
@@ -150,10 +144,6 @@ describe("DocumentModelSubgraph Permission Checks", () => {
     } as SubgraphArgs);
   });
 
-  afterEach(() => {
-    delete process.env.FREE_ENTRY;
-  });
-
   describe("Query: document", () => {
     // Updated to match new flat resolver structure (TestModel_document instead of TestModel.getDocument)
     const callGetDocument = async (ctx: Context, identifier: string) => {
@@ -162,7 +152,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       return queryResolver(null, { identifier }, ctx);
     };
 
-    describe("Global Role Access (hasGlobalReadAccess)", () => {
+    describe("Global Admin Access", () => {
       it("should allow access when user is global admin", async () => {
         const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
 
@@ -171,34 +161,6 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         // Result is DocumentWithChildren: { document: PHDocument, childIds: string[] }
         expect(result).toBeDefined();
         expect(result.document.id).toBe("doc-123");
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-      });
-
-      it("should allow access when user is global user", async () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = await callGetDocument(ctx, "doc-123");
-
-        expect(result).toBeDefined();
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-      });
-
-      it("should allow access when user is global guest", async () => {
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-        const result = await callGetDocument(ctx, "doc-123");
-
-        expect(result).toBeDefined();
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-      });
-
-      it("should allow access when FREE_ENTRY is true", async () => {
-        process.env.FREE_ENTRY = "true";
-        const ctx = createContext({ userAddress: "0xanyone" });
-
-        const result = await callGetDocument(ctx, "doc-123");
-
-        expect(result).toBeDefined();
         expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
       });
     });
@@ -383,22 +345,6 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         expect(result).toHaveLength(1);
         expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
       });
-
-      it("should return all documents for user", async () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = await callFindDocuments(ctx, "drive-1");
-
-        expect(result).toHaveLength(1);
-      });
-
-      it("should return all documents for guest", async () => {
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-        const result = await callFindDocuments(ctx, "drive-1");
-
-        expect(result).toHaveLength(1);
-      });
     });
 
     describe("Document Permission Filtering", () => {
@@ -486,7 +432,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       return mutation(null, { name, parentIdentifier }, ctx);
     };
 
-    describe("Global Role Access (hasGlobalWriteAccess)", () => {
+    describe("Global Admin Access", () => {
       it("should allow creation when user is global admin", async () => {
         const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
 
@@ -494,22 +440,6 @@ describe("DocumentModelSubgraph Permission Checks", () => {
 
         expect(result).toMatchObject({ id: "doc-123" });
         expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
-      });
-
-      it("should allow creation when user is global user", async () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = await callCreateDocument(ctx, "New Doc");
-
-        expect(result).toMatchObject({ id: "doc-123" });
-      });
-
-      it("should deny creation when user is only global guest", async () => {
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-        await expect(callCreateDocument(ctx, "New Doc")).rejects.toThrow(
-          "Forbidden: insufficient permissions to create documents",
-        );
       });
     });
 
@@ -641,21 +571,6 @@ describe("DocumentModelSubgraph Permission Checks", () => {
           ]),
         });
         expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
-      });
-
-      it("should allow operation for global user without permission check", async () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = await callMutation(ctx, "setName", "doc-123", {
-          name: "New Name",
-        });
-
-        expect(result).toMatchObject({
-          id: "doc-123",
-          revisionsList: expect.arrayContaining([
-            expect.objectContaining({ scope: "global", revision: 2 }),
-          ]),
-        });
       });
     });
 
@@ -832,11 +747,9 @@ describe("DocumentModelSubgraph Permission Checks", () => {
   });
 
   describe("AUTH_ENABLED=false behavior", () => {
-    it("should allow all read access when all roles return true", async () => {
+    it("should allow all read access when admin role returns true", async () => {
       const ctx = createContext({
         isAdmin: true,
-        isUser: true,
-        isGuest: true,
         userAddress: "0xanyone",
       });
 
@@ -848,11 +761,9 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
     });
 
-    it("should allow all write access when admin/user roles return true", async () => {
+    it("should allow all write access when admin role returns true", async () => {
       const ctx = createContext({
         isAdmin: true,
-        isUser: true,
-        isGuest: true,
         userAddress: "0xanyone",
       });
 
@@ -926,7 +837,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
     });
 
     it("should skip operation restriction check when no permission service", async () => {
-      const ctx = createContext({ isUser: true, userAddress: "0xuser" });
+      const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
 
       const result = await (
         subgraphWithoutPermService.resolvers.Mutation as any
@@ -950,8 +861,6 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       const ctx = {
         user: { address: "" },
         isAdmin: vi.fn().mockReturnValue(false),
-        isUser: vi.fn().mockReturnValue(false),
-        isGuest: vi.fn().mockReturnValue(false),
       } as unknown as Context;
 
       const queryResolver = (subgraph.resolvers.Query as any)

--- a/packages/reactor-api/test/document-model-subgraph.test.ts
+++ b/packages/reactor-api/test/document-model-subgraph.test.ts
@@ -25,8 +25,6 @@ describe("DocumentModelSubgraph Integration Tests", () => {
     ({
       user: { address: "0xadmin" },
       isAdmin: () => true,
-      isUser: () => false,
-      isGuest: () => false,
     }) as unknown as Context;
 
   beforeEach(async () => {

--- a/packages/reactor-api/test/drive-handlers.ts
+++ b/packages/reactor-api/test/drive-handlers.ts
@@ -17,7 +17,7 @@ export const createDriveHandlers = (
     Mutation: any;
     Sync: any;
   };
-  const context = { driveId, isUser: () => true, isAdmin: () => true };
+  const context = { driveId, isAdmin: () => true };
 
   return [
     graphql.query("getDrive", async ({ variables }) =>

--- a/packages/reactor-api/test/drive-subgraph-permissions.test.ts
+++ b/packages/reactor-api/test/drive-subgraph-permissions.test.ts
@@ -13,16 +13,12 @@ describe("DriveSubgraph Permission Checks", () => {
   // Helper to create context with different permission levels
   const createContext = (options: {
     isAdmin?: boolean;
-    isUser?: boolean;
-    isGuest?: boolean;
     userAddress?: string;
     driveId?: string;
   }) => ({
     driveId: options.driveId ?? driveId,
     user: options.userAddress ? { address: options.userAddress } : undefined,
     isAdmin: () => options.isAdmin ?? false,
-    isUser: () => options.isUser ?? false,
-    isGuest: () => options.isGuest ?? false,
   });
 
   beforeEach(async () => {
@@ -70,30 +66,6 @@ describe("DriveSubgraph Permission Checks", () => {
     describe("Global Role Access", () => {
       it("should allow access when user is global admin", async () => {
         const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
-
-        const result = await callRegisterPullResponderListener(ctx);
-
-        expect(result).toBeDefined();
-        expect(result.listenerId).toBeDefined();
-        expect(
-          mockDocumentPermissionService.canReadDocument,
-        ).not.toHaveBeenCalled();
-      });
-
-      it("should allow access when user is global user", async () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = await callRegisterPullResponderListener(ctx);
-
-        expect(result).toBeDefined();
-        expect(result.listenerId).toBeDefined();
-        expect(
-          mockDocumentPermissionService.canReadDocument,
-        ).not.toHaveBeenCalled();
-      });
-
-      it("should allow access when user is global guest", async () => {
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
 
         const result = await callRegisterPullResponderListener(ctx);
 
@@ -173,26 +145,6 @@ describe("DriveSubgraph Permission Checks", () => {
         expect(
           mockDocumentPermissionService.canWriteDocument,
         ).not.toHaveBeenCalled();
-      });
-
-      it("should allow access when user is global user", async () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = await callPushUpdates(ctx);
-
-        expect(result).toBeDefined();
-        expect(
-          mockDocumentPermissionService.canWriteDocument,
-        ).not.toHaveBeenCalled();
-      });
-
-      it("should deny access when user is only global guest (guests cannot write)", async () => {
-        vi.mocked(
-          mockDocumentPermissionService.canWriteDocument!,
-        ).mockResolvedValue(false);
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-        await expect(callPushUpdates(ctx)).rejects.toThrow("Forbidden");
       });
     });
 
@@ -281,11 +233,9 @@ describe("DriveSubgraph Permission Checks", () => {
 
   describe("AUTH_ENABLED=false behavior", () => {
     it("should allow all access when all global roles return true", async () => {
-      // When AUTH_ENABLED=false, isAdmin/isUser/isGuest all return true
+      // When AUTH_ENABLED=false, isAdmin returns true
       const ctx = createContext({
         isAdmin: true,
-        isUser: true,
-        isGuest: true,
         userAddress: "0xanyone",
       });
 

--- a/packages/reactor-api/test/permissions-integration.test.ts
+++ b/packages/reactor-api/test/permissions-integration.test.ts
@@ -57,14 +57,10 @@ describe("Permissions Integration Tests", () => {
   // Context factory
   const createContext = (options: {
     isAdmin?: boolean;
-    isUser?: boolean;
-    isGuest?: boolean;
     userAddress?: string;
   }) => ({
     user: options.userAddress ? { address: options.userAddress } : undefined,
     isAdmin: () => options.isAdmin ?? false,
-    isUser: () => options.isUser ?? false,
-    isGuest: () => options.isGuest ?? false,
   });
 
   beforeEach(async () => {
@@ -536,25 +532,7 @@ describe("Permissions Integration Tests", () => {
       expect(result).toBeDefined();
     });
 
-    it("should allow user access without document permission", async () => {
-      // No document permission granted
-      const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-      const result = await callDocument(ctx);
-
-      expect(result).toBeDefined();
-    });
-
-    it("should allow guest read access without document permission", async () => {
-      // No document permission granted
-      const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-      const result = await callDocument(ctx);
-
-      expect(result).toBeDefined();
-    });
-
-    it("global role should take precedence over document permission check", async () => {
+    it("global admin should take precedence over document permission check", async () => {
       // Grant conflicting permission (just to show global role wins)
       await documentPermissionService.grantPermission(
         "doc-123",

--- a/packages/reactor-api/test/reactor-subgraph-permissions.test.ts
+++ b/packages/reactor-api/test/reactor-subgraph-permissions.test.ts
@@ -47,14 +47,10 @@ describe("ReactorSubgraph Permission Checks", () => {
   // Helper to create context with different permission levels
   const createContext = (options: {
     isAdmin?: boolean;
-    isUser?: boolean;
-    isGuest?: boolean;
     userAddress?: string;
   }) => ({
     user: options.userAddress ? { address: options.userAddress } : undefined,
     isAdmin: () => options.isAdmin ?? false,
-    isUser: () => options.isUser ?? false,
-    isGuest: () => options.isGuest ?? false,
   });
 
   beforeEach(() => {
@@ -125,24 +121,6 @@ describe("ReactorSubgraph Permission Checks", () => {
     describe("Global Role Access", () => {
       it("should allow access when user is global admin", async () => {
         const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
-
-        const result = await callDocument(ctx);
-
-        expect(result).toBeDefined();
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-      });
-
-      it("should allow access when user is global user", async () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = await callDocument(ctx);
-
-        expect(result).toBeDefined();
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-      });
-
-      it("should allow access when user is global guest", async () => {
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
 
         const result = await callDocument(ctx);
 
@@ -278,20 +256,6 @@ describe("ReactorSubgraph Permission Checks", () => {
         // Permission check passes, may fail later validation
         await expectPermissionPassed(callCreateDocument(ctx));
         expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
-      });
-
-      it("should allow when user is global user", async () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        // Permission check passes, may fail later validation
-        await expectPermissionPassed(callCreateDocument(ctx));
-        expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
-      });
-
-      it("should deny when user is only guest", async () => {
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-        await expect(callCreateDocument(ctx)).rejects.toThrow("Forbidden");
       });
 
       it("should deny when no global access", async () => {
@@ -482,12 +446,10 @@ describe("ReactorSubgraph Permission Checks", () => {
   });
 
   describe("AUTH_ENABLED=false behavior", () => {
-    it("should allow all access when all global roles return true", async () => {
-      // When AUTH_ENABLED=false, isAdmin/isUser/isGuest all return true
+    it("should allow all access when isAdmin returns true", async () => {
+      // When AUTH_ENABLED=false, isAdmin returns true
       const ctx = createContext({
         isAdmin: true,
-        isUser: true,
-        isGuest: true,
         userAddress: "0xanyone",
       });
 

--- a/packages/vetra/subgraphs/__tests__/permission-utils.test.ts
+++ b/packages/vetra/subgraphs/__tests__/permission-utils.test.ts
@@ -7,216 +7,53 @@
 import type { BaseSubgraph, Context } from "@powerhousedao/reactor-api";
 import type { DocumentPermissionService } from "@powerhousedao/reactor-api";
 import { GraphQLError } from "graphql";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   assertCanExecuteOperation,
   assertCanRead,
   assertCanWrite,
   canReadDocument,
   canWriteDocument,
-  hasGlobalReadAccess,
-  hasGlobalWriteAccess,
+  hasGlobalAdminAccess,
 } from "../permission-utils.js";
 
 describe("permission-utils", () => {
   // Helper to create context with different permission levels
   const createContext = (options: {
     isAdmin?: boolean;
-    isUser?: boolean;
-    isGuest?: boolean;
     userAddress?: string;
   }): Context =>
     ({
       user: options.userAddress ? { address: options.userAddress } : undefined,
       isAdmin: vi.fn().mockReturnValue(options.isAdmin ?? false),
-      isUser: vi.fn().mockReturnValue(options.isUser ?? false),
-      isGuest: vi.fn().mockReturnValue(options.isGuest ?? false),
     }) as unknown as Context;
 
-  describe("hasGlobalReadAccess", () => {
-    afterEach(() => {
-      delete process.env.FREE_ENTRY;
+  describe("hasGlobalAdminAccess", () => {
+    it("should return true when user is global admin", () => {
+      const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+
+      const result = hasGlobalAdminAccess(ctx);
+
+      expect(result).toBe(true);
+      expect(ctx.isAdmin).toHaveBeenCalledWith("0xadmin");
     });
 
-    describe("Role-based access", () => {
-      it("should return true when user is global admin", () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+    it("should return false when user is not admin", () => {
+      const ctx = createContext({ userAddress: "0xnorole" });
 
-        const result = hasGlobalReadAccess(ctx);
+      const result = hasGlobalAdminAccess(ctx);
 
-        expect(result).toBe(true);
-        expect(ctx.isAdmin).toHaveBeenCalledWith("0xadmin");
-      });
-
-      it("should return true when user is global user", () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = hasGlobalReadAccess(ctx);
-
-        expect(result).toBe(true);
-        expect(ctx.isUser).toHaveBeenCalledWith("0xuser");
-      });
-
-      it("should return true when user is global guest", () => {
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-        const result = hasGlobalReadAccess(ctx);
-
-        expect(result).toBe(true);
-        expect(ctx.isGuest).toHaveBeenCalledWith("0xguest");
-      });
-
-      it("should return false when user has no global role", () => {
-        const ctx = createContext({ userAddress: "0xnorole" });
-
-        const result = hasGlobalReadAccess(ctx);
-
-        expect(result).toBe(false);
-      });
-
-      it("should return false when user is not authenticated (no address)", () => {
-        const ctx = createContext({});
-
-        const result = hasGlobalReadAccess(ctx);
-
-        expect(result).toBe(false);
-        // Should call with empty string when no user address
-        expect(ctx.isAdmin).toHaveBeenCalledWith("");
-      });
+      expect(result).toBe(false);
     });
 
-    describe("FREE_ENTRY environment variable", () => {
-      it("should return true when FREE_ENTRY is 'true' regardless of roles", () => {
-        process.env.FREE_ENTRY = "true";
-        const ctx = createContext({ userAddress: "0xanyone" });
+    it("should return false when user is not authenticated (no address)", () => {
+      const ctx = createContext({});
 
-        const result = hasGlobalReadAccess(ctx);
+      const result = hasGlobalAdminAccess(ctx);
 
-        expect(result).toBe(true);
-      });
-
-      it("should return true when FREE_ENTRY is 'true' even without authentication", () => {
-        process.env.FREE_ENTRY = "true";
-        const ctx = createContext({});
-
-        const result = hasGlobalReadAccess(ctx);
-
-        expect(result).toBe(true);
-      });
-
-      it("should not grant access when FREE_ENTRY is 'false'", () => {
-        process.env.FREE_ENTRY = "false";
-        const ctx = createContext({ userAddress: "0xanyone" });
-
-        const result = hasGlobalReadAccess(ctx);
-
-        expect(result).toBe(false);
-      });
-
-      it("should not grant access when FREE_ENTRY is not set", () => {
-        const ctx = createContext({ userAddress: "0xanyone" });
-
-        const result = hasGlobalReadAccess(ctx);
-
-        expect(result).toBe(false);
-      });
-    });
-
-    describe("Combined roles", () => {
-      it("should return true when user has multiple roles (admin + user)", () => {
-        const ctx = createContext({
-          isAdmin: true,
-          isUser: true,
-          userAddress: "0xmultirole",
-        });
-
-        const result = hasGlobalReadAccess(ctx);
-
-        expect(result).toBe(true);
-      });
-
-      it("should return true when all roles are true (AUTH_ENABLED=false scenario)", () => {
-        const ctx = createContext({
-          isAdmin: true,
-          isUser: true,
-          isGuest: true,
-          userAddress: "0xanyone",
-        });
-
-        const result = hasGlobalReadAccess(ctx);
-
-        expect(result).toBe(true);
-      });
-    });
-  });
-
-  describe("hasGlobalWriteAccess", () => {
-    describe("Role-based access", () => {
-      it("should return true when user is global admin", () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
-
-        const result = hasGlobalWriteAccess(ctx);
-
-        expect(result).toBe(true);
-      });
-
-      it("should return true when user is global user", () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = hasGlobalWriteAccess(ctx);
-
-        expect(result).toBe(true);
-      });
-
-      it("should return false when user is only global guest", () => {
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-        const result = hasGlobalWriteAccess(ctx);
-
-        expect(result).toBe(false);
-      });
-
-      it("should return false when user has no global role", () => {
-        const ctx = createContext({ userAddress: "0xnorole" });
-
-        const result = hasGlobalWriteAccess(ctx);
-
-        expect(result).toBe(false);
-      });
-
-      it("should return false when user is not authenticated", () => {
-        const ctx = createContext({});
-
-        const result = hasGlobalWriteAccess(ctx);
-
-        expect(result).toBe(false);
-      });
-    });
-
-    describe("Guest cannot write", () => {
-      it("should return false for guest even with FREE_ENTRY", () => {
-        process.env.FREE_ENTRY = "true";
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-        const result = hasGlobalWriteAccess(ctx);
-
-        expect(result).toBe(false);
-        delete process.env.FREE_ENTRY;
-      });
-    });
-
-    describe("Combined roles", () => {
-      it("should return true when user is both guest and user (user wins)", () => {
-        const ctx = createContext({
-          isGuest: true,
-          isUser: true,
-          userAddress: "0xmixed",
-        });
-
-        const result = hasGlobalWriteAccess(ctx);
-
-        expect(result).toBe(true);
-      });
+      expect(result).toBe(false);
+      // Should call with empty string when no user address
+      expect(ctx.isAdmin).toHaveBeenCalledWith("");
     });
   });
 
@@ -245,21 +82,8 @@ describe("permission-utils", () => {
     });
 
     describe("Global access bypass", () => {
-      it("should return true immediately when user has global read access", async () => {
+      it("should return true immediately when user has global admin access", async () => {
         const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
-
-        const result = await canReadDocument(
-          mockSubgraph as BaseSubgraph,
-          "doc-123",
-          ctx,
-        );
-
-        expect(result).toBe(true);
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-      });
-
-      it("should return true for guest without checking document permissions", async () => {
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
 
         const result = await canReadDocument(
           mockSubgraph as BaseSubgraph,
@@ -439,33 +263,6 @@ describe("permission-utils", () => {
 
         expect(result).toBe(true);
         expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
-      });
-
-      it("should return true immediately when user is global user", async () => {
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = await canWriteDocument(
-          mockSubgraph as BaseSubgraph,
-          "doc-123",
-          ctx,
-        );
-
-        expect(result).toBe(true);
-        expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
-      });
-
-      it("should NOT return true for global guest (guests cannot write)", async () => {
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-        const result = await canWriteDocument(
-          mockSubgraph as BaseSubgraph,
-          "doc-123",
-          ctx,
-        );
-
-        // Guest has no global write access, so should check document permissions
-        expect(mockDocumentPermissionService.canWrite).toHaveBeenCalled();
-        expect(result).toBe(false);
       });
     });
 
@@ -659,14 +456,6 @@ describe("permission-utils", () => {
         "Forbidden: insufficient permissions to write to this document",
       );
     });
-
-    it("should throw for guest user (guests cannot write)", async () => {
-      const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-      await expect(
-        assertCanWrite(mockSubgraph as BaseSubgraph, "doc-123", ctx),
-      ).rejects.toThrow("Forbidden");
-    });
   });
 
   describe("assertCanExecuteOperation", () => {
@@ -832,37 +621,11 @@ describe("permission-utils", () => {
   });
 
   describe("Edge Cases", () => {
-    describe("Null/undefined context fields", () => {
-      it("hasGlobalReadAccess should handle context without isAdmin function", () => {
-        const ctx = {
-          user: { address: "0xuser" },
-          isUser: vi.fn().mockReturnValue(true),
-          isGuest: vi.fn().mockReturnValue(false),
-        } as unknown as Context;
-
-        const result = hasGlobalReadAccess(ctx);
-
-        expect(result).toBe(true);
-      });
-
-      it("hasGlobalWriteAccess should handle context without isUser function", () => {
-        const ctx = {
-          user: { address: "0xadmin" },
-          isAdmin: vi.fn().mockReturnValue(true),
-          isGuest: vi.fn().mockReturnValue(false),
-        } as unknown as Context;
-
-        const result = hasGlobalWriteAccess(ctx);
-
-        expect(result).toBe(true);
-      });
-    });
-
     describe("Empty string user address", () => {
       it("should handle empty string user address", () => {
         const ctx = createContext({ userAddress: "" });
 
-        const result = hasGlobalReadAccess(ctx);
+        const result = hasGlobalAdminAccess(ctx);
 
         expect(result).toBe(false);
         expect(ctx.isAdmin).toHaveBeenCalledWith("");

--- a/packages/vetra/subgraphs/__tests__/vetra-read-model-permissions.test.ts
+++ b/packages/vetra/subgraphs/__tests__/vetra-read-model-permissions.test.ts
@@ -12,7 +12,7 @@ import type {
   DocumentPermissionService,
 } from "@powerhousedao/reactor-api";
 import type { IRelationalDbLegacy } from "document-drive";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getResolvers } from "../vetra-read-model/resolvers.js";
 
 // Mock the VetraReadModelProcessorLegacy
@@ -83,15 +83,11 @@ describe("VetraReadModel Subgraph Permission Checks", () => {
   // Helper to create context with different permission levels
   const createContext = (options: {
     isAdmin?: boolean;
-    isUser?: boolean;
-    isGuest?: boolean;
     userAddress?: string;
   }): Context =>
     ({
       user: options.userAddress ? { address: options.userAddress } : undefined,
       isAdmin: vi.fn().mockReturnValue(options.isAdmin ?? false),
-      isUser: vi.fn().mockReturnValue(options.isUser ?? false),
-      isGuest: vi.fn().mockReturnValue(options.isGuest ?? false),
     }) as unknown as Context;
 
   // Setup mock query chain
@@ -121,7 +117,6 @@ describe("VetraReadModel Subgraph Permission Checks", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env.FREE_ENTRY;
 
     // Create mock DocumentPermissionService
     mockDocumentPermissionService = {
@@ -151,10 +146,6 @@ describe("VetraReadModel Subgraph Permission Checks", () => {
     resolvers = getResolvers(mockSubgraph as BaseSubgraph);
   });
 
-  afterEach(() => {
-    delete process.env.FREE_ENTRY;
-  });
-
   describe("Query: vetraPackages", () => {
     const callVetraPackages = async (
       ctx: Context,
@@ -172,37 +163,6 @@ describe("VetraReadModel Subgraph Permission Checks", () => {
       it("should return all packages when user is global admin", async () => {
         setupMockQuery(mockPackages);
         const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
-
-        const result = await callVetraPackages(ctx);
-
-        expect(result).toHaveLength(3);
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-      });
-
-      it("should return all packages when user is global user", async () => {
-        setupMockQuery(mockPackages);
-        const ctx = createContext({ isUser: true, userAddress: "0xuser" });
-
-        const result = await callVetraPackages(ctx);
-
-        expect(result).toHaveLength(3);
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-      });
-
-      it("should return all packages when user is global guest", async () => {
-        setupMockQuery(mockPackages);
-        const ctx = createContext({ isGuest: true, userAddress: "0xguest" });
-
-        const result = await callVetraPackages(ctx);
-
-        expect(result).toHaveLength(3);
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-      });
-
-      it("should return all packages when FREE_ENTRY is true", async () => {
-        process.env.FREE_ENTRY = "true";
-        setupMockQuery(mockPackages);
-        const ctx = createContext({ userAddress: "0xanyone" });
 
         const result = await callVetraPackages(ctx);
 
@@ -397,8 +357,6 @@ describe("VetraReadModel Subgraph Permission Checks", () => {
       setupMockQuery(mockPackages);
       const ctx = createContext({
         isAdmin: true,
-        isUser: true,
-        isGuest: true,
         userAddress: "0xanyone",
       });
 

--- a/packages/vetra/subgraphs/permission-utils.ts
+++ b/packages/vetra/subgraphs/permission-utils.ts
@@ -2,26 +2,6 @@ import type { BaseSubgraph, Context } from "@powerhousedao/reactor-api";
 import { GraphQLError } from "graphql";
 
 /**
- * Check if user has global read access (admin, user, or guest)
- */
-export function hasGlobalReadAccess(ctx: Context): boolean {
-  const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "");
-  const isGlobalUser = ctx.isUser?.(ctx.user?.address ?? "");
-  const isGlobalGuest =
-    ctx.isGuest?.(ctx.user?.address ?? "") || process.env.FREE_ENTRY === "true";
-  return !!(isGlobalAdmin || isGlobalUser || isGlobalGuest);
-}
-
-/**
- * Check if user has global write access (admin or user, not guest)
- */
-export function hasGlobalWriteAccess(ctx: Context): boolean {
-  const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "");
-  const isGlobalUser = ctx.isUser?.(ctx.user?.address ?? "");
-  return !!(isGlobalAdmin || isGlobalUser);
-}
-
-/**
  * Get the parent IDs function for hierarchical permission checks
  */
 function getParentIdsFn(subgraph: BaseSubgraph) {
@@ -36,19 +16,31 @@ function getParentIdsFn(subgraph: BaseSubgraph) {
 }
 
 /**
- * Check if user can read a document (with hierarchy)
+ * Check if user has global admin access.
+ * Legacy fallback when authorizationService is not available.
+ */
+export function hasGlobalAdminAccess(ctx: Context): boolean {
+  return !!ctx.isAdmin?.(ctx.user?.address ?? "");
+}
+
+/**
+ * Check if user can read a document (with hierarchy).
+ * Delegates to AuthorizationService when available.
  */
 export async function canReadDocument(
   subgraph: BaseSubgraph,
   documentId: string,
   ctx: Context,
 ): Promise<boolean> {
-  // Global access allows reading
-  if (hasGlobalReadAccess(ctx)) {
-    return true;
+  if (subgraph.authorizationService) {
+    return subgraph.authorizationService.canRead(
+      documentId,
+      ctx.user?.address,
+      getParentIdsFn(subgraph),
+    );
   }
-
-  // Check document-level permissions with hierarchy
+  // Legacy fallback
+  if (hasGlobalAdminAccess(ctx)) return true;
   if (subgraph.documentPermissionService) {
     return subgraph.documentPermissionService.canRead(
       documentId,
@@ -56,24 +48,27 @@ export async function canReadDocument(
       getParentIdsFn(subgraph),
     );
   }
-
   return false;
 }
 
 /**
- * Check if user can write to a document (with hierarchy)
+ * Check if user can write to a document (with hierarchy).
+ * Delegates to AuthorizationService when available.
  */
 export async function canWriteDocument(
   subgraph: BaseSubgraph,
   documentId: string,
   ctx: Context,
 ): Promise<boolean> {
-  // Global write access allows writing
-  if (hasGlobalWriteAccess(ctx)) {
-    return true;
+  if (subgraph.authorizationService) {
+    return subgraph.authorizationService.canWrite(
+      documentId,
+      ctx.user?.address,
+      getParentIdsFn(subgraph),
+    );
   }
-
-  // Check document-level permissions with hierarchy
+  // Legacy fallback
+  if (hasGlobalAdminAccess(ctx)) return true;
   if (subgraph.documentPermissionService) {
     return subgraph.documentPermissionService.canWrite(
       documentId,
@@ -81,7 +76,6 @@ export async function canWriteDocument(
       getParentIdsFn(subgraph),
     );
   }
-
   return false;
 }
 
@@ -119,7 +113,7 @@ export async function assertCanWrite(
 
 /**
  * Check if user can execute a specific operation on a document.
- * Throws an error if the operation is restricted and user lacks permission.
+ * Delegates to AuthorizationService.canMutate when available.
  */
 export async function assertCanExecuteOperation(
   subgraph: BaseSubgraph,
@@ -127,17 +121,25 @@ export async function assertCanExecuteOperation(
   operationType: string,
   ctx: Context,
 ): Promise<void> {
-  // Skip if no permission service
-  if (!subgraph.documentPermissionService) {
+  if (subgraph.authorizationService) {
+    const canMutate = await subgraph.authorizationService.canMutate(
+      documentId,
+      operationType,
+      ctx.user?.address,
+      getParentIdsFn(subgraph),
+    );
+    if (!canMutate) {
+      throw new GraphQLError(
+        `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
+      );
+    }
     return;
   }
 
-  // Global admins bypass operation-level restrictions
-  if (ctx.isAdmin?.(ctx.user?.address ?? "")) {
-    return;
-  }
+  // Legacy fallback
+  if (!subgraph.documentPermissionService) return;
+  if (ctx.isAdmin?.(ctx.user?.address ?? "")) return;
 
-  // Check if this operation has any restrictions set
   const isRestricted =
     await subgraph.documentPermissionService.isOperationRestricted(
       documentId,
@@ -145,7 +147,6 @@ export async function assertCanExecuteOperation(
     );
 
   if (isRestricted) {
-    // Operation is restricted, check if user has permission
     const canExecute =
       await subgraph.documentPermissionService.canExecuteOperation(
         documentId,

--- a/packages/vetra/subgraphs/vetra-read-model/resolvers.ts
+++ b/packages/vetra/subgraphs/vetra-read-model/resolvers.ts
@@ -1,7 +1,7 @@
 import type { BaseSubgraph, Context } from "@powerhousedao/reactor-api";
 import { VetraReadModelProcessorLegacy } from "../../processors/vetra-read-model/index.legacy.js";
 import type { DB } from "../../processors/vetra-read-model/schema.js";
-import { canReadDocument, hasGlobalReadAccess } from "../permission-utils.js";
+import { canReadDocument, hasGlobalAdminAccess } from "../permission-utils.js";
 
 export const getResolvers = (
   subgraph: BaseSubgraph,
@@ -56,7 +56,7 @@ export const getResolvers = (
         }));
 
         // If user doesn't have global read access, filter by document-level permissions
-        if (!hasGlobalReadAccess(ctx) && subgraph.documentPermissionService) {
+        if (!hasGlobalAdminAccess(ctx) && subgraph.documentPermissionService) {
           const filteredResults = [];
           for (const pkg of mappedResults) {
             const canRead = await canReadDocument(


### PR DESCRIPTION
## Summary

- **Replaces global role-based auth (ADMINS/USERS/GUESTS) with per-document protection model**: documents are fully open by default (read and write for anyone, including anonymous), with opt-in protection per document. A `DEFAULT_PROTECTION` server config allows strict deployments to default to locked-down.
- **New `AuthorizationService`** as single source of truth for all permission checks, with shared helpers in `BaseSubgraph` — eliminates ~700 lines of duplicated logic across 4+ subgraph files.
- **New `DocumentProtection` table** tracking per-document protection status and ownership, with protection inheritance through parent chain (drive → children) using batch queries and cycle detection.
- **Anonymous reads and writes now work on unprotected docs**: auth middleware no longer blocks unauthenticated POST requests (all GraphQL), letting the resolver layer enforce permissions.
- **Clean break from legacy env vars**: `USERS`, `GUESTS`, `FREE_ENTRY` fully removed (with startup deprecation warning if still set). Only `AUTH_ENABLED`, `ADMINS`, `DEFAULT_PROTECTION`, `DOCUMENT_PERMISSIONS_ENABLED`, `SKIP_CREDENTIAL_VERIFICATION` remain.

### Authorization Model

```
1. Supreme admin (ADMINS env)? → ALLOW ALL
2. Is document protected?
   a. NOT protected:
      - READ: anyone (even anonymous) → ALLOW
      - WRITE: anyone (even anonymous) → ALLOW
   b. PROTECTED:
      - READ: requires explicit READ/WRITE/ADMIN grant
      - WRITE: requires explicit WRITE/ADMIN grant
3. Operation restricted? → Check OperationUserPermission
   (allows READ-only users with operation grants to execute)
4. Document owner = implicit ADMIN
5. Drive protected = all children effectively protected
```

### Key Changes

| Area | Change |
|------|--------|
| Database | New `DocumentProtection` table (migration 002) |
| Services | New `AuthorizationService`, extended `DocumentPermissionService` with protection/ownership CRUD |
| Auth middleware | Allow anonymous POST through (resolver-level enforcement) |
| BaseSubgraph | Shared `assertCanRead`/`assertCanWrite`/`assertCanExecuteOperation` helpers |
| Subgraphs | Reactor, DocumentModel, DocumentModelLegacy, Drive all delegate to BaseSubgraph + AuthorizationService |
| Vetra | `permission-utils.ts` delegates to `AuthorizationService` when available |
| Config | Removed `guests`/`users`/`freeEntry`, added `defaultProtection` |
| GraphQL API | New `documentProtection` query (auth required), `setDocumentProtection` and `transferDocumentOwnership` mutations |
| Ownership transfer | Revokes old owner's ADMIN grant before transferring |
| Protection check | `isProtectedWithAncestors` — batch query with cycle detection |
| Tests | 38 AuthorizationService + 46 vetra permission tests passing |

### Review feedback addressed

- [x] `transferDocumentOwnership` revokes old owner's ADMIN grant
- [x] Address normalization (`toLowerCase`) in `canExecuteOperation`/`canMutate`
- [x] Cycle detection in `isProtectedWithAncestors` (visited set + BFS)
- [x] N+1 query optimization (batch `WHERE IN` instead of recursive SELECTs)
- [x] `initializeDocumentProtection` upserts owner on conflict (no more null-owner rows)
- [x] `documentProtection` query requires authentication
- [x] READ-only + operation-grant mutation path fixed (skip `assertCanWrite` when `authorizationService` handles it via `canMutate`)
- [x] Auto-ownership in `DocumentModelSubgraph` and `DocumentModelSubgraphLegacy`
- [x] Startup deprecation warning for `USERS`/`GUESTS`/`FREE_ENTRY`
- [x] `DEFAULT_PROTECTION` case-insensitive parsing
- [x] Shared permission helpers extracted to `BaseSubgraph`
- [x] `isProtected` renamed to `isProtectedWithAncestors` for clarity

## Test plan

- [x] AuthorizationService unit tests (38 tests) — supreme admin, anonymous/authenticated reads and writes, protected/unprotected docs, owner access, operation grants, protection inheritance, address normalization
- [x] permission-utils tests (32 tests) — `hasGlobalAdminAccess`, `canReadDocument`/`canWriteDocument` delegation
- [x] vetra-read-model-permissions tests (14 tests) — admin-only access patterns
- [ ] Manual test: anonymous read + write on unprotected doc via GraphQL explorer
- [ ] Manual test: anonymous read/write on protected doc → Forbidden
- [ ] Manual test: `setDocumentProtection` / `transferDocumentOwnership` mutations
- [ ] Manual test: drive protection cascades to children
- [ ] Manual test: `DEFAULT_PROTECTION=true` for strict deployment mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)