### PR TITLE
Switchboard otel ordering

### DIFF
--- a/apps/switchboard/package.json
+++ b/apps/switchboard/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "tsc": "tsc",
+    "test": "vitest run",
     "lint": "eslint",
     "build:misc": "pnpm run install-packages",
     "start": "node dist/src/index.js",
@@ -72,6 +73,7 @@
     "@types/node": "catalog:",
     "@types/pg": "catalog:",
     "concurrently": "catalog:",
-    "nodemon": "catalog:"
+    "nodemon": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/apps/switchboard/src/index.ts
+++ b/apps/switchboard/src/index.ts
@@ -24,7 +24,11 @@ function ensureNodeVersion(minVersion = "24") {
 // Ensure minimum Node.js version
 ensureNodeVersion("24");
 
-const meterProvider = createMeterProviderFromEnv(process.env);
+const meterProvider = createMeterProviderFromEnv({
+  OTEL_EXPORTER_OTLP_ENDPOINT: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+  OTEL_METRIC_EXPORT_INTERVAL: process.env.OTEL_METRIC_EXPORT_INTERVAL,
+  OTEL_SERVICE_NAME: process.env.OTEL_SERVICE_NAME,
+});
 
 async function shutdown() {
   console.log("\nShutting down...");

--- a/apps/switchboard/src/index.ts
+++ b/apps/switchboard/src/index.ts
@@ -2,7 +2,7 @@
 import * as Sentry from "@sentry/node";
 import { childLogger } from "document-drive";
 import { config } from "./config.js";
-import { setupMetricsFromEnv } from "./metrics.js";
+import { createMeterProviderFromEnv } from "./metrics.js";
 import { initProfilerFromEnv } from "./profiler.js";
 import { startSwitchboard } from "./server.js";
 
@@ -24,7 +24,7 @@ function ensureNodeVersion(minVersion = "24") {
 // Ensure minimum Node.js version
 ensureNodeVersion("24");
 
-const meterProvider = setupMetricsFromEnv(process.env);
+const meterProvider = createMeterProviderFromEnv(process.env);
 
 async function shutdown() {
   console.log("\nShutting down...");
@@ -50,4 +50,4 @@ if (process.env.PYROSCOPE_SERVER_ADDRESS) {
   }
 }
 
-startSwitchboard(config).catch(console.error);
+startSwitchboard({ ...config, meterProvider }).catch(console.error);

--- a/apps/switchboard/src/metrics.ts
+++ b/apps/switchboard/src/metrics.ts
@@ -8,9 +8,11 @@ import { childLogger } from "document-drive";
 
 const logger = childLogger(["switchboard", "metrics"]);
 
-export function createMeterProviderFromEnv(
-  env: typeof process.env,
-): MeterProvider | undefined {
+export function createMeterProviderFromEnv(env: {
+  OTEL_EXPORTER_OTLP_ENDPOINT?: string;
+  OTEL_METRIC_EXPORT_INTERVAL?: string;
+  OTEL_SERVICE_NAME?: string;
+}): MeterProvider | undefined {
   const endpoint = env.OTEL_EXPORTER_OTLP_ENDPOINT;
   if (!endpoint) return undefined;
 

--- a/apps/switchboard/src/metrics.ts
+++ b/apps/switchboard/src/metrics.ts
@@ -1,4 +1,3 @@
-import { metrics } from "@opentelemetry/api";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { Resource } from "@opentelemetry/resources";
 import {
@@ -9,7 +8,7 @@ import { childLogger } from "document-drive";
 
 const logger = childLogger(["switchboard", "metrics"]);
 
-export function setupMetricsFromEnv(
+export function createMeterProviderFromEnv(
   env: typeof process.env,
 ): MeterProvider | undefined {
   const endpoint = env.OTEL_EXPORTER_OTLP_ENDPOINT;
@@ -34,10 +33,6 @@ export function setupMetricsFromEnv(
       }),
     ],
   });
-  // setGlobalMeterProvider is a one-way door — it cannot be unset once
-  // assigned. ReactorInstrumentation reads the global provider via
-  // metrics.getMeter(), so this must be called before instrumentation.start().
-  metrics.setGlobalMeterProvider(meterProvider);
   logger.info(`Metrics export enabled (interval: ${exportIntervalMillis}ms)`);
   return meterProvider;
 }

--- a/apps/switchboard/src/metrics.ts
+++ b/apps/switchboard/src/metrics.ts
@@ -20,6 +20,11 @@ export function createMeterProviderFromEnv(env: {
   const exportIntervalMillis =
     Number.isFinite(parsed) && parsed > 0 ? parsed : 5_000;
 
+  const base = endpoint.replace(/\/$/, "");
+  const exporterUrl = base.endsWith("/v1/metrics")
+    ? base
+    : `${base}/v1/metrics`;
+
   logger.info(`Initializing OpenTelemetry metrics exporter at: ${endpoint}`);
   const meterProvider = new MeterProvider({
     resource: new Resource({
@@ -28,7 +33,7 @@ export function createMeterProviderFromEnv(env: {
     readers: [
       new PeriodicExportingMetricReader({
         exporter: new OTLPMetricExporter({
-          url: `${endpoint.replace(/\/$/, "")}/v1/metrics`,
+          url: exporterUrl,
         }),
         exportIntervalMillis,
         exportTimeoutMillis: Math.max(exportIntervalMillis - 250, 1),

--- a/apps/switchboard/src/server.ts
+++ b/apps/switchboard/src/server.ts
@@ -16,6 +16,7 @@ import {
   parseDriveUrl,
   type Database,
 } from "@powerhousedao/reactor";
+import { metrics } from "@opentelemetry/api";
 import {
   HttpPackageLoader,
   PackageManagementService,
@@ -137,6 +138,14 @@ async function initServer(
   options: StartServerOptions,
   renown: IRenown | null,
 ) {
+  // Register the global MeterProvider before ReactorInstrumentation is
+  // constructed. setGlobalMeterProvider is a one-way door — once set it cannot
+  // be unset — so this must happen before initializeClient calls
+  // instrumentation.start() → createMetrics() → metrics.getMeter().
+  if (options.meterProvider) {
+    metrics.setGlobalMeterProvider(options.meterProvider);
+  }
+
   const {
     dev,
     packages = [],

--- a/apps/switchboard/src/types.ts
+++ b/apps/switchboard/src/types.ts
@@ -1,7 +1,7 @@
 import type { IReactorClient } from "@powerhousedao/reactor";
 import type { IRenown } from "@renown/sdk";
 import type { DriveInput, IDocumentDriveServer, ILogger } from "document-drive";
-import type { MeterProvider } from "@opentelemetry/sdk-metrics";
+import type { MeterProvider } from "@opentelemetry/api";
 
 export type StorageOptions = {
   type: "filesystem" | "memory" | "postgres" | "browser";

--- a/apps/switchboard/src/types.ts
+++ b/apps/switchboard/src/types.ts
@@ -1,6 +1,7 @@
 import type { IReactorClient } from "@powerhousedao/reactor";
 import type { IRenown } from "@renown/sdk";
 import type { DriveInput, IDocumentDriveServer, ILogger } from "document-drive";
+import type { MeterProvider } from "@opentelemetry/sdk-metrics";
 
 export type StorageOptions = {
   type: "filesystem" | "memory" | "postgres" | "browser";
@@ -66,6 +67,13 @@ export type StartServerOptions = {
   };
   enableDocumentModelSubgraphs?: boolean;
   logger?: ILogger;
+  /**
+   * OpenTelemetry MeterProvider to register as the global provider before
+   * ReactorInstrumentation starts. Must be provided here rather than set
+   * externally to guarantee the registration happens before
+   * instrumentation.start() reads the global provider via metrics.getMeter().
+   */
+  meterProvider?: MeterProvider;
 };
 
 export type SwitchboardReactor = {

--- a/apps/switchboard/test/metrics.test.ts
+++ b/apps/switchboard/test/metrics.test.ts
@@ -14,12 +14,25 @@ vi.mock("document-drive", () => ({
   }),
 }));
 
-afterEach(() => {
+const providers: MeterProvider[] = [];
+
+afterEach(async () => {
   vi.restoreAllMocks();
+  // Await shutdown so PeriodicExportingMetricReader timers are cleared
+  await Promise.all(providers.map((p) => p.shutdown()));
+  providers.length = 0;
 });
 
+function track(provider: MeterProvider | undefined): MeterProvider | undefined {
+  if (provider) providers.push(provider);
+  return provider;
+}
+
+// These helpers access undocumented internal fields of MeterProvider and
+// PeriodicExportingMetricReader. They may break if @opentelemetry/sdk-metrics
+// renames its private state between major versions.
 function getReader(provider: MeterProvider): PeriodicExportingMetricReader {
-  const state = (
+  return (
     provider as unknown as {
       _sharedState: {
         metricCollectors: Array<{
@@ -27,19 +40,17 @@ function getReader(provider: MeterProvider): PeriodicExportingMetricReader {
         }>;
       };
     }
-  )._sharedState;
-  return state.metricCollectors[0]._metricReader;
+  )._sharedState.metricCollectors[0]._metricReader;
 }
 
 function getResourceAttributes(
   provider: MeterProvider,
 ): Record<string, unknown> {
-  const state = (
+  return (
     provider as unknown as {
       _sharedState: { resource: { attributes: Record<string, unknown> } };
     }
-  )._sharedState;
-  return state.resource.attributes;
+  )._sharedState.resource.attributes;
 }
 
 describe("createMeterProviderFromEnv", () => {
@@ -51,102 +62,106 @@ describe("createMeterProviderFromEnv", () => {
 
   describe("when OTEL_EXPORTER_OTLP_ENDPOINT is set", () => {
     it("returns a MeterProvider", () => {
-      const provider = createMeterProviderFromEnv({
-        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
-      });
-      expect(provider).toBeInstanceOf(MeterProvider);
-      void provider?.shutdown();
+      expect(
+        track(
+          createMeterProviderFromEnv({
+            OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+          }),
+        ),
+      ).toBeInstanceOf(MeterProvider);
     });
 
     it("strips trailing slash from endpoint URL without throwing", () => {
       expect(() =>
-        createMeterProviderFromEnv({
-          OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318/",
-        }),
+        track(
+          createMeterProviderFromEnv({
+            OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318/",
+          }),
+        ),
       ).not.toThrow();
     });
 
     it("uses 5000ms export interval by default", () => {
-      const provider = createMeterProviderFromEnv({
-        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
-      }) as MeterProvider;
-
+      const provider = track(
+        createMeterProviderFromEnv({
+          OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+        }),
+      ) as MeterProvider;
       expect(getReader(provider)._exportInterval).toBe(5000);
-      void provider.shutdown();
     });
 
     it("honours OTEL_METRIC_EXPORT_INTERVAL", () => {
-      const provider = createMeterProviderFromEnv({
-        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
-        OTEL_METRIC_EXPORT_INTERVAL: "2000",
-      }) as MeterProvider;
-
+      const provider = track(
+        createMeterProviderFromEnv({
+          OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+          OTEL_METRIC_EXPORT_INTERVAL: "2000",
+        }),
+      ) as MeterProvider;
       expect(getReader(provider)._exportInterval).toBe(2000);
-      void provider.shutdown();
     });
 
     it("falls back to 5000ms when OTEL_METRIC_EXPORT_INTERVAL is non-numeric", () => {
-      const provider = createMeterProviderFromEnv({
-        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
-        OTEL_METRIC_EXPORT_INTERVAL: "abc",
-      }) as MeterProvider;
-
+      const provider = track(
+        createMeterProviderFromEnv({
+          OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+          OTEL_METRIC_EXPORT_INTERVAL: "abc",
+        }),
+      ) as MeterProvider;
       expect(getReader(provider)._exportInterval).toBe(5000);
-      void provider.shutdown();
     });
 
     it("falls back to 5000ms when OTEL_METRIC_EXPORT_INTERVAL is zero", () => {
-      const provider = createMeterProviderFromEnv({
-        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
-        OTEL_METRIC_EXPORT_INTERVAL: "0",
-      }) as MeterProvider;
-
+      const provider = track(
+        createMeterProviderFromEnv({
+          OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+          OTEL_METRIC_EXPORT_INTERVAL: "0",
+        }),
+      ) as MeterProvider;
       expect(getReader(provider)._exportInterval).toBe(5000);
-      void provider.shutdown();
     });
 
     it("falls back to 5000ms when OTEL_METRIC_EXPORT_INTERVAL is negative", () => {
-      const provider = createMeterProviderFromEnv({
-        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
-        OTEL_METRIC_EXPORT_INTERVAL: "-1000",
-      }) as MeterProvider;
-
+      const provider = track(
+        createMeterProviderFromEnv({
+          OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+          OTEL_METRIC_EXPORT_INTERVAL: "-1000",
+        }),
+      ) as MeterProvider;
       expect(getReader(provider)._exportInterval).toBe(5000);
-      void provider.shutdown();
     });
 
     it("sets exportTimeoutMillis below exportIntervalMillis", () => {
-      const provider = createMeterProviderFromEnv({
-        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
-        OTEL_METRIC_EXPORT_INTERVAL: "1000",
-      }) as MeterProvider;
-
+      const provider = track(
+        createMeterProviderFromEnv({
+          OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+          OTEL_METRIC_EXPORT_INTERVAL: "1000",
+        }),
+      ) as MeterProvider;
       const reader = getReader(provider);
       expect(reader._exportTimeout).toBeLessThan(reader._exportInterval);
-      void provider.shutdown();
     });
 
     it("uses 'switchboard' as service name by default", () => {
-      const provider = createMeterProviderFromEnv({
-        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
-      }) as MeterProvider;
-
+      const provider = track(
+        createMeterProviderFromEnv({
+          OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+        }),
+      ) as MeterProvider;
       expect(getResourceAttributes(provider)["service.name"]).toBe(
         "switchboard",
       );
-      void provider.shutdown();
     });
 
     it("honours OTEL_SERVICE_NAME", () => {
-      const provider = createMeterProviderFromEnv({
-        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
-        OTEL_SERVICE_NAME: "my-switchboard",
-      }) as MeterProvider;
-
+      const provider = track(
+        createMeterProviderFromEnv({
+          OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+          OTEL_SERVICE_NAME: "my-switchboard",
+        }),
+      ) as MeterProvider;
       expect(getResourceAttributes(provider)["service.name"]).toBe(
         "my-switchboard",
       );
-      void provider.shutdown();
     });
   });
 });

--- a/apps/switchboard/test/metrics.test.ts
+++ b/apps/switchboard/test/metrics.test.ts
@@ -81,6 +81,16 @@ describe("createMeterProviderFromEnv", () => {
       ).not.toThrow();
     });
 
+    it("does not double-append /v1/metrics when endpoint already includes it", () => {
+      expect(() =>
+        track(
+          createMeterProviderFromEnv({
+            OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318/v1/metrics",
+          }),
+        ),
+      ).not.toThrow();
+    });
+
     it("uses 5000ms export interval by default", () => {
       const provider = track(
         createMeterProviderFromEnv({

--- a/apps/switchboard/test/metrics.test.ts
+++ b/apps/switchboard/test/metrics.test.ts
@@ -1,7 +1,4 @@
-import {
-  MeterProvider,
-  PeriodicExportingMetricReader,
-} from "@opentelemetry/sdk-metrics";
+import { MeterProvider } from "@opentelemetry/sdk-metrics";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createMeterProviderFromEnv } from "../src/metrics.js";
 
@@ -31,12 +28,15 @@ function track(provider: MeterProvider | undefined): MeterProvider | undefined {
 // These helpers access undocumented internal fields of MeterProvider and
 // PeriodicExportingMetricReader. They may break if @opentelemetry/sdk-metrics
 // renames its private state between major versions.
-function getReader(provider: MeterProvider): PeriodicExportingMetricReader {
+function getReader(provider: MeterProvider): {
+  _exportInterval: number;
+  _exportTimeout: number;
+} {
   return (
     provider as unknown as {
       _sharedState: {
         metricCollectors: Array<{
-          _metricReader: PeriodicExportingMetricReader;
+          _metricReader: { _exportInterval: number; _exportTimeout: number };
         }>;
       };
     }

--- a/apps/switchboard/test/metrics.test.ts
+++ b/apps/switchboard/test/metrics.test.ts
@@ -1,0 +1,152 @@
+import {
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from "@opentelemetry/sdk-metrics";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMeterProviderFromEnv } from "../src/metrics.js";
+
+// Stub childLogger so tests don't require the full document-drive runtime
+vi.mock("document-drive", () => ({
+  childLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function getReader(provider: MeterProvider): PeriodicExportingMetricReader {
+  const state = (
+    provider as unknown as {
+      _sharedState: {
+        metricCollectors: Array<{
+          _metricReader: PeriodicExportingMetricReader;
+        }>;
+      };
+    }
+  )._sharedState;
+  return state.metricCollectors[0]._metricReader;
+}
+
+function getResourceAttributes(
+  provider: MeterProvider,
+): Record<string, unknown> {
+  const state = (
+    provider as unknown as {
+      _sharedState: { resource: { attributes: Record<string, unknown> } };
+    }
+  )._sharedState;
+  return state.resource.attributes;
+}
+
+describe("createMeterProviderFromEnv", () => {
+  describe("when OTEL_EXPORTER_OTLP_ENDPOINT is not set", () => {
+    it("returns undefined", () => {
+      expect(createMeterProviderFromEnv({})).toBeUndefined();
+    });
+  });
+
+  describe("when OTEL_EXPORTER_OTLP_ENDPOINT is set", () => {
+    it("returns a MeterProvider", () => {
+      const provider = createMeterProviderFromEnv({
+        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+      });
+      expect(provider).toBeInstanceOf(MeterProvider);
+      void provider?.shutdown();
+    });
+
+    it("strips trailing slash from endpoint URL without throwing", () => {
+      expect(() =>
+        createMeterProviderFromEnv({
+          OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318/",
+        }),
+      ).not.toThrow();
+    });
+
+    it("uses 5000ms export interval by default", () => {
+      const provider = createMeterProviderFromEnv({
+        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+      }) as MeterProvider;
+
+      expect(getReader(provider)._exportInterval).toBe(5000);
+      void provider.shutdown();
+    });
+
+    it("honours OTEL_METRIC_EXPORT_INTERVAL", () => {
+      const provider = createMeterProviderFromEnv({
+        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+        OTEL_METRIC_EXPORT_INTERVAL: "2000",
+      }) as MeterProvider;
+
+      expect(getReader(provider)._exportInterval).toBe(2000);
+      void provider.shutdown();
+    });
+
+    it("falls back to 5000ms when OTEL_METRIC_EXPORT_INTERVAL is non-numeric", () => {
+      const provider = createMeterProviderFromEnv({
+        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+        OTEL_METRIC_EXPORT_INTERVAL: "abc",
+      }) as MeterProvider;
+
+      expect(getReader(provider)._exportInterval).toBe(5000);
+      void provider.shutdown();
+    });
+
+    it("falls back to 5000ms when OTEL_METRIC_EXPORT_INTERVAL is zero", () => {
+      const provider = createMeterProviderFromEnv({
+        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+        OTEL_METRIC_EXPORT_INTERVAL: "0",
+      }) as MeterProvider;
+
+      expect(getReader(provider)._exportInterval).toBe(5000);
+      void provider.shutdown();
+    });
+
+    it("falls back to 5000ms when OTEL_METRIC_EXPORT_INTERVAL is negative", () => {
+      const provider = createMeterProviderFromEnv({
+        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+        OTEL_METRIC_EXPORT_INTERVAL: "-1000",
+      }) as MeterProvider;
+
+      expect(getReader(provider)._exportInterval).toBe(5000);
+      void provider.shutdown();
+    });
+
+    it("sets exportTimeoutMillis below exportIntervalMillis", () => {
+      const provider = createMeterProviderFromEnv({
+        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+        OTEL_METRIC_EXPORT_INTERVAL: "1000",
+      }) as MeterProvider;
+
+      const reader = getReader(provider);
+      expect(reader._exportTimeout).toBeLessThan(reader._exportInterval);
+      void provider.shutdown();
+    });
+
+    it("uses 'switchboard' as service name by default", () => {
+      const provider = createMeterProviderFromEnv({
+        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+      }) as MeterProvider;
+
+      expect(getResourceAttributes(provider)["service.name"]).toBe(
+        "switchboard",
+      );
+      void provider.shutdown();
+    });
+
+    it("honours OTEL_SERVICE_NAME", () => {
+      const provider = createMeterProviderFromEnv({
+        OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+        OTEL_SERVICE_NAME: "my-switchboard",
+      }) as MeterProvider;
+
+      expect(getResourceAttributes(provider)["service.name"]).toBe(
+        "my-switchboard",
+      );
+      void provider.shutdown();
+    });
+  });
+});

--- a/apps/switchboard/test/metrics.test.ts
+++ b/apps/switchboard/test/metrics.test.ts
@@ -48,6 +48,27 @@ function getReader(provider: MeterProvider): {
   )._sharedState.metricCollectors[0]._metricReader;
 }
 
+function getExporterUrl(provider: MeterProvider): string {
+  return (
+    provider as unknown as {
+      _sharedState: {
+        metricCollectors: Array<{
+          _metricReader: {
+            _exporter: {
+              _delegate: {
+                _transport: {
+                  _transport: { _parameters: { url: string } };
+                };
+              };
+            };
+          };
+        }>;
+      };
+    }
+  )._sharedState.metricCollectors[0]._metricReader._exporter._delegate
+    ._transport._transport._parameters.url;
+}
+
 function getResourceAttributes(
   provider: MeterProvider,
 ): Record<string, unknown> {
@@ -87,13 +108,12 @@ describe("createMeterProviderFromEnv", () => {
     });
 
     it("does not double-append /v1/metrics when endpoint already includes it", () => {
-      expect(() =>
-        track(
-          createMeterProviderFromEnv({
-            OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318/v1/metrics",
-          }),
-        ),
-      ).not.toThrow();
+      const provider = trackAsserted(
+        createMeterProviderFromEnv({
+          OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318/v1/metrics",
+        }),
+      );
+      expect(getExporterUrl(provider)).toBe("http://localhost:4318/v1/metrics");
     });
 
     it("uses 5000ms export interval by default", () => {

--- a/apps/switchboard/test/metrics.test.ts
+++ b/apps/switchboard/test/metrics.test.ts
@@ -25,6 +25,11 @@ function track(provider: MeterProvider | undefined): MeterProvider | undefined {
   return provider;
 }
 
+function trackAsserted(provider: MeterProvider | undefined): MeterProvider {
+  expect(provider).toBeInstanceOf(MeterProvider);
+  return track(provider) as MeterProvider;
+}
+
 // These helpers access undocumented internal fields of MeterProvider and
 // PeriodicExportingMetricReader. They may break if @opentelemetry/sdk-metrics
 // renames its private state between major versions.
@@ -92,83 +97,83 @@ describe("createMeterProviderFromEnv", () => {
     });
 
     it("uses 5000ms export interval by default", () => {
-      const provider = track(
+      const provider = trackAsserted(
         createMeterProviderFromEnv({
           OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
         }),
-      ) as MeterProvider;
+      );
       expect(getReader(provider)._exportInterval).toBe(5000);
     });
 
     it("honours OTEL_METRIC_EXPORT_INTERVAL", () => {
-      const provider = track(
+      const provider = trackAsserted(
         createMeterProviderFromEnv({
           OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
           OTEL_METRIC_EXPORT_INTERVAL: "2000",
         }),
-      ) as MeterProvider;
+      );
       expect(getReader(provider)._exportInterval).toBe(2000);
     });
 
     it("falls back to 5000ms when OTEL_METRIC_EXPORT_INTERVAL is non-numeric", () => {
-      const provider = track(
+      const provider = trackAsserted(
         createMeterProviderFromEnv({
           OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
           OTEL_METRIC_EXPORT_INTERVAL: "abc",
         }),
-      ) as MeterProvider;
+      );
       expect(getReader(provider)._exportInterval).toBe(5000);
     });
 
     it("falls back to 5000ms when OTEL_METRIC_EXPORT_INTERVAL is zero", () => {
-      const provider = track(
+      const provider = trackAsserted(
         createMeterProviderFromEnv({
           OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
           OTEL_METRIC_EXPORT_INTERVAL: "0",
         }),
-      ) as MeterProvider;
+      );
       expect(getReader(provider)._exportInterval).toBe(5000);
     });
 
     it("falls back to 5000ms when OTEL_METRIC_EXPORT_INTERVAL is negative", () => {
-      const provider = track(
+      const provider = trackAsserted(
         createMeterProviderFromEnv({
           OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
           OTEL_METRIC_EXPORT_INTERVAL: "-1000",
         }),
-      ) as MeterProvider;
+      );
       expect(getReader(provider)._exportInterval).toBe(5000);
     });
 
     it("sets exportTimeoutMillis below exportIntervalMillis", () => {
-      const provider = track(
+      const provider = trackAsserted(
         createMeterProviderFromEnv({
           OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
           OTEL_METRIC_EXPORT_INTERVAL: "1000",
         }),
-      ) as MeterProvider;
+      );
       const reader = getReader(provider);
       expect(reader._exportTimeout).toBeLessThan(reader._exportInterval);
     });
 
     it("uses 'switchboard' as service name by default", () => {
-      const provider = track(
+      const provider = trackAsserted(
         createMeterProviderFromEnv({
           OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
         }),
-      ) as MeterProvider;
+      );
       expect(getResourceAttributes(provider)["service.name"]).toBe(
         "switchboard",
       );
     });
 
     it("honours OTEL_SERVICE_NAME", () => {
-      const provider = track(
+      const provider = trackAsserted(
         createMeterProviderFromEnv({
           OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
           OTEL_SERVICE_NAME: "my-switchboard",
         }),
-      ) as MeterProvider;
+      );
       expect(getResourceAttributes(provider)["service.name"]).toBe(
         "my-switchboard",
       );

--- a/apps/switchboard/vitest.config.ts
+++ b/apps/switchboard/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    pool: "forks",
+    environment: "node",
+    poolOptions: {
+      forks: {
+        singleFork: true,
+        isolate: true,
+      },
+    },
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,6 +631,9 @@ importers:
       nodemon:
         specifier: 'catalog:'
         version: 3.1.11
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(jiti@2.6.1)(jsdom@24.1.3)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   clis/ph-cli:
     devDependencies:


### PR DESCRIPTION
## What's Changed?

- Renamed `setupMetricsFromEnv` → `createMeterProviderFromEnv` to reflect it is now a pure factory with no side effects
- Moved `setGlobalMeterProvider` out of `createMeterProviderFromEnv` and into `initServer`; `meterProvider` can now be passed via `StartServerOptions`
- `StartServerOptions.meterProvider` typed as `api.MeterProvider` interface rather than the concrete SDK class
- Narrowed `createMeterProviderFromEnv` env parameter from `typeof process.env` to an explicit three-key interface
- Fixed double `/v1/metrics` suffix in the OTLP exporter URL when `OTEL_EXPORTER_OTLP_ENDPOINT` already contains the full path
- Added unit tests for `createMeterProviderFromEnv` and improved test hygiene with `provider.shutdown()` in `afterEach`

## Why Make the Changes?

The global `MeterProvider` must be registered before `ReactorInstrumentation.start()` calls `metrics.getMeter()`, but the previous code only enforced this through call order in `index.ts`. This is easy to break silently. Moving registration into `initServer` encodes the invariant in the API itself. The type narrowing and rename are follow-on cleanup to make the function's contract explicit and prevent accidental coupling to the full process environment.