### PR TITLE
Implemented Profiling Open Telemetry Metrics

### DIFF
--- a/packages/opentelemetry-instrumentation-reactor/src/instrumentation.ts
+++ b/packages/opentelemetry-instrumentation-reactor/src/instrumentation.ts
@@ -203,16 +203,26 @@ export class ReactorInstrumentation {
       // window the observation is silently dropped, making the gauge appear
       // to drop to zero under load. The timeout makes the failure explicit.
       const TIMEOUT_MS = 2_000;
-      const depth = await Promise.race([
-        queue.totalSize(),
-        new Promise<never>((_, reject) =>
-          setTimeout(
-            () => reject(new Error("queue.totalSize() timed out")),
-            TIMEOUT_MS,
-          ),
-        ),
-      ]);
-      result.observe(depth);
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const depth = await Promise.race([
+          queue.totalSize(),
+          new Promise<never>((_, reject) => {
+            timeoutId = setTimeout(
+              () => reject(new Error("queue.totalSize() timed out")),
+              TIMEOUT_MS,
+            );
+          }),
+        ]);
+        result.observe(depth);
+      } catch (err) {
+        console.warn(
+          "[ReactorInstrumentation] queueDepth observation failed:",
+          err,
+        );
+      } finally {
+        clearTimeout(timeoutId);
+      }
     };
     this.metrics.queueDepth.addCallback(depthCb);
     this.observableCallbacks.push([this.metrics.queueDepth, depthCb]);

--- a/packages/opentelemetry-instrumentation-reactor/src/instrumentation.ts
+++ b/packages/opentelemetry-instrumentation-reactor/src/instrumentation.ts
@@ -199,10 +199,19 @@ export class ReactorInstrumentation {
 
     const depthCb: ObservableCallback = async (result) => {
       if (!this.metrics) return;
-      // queue.totalSize() is async (DB query). The OTel SDK expects observable
-      // callbacks to complete within the collection window; if this is slow
-      // under DB load the observation may be silently dropped for that scrape.
-      const depth = await queue.totalSize();
+      // queue.totalSize() is a DB query. If it exceeds the OTel collection
+      // window the observation is silently dropped, making the gauge appear
+      // to drop to zero under load. The timeout makes the failure explicit.
+      const TIMEOUT_MS = 2_000;
+      const depth = await Promise.race([
+        queue.totalSize(),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("queue.totalSize() timed out")),
+            TIMEOUT_MS,
+          ),
+        ),
+      ]);
       result.observe(depth);
     };
     this.metrics.queueDepth.addCallback(depthCb);

--- a/packages/opentelemetry-instrumentation-reactor/src/instrumentation.ts
+++ b/packages/opentelemetry-instrumentation-reactor/src/instrumentation.ts
@@ -57,8 +57,9 @@ export class ReactorInstrumentation {
       eventBus.subscribe<JobPendingEvent>(
         ReactorEventTypes.JOB_PENDING,
         (_type, event) => {
-          this.metrics!.queueJobsEnqueued.add(1);
-          this.metrics!.eventbusEventsEmitted.add(1, {
+          if (!this.metrics) return;
+          this.metrics.queueJobsEnqueued.add(1);
+          this.metrics.eventbusEventsEmitted.add(1, {
             "event.type": "JOB_PENDING",
           });
           this.pendingTimestamps.set(event.jobId, performance.now());
@@ -72,8 +73,9 @@ export class ReactorInstrumentation {
       eventBus.subscribe<JobRunningEvent>(
         ReactorEventTypes.JOB_RUNNING,
         (_type, event) => {
-          this.metrics!.queueJobsDequeued.add(1);
-          this.metrics!.eventbusEventsEmitted.add(1, {
+          if (!this.metrics) return;
+          this.metrics.queueJobsDequeued.add(1);
+          this.metrics.eventbusEventsEmitted.add(1, {
             "event.type": "JOB_RUNNING",
           });
           this.runningTimestamps.set(event.jobId, performance.now());
@@ -87,20 +89,19 @@ export class ReactorInstrumentation {
       eventBus.subscribe<JobWriteReadyEvent>(
         ReactorEventTypes.JOB_WRITE_READY,
         (_type, event) => {
+          if (!this.metrics) return;
           const runningTs = this.runningTimestamps.get(event.jobId);
           if (runningTs !== undefined) {
-            this.metrics!.executorJobDuration.record(
+            this.metrics.executorJobDuration.record(
               performance.now() - runningTs,
               { "job.success": "true" },
             );
           }
-          this.metrics!.executorTotalProcessed.add(1, {
+          this.metrics.executorTotalProcessed.add(1, {
             "job.success": "true",
           });
-          this.metrics!.executorOperationsGenerated.add(
-            event.operations.length,
-          );
-          this.metrics!.eventbusEventsEmitted.add(1, {
+          this.metrics.executorOperationsGenerated.add(event.operations.length);
+          this.metrics.eventbusEventsEmitted.add(1, {
             "event.type": "JOB_WRITE_READY",
           });
           this.writeReadyTimestamps.set(event.jobId, performance.now());
@@ -114,21 +115,22 @@ export class ReactorInstrumentation {
       eventBus.subscribe<JobReadReadyEvent>(
         ReactorEventTypes.JOB_READ_READY,
         (_type, event) => {
+          if (!this.metrics) return;
           const writeReadyTs = this.writeReadyTimestamps.get(event.jobId);
           if (writeReadyTs !== undefined) {
-            this.metrics!.readmodelIndexDuration.record(
+            this.metrics.readmodelIndexDuration.record(
               performance.now() - writeReadyTs,
             );
           }
           const pendingTs = this.pendingTimestamps.get(event.jobId);
           if (pendingTs !== undefined) {
-            this.metrics!.jobTotalDuration.record(
+            this.metrics.jobTotalDuration.record(
               performance.now() - pendingTs,
               { "job.success": "true" },
             );
           }
-          this.metrics!.queueJobsCompleted.add(1);
-          this.metrics!.eventbusEventsEmitted.add(1, {
+          this.metrics.queueJobsCompleted.add(1);
+          this.metrics.eventbusEventsEmitted.add(1, {
             "event.type": "JOB_READ_READY",
           });
           this.cleanup(event.jobId);
@@ -142,18 +144,19 @@ export class ReactorInstrumentation {
       eventBus.subscribe<ReactorJobFailedEvent>(
         ReactorEventTypes.JOB_FAILED,
         (_type, event) => {
-          this.metrics!.queueJobsFailed.add(1);
-          this.metrics!.executorTotalProcessed.add(1, {
+          if (!this.metrics) return;
+          this.metrics.queueJobsFailed.add(1);
+          this.metrics.executorTotalProcessed.add(1, {
             "job.success": "false",
           });
           const pendingTs = this.pendingTimestamps.get(event.jobId);
           if (pendingTs !== undefined) {
-            this.metrics!.jobTotalDuration.record(
+            this.metrics.jobTotalDuration.record(
               performance.now() - pendingTs,
               { "job.success": "false" },
             );
           }
-          this.metrics!.eventbusEventsEmitted.add(1, {
+          this.metrics.eventbusEventsEmitted.add(1, {
             "event.type": "JOB_FAILED",
           });
           this.cleanup(event.jobId);
@@ -167,10 +170,11 @@ export class ReactorInstrumentation {
       eventBus.subscribe<DeadLetterAddedEvent>(
         SyncEventTypes.DEAD_LETTER_ADDED,
         (_type, event) => {
-          this.metrics!.syncDeadLettersAdded.add(1, {
+          if (!this.metrics) return;
+          this.metrics.syncDeadLettersAdded.add(1, {
             "remote.name": event.remoteName,
           });
-          this.metrics!.eventbusEventsEmitted.add(1, {
+          this.metrics.eventbusEventsEmitted.add(1, {
             "event.type": "DEAD_LETTER_ADDED",
           });
         },
@@ -184,21 +188,22 @@ export class ReactorInstrumentation {
     syncModule: SyncModule | undefined,
   ): void {
     this.metrics!.queueDepth.addCallback(async (result) => {
+      if (!this.metrics) return;
+      // queue.totalSize() is async (DB query). The OTel SDK expects observable
+      // callbacks to complete within the collection window; if this is slow
+      // under DB load the observation may be silently dropped for that scrape.
       const depth = await queue.totalSize();
       result.observe(depth);
     });
 
-    this.metrics!.queueExecuting.addCallback((result) => {
-      const status = executorManager.getStatus();
-      result.observe(status.activeJobs);
-    });
-
     this.metrics!.executorActiveJobs.addCallback((result) => {
+      if (!this.metrics) return;
       const status = executorManager.getStatus();
       result.observe(status.activeJobs);
     });
 
     this.metrics!.syncRemotes.addCallback((result) => {
+      if (!this.metrics) return;
       const count = syncModule?.syncManager.list().length ?? 0;
       result.observe(count);
     });

--- a/packages/opentelemetry-instrumentation-reactor/src/instrumentation.ts
+++ b/packages/opentelemetry-instrumentation-reactor/src/instrumentation.ts
@@ -187,7 +187,8 @@ export class ReactorInstrumentation {
     executorManager: IJobExecutorManager,
     syncModule: SyncModule | undefined,
   ): void {
-    this.metrics!.queueDepth.addCallback(async (result) => {
+    if (!this.metrics) return;
+    this.metrics.queueDepth.addCallback(async (result) => {
       if (!this.metrics) return;
       // queue.totalSize() is async (DB query). The OTel SDK expects observable
       // callbacks to complete within the collection window; if this is slow
@@ -196,13 +197,13 @@ export class ReactorInstrumentation {
       result.observe(depth);
     });
 
-    this.metrics!.executorActiveJobs.addCallback((result) => {
+    this.metrics.executorActiveJobs.addCallback((result) => {
       if (!this.metrics) return;
       const status = executorManager.getStatus();
       result.observe(status.activeJobs);
     });
 
-    this.metrics!.syncRemotes.addCallback((result) => {
+    this.metrics.syncRemotes.addCallback((result) => {
       if (!this.metrics) return;
       const count = syncModule?.syncManager.list().length ?? 0;
       result.observe(count);

--- a/packages/opentelemetry-instrumentation-reactor/src/instrumentation.ts
+++ b/packages/opentelemetry-instrumentation-reactor/src/instrumentation.ts
@@ -13,12 +13,15 @@ import type {
   SyncModule,
   Unsubscribe,
 } from "@powerhousedao/reactor";
+import type { ObservableCallback, ObservableGauge } from "@opentelemetry/api";
 import { createMetrics, type ReactorMetrics } from "./metrics.js";
 
 export class ReactorInstrumentation {
   private readonly module: ReactorModule;
   private metrics: ReactorMetrics | undefined;
   private unsubscribes: Unsubscribe[] = [];
+  private observableCallbacks: Array<[ObservableGauge, ObservableCallback]> =
+    [];
 
   private pendingTimestamps = new Map<string, number>();
   private runningTimestamps = new Map<string, number>();
@@ -46,6 +49,10 @@ export class ReactorInstrumentation {
       unsub();
     }
     this.unsubscribes = [];
+    for (const [gauge, cb] of this.observableCallbacks) {
+      gauge.removeCallback(cb);
+    }
+    this.observableCallbacks = [];
     this.pendingTimestamps.clear();
     this.runningTimestamps.clear();
     this.writeReadyTimestamps.clear();
@@ -105,6 +112,7 @@ export class ReactorInstrumentation {
             "event.type": "JOB_WRITE_READY",
           });
           this.writeReadyTimestamps.set(event.jobId, performance.now());
+          this.runningTimestamps.delete(event.jobId);
         },
       ),
     );
@@ -188,26 +196,36 @@ export class ReactorInstrumentation {
     syncModule: SyncModule | undefined,
   ): void {
     if (!this.metrics) return;
-    this.metrics.queueDepth.addCallback(async (result) => {
+
+    const depthCb: ObservableCallback = async (result) => {
       if (!this.metrics) return;
       // queue.totalSize() is async (DB query). The OTel SDK expects observable
       // callbacks to complete within the collection window; if this is slow
       // under DB load the observation may be silently dropped for that scrape.
       const depth = await queue.totalSize();
       result.observe(depth);
-    });
+    };
+    this.metrics.queueDepth.addCallback(depthCb);
+    this.observableCallbacks.push([this.metrics.queueDepth, depthCb]);
 
-    this.metrics.executorActiveJobs.addCallback((result) => {
+    const activeJobsCb: ObservableCallback = (result) => {
       if (!this.metrics) return;
       const status = executorManager.getStatus();
       result.observe(status.activeJobs);
-    });
+    };
+    this.metrics.executorActiveJobs.addCallback(activeJobsCb);
+    this.observableCallbacks.push([
+      this.metrics.executorActiveJobs,
+      activeJobsCb,
+    ]);
 
-    this.metrics.syncRemotes.addCallback((result) => {
+    const remotesCb: ObservableCallback = (result) => {
       if (!this.metrics) return;
       const count = syncModule?.syncManager.list().length ?? 0;
       result.observe(count);
-    });
+    };
+    this.metrics.syncRemotes.addCallback(remotesCb);
+    this.observableCallbacks.push([this.metrics.syncRemotes, remotesCb]);
   }
 
   private cleanup(jobId: string): void {

--- a/packages/opentelemetry-instrumentation-reactor/src/metrics.ts
+++ b/packages/opentelemetry-instrumentation-reactor/src/metrics.ts
@@ -27,10 +27,6 @@ export function createMetrics() {
       description: "Pending jobs across all queues",
       unit: "{job}",
     }),
-    queueExecuting: meter.createObservableGauge("reactor.queue.executing", {
-      description: "Jobs currently executing",
-      unit: "{job}",
-    }),
 
     // Executor metrics
     executorJobDuration: meter.createHistogram(
@@ -47,13 +43,10 @@ export function createMetrics() {
         unit: "{job}",
       },
     ),
-    executorTotalProcessed: meter.createCounter(
-      "reactor.executor.total_processed",
-      {
-        description: "Total jobs processed",
-        unit: "{job}",
-      },
-    ),
+    executorTotalProcessed: meter.createCounter("reactor.executor.processed", {
+      description: "Total jobs processed",
+      unit: "{job}",
+    }),
     executorOperationsGenerated: meter.createCounter(
       "reactor.executor.operations_generated",
       {

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -104,6 +104,7 @@ tsx reactor-direct.ts 5 -o 20 --percentiles --verbose --show-action-types
 | `--db`                |       | Database connection string or PGlite path                                                                                |
 | `--doc-id`            | `-d`  | Use an existing document (skips creation)                                                                                |
 | `--pyroscope`         |       | Enable Pyroscope profiling (optionally pass server address). Automatically runs `pyroscope-analyse.ts` after completion. |
+| `--otel`              |       | Enable OpenTelemetry metrics export (optionally pass OTLP endpoint, default: `http://localhost:4318`)                    |
 | `--file`              |       | Write output to a timestamped file (default name: `reactor-direct.txt`)                                                  |
 | `--output`            | `-O`  | Write output to a specific file (no timestamp prefix)                                                                    |
 | `--verbose`           | `-v`  | Show per-operation timings                                                                                               |
@@ -259,8 +260,9 @@ The script runs in order:
 
 1. `pnpm --filter document-model run tsc --build`
 2. `pnpm --filter @powerhousedao/reactor run build` (declarations) + `build:bundle` (JS)
-3. `DATABASE_URL=... pnpm --filter document-drive run migrate`
-4. `tsx reactor-direct.ts [your args]`
+3. `pnpm --filter @powerhousedao/opentelemetry-instrumentation-reactor run build`
+4. `DATABASE_URL=... pnpm --filter document-drive run migrate`
+5. `tsx reactor-direct.ts [your args]`
 
 All arguments are passed through to `reactor-direct.ts`. See the [`reactor-direct.ts`](#reactor-directts--direct-reactor-profiling) section for available flags.
 
@@ -285,23 +287,24 @@ Starts the switchboard with [Pyroscope](https://pyroscope.io/) continuous profil
 
 ### `docker-compose.yml`
 
-Provides PostgreSQL 16 and Pyroscope containers for profiling:
+Provides PostgreSQL 16, Pyroscope, an OpenTelemetry collector, and Prometheus for profiling:
 
 ```bash
-# Start PostgreSQL
-docker compose -f scripts/profiling/docker-compose.yml up postgres
+# Start all services
+docker compose -f scripts/profiling/docker-compose.yml up -d --wait
 
-# Start Pyroscope (view at http://localhost:4040)
-docker compose -f scripts/profiling/docker-compose.yml up pyroscope
-
-# Start both
-docker compose -f scripts/profiling/docker-compose.yml up
+# Start individual services
+docker compose -f scripts/profiling/docker-compose.yml up postgres -d
+docker compose -f scripts/profiling/docker-compose.yml up pyroscope -d
+docker compose -f scripts/profiling/docker-compose.yml up otel-collector prometheus -d
 ```
 
-| Service     | Port | Description                                            |
-| ----------- | ---- | ------------------------------------------------------ |
-| `postgres`  | 5432 | PostgreSQL 16 (user: `postgres`, password: `postgres`) |
-| `pyroscope` | 4040 | Grafana Pyroscope continuous profiling server          |
+| Service          | Port       | Description                                            |
+| ---------------- | ---------- | ------------------------------------------------------ |
+| `postgres`       | 5432       | PostgreSQL 16 (user: `postgres`, password: `postgres`) |
+| `pyroscope`      | 4040       | Grafana Pyroscope continuous profiling server          |
+| `otel-collector` | 4317, 4318 | OpenTelemetry collector (gRPC + HTTP OTLP receivers)   |
+| `prometheus`     | 9090       | Prometheus metrics UI                                  |
 
 ## Typical Workflows
 
@@ -339,6 +342,41 @@ tsx pyroscope-analyse.ts 'http://localhost:4040/?query=...'
 tsx pyroscope-analyse.ts 'http://localhost:4040/?query=...' --baseline ./1771254033-pyroscope
 
 # Open http://localhost:4040 to view flame graphs interactively
+```
+
+### Profile reactor with OTel metrics
+
+```bash
+docker compose -f scripts/profiling/docker-compose.yml up otel-collector prometheus postgres -d --wait
+
+./scripts/profiling/run-reactor-direct.sh 1 -o 25 -b 5 -l 2000 \
+  --db "postgresql://postgres:postgres@localhost:5432/postgres" \
+  --otel
+
+# Open http://localhost:9090 and query:
+#   reactor_job_total_duration_milliseconds_bucket
+#   reactor_executor_operations_generated_total
+#   reactor_queue_jobs_completed_total
+#   reactor_eventbus_events_emitted_total
+#
+# Percentile examples:
+#   histogram_quantile(0.99, rate(reactor_job_total_duration_milliseconds_bucket[2m]))
+#   histogram_quantile(0.50, rate(reactor_job_total_duration_milliseconds_bucket[2m]))
+```
+
+### Profile reactor with Pyroscope and OTel metrics
+
+```bash
+docker compose -f scripts/profiling/docker-compose.yml up -d --wait
+
+./scripts/profiling/run-reactor-direct.sh 1 -o 25 -b 5 -l 2000 \
+  --db "postgresql://postgres:postgres@localhost:5432/postgres" \
+  --pyroscope http://localhost:4040 \
+  --otel http://localhost:4318 \
+  --file
+
+# Flame graphs: http://localhost:4040
+# Metrics:      http://localhost:9090
 ```
 
 ### End-to-end switchboard benchmark

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -275,6 +275,8 @@ Starts the switchboard with [Pyroscope](https://pyroscope.io/) continuous profil
 ./scripts/profiling/switchboard-pyroscope.sh --runtime bun
 ./scripts/profiling/switchboard-pyroscope.sh --mode legacy
 ./scripts/profiling/switchboard-pyroscope.sh -r bun -m legacy --postgres "postgresql://postgres:postgres@localhost:5432/reactor"
+./scripts/profiling/switchboard-pyroscope.sh --otel
+./scripts/profiling/switchboard-pyroscope.sh --otel http://localhost:4318
 ```
 
 | Flag         | Short | Description                                                                                                                     |
@@ -282,6 +284,7 @@ Starts the switchboard with [Pyroscope](https://pyroscope.io/) continuous profil
 | `--runtime`  | `-r`  | Runtime: `node` (default) or `bun`                                                                                              |
 | `--mode`     | `-m`  | Storage mode: `v2` (default) or `legacy`                                                                                        |
 | `--postgres` | `-p`  | PostgreSQL database URL; sets `DATABASE_URL` — migrations run automatically before the server starts when `DATABASE_URL` is set |
+| `--otel`     |       | Enable OpenTelemetry metrics export (default: `http://localhost:4318`); sets `OTEL_EXPORTER_OTLP_ENDPOINT`                      |
 
 ## Infrastructure
 

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -412,7 +412,7 @@ histogram_quantile(0.01, rate(reactor_job_total_duration_milliseconds_bucket[30s
 
 # Slowest jobs over time (P99), normalised by batch size
 # Replace 5 with your --batch-size value
-histogram_quantile(0.99, rate(reactor_job_total_duration_milliseconds_bucket[20s])) / 5
+histogram_quantile(0.99, rate(reactor_job_total_duration_milliseconds_bucket[30s])) / 5
 
 # P99 and P50 job latency
 histogram_quantile(0.99, rate(reactor_job_total_duration_milliseconds_bucket[2m]))

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -353,16 +353,66 @@ docker compose -f scripts/profiling/docker-compose.yml up otel-collector prometh
   --db "postgresql://postgres:postgres@localhost:5432/postgres" \
   --otel
 
-# Open http://localhost:9090 and query:
-#   reactor_job_total_duration_milliseconds_bucket
-#   reactor_executor_operations_generated_total
-#   reactor_queue_jobs_completed_total
-#   reactor_eventbus_events_emitted_total
-#
-# Percentile examples:
-#   histogram_quantile(0.99, rate(reactor_job_total_duration_milliseconds_bucket[2m]))
-#   histogram_quantile(0.50, rate(reactor_job_total_duration_milliseconds_bucket[2m]))
+# Open http://localhost:9090 to query metrics (use the Graph tab for time series)
 ```
+
+### Prometheus metrics reference
+
+#### Counters — use `rate(...[interval])` for per-second rates
+
+| Metric                                        | Description                           |
+| --------------------------------------------- | ------------------------------------- |
+| `reactor_queue_jobs_enqueued_total`           | Jobs added to the queue               |
+| `reactor_queue_jobs_dequeued_total`           | Jobs dequeued for execution           |
+| `reactor_queue_jobs_completed_total`          | Jobs completed (READ_READY)           |
+| `reactor_queue_jobs_failed_total`             | Jobs permanently failed               |
+| `reactor_executor_total_processed_total`      | Total jobs processed by executors     |
+| `reactor_executor_operations_generated_total` | Operations produced by executors      |
+| `reactor_eventbus_events_emitted_total`       | Events emitted on the event bus       |
+| `reactor_sync_dead_letters_added_total`       | Sync ops moved to dead letter storage |
+
+#### Gauges — instant values, useful for queue depth graphs
+
+| Metric                         | Description                    |
+| ------------------------------ | ------------------------------ |
+| `reactor_queue_depth`          | Pending jobs across all queues |
+| `reactor_queue_executing`      | Jobs currently executing       |
+| `reactor_executor_active_jobs` | Jobs currently in an executor  |
+| `reactor_sync_remotes`         | Active remote count            |
+
+#### Histograms — available with `_bucket`, `_sum`, `_count` suffixes
+
+| Metric                                          | Description                                 |
+| ----------------------------------------------- | ------------------------------------------- |
+| `reactor_executor_job_duration_milliseconds`    | Execution time: RUNNING → WRITE_READY       |
+| `reactor_job_total_duration_milliseconds`       | Full lifecycle: PENDING → READ_READY/FAILED |
+| `reactor_readmodel_index_duration_milliseconds` | Indexing time: WRITE_READY → READ_READY     |
+
+#### Example PromQL queries
+
+```promql
+# Queue depth over time (Graph tab)
+reactor_queue_depth
+
+# Throughput: completed jobs per second
+rate(reactor_queue_jobs_completed_total[1m])
+
+# Failure rate
+rate(reactor_queue_jobs_failed_total[1m])
+
+# P99 and P50 job latency
+histogram_quantile(0.99, rate(reactor_job_total_duration_milliseconds_bucket[2m]))
+histogram_quantile(0.50, rate(reactor_job_total_duration_milliseconds_bucket[2m]))
+
+# Average executor time vs read-model indexing time
+rate(reactor_executor_job_duration_milliseconds_sum[1m]) / rate(reactor_executor_job_duration_milliseconds_count[1m])
+rate(reactor_readmodel_index_duration_milliseconds_sum[1m]) / rate(reactor_readmodel_index_duration_milliseconds_count[1m])
+
+# Operations generated per second
+rate(reactor_executor_operations_generated_total[1m])
+```
+
+> **Tip:** For short benchmark runs, switch to an instant query (Table tab) since `rate()` needs at least two scrape points (scrape interval is 5s).
 
 ### Profile reactor with Pyroscope and OTel metrics
 

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -366,7 +366,7 @@ docker compose -f scripts/profiling/docker-compose.yml up otel-collector prometh
 | `reactor_queue_jobs_dequeued_total`           | Jobs dequeued for execution           |
 | `reactor_queue_jobs_completed_total`          | Jobs completed (READ_READY)           |
 | `reactor_queue_jobs_failed_total`             | Jobs permanently failed               |
-| `reactor_executor_total_processed_total`      | Total jobs processed by executors     |
+| `reactor_executor_processed_total`            | Total jobs processed by executors     |
 | `reactor_executor_operations_generated_total` | Operations produced by executors      |
 | `reactor_eventbus_events_emitted_total`       | Events emitted on the event bus       |
 | `reactor_sync_dead_letters_added_total`       | Sync ops moved to dead letter storage |
@@ -376,8 +376,7 @@ docker compose -f scripts/profiling/docker-compose.yml up otel-collector prometh
 | Metric                         | Description                    |
 | ------------------------------ | ------------------------------ |
 | `reactor_queue_depth`          | Pending jobs across all queues |
-| `reactor_queue_executing`      | Jobs currently executing       |
-| `reactor_executor_active_jobs` | Jobs currently in an executor  |
+| `reactor_executor_active_jobs` | Jobs currently executing       |
 | `reactor_sync_remotes`         | Active remote count            |
 
 #### Histograms — available with `_bucket`, `_sum`, `_count` suffixes

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -400,6 +400,18 @@ rate(reactor_queue_jobs_completed_total[1m])
 # Failure rate
 rate(reactor_queue_jobs_failed_total[1m])
 
+# Average ms per operation (accounts for batch size — matches script output)
+sum(rate(reactor_job_total_duration_milliseconds_sum[60s])) /
+  sum(rate(reactor_executor_operations_generated_total[60s]))
+
+# Fastest jobs over time (P1), normalised by batch size
+# Replace 5 with your --batch-size value
+histogram_quantile(0.01, rate(reactor_job_total_duration_milliseconds_bucket[30s])) / 5
+
+# Slowest jobs over time (P99), normalised by batch size
+# Replace 5 with your --batch-size value
+histogram_quantile(0.99, rate(reactor_job_total_duration_milliseconds_bucket[20s])) / 5
+
 # P99 and P50 job latency
 histogram_quantile(0.99, rate(reactor_job_total_duration_milliseconds_bucket[2m]))
 histogram_quantile(0.50, rate(reactor_job_total_duration_milliseconds_bucket[2m]))

--- a/scripts/profiling/docker-compose.yml
+++ b/scripts/profiling/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   postgres:
     image: postgres:16-alpine
+    platform: linux/arm64/v8
     container_name: postgres16
     restart: unless-stopped
     mem_limit: 1g
@@ -17,7 +18,7 @@ services:
       - postgres16-data:/var/lib/postgresql/data
 
   pyroscope:
-    image: grafana/pyroscope:latest
+    image: grafana/pyroscope:1.18.1
     container_name: pyroscope
     command: server
     restart: unless-stopped
@@ -27,7 +28,7 @@ services:
       - "4040:4040"
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:latest
+    image: otel/opentelemetry-collector-contrib:0.147.0
     container_name: otel-collector
     restart: unless-stopped
     mem_limit: 256m
@@ -48,7 +49,7 @@ services:
       start_period: 5s
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.10.0
     container_name: prometheus
     restart: unless-stopped
     mem_limit: 256m
@@ -62,7 +63,7 @@ services:
 
     depends_on:
       otel-collector:
-        condition: service_started
+        condition: service_healthy
 
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/ready"]

--- a/scripts/profiling/docker-compose.yml
+++ b/scripts/profiling/docker-compose.yml
@@ -26,5 +26,51 @@ services:
     ports:
       - "4040:4040"
 
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: otel-collector
+    restart: unless-stopped
+    mem_limit: 256m
+
+    ports:
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
+      - "8889:8889" # Prometheus scrape endpoint
+
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
+
+    healthcheck:
+      test: ["CMD", "/otelcol-contrib", "--version"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    mem_limit: 256m
+
+    ports:
+      - "9090:9090"
+
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+
+    depends_on:
+      otel-collector:
+        condition: service_started
+
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/ready"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
 volumes:
   postgres16-data:
+  prometheus-data:

--- a/scripts/profiling/docker-compose.yml
+++ b/scripts/profiling/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   postgres:
     image: postgres:16-alpine
-    platform: linux/arm64/v8
     container_name: postgres16
     restart: unless-stopped
     mem_limit: 1g

--- a/scripts/profiling/otel-collector-config.yaml
+++ b/scripts/profiling/otel-collector-config.yaml
@@ -1,0 +1,22 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "0.0.0.0:4318"
+      grpc:
+        endpoint: "0.0.0.0:4317"
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+
+extensions:
+  health_check:
+    endpoint: "0.0.0.0:13133"
+
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]

--- a/scripts/profiling/package.json
+++ b/scripts/profiling/package.json
@@ -11,6 +11,10 @@
   "packageManager": "pnpm@10.16.1",
   "dependencies": {
     "@electric-sql/pglite": "catalog:",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.57.2",
+    "@opentelemetry/sdk-metrics": "^1.29.0",
+    "@powerhousedao/opentelemetry-instrumentation-reactor": "workspace:*",
     "@powerhousedao/reactor": "workspace:*",
     "@pyroscope/nodejs": "^0.4.7",
     "document-model": "workspace:*",

--- a/scripts/profiling/prometheus.yml
+++ b/scripts/profiling/prometheus.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: "reactor"
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["otel-collector:8889"]

--- a/scripts/profiling/reactor-direct.ts
+++ b/scripts/profiling/reactor-direct.ts
@@ -843,13 +843,13 @@ async function main() {
       Pyroscope.stopWallProfiling();
       Pyroscope.stopCpuProfiling();
     }
+    reactor.kill();
     if (instrumentation) {
       instrumentation.stop();
     }
     if (meterProvider) {
       await meterProvider.shutdown();
     }
-    reactor.kill();
     await db.destroy();
 
     // Summary

--- a/scripts/profiling/reactor-direct.ts
+++ b/scripts/profiling/reactor-direct.ts
@@ -23,6 +23,13 @@
  */
 
 import { PGlite } from "@electric-sql/pglite";
+import { metrics } from "@opentelemetry/api";
+import {
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from "@opentelemetry/sdk-metrics";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
+import { ReactorInstrumentation } from "@powerhousedao/opentelemetry-instrumentation-reactor";
 import {
   JobStatus,
   REACTOR_SCHEMA,
@@ -30,6 +37,7 @@ import {
   runMigrations,
   type Database,
   type IReactor,
+  type ReactorModule,
 } from "@powerhousedao/reactor";
 import Pyroscope from "@pyroscope/nodejs";
 import { documentModelDocumentModelModule } from "document-model";
@@ -268,6 +276,7 @@ function parseArgs(args: string[]): {
   dbPath: string | undefined;
   docId: string | undefined;
   pyroscope: string | undefined;
+  otel: string | undefined;
   output: string | undefined;
   outputTimestamp: boolean;
 } {
@@ -281,6 +290,7 @@ function parseArgs(args: string[]): {
   let dbPath: string | undefined = undefined;
   let docId: string | undefined = undefined;
   let pyroscope: string | undefined = undefined;
+  let otel: string | undefined = undefined;
   let output: string | undefined = undefined;
   let outputTimestamp = false;
 
@@ -310,6 +320,14 @@ function parseArgs(args: string[]): {
         i++;
       } else {
         pyroscope = "http://localhost:4040";
+      }
+    } else if (arg === "--otel") {
+      const nextArg = args[i + 1];
+      if (nextArg && !nextArg.startsWith("-")) {
+        otel = nextArg;
+        i++;
+      } else {
+        otel = "http://localhost:4318";
       }
     } else if ((arg === "--output" || arg === "-O") && args[i + 1]) {
       output = args[++i];
@@ -345,6 +363,8 @@ Options:
   --file [name]             Write output to a timestamped file (default: reactor-direct.txt)
   --output, -O <file>       Write output to a specific file (no timestamp prefix)
   --pyroscope [address]     Enable Pyroscope profiling (default: http://localhost:4040)
+  --otel [endpoint]         Enable OpenTelemetry metrics export (default: http://localhost:4318)
+                            Exports to OTLP HTTP collector at {endpoint}/v1/metrics
   --help, -h                Show this help message
 
 Process flow:
@@ -432,6 +452,7 @@ Examples:
     dbPath,
     docId,
     pyroscope,
+    otel,
     output,
     outputTimestamp,
   };
@@ -476,6 +497,7 @@ async function main() {
     dbPath,
     docId,
     pyroscope: pyroscopeServer,
+    otel: otelEndpoint,
     output: outputFile,
     outputTimestamp,
   } = parseArgs(process.argv.slice(2));
@@ -594,14 +616,40 @@ async function main() {
       throw new Error(`Migration failed: ${migrationResult.error.message}`);
     }
 
-    const reactor = await new ReactorBuilder()
+    const reactorModule = await new ReactorBuilder()
       .withDocumentModels([documentModelDocumentModelModule])
       .withKysely(db as Kysely<Database>)
       .withMigrationStrategy("none")
-      .build();
+      .buildModule();
+    const reactor = reactorModule.reactor;
 
     const initDuration = ((Date.now() - initStart) / 1000).toFixed(2);
     console.log(`Reactor initialized in ${initDuration}s`);
+
+    let meterProvider: MeterProvider | undefined;
+    let instrumentation: ReactorInstrumentation | undefined;
+
+    if (otelEndpoint) {
+      console.log(
+        `Initializing OpenTelemetry metrics exporter at: ${otelEndpoint}`,
+      );
+      meterProvider = new MeterProvider({
+        readers: [
+          new PeriodicExportingMetricReader({
+            exporter: new OTLPMetricExporter({
+              url: `${otelEndpoint}/v1/metrics`,
+            }),
+            exportIntervalMillis: 5_000,
+          }),
+        ],
+      });
+      metrics.setGlobalMeterProvider(meterProvider);
+      instrumentation = new ReactorInstrumentation(
+        reactorModule as ReactorModule,
+      );
+      instrumentation.start();
+      console.log("  Metrics export enabled (interval: 5s)");
+    }
 
     const initialMemory = getMemoryStats();
     console.log(`\nInitial memory: ${formatMemory(initialMemory)}`);
@@ -794,6 +842,12 @@ async function main() {
     if (pyroscopeServer) {
       Pyroscope.stopWallProfiling();
       Pyroscope.stopCpuProfiling();
+    }
+    if (instrumentation) {
+      instrumentation.stop();
+    }
+    if (meterProvider) {
+      await meterProvider.shutdown();
     }
     reactor.kill();
     await db.destroy();

--- a/scripts/profiling/reactor-direct.ts
+++ b/scripts/profiling/reactor-direct.ts
@@ -518,6 +518,9 @@ async function main() {
     mkdirSync(dirname(outputPath), { recursive: true });
     console.log(`Writing output to: ${outputPath}`);
     outputStream = createWriteStream(outputPath);
+    outputStream.on("error", (err) => {
+      console.error(`Output file write error: ${err.message}`);
+    });
 
     // Buffer that simulates terminal \r behavior: carriage return resets
     // the current line so only the final version is written to the file.

--- a/scripts/profiling/reactor-direct.ts
+++ b/scripts/profiling/reactor-direct.ts
@@ -37,7 +37,6 @@ import {
   runMigrations,
   type Database,
   type IReactor,
-  type ReactorModule,
 } from "@powerhousedao/reactor";
 import Pyroscope from "@pyroscope/nodejs";
 import { documentModelDocumentModelModule } from "document-model";
@@ -644,9 +643,7 @@ async function main() {
         ],
       });
       metrics.setGlobalMeterProvider(meterProvider);
-      instrumentation = new ReactorInstrumentation(
-        reactorModule as ReactorModule,
-      );
+      instrumentation = new ReactorInstrumentation(reactorModule);
       instrumentation.start();
       console.log("  Metrics export enabled (interval: 5s)");
     }

--- a/scripts/profiling/reactor-direct.ts
+++ b/scripts/profiling/reactor-direct.ts
@@ -841,11 +841,14 @@ async function main() {
       Pyroscope.stopCpuProfiling();
     }
     reactor.kill();
+    if (meterProvider) {
+      // Shutdown before instrumentation.stop() so the final collection pass
+      // captures gauge observations while this.metrics is still defined.
+      // stop() is called after to unsubscribe event-bus listeners and clear state.
+      await meterProvider.shutdown();
+    }
     if (instrumentation) {
       instrumentation.stop();
-    }
-    if (meterProvider) {
-      await meterProvider.shutdown();
     }
     await db.destroy();
 

--- a/scripts/profiling/run-reactor-direct.sh
+++ b/scripts/profiling/run-reactor-direct.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 BUILD_OTEL=false
-for arg in "$@"; do [[ "$arg" == "--otel" || "$arg" == "--otel="* ]] && BUILD_OTEL=true; done
+for arg in "$@"; do [[ "$arg" == "--otel" ]] && BUILD_OTEL=true; done
 
 TOTAL_STEPS=3
 $BUILD_OTEL && TOTAL_STEPS=4

--- a/scripts/profiling/run-reactor-direct.sh
+++ b/scripts/profiling/run-reactor-direct.sh
@@ -5,14 +5,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 echo "Building packages..."
 
-echo "  [1/3] document-model"
+echo "  [1/4] document-model"
 pnpm --filter document-model run tsc --build
 
-echo "  [2/3] @powerhousedao/reactor"
+echo "  [2/4] @powerhousedao/reactor"
 pnpm --filter @powerhousedao/reactor run build
 pnpm --filter @powerhousedao/reactor run build:bundle
 
-echo "  [3/3] Running migrations"
+echo "  [3/4] @powerhousedao/opentelemetry-instrumentation-reactor"
+pnpm --filter @powerhousedao/opentelemetry-instrumentation-reactor run build
+
+echo "  [4/4] Running migrations"
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres" \
   pnpm --filter document-drive run migrate
 

--- a/scripts/profiling/run-reactor-direct.sh
+++ b/scripts/profiling/run-reactor-direct.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 BUILD_OTEL=false
-[[ " $* " == *" --otel"* ]] && BUILD_OTEL=true
+for arg in "$@"; do [[ "$arg" == "--otel" || "$arg" == "--otel="* ]] && BUILD_OTEL=true; done
 
 TOTAL_STEPS=3
 $BUILD_OTEL && TOTAL_STEPS=4

--- a/scripts/profiling/run-reactor-direct.sh
+++ b/scripts/profiling/run-reactor-direct.sh
@@ -3,19 +3,28 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+BUILD_OTEL=false
+[[ " $* " == *" --otel"* ]] && BUILD_OTEL=true
+
+TOTAL_STEPS=3
+$BUILD_OTEL && TOTAL_STEPS=4
+STEP=0
+
 echo "Building packages..."
 
-echo "  [1/4] document-model"
+STEP=$((STEP + 1)); echo "  [${STEP}/${TOTAL_STEPS}] document-model"
 pnpm --filter document-model run tsc --build
 
-echo "  [2/4] @powerhousedao/reactor"
+STEP=$((STEP + 1)); echo "  [${STEP}/${TOTAL_STEPS}] @powerhousedao/reactor"
 pnpm --filter @powerhousedao/reactor run build
 pnpm --filter @powerhousedao/reactor run build:bundle
 
-echo "  [3/4] @powerhousedao/opentelemetry-instrumentation-reactor"
-pnpm --filter @powerhousedao/opentelemetry-instrumentation-reactor run build
+if $BUILD_OTEL; then
+  STEP=$((STEP + 1)); echo "  [${STEP}/${TOTAL_STEPS}] @powerhousedao/opentelemetry-instrumentation-reactor"
+  pnpm --filter @powerhousedao/opentelemetry-instrumentation-reactor run build
+fi
 
-echo "  [4/4] Running migrations"
+STEP=$((STEP + 1)); echo "  [${STEP}/${TOTAL_STEPS}] Running migrations"
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres" \
   pnpm --filter document-drive run migrate
 

--- a/scripts/profiling/switchboard-pyroscope.sh
+++ b/scripts/profiling/switchboard-pyroscope.sh
@@ -64,10 +64,11 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --otel)
-      OTEL_ENDPOINT="${2:-http://localhost:4318}"
       if [ -n "${2:-}" ] && [[ "$2" != --* ]]; then
+        OTEL_ENDPOINT="$2"
         shift 2
       else
+        OTEL_ENDPOINT="http://localhost:4318"
         shift 1
       fi
       ;;

--- a/scripts/profiling/switchboard-pyroscope.sh
+++ b/scripts/profiling/switchboard-pyroscope.sh
@@ -11,6 +11,7 @@ RUNTIME="node"
 STORAGE_V2="true"
 STORAGE_MODE_LABEL="v2"
 DATABASE_URL=""
+OTEL_ENDPOINT=""
 
 # Parse our flags (before passing rest to switchboard)
 SWITCHBOARD_ARGS=()
@@ -62,6 +63,14 @@ while [[ $# -gt 0 ]]; do
       DATABASE_URL="$2"
       shift 2
       ;;
+    --otel)
+      OTEL_ENDPOINT="${2:-http://localhost:4318}"
+      if [ -n "${2:-}" ] && [[ "$2" != --* ]]; then
+        shift 2
+      else
+        shift 1
+      fi
+      ;;
     --help|-h)
       echo "Usage: ./scripts/profiling/switchboard-pyroscope.sh [options] [switchboard-options...]"
       echo ""
@@ -69,6 +78,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --runtime, -r <node|bun>  Runtime to use (default: node)"
       echo "  --mode, -m <v2|legacy>    Storage mode: 'v2' (default) or 'legacy'"
       echo "  --postgres, -p <url>      Set PostgreSQL database URL"
+      echo "  --otel [endpoint]         Enable OpenTelemetry metrics export (default: http://localhost:4318)"
       echo "  --help, -h                Show this help message"
       echo ""
       echo "All other options are passed to switchboard."
@@ -137,6 +147,9 @@ else
   echo "Pyroscope: disabled (@datadog/pprof native addon is incompatible with bun)"
 fi
 echo "Storage mode: ${STORAGE_MODE_LABEL}"
+if [ -n "$OTEL_ENDPOINT" ]; then
+  echo "OTel endpoint: ${OTEL_ENDPOINT}"
+fi
 if [ -n "$STORAGE_V2" ]; then
   echo "  REACTOR_STORAGE_V2=true"
 fi
@@ -159,15 +172,19 @@ echo "=========================================="
 echo
 
 # Build all required packages
+TOTAL_STEPS=5
+[ -n "$OTEL_ENDPOINT" ] && TOTAL_STEPS=6
+STEP=0
+
 echo "Building packages..."
 
-echo "  [1/6] document-model"
+STEP=$((STEP + 1)); echo "  [${STEP}/${TOTAL_STEPS}] document-model"
 if ! pnpm --filter document-model run tsc --build; then
   echo "Error: document-model build failed — aborting"
   exit 1
 fi
 
-echo "  [2/6] @powerhousedao/reactor"
+STEP=$((STEP + 1)); echo "  [${STEP}/${TOTAL_STEPS}] @powerhousedao/reactor"
 if ! pnpm --filter @powerhousedao/reactor run build; then
   echo "Error: reactor build failed — aborting"
   exit 1
@@ -177,14 +194,15 @@ if ! pnpm --filter @powerhousedao/reactor run build:bundle; then
   exit 1
 fi
 
-echo "  [3/6] @powerhousedao/opentelemetry-instrumentation-reactor"
-if ! pnpm --filter @powerhousedao/opentelemetry-instrumentation-reactor run build; then
-  echo "Error: opentelemetry-instrumentation-reactor build failed — aborting"
-  exit 1
+if [ -n "$OTEL_ENDPOINT" ]; then
+  STEP=$((STEP + 1)); echo "  [${STEP}/${TOTAL_STEPS}] @powerhousedao/opentelemetry-instrumentation-reactor"
+  if ! pnpm --filter @powerhousedao/opentelemetry-instrumentation-reactor run build; then
+    echo "Error: opentelemetry-instrumentation-reactor build failed — aborting"
+    exit 1
+  fi
 fi
 
-echo "  [4/6] document-drive migrations"
-
+STEP=$((STEP + 1)); echo "  [${STEP}/${TOTAL_STEPS}] document-drive migrations"
 if [ -n "$DATABASE_URL" ]; then
   if ! pnpm --filter document-drive run migrate; then
     echo "Error: database migration failed — aborting"
@@ -194,13 +212,13 @@ else
   echo "  (skipped — no --postgres provided)"
 fi
 
-echo "  [5/6] @powerhousedao/switchboard"
+STEP=$((STEP + 1)); echo "  [${STEP}/${TOTAL_STEPS}] @powerhousedao/switchboard"
 if ! pnpm --filter @powerhousedao/switchboard run tsc --build; then
   echo "Error: switchboard build failed — aborting"
   exit 1
 fi
 
-echo "  [6/6] @powerhousedao/reactor-api"
+STEP=$((STEP + 1)); echo "  [${STEP}/${TOTAL_STEPS}] @powerhousedao/reactor-api"
 if ! pnpm --filter @powerhousedao/reactor-api run build:misc; then
   echo "Error: reactor-api build:misc failed — aborting"
   exit 1
@@ -216,9 +234,18 @@ if [ ! -f "$SWITCHBOARD_PATH" ]; then
   exit 1
 fi
 
+# Export OTel endpoint for switchboard to consume
+if [ -n "$OTEL_ENDPOINT" ]; then
+  export OTEL_EXPORTER_OTLP_ENDPOINT="$OTEL_ENDPOINT"
+fi
+
 # Run switchboard
-if [ -n "$PYROSCOPE_ENABLED" ]; then
+if [ -n "$PYROSCOPE_ENABLED" ] && [ -n "$OTEL_ENDPOINT" ]; then
+  echo "Starting Switchboard with ${RUNTIME}, Pyroscope profiling and OTel metrics..."
+elif [ -n "$PYROSCOPE_ENABLED" ]; then
   echo "Starting Switchboard with ${RUNTIME} and Pyroscope profiling..."
+elif [ -n "$OTEL_ENDPOINT" ]; then
+  echo "Starting Switchboard with ${RUNTIME} and OTel metrics..."
 else
   echo "Starting Switchboard with ${RUNTIME}..."
 fi

--- a/scripts/profiling/switchboard-pyroscope.sh
+++ b/scripts/profiling/switchboard-pyroscope.sh
@@ -161,13 +161,13 @@ echo
 # Build all required packages
 echo "Building packages..."
 
-echo "  [1/5] document-model"
+echo "  [1/6] document-model"
 if ! pnpm --filter document-model run tsc --build; then
   echo "Error: document-model build failed — aborting"
   exit 1
 fi
 
-echo "  [2/5] @powerhousedao/reactor"
+echo "  [2/6] @powerhousedao/reactor"
 if ! pnpm --filter @powerhousedao/reactor run build; then
   echo "Error: reactor build failed — aborting"
   exit 1
@@ -177,7 +177,14 @@ if ! pnpm --filter @powerhousedao/reactor run build:bundle; then
   exit 1
 fi
 
-echo "  [3/5] document-drive migrations"
+echo "  [3/6] @powerhousedao/opentelemetry-instrumentation-reactor"
+if ! pnpm --filter @powerhousedao/opentelemetry-instrumentation-reactor run build; then
+  echo "Error: opentelemetry-instrumentation-reactor build failed — aborting"
+  exit 1
+fi
+
+echo "  [4/6] document-drive migrations"
+
 if [ -n "$DATABASE_URL" ]; then
   if ! pnpm --filter document-drive run migrate; then
     echo "Error: database migration failed — aborting"
@@ -187,13 +194,13 @@ else
   echo "  (skipped — no --postgres provided)"
 fi
 
-echo "  [4/5] @powerhousedao/switchboard"
+echo "  [5/6] @powerhousedao/switchboard"
 if ! pnpm --filter @powerhousedao/switchboard run tsc --build; then
   echo "Error: switchboard build failed — aborting"
   exit 1
 fi
 
-echo "  [5/5] @powerhousedao/reactor-api"
+echo "  [6/6] @powerhousedao/reactor-api"
 if ! pnpm --filter @powerhousedao/reactor-api run build:misc; then
   echo "Error: reactor-api build:misc failed — aborting"
   exit 1

--- a/scripts/profiling/switchboard-pyroscope.sh
+++ b/scripts/profiling/switchboard-pyroscope.sh
@@ -235,7 +235,11 @@ if [ ! -f "$SWITCHBOARD_PATH" ]; then
   exit 1
 fi
 
-# Export OTel endpoint for switchboard to consume
+# Export OTel endpoint for switchboard to consume.
+# TODO: switchboard initialises ReactorInstrumentation but does not set up a
+# MeterProvider or OTLP exporter, so this env var currently has no effect.
+# A follow-on PR should add MeterProvider + OTLPMetricExporter initialisation
+# to apps/switchboard/src/server.ts reading from OTEL_EXPORTER_OTLP_ENDPOINT.
 if [ -n "$OTEL_ENDPOINT" ]; then
   export OTEL_EXPORTER_OTLP_ENDPOINT="$OTEL_ENDPOINT"
 fi

--- a/scripts/profiling/tsconfig.json
+++ b/scripts/profiling/tsconfig.json
@@ -1,24 +1,20 @@
 {
   "extends": "../../tsconfig.options.json",
   "compilerOptions": {
-    "types": [
-      "node"
-    ],
+    "types": ["node"],
     "resolveJsonModule": true,
     "noEmit": true,
     "moduleResolution": "NodeNext",
     "skipLibCheck": true
   },
-  "include": [
-    "**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
-  ],
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"],
   "references": [
     {
       "path": "../../packages/document-model"
+    },
+    {
+      "path": "../../packages/opentelemetry-instrumentation-reactor"
     },
     {
       "path": "../../packages/reactor"


### PR DESCRIPTION
Adds OpenTelemetry metrics support to the profiling scripts, enabling real-time visibility into reactor performance during benchmarks via Prometheus. Building on the work introduced with https://github.com/powerhouse-inc/powerhouse/commit/67d5c31e59417a2c5ca32090a342d656885d1aa1 also see https://github.com/powerhouse-inc/powerhouse/blob/main/packages/opentelemetry-instrumentation-reactor/docs/taxonomy.md

## What's Been Added?                                                                                                      

- `reactor-direct.ts`: new `--otel [endpoint]` flag that initialises an OTel MeterProvider with OTLP HTTP export, hooks up ReactorInstrumentation, and tears down cleanly after the benchmark
- Docker Compose: adds otel-collector and prometheus services alongside the existing postgres and pyroscope containers
- `otel-collector-config.yaml`: new config wiring OTLP receivers (gRPC + HTTP) to a Prometheus scrape endpoint
- `prometheus.yml`: new config scraping the collector every 5s
- `run-reactor-direct.sh`: updated build sequence to include the opentelemetry-instrumentation-reactor package
- `switchboard-pyroscope.sh`: same build sequence update
- `README.md`: full metrics reference (counters, gauges, histograms), PromQL query examples, and new workflow sections for OTel and combined Pyroscope+OTel profiling

The PR screenshots show Prometheus graphs of average ms/op, fastest operations (P1), and slowest operations (P99) over time during a live benchmark run.

## Examples

### Average ms/op(job)
<img width="1715" height="783" alt="Screenshot 2026-03-13 at 09 38 28" src="https://github.com/user-attachments/assets/59e35af4-5a3d-4f2b-a72e-b92c16b165fa" />

### Fastest Operations Over Time
<img width="1720" height="763" alt="Screenshot 2026-03-13 at 09 38 53" src="https://github.com/user-attachments/assets/c6793075-7212-423b-9c75-a1bb9d14d66d" />

### Slowest Operations Over Time
<img width="1716" height="766" alt="Screenshot 2026-03-13 at 09 39 17" src="https://github.com/user-attachments/assets/da19ee6d-93a3-416c-a000-6f8ca8e9d233" />
