### PR TITLE
feat(codegen): generate controller.ts for each document model

### DIFF
--- a/packages/codegen/src/file-builders/document-model/gen-dir.ts
+++ b/packages/codegen/src/file-builders/document-model/gen-dir.ts
@@ -7,6 +7,7 @@ import {
   documentModelDocumentSchemaFileTemplate,
   documentModelDocumentTypeTemplate,
   documentModelGenActionsFileTemplate,
+  documentModelGenControllerFileTemplate,
   documentModelGenCreatorsFileTemplate,
   documentModelGenIndexFileTemplate,
   documentModelGenReducerFileTemplate,
@@ -42,6 +43,7 @@ export async function makeGenDirFiles(
   await makeDocumentModelGenIndexFile(fileMakerArgs);
   await makeDocumentModelGenDocumentModelFile(fileMakerArgs);
   await makeDocumentModelGenPhFactoriesFile(fileMakerArgs);
+  await makeDocumentModelGenControllerFile(fileMakerArgs);
 
   const modules = fileMakerArgs.modules;
 
@@ -183,6 +185,20 @@ async function makeDocumentModelGenPhFactoriesFile(
   const { project, genDirPath } = args;
 
   const filePath = path.join(genDirPath, "ph-factories.ts");
+
+  const { sourceFile } = getOrCreateSourceFile(project, filePath);
+
+  sourceFile.replaceWithText(template);
+  await formatSourceFileWithPrettier(sourceFile);
+}
+
+async function makeDocumentModelGenControllerFile(
+  args: DocumentModelFileMakerArgs,
+) {
+  const template = documentModelGenControllerFileTemplate(args);
+  const { project, genDirPath } = args;
+
+  const filePath = path.join(genDirPath, "controller.ts");
 
   const { sourceFile } = getOrCreateSourceFile(project, filePath);
 

--- a/packages/codegen/src/templates/document-model/gen/controller.ts
+++ b/packages/codegen/src/templates/document-model/gen/controller.ts
@@ -1,0 +1,16 @@
+import type { DocumentModelTemplateInputs } from "@powerhousedao/codegen/file-builders";
+import { ts } from "@tmpl/core";
+
+export const documentModelGenControllerFileTemplate = (
+  v: DocumentModelTemplateInputs,
+) =>
+  ts`
+import { PHDocumentController } from "document-model/core";
+import { ${v.pascalCaseDocumentType} } from "../module.js";
+import type { ${v.actionTypeName}, ${v.phStateName} } from "./types.js";
+
+export const ${v.pascalCaseDocumentType}Controller = PHDocumentController.forDocumentModel<
+  ${v.phStateName},
+  ${v.actionTypeName}
+>(${v.pascalCaseDocumentType});
+`.raw;

--- a/packages/codegen/src/templates/document-model/gen/index.ts
+++ b/packages/codegen/src/templates/document-model/gen/index.ts
@@ -29,6 +29,7 @@ export {
 } from './ph-factories.js';
 export * from "./utils.js";
 export * from "./reducer.js";
+export * from "./controller.js";
 export * from "./schema/index.js";
 export * from "./document-type.js";
 export * from "./document-schema.js";

--- a/packages/codegen/src/templates/index.ts
+++ b/packages/codegen/src/templates/index.ts
@@ -35,6 +35,7 @@ export * from "./document-editor/editor.js";
 export * from "./document-editor/module.js";
 export * from "./document-model/actions.js";
 export * from "./document-model/gen/actions.js";
+export * from "./document-model/gen/controller.js";
 export * from "./document-model/gen/creators.js";
 export * from "./document-model/gen/document-schema.js";
 export * from "./document-model/gen/document-type.js";


### PR DESCRIPTION
## Summary
- Adds a codegen template that generates a typed `PHDocumentController` for each document model
- The controller is generated in the `gen/` directory and exported from the gen index
- Follows the same pattern as the hand-written `DocumentModelController` in `document-model` package

## Test plan
- [x] Ran `pnpm test:bun generate-doc-model.test.ts` — all 10 tests pass