### PR TITLE
fix(reactor): discover existing drives on ProcessorManager restart

### DIFF
--- a/packages/reactor/src/processors/processor-manager.ts
+++ b/packages/reactor/src/processors/processor-manager.ts
@@ -13,6 +13,7 @@ import { BaseReadModel } from "../read-models/base-read-model.js";
 import type { DocumentViewDatabase } from "../read-models/types.js";
 import type { IConsistencyTracker } from "../shared/consistency-tracker.js";
 import {
+  DRIVE_DOCUMENT_TYPE,
   createMinimalDriveHeader,
   extractDeletedDocumentId,
   extractDriveHeader,
@@ -54,6 +55,11 @@ export class ProcessorManager
       consistencyTracker,
       "processor-manager",
     );
+  }
+
+  override async init(): Promise<void> {
+    await super.init();
+    await this.discoverExistingDrives();
   }
 
   override async indexOperations(items: OperationWithContext[]): Promise<void> {
@@ -165,6 +171,19 @@ export class ProcessorManager
 
       await this.cleanupDriveProcessors(driveId);
       this.knownDriveIds.delete(driveId);
+    }
+  }
+
+  private async discoverExistingDrives(): Promise<void> {
+    const drives = await this.db
+      .selectFrom("DocumentSnapshot")
+      .select("documentId")
+      .where("documentType", "=", DRIVE_DOCUMENT_TYPE)
+      .where("isDeleted", "=", false)
+      .execute();
+
+    for (const drive of drives) {
+      this.knownDriveIds.add(drive.documentId);
     }
   }
 

--- a/packages/reactor/src/processors/utils.ts
+++ b/packages/reactor/src/processors/utils.ts
@@ -2,7 +2,7 @@ import type { OperationWithContext } from "@powerhousedao/shared/document-model"
 import type { ProcessorFilter } from "@powerhousedao/shared/processors";
 import type { PHDocumentHeader } from "document-model";
 
-const DRIVE_DOCUMENT_TYPE = "powerhouse/document-drive";
+export const DRIVE_DOCUMENT_TYPE = "powerhouse/document-drive";
 
 export function isDriveCreation(op: OperationWithContext): boolean {
   return (

--- a/packages/reactor/test/processors/processor-manager.test.ts
+++ b/packages/reactor/test/processors/processor-manager.test.ts
@@ -525,6 +525,56 @@ describe("ProcessorManager Standalone Tests", () => {
       expect(viewState).toBeDefined();
       expect(viewState?.lastOrdinal).toBe(0);
     });
+
+    it("should discover existing drives from DocumentSnapshot on restart", async () => {
+      const driveId = generateId();
+
+      // Simulate a previous run: insert a drive snapshot and advance the ordinal
+      await db
+        .insertInto("DocumentSnapshot")
+        .values({
+          id: generateId(),
+          documentId: driveId,
+          slug: "test-drive",
+          name: "Test Drive",
+          scope: "global",
+          branch: "main",
+          content: JSON.stringify({}),
+          documentType: DRIVE_DOCUMENT_TYPE,
+          lastOperationIndex: 0,
+          lastOperationHash: "hash-0",
+          identifiers: JSON.stringify({}),
+          metadata: JSON.stringify({}),
+        })
+        .execute();
+
+      await db
+        .updateTable("ViewState")
+        .set({ lastOrdinal: 10 })
+        .where("readModelId", "=", "processor-manager")
+        .execute();
+
+      // Create a fresh ProcessorManager against the same DB (simulates restart)
+      const consistencyTracker = new ConsistencyTracker();
+      const restartedManager = new ProcessorManager(
+        db as unknown as Kysely<DocumentViewDatabase>,
+        operationIndex,
+        mockWriteCache,
+        consistencyTracker,
+      );
+      await restartedManager.init();
+
+      // Register a factory — it should be called for the existing drive
+      const mockFactory = createMockProcessorFactory();
+      await restartedManager.registerFactory(
+        "test-factory",
+        mockFactory.factory,
+      );
+
+      expect(mockFactory.factoryCallCount).toBe(1);
+      expect(mockFactory.lastDriveHeader?.id).toBe(driveId);
+      expect(restartedManager.getProcessorsForDrive(driveId)).toHaveLength(1);
+    });
   });
 
   describe("indexOperations", () => {


### PR DESCRIPTION
## Summary

- **Fix**: `ProcessorManager.knownDriveIds` is in-memory only and lost on restart. When the reactor restarts with existing PGlite storage, `init()` only processes operations since the last ordinal — if there are none, `knownDriveIds` stays empty and `registerFactory()` never calls factories for existing drives. Processors silently fail to load.
- **Solution**: Override `init()` to query the `DocumentSnapshot` table for existing `powerhouse/document-drive` documents, populating `knownDriveIds` before factories are registered.
- Affects any processor package relying on the new `IProcessor`/`onOperations` interface when `REACTOR_STORAGE_V2=true` (default).

## Test plan

- [ ] Start reactor with a drive and processor package → processor loads ✅
- [ ] Stop reactor, restart without clearing storage → processor still loads ✅ (was broken before)
- [ ] Delete storage, restart → processor loads on first document creation ✅ (unchanged behavior)
- [ ] Add unit test for `discoverExistingDrives` populating `knownDriveIds` from `DocumentSnapshot`