### PR TITLE
Add --async flag to docs-create and auto-migrate in switchboard-pyroscope

### DIFF
--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -182,20 +182,21 @@ tsx docs-create.ts 1 -o 25 --async
 tsx docs-create.ts 1 -o 100 -b 10 --async
 ```
 
-| Flag                  | Short | Description                                                          |
-| --------------------- | ----- | -------------------------------------------------------------------- |
-| `N` (positional)      |       | Number of documents to create (default: 10)                          |
-| `--operations`        | `-o`  | Operations per loop (default: 0)                                     |
-| `--op-loops`          | `-l`  | Loops per document (default: 1)                                      |
-| `--batch-size`        | `-b`  | Operations per `mutateDocument` call (default: 1)                    |
-| `--doc-id`            | `-d`  | Use existing document(s), can be repeated                            |
-| `--endpoint`          |       | GraphQL endpoint (default: `http://localhost:4001/graphql`)          |
-| `--async`             |       | Use `*Async` mutation variants (fire-and-forget; returns job ID)     |
-| `--file`              |       | Write output to a timestamped file (default name: `docs-create.txt`) |
-| `--output`            | `-O`  | Write output to a specific file (no timestamp prefix)                |
-| `--verbose`           | `-v`  | Show detailed operation timings                                      |
-| `--percentiles`       | `-p`  | Show p50/p90/p95/p99 stats                                           |
-| `--show-action-types` | `-a`  | Show action names in min/max timings                                 |
+| Flag                  | Short | Description                                                                 |
+| --------------------- | ----- | --------------------------------------------------------------------------- |
+| `N` (positional)      |       | Number of documents to create (default: 10)                                 |
+| `--operations`        | `-o`  | Operations per loop (default: 0)                                            |
+| `--op-loops`          | `-l`  | Loops per document (default: 1)                                             |
+| `--batch-size`        | `-b`  | Operations per `mutateDocument` call (default: 1)                           |
+| `--doc-id`            | `-d`  | Use existing document(s), can be repeated                                   |
+| `--endpoint`          |       | GraphQL endpoint (default: `http://localhost:4001/graphql`)                 |
+| `--async`             |       | Use `*Async` mutation variants (fire-and-forget; returns job ID)            |
+| `--async-timeout`     |       | Max ms to wait for a polled job to reach terminal status (default: `30000`) |
+| `--file`              |       | Write output to a timestamped file (default name: `docs-create.txt`)        |
+| `--output`            | `-O`  | Write output to a specific file (no timestamp prefix)                       |
+| `--verbose`           | `-v`  | Show detailed operation timings                                             |
+| `--percentiles`       | `-p`  | Show p50/p90/p95/p99 stats                                                  |
+| `--show-action-types` | `-a`  | Show action names in min/max timings                                        |
 
 ### `docs-count.ts` — Count documents (fast)
 

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -247,11 +247,11 @@ Starts the switchboard with [Pyroscope](https://pyroscope.io/) continuous profil
 ./scripts/profiling/switchboard-pyroscope.sh -r bun -m legacy --postgres "postgresql://postgres:postgres@localhost:5432/reactor"
 ```
 
-| Flag         | Short | Description                              |
-| ------------ | ----- | ---------------------------------------- |
-| `--runtime`  | `-r`  | Runtime: `node` (default) or `bun`       |
-| `--mode`     | `-m`  | Storage mode: `v2` (default) or `legacy` |
-| `--postgres` | `-p`  | PostgreSQL database URL                  |
+| Flag         | Short | Description                                                                                                                     |
+| ------------ | ----- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `--runtime`  | `-r`  | Runtime: `node` (default) or `bun`                                                                                              |
+| `--mode`     | `-m`  | Storage mode: `v2` (default) or `legacy`                                                                                        |
+| `--postgres` | `-p`  | PostgreSQL database URL; sets `DATABASE_URL` — migrations run automatically before the server starts when `DATABASE_URL` is set |
 
 ## Infrastructure
 
@@ -326,10 +326,8 @@ tsx docs-reset.ts
 ```bash
 docker compose -f scripts/profiling/docker-compose.yml up pyroscope postgres -d
 
-# Migrate the database schema (required once per fresh database)
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres" pnpm --filter document-drive run migrate
-
 # Terminal 1: start switchboard with Pyroscope (wall:wall + CPU mode)
+# Migrations run automatically when --postgres is provided
 ./scripts/profiling/switchboard-pyroscope.sh \
   --postgres "postgresql://postgres:postgres@localhost:5432/postgres"
 

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -172,6 +172,12 @@ tsx docs-create.ts 5 -o 20 -l 10 -p -O results.txt
 
 # Show percentiles and action type names in min/max
 tsx docs-create.ts 5 -o 20 --percentiles --show-action-types
+
+# Use async mutation variants (returns job ID instead of document)
+tsx docs-create.ts 1 -o 25 --async
+
+# Async with batching
+tsx docs-create.ts 1 -o 100 -b 10 --async
 ```
 
 | Flag                  | Short | Description                                                          |
@@ -182,6 +188,7 @@ tsx docs-create.ts 5 -o 20 --percentiles --show-action-types
 | `--batch-size`        | `-b`  | Operations per `mutateDocument` call (default: 1)                    |
 | `--doc-id`            | `-d`  | Use existing document(s), can be repeated                            |
 | `--endpoint`          |       | GraphQL endpoint (default: `http://localhost:4001/graphql`)          |
+| `--async`             |       | Use `*Async` mutation variants (fire-and-forget; returns job ID)     |
 | `--file`              |       | Write output to a timestamped file (default name: `docs-create.txt`) |
 | `--output`            | `-O`  | Write output to a specific file (no timestamp prefix)                |
 | `--verbose`           | `-v`  | Show detailed operation timings                                      |

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -39,9 +39,11 @@ pnpm --filter document-model run tsc --build
 pnpm --filter @powerhousedao/reactor run build
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres" pnpm --filter document-drive run migrate
 pnpm --filter @powerhousedao/switchboard run tsc --build
+pnpm --filter @powerhousedao/reactor-api run build:misc
 ```
 
 - `migrate` runs `prisma generate && prisma db push` — required once per fresh PostgreSQL database to create the schema. Re-run if you wipe the database.
+- `build:misc` copies `.graphql` schema files into the reactor-api dist. Without this, the reactor subgraph (which provides `jobStatus` and other queries) fails to start silently.
 - Rebuild after any source changes in these packages, otherwise the scripts will run against stale code.
 
 Scripts are run with [tsx](https://github.com/privatenumber/tsx). The GraphQL-based scripts (`docs-*`) require a running switchboard instance (default: `http://localhost:4001/graphql`).

--- a/scripts/profiling/docs-create.ts
+++ b/scripts/profiling/docs-create.ts
@@ -659,6 +659,7 @@ async function main() {
           // (fire-and-forget into pollPromises) so results stream to stdout as
           // each poll resolves during dispatch rather than bursting at the end.
           for (let loop = 1; loop <= opLoops; loop++) {
+            const loopDispatchStart = performance.now();
             const requests = buildRequests(
               docId,
               docNum,
@@ -703,6 +704,13 @@ async function main() {
                 );
               }
             }
+            const loopDispatchMs = Math.round(
+              performance.now() - loopDispatchStart,
+            );
+            const msPerOp = Math.round(loopDispatchMs / operations);
+            process.stdout.write(
+              `\r  [${docNum}/${docCount}] ${docId}: loop ${loop}/${opLoops} dispatched in ${loopDispatchMs}ms (${msPerOp}ms/op)\n`,
+            );
           }
 
           // Wait for any polls still in flight after dispatch completes, then aggregate

--- a/scripts/profiling/docs-create.ts
+++ b/scripts/profiling/docs-create.ts
@@ -267,7 +267,7 @@ const JOB_STATUS_QUERY = `
     jobStatus(jobId: $jobId) { status completedAt }
   }
 `;
-const TERMINAL_JOB_STATUSES = new Set(["READ_MODELS_READY", "FAILED"]);
+const TERMINAL_JOB_STATUSES = new Set(["READ_READY", "FAILED"]);
 const JOB_POLL_INTERVAL_MS = 200;
 
 interface JobStatusResponse {

--- a/scripts/profiling/docs-create.ts
+++ b/scripts/profiling/docs-create.ts
@@ -173,28 +173,22 @@ async function createDocument(client: GraphQLClient): Promise<string> {
   return DocumentModel_createEmptyDocument.id;
 }
 
-async function performOperations(
-  client: GraphQLClient,
+type RequestDescriptor = {
+  mutation: string;
+  variables: Record<string, unknown>;
+  batchEnd: number;
+  batchCount: number;
+  actionType: string;
+};
+
+function buildRequests(
   documentId: string,
   docIndex: number,
   operationCount: number,
   batchSize: number,
   asyncMutate: boolean,
-  onProgress: (opNum: number, durationMs: number, batchCount: number) => void,
-): Promise<OperationsResult> {
-  let minOp: OperationTiming | null = null;
-  let maxOp: OperationTiming | null = null;
-  const durations: number[] = [];
-
-  // Build all request descriptors up front
-  const requests: Array<{
-    mutation: string;
-    variables: Record<string, unknown>;
-    batchEnd: number;
-    batchCount: number;
-    actionType: string;
-  }> = [];
-
+): RequestDescriptor[] {
+  const requests: RequestDescriptor[] = [];
   for (let i = 0; i < operationCount; i += batchSize) {
     const batchEnd = Math.min(i + batchSize, operationCount);
     const batchCount = batchEnd - i;
@@ -220,8 +214,30 @@ async function performOperations(
       actionType: batchCount === 1 ? actionTypes[0] : `batch(${batchCount})`,
     });
   }
+  return requests;
+}
 
-  const executeRequest = async (req: (typeof requests)[number]) => {
+async function performOperations(
+  client: GraphQLClient,
+  documentId: string,
+  docIndex: number,
+  operationCount: number,
+  batchSize: number,
+  onProgress: (opNum: number, durationMs: number, batchCount: number) => void,
+): Promise<OperationsResult> {
+  let minOp: OperationTiming | null = null;
+  let maxOp: OperationTiming | null = null;
+  const durations: number[] = [];
+
+  const requests = buildRequests(
+    documentId,
+    docIndex,
+    operationCount,
+    batchSize,
+    false,
+  );
+
+  for (const req of requests) {
     const opStart = performance.now();
     await client.request(req.mutation, req.variables);
     const batchDurationMs = performance.now() - opStart;
@@ -237,47 +253,91 @@ async function performOperations(
       actionType: req.actionType,
     };
 
-    if (minOp === null || perOpDurationMs < minOp.durationMs) {
-      minOp = timing;
-    }
-    if (maxOp === null || perOpDurationMs > maxOp.durationMs) {
-      maxOp = timing;
-    }
+    if (minOp === null || perOpDurationMs < minOp.durationMs) minOp = timing;
+    if (maxOp === null || perOpDurationMs > maxOp.durationMs) maxOp = timing;
 
     onProgress(req.batchEnd, batchDurationMs, req.batchCount);
-  };
-
-  if (asyncMutate) {
-    // Fire all requests consecutively without awaiting intermediate responses,
-    // filling the server queue as fast as possible. Only the final job ID is
-    // awaited to confirm the last operation was accepted.
-    const promises = requests.map((req) =>
-      client.request(req.mutation, req.variables),
-    );
-    const overallStart = performance.now();
-    await promises[promises.length - 1];
-    const totalMs = performance.now() - overallStart;
-    const perOpMs = totalMs / operationCount;
-
-    for (let i = 0; i < operationCount; i++) {
-      durations.push(perOpMs);
-    }
-    const last = requests[requests.length - 1];
-    const timing: OperationTiming = {
-      opIndex: last.batchEnd,
-      durationMs: perOpMs,
-      actionType: last.actionType,
-    };
-    minOp = timing;
-    maxOp = timing;
-    onProgress(last.batchEnd, totalMs, operationCount);
-  } else {
-    for (const req of requests) {
-      await executeRequest(req);
-    }
   }
 
   return { minOp, maxOp, durations };
+}
+
+const JOB_STATUS_QUERY = `
+  query GetJobStatus($jobId: String!) {
+    jobStatus(jobId: $jobId) { status completedAt }
+  }
+`;
+const TERMINAL_JOB_STATUSES = new Set(["READ_MODELS_READY", "FAILED"]);
+const JOB_POLL_INTERVAL_MS = 200;
+
+interface JobStatusResponse {
+  jobStatus: { status: string; completedAt: string | null };
+}
+
+async function performOperationsAsync(
+  client: GraphQLClient,
+  documentId: string,
+  docIndex: number,
+  operationCount: number,
+  batchSize: number,
+  onProgress: (opNum: number, durationMs: number, batchCount: number) => void,
+): Promise<OperationsResult> {
+  const requests = buildRequests(
+    documentId,
+    docIndex,
+    operationCount,
+    batchSize,
+    true,
+  );
+
+  // Start timer before dispatching — captures full queue-fill + execution time
+  const overallStart = performance.now();
+
+  // Dispatch requests consecutively so the server receives them in order.
+  // Each response is { op0: jobId, op1: jobId, ... } (one ID per alias).
+  // Awaiting each response before sending the next ensures the queue order
+  // matches the dispatch order, so we can target the final job ID.
+  let lastJobId: string | undefined;
+  for (const req of requests) {
+    const result = await client.request<Record<string, string>>(
+      req.mutation,
+      req.variables,
+    );
+    const jobIds = Object.values(result);
+    lastJobId = jobIds[jobIds.length - 1];
+  }
+
+  // Poll only the final job — when it completes all preceding jobs are done
+  while (lastJobId !== undefined) {
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, JOB_POLL_INTERVAL_MS),
+    );
+    const { jobStatus } = await client.request<JobStatusResponse>(
+      JOB_STATUS_QUERY,
+      { jobId: lastJobId },
+    );
+    if (
+      TERMINAL_JOB_STATUSES.has(jobStatus.status) ||
+      jobStatus.completedAt !== null
+    ) {
+      break;
+    }
+  }
+
+  const totalMs = performance.now() - overallStart;
+  const perOpMs = totalMs / operationCount;
+
+  const durations = Array.from({ length: operationCount }, () => perOpMs);
+  const last = requests[requests.length - 1];
+  const timing: OperationTiming = {
+    opIndex: last.batchEnd,
+    durationMs: perOpMs,
+    actionType: last.actionType,
+  };
+
+  onProgress(last.batchEnd, totalMs, operationCount);
+
+  return { minOp: timing, maxOp: timing, durations };
 }
 
 function parseArgs(args: string[]): {
@@ -604,13 +664,15 @@ async function main() {
             console.log(`  [${docNum}/${docCount}] ${docId} ${loopPrefix}:`);
           }
 
-          const result = await performOperations(
+          const performFn = asyncMutate
+            ? performOperationsAsync
+            : performOperations;
+          const result = await performFn(
             client,
             docId,
             docNum,
             operations,
             batchSize,
-            asyncMutate,
             (opNum, durationMs, batchCount) => {
               const batchInfo = batchCount > 1 ? ` (${batchCount} ops)` : "";
               if (verbose) {

--- a/scripts/profiling/docs-create.ts
+++ b/scripts/profiling/docs-create.ts
@@ -288,13 +288,15 @@ async function pollJobAsync(
   client: GraphQLClient,
   job: SampledJob,
   timeoutMs: number,
-): Promise<{ result: OperationsResult; totalMs: number }> {
+): Promise<{ result: OperationsResult; totalMs: number; timedOut: boolean }> {
   const deadline = performance.now() + timeoutMs;
+  let timedOut = false;
   while (true) {
     await new Promise<void>((resolve) =>
       setTimeout(resolve, JOB_POLL_INTERVAL_MS),
     );
     if (performance.now() >= deadline) {
+      timedOut = true;
       process.stderr.write(
         `\nWarning: job ${job.jobId} (req ${job.reqNum}) did not reach a terminal status within ${timeoutMs}ms — giving up.\n`,
       );
@@ -321,7 +323,11 @@ async function pollJobAsync(
     durationMs: perOpMs,
     actionType: job.actionType,
   };
-  return { result: { minOp: timing, maxOp: timing, durations }, totalMs };
+  return {
+    result: { minOp: timing, maxOp: timing, durations },
+    totalMs,
+    timedOut,
+  };
 }
 
 function parseArgs(args: string[]): {
@@ -370,13 +376,15 @@ function parseArgs(args: string[]): {
     } else if (arg === "--async") {
       asyncMutate = true;
       const nextArg = args[i + 1];
-      if (
-        nextArg &&
-        !isNaN(Number(nextArg)) &&
-        Number(nextArg) > 0 &&
-        !nextArg.startsWith("-")
-      ) {
-        asyncPollRate = Number(nextArg);
+      if (nextArg && !nextArg.startsWith("-")) {
+        const n = Number(nextArg);
+        if (isNaN(n) || n <= 0 || !Number.isInteger(n)) {
+          console.error(
+            `Error: --async N must be a positive integer, got: ${nextArg}`,
+          );
+          process.exit(1);
+        }
+        asyncPollRate = n;
         i++;
       }
     } else if (arg === "--async-timeout" && args[i + 1]) {
@@ -663,6 +671,7 @@ async function main() {
         timing: OperationTiming;
       } | null = null;
       const allDurations: number[] = [];
+      let timedOutCount = 0;
 
       for (let i = 0; i < documentIds.length; i++) {
         const docNum = i + 1;
@@ -673,6 +682,7 @@ async function main() {
           const pollPromises: Promise<{
             result: OperationsResult;
             totalMs: number;
+            timedOut: boolean;
             job: SampledJob;
           }>[] = [];
           let globalReqNum = 0;
@@ -722,9 +732,15 @@ async function main() {
                 pollPromises.push(
                   pollJobAsync(client, job, asyncTimeoutMs).then((r) => {
                     const ms = Math.round(r.totalMs);
-                    process.stdout.write(
-                      `\r  [${docNum}/${docCount}] ${docId}: op ${job.reqNum}/${totalRequests} (${ms}ms)\n`,
-                    );
+                    if (r.timedOut) {
+                      process.stdout.write(
+                        `\r  [${docNum}/${docCount}] ${docId}: op ${job.reqNum}/${totalRequests} TIMED OUT after ${ms}ms\n`,
+                      );
+                    } else {
+                      process.stdout.write(
+                        `\r  [${docNum}/${docCount}] ${docId}: op ${job.reqNum}/${totalRequests} (${ms}ms)\n`,
+                      );
+                    }
                     return { ...r, job };
                   }),
                 );
@@ -746,7 +762,13 @@ async function main() {
 
           // Wait for any polls still in flight after dispatch completes, then aggregate
           const allPollResults = await Promise.all(pollPromises);
-          for (const { result, job } of allPollResults) {
+          for (const { result, timedOut, job } of allPollResults) {
+            // Skip timed-out jobs — their totalMs reflects the timeout cap, not
+            // real processing time, and would skew min/max and percentiles.
+            if (timedOut) {
+              timedOutCount++;
+              continue;
+            }
             if (
               result.minOp &&
               (overallMinOp === null ||
@@ -864,8 +886,10 @@ async function main() {
             ? `, min: ${overallMinOp.timing.durationMs}ms (${overallMinOp.timing.actionType}), max: ${overallMaxOp.timing.durationMs}ms (${overallMaxOp.timing.actionType})`
             : `, min: ${overallMinOp.timing.durationMs}ms, max: ${overallMaxOp.timing.durationMs}ms`
           : "";
+      const timedOutStr =
+        timedOutCount > 0 ? `, timed-out jobs: ${timedOutCount}` : "";
       console.log(
-        `  Completed ${totalOps} operations in ${opsDuration}s (avg: ${avgMsPerOp}ms/op${overallMinMax})`,
+        `  Completed ${totalOps} operations in ${opsDuration}s (avg: ${avgMsPerOp}ms/op${overallMinMax}${timedOutStr})`,
       );
       if (showPercentiles) {
         const percentiles = calculatePercentiles(allDurations);

--- a/scripts/profiling/docs-create.ts
+++ b/scripts/profiling/docs-create.ts
@@ -689,10 +689,9 @@ async function main() {
                 };
                 pollPromises.push(
                   pollJobAsync(client, job).then((r) => {
-                    const loopDuration = (r.totalMs / 1000).toFixed(2);
-                    const msPerOp = (r.totalMs / job.batchCount).toFixed(0);
+                    const ms = Math.round(r.totalMs);
                     process.stdout.write(
-                      `\r  [${docNum}/${docCount}] ${docId}: req ${job.reqNum}/${totalRequests} (${loopDuration}s, ${msPerOp}ms/op)\n`,
+                      `\r  [${docNum}/${docCount}] ${docId}: op ${job.reqNum}/${totalRequests} (${ms}ms)\n`,
                     );
                     return { ...r, job };
                   }),

--- a/scripts/profiling/docs-create.ts
+++ b/scripts/profiling/docs-create.ts
@@ -287,11 +287,19 @@ interface SampledJob {
 async function pollJobAsync(
   client: GraphQLClient,
   job: SampledJob,
+  timeoutMs: number,
 ): Promise<{ result: OperationsResult; totalMs: number }> {
+  const deadline = performance.now() + timeoutMs;
   while (true) {
     await new Promise<void>((resolve) =>
       setTimeout(resolve, JOB_POLL_INTERVAL_MS),
     );
+    if (performance.now() >= deadline) {
+      process.stderr.write(
+        `\nWarning: job ${job.jobId} (req ${job.reqNum}) did not reach a terminal status within ${timeoutMs}ms — giving up.\n`,
+      );
+      break;
+    }
     const { jobStatus } = await client.request<JobStatusResponse>(
       JOB_STATUS_QUERY,
       { jobId: job.jobId },
@@ -325,6 +333,7 @@ function parseArgs(args: string[]): {
   docIds: string[];
   asyncMutate: boolean;
   asyncPollRate: number;
+  asyncTimeoutMs: number;
   verbose: boolean;
   percentiles: boolean;
   showActionTypes: boolean;
@@ -339,6 +348,7 @@ function parseArgs(args: string[]): {
   const docIds: string[] = [];
   let asyncMutate = false;
   let asyncPollRate = 100;
+  let asyncTimeoutMs = 30_000;
   let verbose = false;
   let percentiles = false;
   let showActionTypes = false;
@@ -369,6 +379,8 @@ function parseArgs(args: string[]): {
         asyncPollRate = Number(nextArg);
         i++;
       }
+    } else if (arg === "--async-timeout" && args[i + 1]) {
+      asyncTimeoutMs = Number(args[++i]);
     } else if (arg === "--verbose" || arg === "-v") {
       verbose = true;
     } else if (arg === "--percentiles" || arg === "-p") {
@@ -403,6 +415,7 @@ Options:
                             (can be specified multiple times, skips document creation)
   --endpoint <url>          GraphQL endpoint (default: ${DEFAULT_ENDPOINT})
   --async [N]               Use *Async mutation variants; poll every Nth operation (default N=100)
+  --async-timeout <ms>      Max ms to wait for a polled job to reach a terminal status (default: 30000)
   --verbose, -v             Show detailed operation timings
   --percentiles, -p         Show percentile statistics (p50, p90, p95, p99) per line
   --show-action-types, -a   Show action type names in min/max timings
@@ -462,6 +475,13 @@ Examples:
     process.exit(1);
   }
 
+  if (isNaN(asyncTimeoutMs) || asyncTimeoutMs < 1) {
+    console.error(
+      `Error: Invalid --async-timeout value: must be a positive integer (ms).`,
+    );
+    process.exit(1);
+  }
+
   if (operations === 0 && opLoops > 1) {
     console.warn(
       `Warning: --op-loops=${opLoops} has no effect when operations is 0.`,
@@ -489,6 +509,7 @@ Examples:
     docIds,
     asyncMutate,
     asyncPollRate,
+    asyncTimeoutMs,
     verbose,
     percentiles,
     showActionTypes,
@@ -507,6 +528,7 @@ async function main() {
     docIds,
     asyncMutate,
     asyncPollRate,
+    asyncTimeoutMs,
     verbose,
     percentiles: showPercentiles,
     showActionTypes,
@@ -674,7 +696,16 @@ async function main() {
                 req.mutation,
                 req.variables,
               );
-              const jobId = Object.values(result).at(-1)!;
+              // The batch mutation aliases each op; we sample the last one as
+              // representative. Validate early so polling never runs against
+              // "undefined".
+              const resultValues = Object.values(result);
+              if (resultValues.length === 0) {
+                throw new Error(
+                  `Empty mutation response for request ${globalReqNum}`,
+                );
+              }
+              const jobId = resultValues.at(-1) as string;
               if (
                 globalReqNum % asyncPollRate === 0 ||
                 globalReqNum === totalRequests
@@ -689,7 +720,7 @@ async function main() {
                   reqNum: globalReqNum,
                 };
                 pollPromises.push(
-                  pollJobAsync(client, job).then((r) => {
+                  pollJobAsync(client, job, asyncTimeoutMs).then((r) => {
                     const ms = Math.round(r.totalMs);
                     process.stdout.write(
                       `\r  [${docNum}/${docCount}] ${docId}: op ${job.reqNum}/${totalRequests} (${ms}ms)\n`,

--- a/scripts/profiling/docs-create.ts
+++ b/scripts/profiling/docs-create.ts
@@ -144,19 +144,23 @@ function formatPercentiles(p: Percentiles): string {
   return `p50: ${p.p50}ms, p90: ${p.p90}ms, p95: ${p.p95}ms, p99: ${p.p99}ms`;
 }
 
-// Build a single GraphQL mutation that sends batchSize operations using aliases
+// Build a single GraphQL mutation that sends batchSize operations using aliases.
+// When asyncMutate is true, the *Async variant of each mutation is used.
+// Async mutations return String! (job ID) so no selection set is included.
 function buildBatchMutation(
   ops: Array<{ mutationName: string; inputType: string }>,
+  asyncMutate: boolean,
 ): string {
   const varDecls = [
     "$docId: PHID!",
     ...ops.map((op, i) => `$input${i}: ${op.inputType}!`),
   ].join(", ");
   const body = ops
-    .map(
-      (op, i) =>
-        `  op${i}: ${op.mutationName}(docId: $docId, input: $input${i}) { id }`,
-    )
+    .map((op, i) => {
+      const name = asyncMutate ? `${op.mutationName}Async` : op.mutationName;
+      const selection = asyncMutate ? "" : " { id }";
+      return `  op${i}: ${name}(docId: $docId, input: $input${i})${selection}`;
+    })
     .join("\n");
   return `mutation BatchOps(${varDecls}) {\n${body}\n}`;
 }
@@ -175,17 +179,25 @@ async function performOperations(
   docIndex: number,
   operationCount: number,
   batchSize: number,
+  asyncMutate: boolean,
   onProgress: (opNum: number, durationMs: number, batchCount: number) => void,
 ): Promise<OperationsResult> {
   let minOp: OperationTiming | null = null;
   let maxOp: OperationTiming | null = null;
   const durations: number[] = [];
 
+  // Build all request descriptors up front
+  const requests: Array<{
+    mutation: string;
+    variables: Record<string, unknown>;
+    batchEnd: number;
+    batchCount: number;
+    actionType: string;
+  }> = [];
+
   for (let i = 0; i < operationCount; i += batchSize) {
     const batchEnd = Math.min(i + batchSize, operationCount);
     const batchCount = batchEnd - i;
-
-    // Build batch of operations
     const batchOps: Array<{ mutationName: string; inputType: string }> = [];
     const actionTypes: string[] = [];
     const variables: Record<string, unknown> = { docId: documentId };
@@ -200,25 +212,29 @@ async function performOperations(
       variables[`input${j - i}`] = config.buildInput(docIndex, j + 1);
     }
 
-    const mutation = buildBatchMutation(batchOps);
+    requests.push({
+      mutation: buildBatchMutation(batchOps, asyncMutate),
+      variables,
+      batchEnd,
+      batchCount,
+      actionType: batchCount === 1 ? actionTypes[0] : `batch(${batchCount})`,
+    });
+  }
 
+  const executeRequest = async (req: (typeof requests)[number]) => {
     const opStart = performance.now();
-    await client.request(mutation, variables);
+    await client.request(req.mutation, req.variables);
     const batchDurationMs = performance.now() - opStart;
+    const perOpDurationMs = batchDurationMs / req.batchCount;
 
-    // Calculate per-operation duration for consistent min/max tracking
-    const perOpDurationMs = batchDurationMs / batchCount;
-
-    for (let j = 0; j < batchCount; j++) {
+    for (let j = 0; j < req.batchCount; j++) {
       durations.push(perOpDurationMs);
     }
 
-    const actionType =
-      batchCount === 1 ? actionTypes[0] : `batch(${batchCount})`;
     const timing: OperationTiming = {
-      opIndex: batchEnd,
+      opIndex: req.batchEnd,
       durationMs: perOpDurationMs,
-      actionType,
+      actionType: req.actionType,
     };
 
     if (minOp === null || perOpDurationMs < minOp.durationMs) {
@@ -228,7 +244,37 @@ async function performOperations(
       maxOp = timing;
     }
 
-    onProgress(batchEnd, batchDurationMs, batchCount);
+    onProgress(req.batchEnd, batchDurationMs, req.batchCount);
+  };
+
+  if (asyncMutate) {
+    // Fire all requests consecutively without awaiting intermediate responses,
+    // filling the server queue as fast as possible. Only the final job ID is
+    // awaited to confirm the last operation was accepted.
+    const promises = requests.map((req) =>
+      client.request(req.mutation, req.variables),
+    );
+    const overallStart = performance.now();
+    await promises[promises.length - 1];
+    const totalMs = performance.now() - overallStart;
+    const perOpMs = totalMs / operationCount;
+
+    for (let i = 0; i < operationCount; i++) {
+      durations.push(perOpMs);
+    }
+    const last = requests[requests.length - 1];
+    const timing: OperationTiming = {
+      opIndex: last.batchEnd,
+      durationMs: perOpMs,
+      actionType: last.actionType,
+    };
+    minOp = timing;
+    maxOp = timing;
+    onProgress(last.batchEnd, totalMs, operationCount);
+  } else {
+    for (const req of requests) {
+      await executeRequest(req);
+    }
   }
 
   return { minOp, maxOp, durations };
@@ -241,6 +287,7 @@ function parseArgs(args: string[]): {
   batchSize: number;
   endpoint: string;
   docIds: string[];
+  asyncMutate: boolean;
   verbose: boolean;
   percentiles: boolean;
   showActionTypes: boolean;
@@ -253,6 +300,7 @@ function parseArgs(args: string[]): {
   let batchSize = 1;
   let endpoint = DEFAULT_ENDPOINT;
   const docIds: string[] = [];
+  let asyncMutate = false;
   let verbose = false;
   let percentiles = false;
   let showActionTypes = false;
@@ -271,6 +319,8 @@ function parseArgs(args: string[]): {
       batchSize = Number(args[++i]);
     } else if ((arg === "--doc-id" || arg === "-d") && args[i + 1]) {
       docIds.push(args[++i]);
+    } else if (arg === "--async") {
+      asyncMutate = true;
     } else if (arg === "--verbose" || arg === "-v") {
       verbose = true;
     } else if (arg === "--percentiles" || arg === "-p") {
@@ -304,6 +354,7 @@ Options:
   --doc-id, -d <id>         Use existing document(s) instead of creating new ones
                             (can be specified multiple times, skips document creation)
   --endpoint <url>          GraphQL endpoint (default: ${DEFAULT_ENDPOINT})
+  --async                   Use the *Async mutation variants (returns job ID, not document)
   --verbose, -v             Show detailed operation timings
   --percentiles, -p         Show percentile statistics (p50, p90, p95, p99) per line
   --show-action-types, -a   Show action type names in min/max timings
@@ -388,6 +439,7 @@ Examples:
     batchSize,
     endpoint,
     docIds,
+    asyncMutate,
     verbose,
     percentiles,
     showActionTypes,
@@ -404,6 +456,7 @@ async function main() {
     batchSize,
     endpoint,
     docIds,
+    asyncMutate,
     verbose,
     percentiles: showPercentiles,
     showActionTypes,
@@ -557,6 +610,7 @@ async function main() {
             docNum,
             operations,
             batchSize,
+            asyncMutate,
             (opNum, durationMs, batchCount) => {
               const batchInfo = batchCount > 1 ? ` (${batchCount} ops)` : "";
               if (verbose) {

--- a/scripts/profiling/docs-create.ts
+++ b/scripts/profiling/docs-create.ts
@@ -292,9 +292,9 @@ async function pollJobAsync(
   const deadline = performance.now() + timeoutMs;
   let timedOut = false;
   while (true) {
-    await new Promise<void>((resolve) =>
-      setTimeout(resolve, JOB_POLL_INTERVAL_MS),
-    );
+    // Check deadline before sleeping so timeouts shorter than
+    // JOB_POLL_INTERVAL_MS still attempt at least one poll on the first
+    // iteration rather than timing out in the sleep.
     if (performance.now() >= deadline) {
       timedOut = true;
       process.stderr.write(
@@ -302,6 +302,9 @@ async function pollJobAsync(
       );
       break;
     }
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, JOB_POLL_INTERVAL_MS),
+    );
     const { jobStatus } = await client.request<JobStatusResponse>(
       JOB_STATUS_QUERY,
       { jobId: job.jobId },
@@ -483,7 +486,11 @@ Examples:
     process.exit(1);
   }
 
-  if (isNaN(asyncTimeoutMs) || asyncTimeoutMs < 1) {
+  if (
+    isNaN(asyncTimeoutMs) ||
+    asyncTimeoutMs < 1 ||
+    !Number.isInteger(asyncTimeoutMs)
+  ) {
     console.error(
       `Error: Invalid --async-timeout value: must be a positive integer (ms).`,
     );
@@ -500,6 +507,10 @@ Examples:
     console.warn(
       `Warning: --batch-size=${batchSize} has no effect when operations is 0.`,
     );
+  }
+
+  if (operations === 0 && asyncMutate) {
+    console.warn(`Warning: --async has no effect when operations is 0.`);
   }
 
   if (docIds.length > 0 && operations === 0) {
@@ -672,6 +683,7 @@ async function main() {
       } | null = null;
       const allDurations: number[] = [];
       let timedOutCount = 0;
+      let sampledJobCount = 0;
 
       for (let i = 0; i < documentIds.length; i++) {
         const docNum = i + 1;
@@ -715,7 +727,12 @@ async function main() {
                   `Empty mutation response for request ${globalReqNum}`,
                 );
               }
-              const jobId = resultValues.at(-1) as string;
+              const jobId = resultValues.at(-1);
+              if (typeof jobId !== "string" || jobId === "") {
+                throw new Error(
+                  `Invalid job ID in mutation response for request ${globalReqNum}: ${JSON.stringify(jobId)}`,
+                );
+              }
               if (
                 globalReqNum % asyncPollRate === 0 ||
                 globalReqNum === totalRequests
@@ -769,6 +786,7 @@ async function main() {
               timedOutCount++;
               continue;
             }
+            sampledJobCount++;
             if (
               result.minOp &&
               (overallMinOp === null ||
@@ -888,8 +906,12 @@ async function main() {
           : "";
       const timedOutStr =
         timedOutCount > 0 ? `, timed-out jobs: ${timedOutCount}` : "";
+      const sampledStr =
+        sampledJobCount > 0
+          ? ` (stats from ${sampledJobCount} sampled jobs)`
+          : "";
       console.log(
-        `  Completed ${totalOps} operations in ${opsDuration}s (avg: ${avgMsPerOp}ms/op${overallMinMax}${timedOutStr})`,
+        `  Completed ${totalOps} operations in ${opsDuration}s (avg: ${avgMsPerOp}ms/op${overallMinMax}${timedOutStr})${sampledStr}`,
       );
       if (showPercentiles) {
         const percentiles = calculatePercentiles(allDurations);

--- a/scripts/profiling/docs-create.ts
+++ b/scripts/profiling/docs-create.ts
@@ -664,28 +664,39 @@ async function main() {
             console.log(`  [${docNum}/${docCount}] ${docId} ${loopPrefix}:`);
           }
 
-          const performFn = asyncMutate
-            ? performOperationsAsync
-            : performOperations;
-          const result = await performFn(
-            client,
-            docId,
-            docNum,
-            operations,
-            batchSize,
-            (opNum, durationMs, batchCount) => {
-              const batchInfo = batchCount > 1 ? ` (${batchCount} ops)` : "";
-              if (verbose) {
-                console.log(
-                  `    op ${opNum}/${operations}: ${durationMs}ms${batchInfo}`,
-                );
-              } else {
-                process.stdout.write(
-                  `\r  [${docNum}/${docCount}] ${docId}: ${loopPrefix}${opNum}/${operations} ops`,
-                );
-              }
-            },
-          );
+          const onProgress = (
+            opNum: number,
+            durationMs: number,
+            batchCount: number,
+          ) => {
+            const batchInfo = batchCount > 1 ? ` (${batchCount} ops)` : "";
+            if (verbose) {
+              console.log(
+                `    op ${opNum}/${operations}: ${durationMs}ms${batchInfo}`,
+              );
+            } else {
+              process.stdout.write(
+                `\r  [${docNum}/${docCount}] ${docId}: ${loopPrefix}${opNum}/${operations} ops`,
+              );
+            }
+          };
+          const result = await (asyncMutate
+            ? performOperationsAsync(
+                client,
+                docId,
+                docNum,
+                operations,
+                batchSize,
+                onProgress,
+              )
+            : performOperations(
+                client,
+                docId,
+                docNum,
+                operations,
+                batchSize,
+                onProgress,
+              ));
 
           if (
             result.minOp &&

--- a/scripts/profiling/docs-create.ts
+++ b/scripts/profiling/docs-create.ts
@@ -267,77 +267,53 @@ const JOB_STATUS_QUERY = `
     jobStatus(jobId: $jobId) { status completedAt }
   }
 `;
-const TERMINAL_JOB_STATUSES = new Set(["READ_READY", "FAILED"]);
-const JOB_POLL_INTERVAL_MS = 200;
+const TERMINAL_JOB_STATUSES = new Set(["WRITE_READY", "READ_READY", "FAILED"]);
+const JOB_POLL_INTERVAL_MS = 5;
 
 interface JobStatusResponse {
   jobStatus: { status: string; completedAt: string | null };
 }
 
-async function performOperationsAsync(
+interface SampledJob {
+  jobId: string;
+  dispatchedAt: number; // performance.now() captured before the dispatch request
+  batchEnd: number;
+  batchCount: number;
+  actionType: string;
+  loopNum: number;
+  reqNum: number;
+}
+
+async function pollJobAsync(
   client: GraphQLClient,
-  documentId: string,
-  docIndex: number,
-  operationCount: number,
-  batchSize: number,
-  onProgress: (opNum: number, durationMs: number, batchCount: number) => void,
-): Promise<OperationsResult> {
-  const requests = buildRequests(
-    documentId,
-    docIndex,
-    operationCount,
-    batchSize,
-    true,
-  );
-
-  // Start timer before dispatching — captures full queue-fill + execution time
-  const overallStart = performance.now();
-
-  // Dispatch requests consecutively so the server receives them in order.
-  // Each response is { op0: jobId, op1: jobId, ... } (one ID per alias).
-  // Awaiting each response before sending the next ensures the queue order
-  // matches the dispatch order, so we can target the final job ID.
-  let lastJobId: string | undefined;
-  for (const req of requests) {
-    const result = await client.request<Record<string, string>>(
-      req.mutation,
-      req.variables,
-    );
-    const jobIds = Object.values(result);
-    lastJobId = jobIds[jobIds.length - 1];
-  }
-
-  // Poll only the final job — when it completes all preceding jobs are done
-  while (lastJobId !== undefined) {
+  job: SampledJob,
+): Promise<{ result: OperationsResult; totalMs: number }> {
+  while (true) {
     await new Promise<void>((resolve) =>
       setTimeout(resolve, JOB_POLL_INTERVAL_MS),
     );
     const { jobStatus } = await client.request<JobStatusResponse>(
       JOB_STATUS_QUERY,
-      { jobId: lastJobId },
+      { jobId: job.jobId },
     );
     if (
       TERMINAL_JOB_STATUSES.has(jobStatus.status) ||
       jobStatus.completedAt !== null
-    ) {
+    )
       break;
-    }
   }
-
-  const totalMs = performance.now() - overallStart;
-  const perOpMs = totalMs / operationCount;
-
-  const durations = Array.from({ length: operationCount }, () => perOpMs);
-  const last = requests[requests.length - 1];
+  // Measures wall-clock time from before the dispatch request to when the
+  // terminal poll response arrives — includes dispatch round-trip + processing
+  // + one poll interval of overhead.
+  const totalMs = performance.now() - job.dispatchedAt;
+  const perOpMs = totalMs / job.batchCount;
+  const durations = Array.from({ length: job.batchCount }, () => perOpMs);
   const timing: OperationTiming = {
-    opIndex: last.batchEnd,
+    opIndex: job.batchEnd,
     durationMs: perOpMs,
-    actionType: last.actionType,
+    actionType: job.actionType,
   };
-
-  onProgress(last.batchEnd, totalMs, operationCount);
-
-  return { minOp: timing, maxOp: timing, durations };
+  return { result: { minOp: timing, maxOp: timing, durations }, totalMs };
 }
 
 function parseArgs(args: string[]): {
@@ -348,6 +324,7 @@ function parseArgs(args: string[]): {
   endpoint: string;
   docIds: string[];
   asyncMutate: boolean;
+  asyncPollRate: number;
   verbose: boolean;
   percentiles: boolean;
   showActionTypes: boolean;
@@ -361,6 +338,7 @@ function parseArgs(args: string[]): {
   let endpoint = DEFAULT_ENDPOINT;
   const docIds: string[] = [];
   let asyncMutate = false;
+  let asyncPollRate = 100;
   let verbose = false;
   let percentiles = false;
   let showActionTypes = false;
@@ -381,6 +359,16 @@ function parseArgs(args: string[]): {
       docIds.push(args[++i]);
     } else if (arg === "--async") {
       asyncMutate = true;
+      const nextArg = args[i + 1];
+      if (
+        nextArg &&
+        !isNaN(Number(nextArg)) &&
+        Number(nextArg) > 0 &&
+        !nextArg.startsWith("-")
+      ) {
+        asyncPollRate = Number(nextArg);
+        i++;
+      }
     } else if (arg === "--verbose" || arg === "-v") {
       verbose = true;
     } else if (arg === "--percentiles" || arg === "-p") {
@@ -414,7 +402,7 @@ Options:
   --doc-id, -d <id>         Use existing document(s) instead of creating new ones
                             (can be specified multiple times, skips document creation)
   --endpoint <url>          GraphQL endpoint (default: ${DEFAULT_ENDPOINT})
-  --async                   Use the *Async mutation variants (returns job ID, not document)
+  --async [N]               Use *Async mutation variants; poll every Nth operation (default N=100)
   --verbose, -v             Show detailed operation timings
   --percentiles, -p         Show percentile statistics (p50, p90, p95, p99) per line
   --show-action-types, -a   Show action type names in min/max timings
@@ -500,6 +488,7 @@ Examples:
     endpoint,
     docIds,
     asyncMutate,
+    asyncPollRate,
     verbose,
     percentiles,
     showActionTypes,
@@ -517,6 +506,7 @@ async function main() {
     endpoint,
     docIds,
     asyncMutate,
+    asyncPollRate,
     verbose,
     percentiles: showPercentiles,
     showActionTypes,
@@ -656,92 +646,172 @@ async function main() {
         const docNum = i + 1;
         const docId = documentIds[i];
 
-        for (let loop = 1; loop <= opLoops; loop++) {
-          const loopStartTime = performance.now();
-          const loopPrefix = opLoops > 1 ? `loop ${loop}/${opLoops}: ` : "";
+        if (asyncMutate && operations > 0) {
+          const totalRequests = opLoops * Math.ceil(operations / batchSize);
+          const pollPromises: Promise<{
+            result: OperationsResult;
+            totalMs: number;
+            job: SampledJob;
+          }>[] = [];
+          let globalReqNum = 0;
 
-          if (verbose) {
-            console.log(`  [${docNum}/${docCount}] ${docId} ${loopPrefix}:`);
+          // Dispatch sequentially; start polling each sampled job immediately
+          // (fire-and-forget into pollPromises) so results stream to stdout as
+          // each poll resolves during dispatch rather than bursting at the end.
+          for (let loop = 1; loop <= opLoops; loop++) {
+            const requests = buildRequests(
+              docId,
+              docNum,
+              operations,
+              batchSize,
+              true,
+            );
+            for (const req of requests) {
+              globalReqNum++;
+              const dispatchedAt = performance.now();
+              const result = await client.request<Record<string, string>>(
+                req.mutation,
+                req.variables,
+              );
+              const jobId = Object.values(result).at(-1)!;
+              if (
+                globalReqNum % asyncPollRate === 0 ||
+                globalReqNum === totalRequests
+              ) {
+                const job: SampledJob = {
+                  jobId,
+                  dispatchedAt,
+                  batchEnd: req.batchEnd,
+                  batchCount: req.batchCount,
+                  actionType: req.actionType,
+                  loopNum: loop,
+                  reqNum: globalReqNum,
+                };
+                pollPromises.push(
+                  pollJobAsync(client, job).then((r) => {
+                    const loopDuration = (r.totalMs / 1000).toFixed(2);
+                    const msPerOp = (r.totalMs / job.batchCount).toFixed(0);
+                    process.stdout.write(
+                      `\r  [${docNum}/${docCount}] ${docId}: req ${job.reqNum}/${totalRequests} (${loopDuration}s, ${msPerOp}ms/op)\n`,
+                    );
+                    return { ...r, job };
+                  }),
+                );
+              }
+              if (!verbose) {
+                process.stdout.write(
+                  `\r  [${docNum}/${docCount}] ${docId}: dispatching ${globalReqNum}/${totalRequests}...`,
+                );
+              }
+            }
           }
 
-          const onProgress = (
-            opNum: number,
-            durationMs: number,
-            batchCount: number,
-          ) => {
-            const batchInfo = batchCount > 1 ? ` (${batchCount} ops)` : "";
+          // Wait for any polls still in flight after dispatch completes, then aggregate
+          const allPollResults = await Promise.all(pollPromises);
+          for (const { result, job } of allPollResults) {
+            if (
+              result.minOp &&
+              (overallMinOp === null ||
+                result.minOp.durationMs < overallMinOp.timing.durationMs)
+            )
+              overallMinOp = {
+                docId,
+                docNum,
+                loop: job.loopNum,
+                timing: result.minOp,
+              };
+            if (
+              result.maxOp &&
+              (overallMaxOp === null ||
+                result.maxOp.durationMs > overallMaxOp.timing.durationMs)
+            )
+              overallMaxOp = {
+                docId,
+                docNum,
+                loop: job.loopNum,
+                timing: result.maxOp,
+              };
+            if (showPercentiles) allDurations.push(...result.durations);
+          }
+        } else {
+          for (let loop = 1; loop <= opLoops; loop++) {
+            const loopStartTime = performance.now();
+            const loopPrefix = opLoops > 1 ? `loop ${loop}/${opLoops}: ` : "";
+
+            if (verbose) {
+              console.log(`  [${docNum}/${docCount}] ${docId} ${loopPrefix}:`);
+            }
+
+            const onProgress = (
+              opNum: number,
+              durationMs: number,
+              batchCount: number,
+            ) => {
+              const batchInfo = batchCount > 1 ? ` (${batchCount} ops)` : "";
+              if (verbose) {
+                console.log(
+                  `    op ${opNum}/${operations}: ${durationMs}ms${batchInfo}`,
+                );
+              } else {
+                process.stdout.write(
+                  `\r  [${docNum}/${docCount}] ${docId}: ${loopPrefix}${opNum}/${operations} ops`,
+                );
+              }
+            };
+            const result = await performOperations(
+              client,
+              docId,
+              docNum,
+              operations,
+              batchSize,
+              onProgress,
+            );
+
+            if (
+              result.minOp &&
+              (overallMinOp === null ||
+                result.minOp.durationMs < overallMinOp.timing.durationMs)
+            ) {
+              overallMinOp = { docId, docNum, loop, timing: result.minOp };
+            }
+            if (
+              result.maxOp &&
+              (overallMaxOp === null ||
+                result.maxOp.durationMs > overallMaxOp.timing.durationMs)
+            ) {
+              overallMaxOp = { docId, docNum, loop, timing: result.maxOp };
+            }
+            if (showPercentiles) {
+              allDurations.push(...result.durations);
+            }
+
+            const loopDurationMs = performance.now() - loopStartTime;
+            const loopDuration = (loopDurationMs / 1000).toFixed(2);
+            const msPerOp = (loopDurationMs / operations).toFixed(0);
+
+            const minMax =
+              result.minOp && result.maxOp
+                ? showActionTypes
+                  ? `, min: ${result.minOp.durationMs}ms (${result.minOp.actionType}), max: ${result.maxOp.durationMs}ms (${result.maxOp.actionType})`
+                  : `, min: ${result.minOp.durationMs}ms, max: ${result.maxOp.durationMs}ms`
+                : "";
+
+            const loopPercentiles = showPercentiles
+              ? calculatePercentiles(result.durations)
+              : null;
+            const percentilesStr = loopPercentiles
+              ? `\n      ${formatPercentiles(loopPercentiles)}`
+              : "";
+
             if (verbose) {
               console.log(
-                `    op ${opNum}/${operations}: ${durationMs}ms${batchInfo}`,
+                `    Done: ${loopDuration}s, ${msPerOp}ms/op${minMax}${percentilesStr}`,
               );
             } else {
               process.stdout.write(
-                `\r  [${docNum}/${docCount}] ${docId}: ${loopPrefix}${opNum}/${operations} ops`,
+                ` (${loopDuration}s, ${msPerOp}ms/op${minMax})${percentilesStr}\n`,
               );
             }
-          };
-          const result = await (asyncMutate
-            ? performOperationsAsync(
-                client,
-                docId,
-                docNum,
-                operations,
-                batchSize,
-                onProgress,
-              )
-            : performOperations(
-                client,
-                docId,
-                docNum,
-                operations,
-                batchSize,
-                onProgress,
-              ));
-
-          if (
-            result.minOp &&
-            (overallMinOp === null ||
-              result.minOp.durationMs < overallMinOp.timing.durationMs)
-          ) {
-            overallMinOp = { docId, docNum, loop, timing: result.minOp };
-          }
-          if (
-            result.maxOp &&
-            (overallMaxOp === null ||
-              result.maxOp.durationMs > overallMaxOp.timing.durationMs)
-          ) {
-            overallMaxOp = { docId, docNum, loop, timing: result.maxOp };
-          }
-          if (showPercentiles) {
-            allDurations.push(...result.durations);
-          }
-
-          const loopDurationMs = performance.now() - loopStartTime;
-          const loopDuration = (loopDurationMs / 1000).toFixed(2);
-          const msPerOp = (loopDurationMs / operations).toFixed(0);
-
-          const minMax =
-            result.minOp && result.maxOp
-              ? showActionTypes
-                ? `, min: ${result.minOp.durationMs}ms (${result.minOp.actionType}), max: ${result.maxOp.durationMs}ms (${result.maxOp.actionType})`
-                : `, min: ${result.minOp.durationMs}ms, max: ${result.maxOp.durationMs}ms`
-              : "";
-
-          const loopPercentiles = showPercentiles
-            ? calculatePercentiles(result.durations)
-            : null;
-          const percentilesStr = loopPercentiles
-            ? `\n      ${formatPercentiles(loopPercentiles)}`
-            : "";
-
-          if (verbose) {
-            console.log(
-              `    Done: ${loopDuration}s, ${msPerOp}ms/op${minMax}${percentilesStr}`,
-            );
-          } else {
-            process.stdout.write(
-              ` (${loopDuration}s, ${msPerOp}ms/op${minMax})${percentilesStr}\n`,
-            );
           }
         }
       }

--- a/scripts/profiling/switchboard-pyroscope.sh
+++ b/scripts/profiling/switchboard-pyroscope.sh
@@ -158,6 +158,17 @@ echo "Press Ctrl+C to stop"
 echo "=========================================="
 echo
 
+# Run database migrations if a PostgreSQL URL was provided
+if [ -n "$DATABASE_URL" ]; then
+  echo "Running database migrations..."
+  if ! pnpm --filter document-drive run migrate; then
+    echo "Error: database migration failed — aborting"
+    exit 1
+  fi
+  echo "Migrations complete."
+  echo
+fi
+
 # Check if switchboard is installed
 SWITCHBOARD_PATH="${SCRIPT_DIR}/apps/switchboard/dist/src/index.js"
 if [ ! -f "$SWITCHBOARD_PATH" ]; then


### PR DESCRIPTION
## Summary

This PR adds two independent improvements to the profiling toolset: an `--async` mode for `docs-create.ts` that saturates the switchboard queue as fast as possible, and automatic database migrations in `switchboard-pyroscope.sh` when running against Postgres.

---

## `docs-create.ts`: `--async` flag

Adds a two-phase async dispatch mode for high-throughput profiling runs.

**Phase 1 - dispatch:** Requests are sent sequentially without awaiting job completion. Every Nth job (configurable via `--async [N]`, default `N=100`) immediately starts a concurrent poll in the background as it's dispatched.

**Phase 2 - drain:** Once all requests are dispatched, remaining in-flight polls are awaited. Results stream to stdout as each poll resolves.

**Additional details:**
- `*Async` mutation variants return `String!` (a job ID) - the GraphQL selection set is omitted accordingly
- Compatible with `--batch-size`
- `--async-timeout <ms>` (default 30s) caps how long each poll will wait before printing a `TIMED OUT` warning to stderr and moving on
- Timed-out jobs are excluded from min/max/percentile aggregation and counted separately in the summary line
- `JOB_POLL_INTERVAL_MS` reduced from 200ms to 5ms to reflect actual job latency rather than poll overhead
- Per-loop dispatch timing (duration + ms/op) is logged to help identify bottlenecks
- Summary line notes when stats are sampled (e.g. `"stats from N sampled jobs"`) to avoid misleading aggregates

**Validation:**
- `--async N` must be a positive integer (rejects `0` and floats)
- `--async-timeout` validated as an integer
- Warns if `--async` is combined with `--operations 0`
- Job ID validated as a non-empty string before polling begins

---

## `switchboard-pyroscope.sh` - auto-migrate on Postgres

When `--postgres` is provided and `DATABASE_URL` is set, database migrations now run automatically before switchboard starts. This removes a common manual step that caused silent failures.

---

## README

- Added `pnpm --filter @powerhousedao/reactor-api run build:misc` as a required prerequisite (the missing `schema.graphql` in `dist/` caused the reactor subgraph to fail silently)
- Updated `--postgres` flag description to reflect the `DATABASE_URL` condition
- Added `--async` and `--async-timeout` to the flag reference table

 ---  
 
 # Next Steps
 
See https://github.com/powerhouse-inc/powerhouse/pull/2386#issuecomment-4031938786