### PR TITLE
Add Latency Diagnostics to Switchboard

### DIFF
--- a/packages/opentelemetry-instrumentation-reactor/docs/taxonomy.md
+++ b/packages/opentelemetry-instrumentation-reactor/docs/taxonomy.md
@@ -31,9 +31,10 @@ which use UCUM (Unified Code for Units of Measure). Curly-brace annotations like
 
 ## Job Lifecycle (`reactor.job.*`)
 
-| Name                         | Type      | Unit | Description                                       | Attributes                 |
-| ---------------------------- | --------- | ---- | ------------------------------------------------- | -------------------------- |
-| `reactor.job.total.duration` | Histogram | `ms` | Full job lifecycle (PENDING to READ_READY/FAILED) | `job.success` (true/false) |
+| Name                          | Type      | Unit | Description                                       | Attributes                 |
+| ----------------------------- | --------- | ---- | ------------------------------------------------- | -------------------------- |
+| `reactor.queue.wait.duration` | Histogram | `ms` | Queue wait time per job (PENDING to RUNNING)      |                            |
+| `reactor.job.total.duration`  | Histogram | `ms` | Full job lifecycle (PENDING to READ_READY/FAILED) | `job.success` (true/false) |
 
 ## Read Models (`reactor.readmodel.*`)
 
@@ -59,7 +60,7 @@ which use UCUM (Unified Code for Units of Measure). Curly-brace annotations like
 | Event               | Code  | Metrics Recorded                                                                                                |
 | ------------------- | ----- | --------------------------------------------------------------------------------------------------------------- |
 | `JOB_PENDING`       | 10001 | `queue.jobs.enqueued`, `eventbus.events.emitted`                                                                |
-| `JOB_RUNNING`       | 10002 | `queue.jobs.dequeued`, `eventbus.events.emitted`                                                                |
+| `JOB_RUNNING`       | 10002 | `queue.jobs.dequeued`, `queue.wait.duration`, `eventbus.events.emitted`                                         |
 | `JOB_WRITE_READY`   | 10003 | `executor.job.duration`, `executor.total_processed`, `executor.operations_generated`, `eventbus.events.emitted` |
 | `JOB_READ_READY`    | 10004 | `readmodel.index.duration`, `job.total.duration`, `queue.jobs.completed`, `eventbus.events.emitted`             |
 | `JOB_FAILED`        | 10005 | `queue.jobs.failed`, `executor.total_processed`, `job.total.duration`, `eventbus.events.emitted`                |

--- a/packages/opentelemetry-instrumentation-reactor/src/instrumentation.ts
+++ b/packages/opentelemetry-instrumentation-reactor/src/instrumentation.ts
@@ -81,11 +81,16 @@ export class ReactorInstrumentation {
         ReactorEventTypes.JOB_RUNNING,
         (_type, event) => {
           if (!this.metrics) return;
+          const now = performance.now();
           this.metrics.queueJobsDequeued.add(1);
           this.metrics.eventbusEventsEmitted.add(1, {
             "event.type": "JOB_RUNNING",
           });
-          this.runningTimestamps.set(event.jobId, performance.now());
+          const pendingTs = this.pendingTimestamps.get(event.jobId);
+          if (pendingTs !== undefined) {
+            this.metrics.queueWaitDuration.record(now - pendingTs);
+          }
+          this.runningTimestamps.set(event.jobId, now);
         },
       ),
     );

--- a/packages/opentelemetry-instrumentation-reactor/src/metrics.ts
+++ b/packages/opentelemetry-instrumentation-reactor/src/metrics.ts
@@ -56,6 +56,10 @@ export function createMetrics() {
     ),
 
     // Job lifecycle metrics
+    queueWaitDuration: meter.createHistogram("reactor.queue.wait.duration", {
+      description: "Queue wait time per job (PENDING to RUNNING)",
+      unit: "ms",
+    }),
     jobTotalDuration: meter.createHistogram("reactor.job.total.duration", {
       description: "Full job lifecycle (PENDING to READ_READY/FAILED)",
       unit: "ms",

--- a/packages/reactor-api/package.json
+++ b/packages/reactor-api/package.json
@@ -45,10 +45,9 @@
   "author": "",
   "license": "AGPL-3.0-only",
   "dependencies": {
-    "@apollo/gateway": "^2.11.3",
-    "@apollo/server": "^5.0.0",
-    "@apollo/subgraph": "^2.11.3",
-    "@as-integrations/express4": "^1.1.2",
+    "@graphql-tools/schema": "catalog:",
+    "@graphql-tools/utils": "catalog:",
+    "graphql-yoga": "catalog:",
     "@electric-sql/pglite": "catalog:",
     "@opentelemetry/auto-instrumentations-node": "^0.57.1",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.57.2",

--- a/packages/reactor-api/src/graphql/analytics-subgraph.ts
+++ b/packages/reactor-api/src/graphql/analytics-subgraph.ts
@@ -1,4 +1,3 @@
-import type { GraphQLResolverMap } from "@apollo/subgraph/dist/schema-helper/resolverMap.js";
 import type { IAnalyticsStore } from "@powerhousedao/analytics-engine-core";
 import { AnalyticsQueryEngine } from "@powerhousedao/analytics-engine-core";
 import {
@@ -19,7 +18,7 @@ export class AnalyticsSubgraph extends BaseSubgraph {
     ${typedefs}
   `;
 
-  resolvers = AnalyticsResolvers as GraphQLResolverMap<Context>;
+  resolvers = AnalyticsResolvers as Record<string, unknown>;
 
   constructor(args: SubgraphArgs) {
     super(args);

--- a/packages/reactor-api/src/graphql/graphql-manager.ts
+++ b/packages/reactor-api/src/graphql/graphql-manager.ts
@@ -604,16 +604,21 @@ export class GraphQLManager {
     return makeExecutableSchema({
       typeDefs: allTypeDefs,
       resolvers: allResolvers as any,
+      resolverValidationOptions: { requireResolversToMatchSchema: "ignore" },
     });
   }
 
   #makeYogaHandler(
     yoga: ReturnType<typeof createYoga<Record<string, unknown>>>,
   ): express.RequestHandler {
+    // Use yoga.requestListener which properly chains handleNodeRequestAndResponse
+    // with sendNodeResponse. Calling handleNodeRequestAndResponse alone returns
+    // a Fetch API Response object but does not write it to the Node.js response,
+    // causing the client to hang.
     return (req, res, next) => {
-      Promise.resolve(
-        yoga.handleNodeRequestAndResponse(req, res, { req, res }),
-      ).catch((err: unknown) => next(err));
+      Promise.resolve(yoga.requestListener(req, res)).catch((err: unknown) =>
+        next(err),
+      );
     };
   }
 
@@ -637,7 +642,7 @@ export class GraphQLManager {
     });
     this.subgraphHandlers.set(superGraphPath, {
       handler: this.#makeYogaHandler(yoga),
-      matcher: match(superGraphPath + "/:rest*", { end: false }),
+      matcher: match(superGraphPath, { end: false }),
     });
 
     if (!this.initialized) {

--- a/packages/reactor-api/src/graphql/graphql-manager.ts
+++ b/packages/reactor-api/src/graphql/graphql-manager.ts
@@ -1,4 +1,4 @@
-import { mergeSchemas } from "@graphql-tools/schema";
+import { makeExecutableSchema } from "@graphql-tools/schema";
 import { createYoga } from "graphql-yoga";
 import type { IAnalyticsStore } from "@powerhousedao/analytics-engine-core";
 import type { IReactorClient, ISyncManager } from "@powerhousedao/reactor";
@@ -19,7 +19,7 @@ import type { DocumentModelModule } from "document-model";
 import type express from "express";
 import type { IRouter } from "express";
 import { Router } from "express";
-import type { GraphQLSchema } from "graphql";
+import type { DocumentNode, GraphQLSchema } from "graphql";
 import type http from "node:http";
 import path from "node:path";
 import { match, type MatchFunction, type ParamData } from "path-to-regexp";
@@ -586,17 +586,25 @@ export class GraphQLManager {
 
   #buildMergedSchema(): GraphQLSchema {
     const subgraphs = this.#getAllSubgraphs();
-    const schemas = Array.from(subgraphs.values()).map((subgraph) =>
-      createSchema(
+    if (subgraphs.size === 0) {
+      throw new Error("No subgraph schemas available to merge");
+    }
+    const allTypeDefs: DocumentNode[] = [];
+    const allResolvers: Record<string, unknown>[] = [];
+    for (const subgraph of subgraphs.values()) {
+      const mod = buildSubgraphSchemaModule(
         this.cachedDocumentModels,
         subgraph.resolvers,
         subgraph.typeDefs,
-      ),
-    );
-    if (schemas.length === 0) {
-      throw new Error("No subgraph schemas available to merge");
+      );
+      allTypeDefs.push(mod.typeDefs);
+      allResolvers.push(mod.resolvers);
     }
-    return mergeSchemas({ schemas });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return makeExecutableSchema({
+      typeDefs: allTypeDefs,
+      resolvers: allResolvers as any,
+    });
   }
 
   #makeYogaHandler(

--- a/packages/reactor-api/src/graphql/graphql-manager.ts
+++ b/packages/reactor-api/src/graphql/graphql-manager.ts
@@ -1,20 +1,5 @@
-import type {
-  GetDataSourceFunction,
-  GraphQLDataSourceProcessOptions,
-  ServiceDefinition,
-  SubgraphHealthCheckFunction,
-  SupergraphSdlUpdateFunction,
-} from "@apollo/gateway";
-import {
-  ApolloGateway,
-  LocalCompose,
-  RemoteGraphQLDataSource,
-} from "@apollo/gateway";
-import { ApolloServer } from "@apollo/server";
-import { ApolloServerPluginInlineTraceDisabled } from "@apollo/server/plugin/disabled";
-import { ApolloServerPluginDrainHttpServer } from "@apollo/server/plugin/drainHttpServer";
-import { ApolloServerPluginLandingPageLocalDefault } from "@apollo/server/plugin/landingPage/default";
-import { expressMiddleware } from "@as-integrations/express4";
+import { mergeSchemas } from "@graphql-tools/schema";
+import { createYoga } from "graphql-yoga";
 import type { IAnalyticsStore } from "@powerhousedao/analytics-engine-core";
 import type { IReactorClient, ISyncManager } from "@powerhousedao/reactor";
 import type {
@@ -37,7 +22,6 @@ import { Router } from "express";
 import type { GraphQLSchema } from "graphql";
 import type http from "node:http";
 import path from "node:path";
-import { setTimeout } from "node:timers/promises";
 import { match, type MatchFunction, type ParamData } from "path-to-regexp";
 import type { WebSocketServer } from "ws";
 import type { AuthConfig } from "../services/auth.service.js";
@@ -50,18 +34,6 @@ import {
 } from "../utils/create-schema.js";
 import { DocumentModelSubgraph } from "./document-model-subgraph.js";
 import { useServer } from "./websocket.js";
-
-class AuthenticatedDataSource extends RemoteGraphQLDataSource {
-  willSendRequest(options: GraphQLDataSourceProcessOptions) {
-    const { authorization } = options.context.headers as {
-      authorization: string;
-    };
-    // console.log("context", options.context.headers.authorization);
-    if (authorization && options?.request.http) {
-      options.request.http.headers.set("authorization", authorization);
-    }
-  }
-}
 
 const DOCUMENT_MODELS_TO_EXCLUDE: string[] = [];
 
@@ -129,8 +101,6 @@ export class GraphQLManager {
   private readonly subgraphs = new Map<string, ISubgraph[]>();
   private authService: AuthService | null = null;
 
-  private coreApolloServer: ApolloServer<Context> | null = null;
-  private readonly subgraphServers = new Map<string, ApolloServer<Context>>();
   private readonly subgraphHandlers = new Map<
     string,
     {
@@ -142,20 +112,9 @@ export class GraphQLManager {
     string,
     { dispose: () => void | Promise<void> }
   >();
-  private gatewayOptions: {
-    update: SupergraphSdlUpdateFunction;
-    healthCheck: SubgraphHealthCheckFunction;
-    getDataSource: GetDataSourceFunction;
-  } | null = null;
 
   /** Cached document models for schema generation - updated on init and regenerate */
   private cachedDocumentModels: DocumentModelModule[] = [];
-
-  private readonly apolloLogger = childLogger([
-    "reactor-api",
-    "graphql-manager",
-    "apollo",
-  ]);
 
   constructor(
     private readonly path: string,
@@ -232,7 +191,7 @@ export class GraphQLManager {
       await this.#setupDocumentModelSubgraphs("graphql", models);
     }
 
-    await this.#createApolloGateway();
+    await this.#setupSupergraph();
 
     return this.updateRouter();
   }
@@ -414,15 +373,12 @@ export class GraphQLManager {
 
     await this.#setupSubgraphs(this.subgraphs);
 
-    // Update Apollo Gateway's supergraph when subgraphs change
-    if (this.gatewayOptions) {
-      try {
-        const { supergraphSdl } = await this.#buildSupergrahSdl();
-        this.gatewayOptions.update(supergraphSdl);
-        this.logger.debug("Updated Apollo Gateway supergraph");
-      } catch (error) {
-        this.logger.error("Failed to update Apollo Gateway supergraph", error);
-      }
+    // Rebuild the merged supergraph when subgraphs change
+    try {
+      this.#buildMergedSupergraph();
+      this.logger.debug("Rebuilt merged supergraph");
+    } catch (error) {
+      this.logger.error("Failed to rebuild merged supergraph", error);
     }
   }
 
@@ -482,29 +438,21 @@ export class GraphQLManager {
     });
   }
 
-  async #createApolloServer(schema: GraphQLSchema) {
-    const server = new ApolloServer<Context>({
+  #createYogaServer(schema: GraphQLSchema) {
+    const relationalDb = this.relationalDb;
+    const getFields = this.getAdditionalContextFields.bind(this);
+    return createYoga<Record<string, unknown>>({
       schema,
-      logger: this.apolloLogger,
-      introspection: true,
-      plugins: [
-        ApolloServerPluginInlineTraceDisabled(),
-        ApolloServerPluginLandingPageLocalDefault(),
-      ],
+      graphiql: true,
+      logging: false,
+      context: ({ req }: { req?: express.Request }) =>
+        Promise.resolve({
+          headers: req?.headers ?? {},
+          driveId: req?.params?.drive,
+          db: relationalDb,
+          ...getFields(),
+        }),
     });
-    server.startInBackgroundHandlingStartupErrorsByLoggingAndFailingAllRequests();
-    await this.#waitForServer(server);
-    return server;
-  }
-
-  async #waitForServer(server: ApolloServer<Context>): Promise<boolean> {
-    try {
-      server.assertStarted("waitForServer");
-      return true;
-    } catch {
-      await setTimeout(100);
-      return this.#waitForServer(server);
-    }
   }
 
   #getSubgraphPath(subgraph: ISubgraph, supergraph: string) {
@@ -535,12 +483,7 @@ export class GraphQLManager {
             subgraph.typeDefs,
           );
 
-          // create and start apollo server
-          const existingServer = this.subgraphServers.get(subgraphPath);
-          const server =
-            existingServer || (await this.#createApolloServer(schema));
-
-          this.subgraphServers.set(subgraphPath, server);
+          const server = this.#createYogaServer(schema);
 
           if (subgraph.hasSubscriptions) {
             try {
@@ -571,7 +514,7 @@ export class GraphQLManager {
             }
           }
 
-          this.#setupApolloExpressMiddleware(server, subgraphPath);
+          this.#setupYogaExpressMiddleware(server, subgraphPath);
         } catch (error) {
           this.logger.error(
             "Failed to setup subgraph @name at path @path: @error",
@@ -641,89 +584,71 @@ export class GraphQLManager {
     this.logger.info(`Registered REST endpoint: GET ${routePath}`);
   }
 
-  #buildSubgraphSchemaModule(subgraph: ISubgraph) {
-    return buildSubgraphSchemaModule(
-      this.cachedDocumentModels,
-      subgraph.resolvers,
-      subgraph.typeDefs,
-    );
-  }
-
-  async #buildSupergrahSdl() {
-    if (!this.gatewayOptions) {
-      throw new Error("Gateway is not ready");
-    }
+  #buildMergedSchema(): GraphQLSchema {
     const subgraphs = this.#getAllSubgraphs();
-
-    const herokuOrLocal = process.env.HEROKU_APP_DEFAULT_DOMAIN_NAME
-      ? `https://${process.env.HEROKU_APP_DEFAULT_DOMAIN_NAME}`
-      : `http://localhost:${this.port}`;
-
-    const serviceList: ServiceDefinition[] = Array.from(
-      subgraphs.entries(),
-    ).map(([path, subgraph]) => ({
-      name: path.replace("/", ":"),
-      typeDefs: this.#buildSubgraphSchemaModule(subgraph).typeDefs,
-      url: `${herokuOrLocal}${path}`,
-    }));
-
-    const localCompose = new LocalCompose({
-      localServiceList: serviceList,
-    });
-    return await localCompose.initialize(this.gatewayOptions!);
+    const schemas = Array.from(subgraphs.values()).map((subgraph) =>
+      createSchema(
+        this.cachedDocumentModels,
+        subgraph.resolvers,
+        subgraph.typeDefs,
+      ),
+    );
+    if (schemas.length === 0) {
+      throw new Error("No subgraph schemas available to merge");
+    }
+    return mergeSchemas({ schemas });
   }
 
-  async #createApolloGateway() {
-    const gateway = new ApolloGateway({
-      supergraphSdl: async (options) => {
-        this.gatewayOptions = options;
-        return await this.#buildSupergrahSdl();
-      },
-      buildService: (serviceConfig) => {
-        return new AuthenticatedDataSource(serviceConfig);
-      },
-    });
+  #makeYogaHandler(
+    yoga: ReturnType<typeof createYoga<Record<string, unknown>>>,
+  ): express.RequestHandler {
+    return (req, res, next) => {
+      Promise.resolve(
+        yoga.handleNodeRequestAndResponse(req, res, { req, res }),
+      ).catch((err: unknown) => next(err));
+    };
+  }
 
-    if (this.coreApolloServer) {
-      throw new Error("Supergrah server is already running");
-    }
-
-    this.coreApolloServer = new ApolloServer<Context>({
-      gateway,
-      logger: this.apolloLogger,
-      introspection: true,
-      plugins: [
-        ApolloServerPluginDrainHttpServer({ httpServer: this.httpServer }),
-        ApolloServerPluginInlineTraceDisabled(),
-        ApolloServerPluginLandingPageLocalDefault(),
-      ],
-    });
-
-    await this.coreApolloServer.start();
-    await this.#waitForServer(this.coreApolloServer);
-
+  #buildMergedSupergraph() {
     const superGraphPath = path.join(this.path, "graphql");
-    this.#setupApolloExpressMiddleware(this.coreApolloServer, superGraphPath);
+    const mergedSchema = this.#buildMergedSchema();
+    const relationalDb = this.relationalDb;
+    const getFields = this.getAdditionalContextFields.bind(this);
+    const yoga = createYoga<Record<string, unknown>>({
+      schema: mergedSchema,
+      graphiql: true,
+      logging: false,
+      graphqlEndpoint: superGraphPath,
+      context: ({ req }: { req?: express.Request }) =>
+        Promise.resolve({
+          headers: req?.headers ?? {},
+          driveId: req?.params?.drive,
+          db: relationalDb,
+          ...getFields(),
+        }),
+    });
+    this.subgraphHandlers.set(superGraphPath, {
+      handler: this.#makeYogaHandler(yoga),
+      matcher: match(superGraphPath + "/:rest*", { end: false }),
+    });
 
     if (!this.initialized) {
-      this.logger.info(`Registered ${superGraphPath} supergraph `);
+      this.logger.info(`Registered ${superGraphPath} supergraph`);
       this.initialized = true;
     }
-    return;
   }
 
-  #setupApolloExpressMiddleware(server: ApolloServer<Context>, path: string) {
-    this.subgraphHandlers.set(path, {
-      handler: expressMiddleware(server, {
-        context: ({ req }) =>
-          Promise.resolve<Context>({
-            headers: req.headers,
-            driveId: req.params.drive ?? undefined,
-            db: this.relationalDb,
-            ...this.getAdditionalContextFields(),
-          }),
-      }),
-      matcher: match(path),
+  async #setupSupergraph() {
+    this.#buildMergedSupergraph();
+  }
+
+  #setupYogaExpressMiddleware(
+    yoga: ReturnType<typeof createYoga<Record<string, unknown>>>,
+    yogaPath: string,
+  ) {
+    this.subgraphHandlers.set(yogaPath, {
+      handler: this.#makeYogaHandler(yoga),
+      matcher: match(yogaPath),
     });
   }
 }

--- a/packages/reactor-api/src/graphql/reactor/subgraph.ts
+++ b/packages/reactor-api/src/graphql/reactor/subgraph.ts
@@ -351,19 +351,38 @@ export class ReactorSubgraph extends BaseSubgraph {
 
       mutateDocumentAsync: async (_parent, args, ctx: Context) => {
         this.logger.debug("mutateDocumentAsync(@args)", args);
+        const t0 = performance.now();
         try {
           if (!this.authorizationService) {
             await this.assertCanWrite(args.documentIdentifier, ctx);
           }
 
+          const t1 = performance.now();
           // Check operation-level permissions for each action
           await this.assertCanExecuteOperations(
             args.documentIdentifier,
             args.actions,
             ctx,
           );
+          const t2 = performance.now();
 
-          return await resolvers.mutateDocumentAsync(this.reactorClient, args);
+          const result = await resolvers.mutateDocumentAsync(
+            this.reactorClient,
+            args,
+          );
+          const t3 = performance.now();
+
+          this.logger.debug(
+            "mutateDocumentAsync timing: authCheck=@authCheck ms assertOps=@assertOps ms execute=@execute ms total=@total ms",
+            {
+              authCheck: (t1 - t0).toFixed(2),
+              assertOps: (t2 - t1).toFixed(2),
+              execute: (t3 - t2).toFixed(2),
+              total: (t3 - t0).toFixed(2),
+            },
+          );
+
+          return result;
         } catch (error) {
           this.logger.error(
             "Error in mutateDocumentAsync(@args): @Error",

--- a/packages/reactor-api/src/server.ts
+++ b/packages/reactor-api/src/server.ts
@@ -26,7 +26,7 @@ import {
   createRelationalDbLegacy,
   ProcessorManagerLegacy,
 } from "document-drive";
-import type { DocumentModelModule } from "document-model";
+import type { Action, DocumentModelModule } from "document-model";
 import type { Express } from "express";
 import express from "express";
 import type { Kysely } from "kysely";
@@ -622,6 +622,42 @@ async function _setupAPI(
     options.https,
     logger,
   );
+
+  // Diagnostic endpoint: bypasses Apollo/GraphQL entirely to isolate latency.
+  // POST /reactor/mutate-async
+  // Body: { documentId: string, branch?: string, actions: unknown[] }
+  // Response: { jobId: string, durationMs: number }
+  app.post("/reactor/mutate-async", express.json(), async (req, res) => {
+    const t0 = performance.now();
+    const body = req.body as {
+      documentId?: unknown;
+      branch?: unknown;
+      actions?: unknown;
+    };
+
+    if (typeof body.documentId !== "string" || !Array.isArray(body.actions)) {
+      res.status(400).json({
+        error: "documentId (string) and actions (array) are required",
+      });
+      return;
+    }
+
+    const branch = typeof body.branch === "string" ? body.branch : "main";
+
+    try {
+      const job = await reactorClient.executeAsync(
+        body.documentId,
+        branch,
+        body.actions as Action[],
+      );
+      res.json({ jobId: job.id, durationMs: performance.now() - t0 });
+    } catch (error) {
+      res.status(500).json({
+        error: error instanceof Error ? error.message : "Unknown error",
+        durationMs: performance.now() - t0,
+      });
+    }
+  });
 
   // set up subgraph manager
   const coreSubgraphs: SubgraphClass[] = DefaultCoreSubgraphs.slice();

--- a/packages/reactor-api/src/server.ts
+++ b/packages/reactor-api/src/server.ts
@@ -624,6 +624,43 @@ async function _setupAPI(
   );
 
   // Diagnostic endpoint: bypasses Apollo/GraphQL entirely to isolate latency.
+  // POST /reactor/mutate
+  // Body: { documentId: string, branch?: string, actions: unknown[] }
+  // Response: { durationMs: number }
+  // Calls execute() and waits for full completion (equivalent to sync GraphQL mutation).
+  app.post("/reactor/mutate", express.json(), async (req, res) => {
+    const t0 = performance.now();
+    const body = req.body as {
+      documentId?: unknown;
+      branch?: unknown;
+      actions?: unknown;
+    };
+
+    if (typeof body.documentId !== "string" || !Array.isArray(body.actions)) {
+      res.status(400).json({
+        error: "documentId (string) and actions (array) are required",
+      });
+      return;
+    }
+
+    const branch = typeof body.branch === "string" ? body.branch : "main";
+
+    try {
+      await reactorClient.execute(
+        body.documentId,
+        branch,
+        body.actions as Action[],
+      );
+      res.json({ durationMs: performance.now() - t0 });
+    } catch (error) {
+      res.status(500).json({
+        error: error instanceof Error ? error.message : "Unknown error",
+        durationMs: performance.now() - t0,
+      });
+    }
+  });
+
+  // Diagnostic endpoint: bypasses Apollo/GraphQL entirely to isolate latency.
   // POST /reactor/mutate-async
   // Body: { documentId: string, branch?: string, actions: unknown[] }
   // Response: { jobId: string, durationMs: number }

--- a/packages/reactor-api/src/utils/create-schema.ts
+++ b/packages/reactor-api/src/utils/create-schema.ts
@@ -1,8 +1,4 @@
-import { buildSubgraphSchema } from "@apollo/subgraph";
-import type {
-  GraphQLResolverMap,
-  GraphQLSchemaModule,
-} from "@apollo/subgraph/dist/schema-helper/resolverMap.js";
+import { makeExecutableSchema } from "@graphql-tools/schema";
 import { typeDefs as scalarsTypeDefs } from "@powerhousedao/document-engineering/graphql";
 import type { Context } from "@powerhousedao/reactor-api";
 import { camelCase, pascalCase } from "change-case";
@@ -41,9 +37,9 @@ const stripScalarDefinitions = (doc: DocumentNode): string => {
 
 export const buildSubgraphSchemaModule = (
   documentModels: DocumentModelModule[],
-  resolvers: GraphQLResolverMap<Context>,
+  resolvers: Record<string, unknown>,
   typeDefs: DocumentNode,
-): GraphQLSchemaModule => {
+): { typeDefs: DocumentNode; resolvers: Record<string, unknown> } => {
   const newResolvers = {
     ...resolvers,
     JSONObject: GraphQLJSONObject,
@@ -54,14 +50,18 @@ export const buildSubgraphSchemaModule = (
     resolvers: newResolvers,
   };
 };
+
 export const createSchema = (
   documentModels: DocumentModelModule[],
-  resolvers: GraphQLResolverMap<Context>,
+  resolvers: Record<string, unknown>,
   typeDefs: DocumentNode,
 ) => {
-  return buildSubgraphSchema(
-    buildSubgraphSchemaModule(documentModels, resolvers, typeDefs),
-  );
+  const module = buildSubgraphSchemaModule(documentModels, resolvers, typeDefs);
+  return makeExecutableSchema({
+    typeDefs: module.typeDefs,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolvers: module.resolvers as any,
+  });
 };
 
 export function getDocumentModelSchemaName(

--- a/packages/reactor-api/src/utils/create-schema.ts
+++ b/packages/reactor-api/src/utils/create-schema.ts
@@ -51,6 +51,15 @@ export const buildSubgraphSchemaModule = (
   };
 };
 
+// Minimal base SDL so that `extend type Query/Mutation/Subscription` in
+// individual subgraph schemas doesn't cause "type not defined" errors when
+// building a standalone schema (e.g. for WebSocket subscription setup).
+const BASE_TYPES_SDL = gql`
+  type Query
+  type Mutation
+  type Subscription
+`;
+
 export const createSchema = (
   documentModels: DocumentModelModule[],
   resolvers: Record<string, unknown>,
@@ -58,7 +67,7 @@ export const createSchema = (
 ) => {
   const module = buildSubgraphSchemaModule(documentModels, resolvers, typeDefs);
   return makeExecutableSchema({
-    typeDefs: module.typeDefs,
+    typeDefs: [BASE_TYPES_SDL, module.typeDefs],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     resolvers: module.resolvers as any,
   });

--- a/packages/reactor-api/src/utils/create-schema.ts
+++ b/packages/reactor-api/src/utils/create-schema.ts
@@ -70,6 +70,7 @@ export const createSchema = (
     typeDefs: [BASE_TYPES_SDL, module.typeDefs],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     resolvers: module.resolvers as any,
+    resolverValidationOptions: { requireResolversToMatchSchema: "ignore" },
   });
 };
 

--- a/packages/reactor/src/storage/migrations/015_add_operation_revision_index.ts
+++ b/packages/reactor/src/storage/migrations/015_add_operation_revision_index.ts
@@ -1,0 +1,9 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createIndex("idx_operation_doc_branch_scope_index")
+    .on("Operation")
+    .columns(["documentId", "branch", "scope", "index"])
+    .execute();
+}

--- a/packages/reactor/src/storage/migrations/migrator.ts
+++ b/packages/reactor/src/storage/migrations/migrator.ts
@@ -17,6 +17,7 @@ import * as migration011 from "./011_add_cursor_type_column.js";
 import * as migration012 from "./012_add_source_remote_column.js";
 import * as migration013 from "./013_create_sync_dead_letters_table.js";
 import * as migration014 from "./014_create_processor_cursor_table.js";
+import * as migration015 from "./015_add_operation_revision_index.js";
 
 const migrations = {
   "001_create_operation_table": migration001,
@@ -33,6 +34,7 @@ const migrations = {
   "012_add_source_remote_column": migration012,
   "013_create_sync_dead_letters_table": migration013,
   "014_create_processor_cursor_table": migration014,
+  "015_add_operation_revision_index": migration015,
 };
 
 class ProgrammaticMigrationProvider implements MigrationProvider {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,12 @@ catalogs:
     '@graphql-codegen/typescript-resolvers':
       specifier: 5.1.5
       version: 5.1.5
+    '@graphql-tools/merge':
+      specifier: 9.1.7
+      version: 9.1.7
+    '@graphql-tools/schema':
+      specifier: 10.0.31
+      version: 10.0.31
     '@graphql-tools/utils':
       specifier: 11.0.0
       version: 11.0.0
@@ -135,6 +141,9 @@ catalogs:
     graphql-tag:
       specifier: 2.12.6
       version: 2.12.6
+    graphql-yoga:
+      specifier: 5.18.1
+      version: 5.18.1
     knex:
       specifier: 3.1.0
       version: 3.1.0
@@ -1779,21 +1788,18 @@ importers:
 
   packages/reactor-api:
     dependencies:
-      '@apollo/gateway':
-        specifier: ^2.11.3
-        version: 2.13.1(encoding@0.1.13)(graphql@16.12.0)
-      '@apollo/server':
-        specifier: ^5.0.0
-        version: 5.4.0(graphql@16.12.0)
-      '@apollo/subgraph':
-        specifier: ^2.11.3
-        version: 2.13.1(graphql@16.12.0)
-      '@as-integrations/express4':
-        specifier: ^1.1.2
-        version: 1.1.2(@apollo/server@5.4.0(graphql@16.12.0))(express@4.22.1)
       '@electric-sql/pglite':
         specifier: 'catalog:'
         version: 0.3.15
+      '@graphql-tools/merge':
+        specifier: 'catalog:'
+        version: 9.1.7(graphql@16.12.0)
+      '@graphql-tools/schema':
+        specifier: 'catalog:'
+        version: 10.0.31(graphql@16.12.0)
+      '@graphql-tools/utils':
+        specifier: 'catalog:'
+        version: 11.0.0(graphql@16.12.0)
       '@opentelemetry/auto-instrumentations-node':
         specifier: ^0.57.1
         version: 0.57.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
@@ -1884,6 +1890,9 @@ importers:
       graphql-ws:
         specifier: ^6.0.6
         version: 6.0.7(graphql@16.12.0)(ws@8.19.0)
+      graphql-yoga:
+        specifier: 'catalog:'
+        version: 5.18.1(graphql@16.12.0)
       knex:
         specifier: 'catalog:'
         version: 3.1.0(better-sqlite3@12.6.2)(mysql2@3.17.2)(mysql@2.18.1)(pg@8.18.0)(sqlite3@5.1.7)(tedious@19.2.1(@azure/core-client@1.10.1))
@@ -2877,11 +2886,6 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@apollo/cache-control-types@1.0.3':
-    resolution: {integrity: sha512-F17/vCp7QVwom9eG7ToauIKdAxpSoadsJnqIfyryLFSkLSOEqu+eC5Z3N8OXcUVStuOMcNHlyraRsA6rRICu4g==}
-    peerDependencies:
-      graphql: 14.x || 15.x || 16.x
-
   '@apollo/client@3.14.0':
     resolution: {integrity: sha512-0YQKKRIxiMlIou+SekQqdCo0ZTHxOcES+K8vKB53cIDpwABNR0P0yRzPgsbgcj3zRJniD93S/ontsnZsCLZrxQ==}
     peerDependencies:
@@ -2900,146 +2904,6 @@ packages:
       subscriptions-transport-ws:
         optional: true
 
-  '@apollo/composition@2.13.1':
-    resolution: {integrity: sha512-F7FUlCspipP4GgzB4sB+49IS7aztrT9SAstQhhjDJD1HFzfqg8coY9w0IwXEOlZaANnC1wUEED+AgI69IOsp/Q==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      graphql: ^16.5.0
-
-  '@apollo/federation-internals@2.13.1':
-    resolution: {integrity: sha512-3w+pEjew3xDHTjM4INvBiy0+F/Puje7NSnH0S9WkFiiSjYDu9wwHW6yw5Frx8jN1T17lGOgAGbx1S+YTosCs6Q==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      graphql: ^16.5.0
-
-  '@apollo/gateway@2.13.1':
-    resolution: {integrity: sha512-8ZgU8kAJ8kuPmbzcIDlmBXqv3uX3r9x468G15r4UsItYCd5FTjPy/rvSCm7IBwaR9fv0R3/AIq6gFt0LNdiohg==}
-    engines: {node: '>=14.15.0'}
-    peerDependencies:
-      graphql: ^16.5.0
-
-  '@apollo/protobufjs@1.2.7':
-    resolution: {integrity: sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==}
-    hasBin: true
-
-  '@apollo/query-graphs@2.13.1':
-    resolution: {integrity: sha512-YfcwdYMCXkq8ODgZ2vGY2d7m+5i9Sjl8UygsFkVzpJUfDJCnOA35bEcs4oRCdcz3Esc1+j8Z4ORhx+4UoPsk9Q==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      graphql: ^16.5.0
-
-  '@apollo/query-planner@2.13.1':
-    resolution: {integrity: sha512-X+47w93wtR7iwY4uJ3RbN+0DYZrR8xqXYA0thKIYm5W8gqIMUeR4JRJBDvO7bqpxIN8Z+kJKmzHqkZk6HGVk7g==}
-    engines: {node: '>=14.15.0'}
-    peerDependencies:
-      graphql: ^16.5.0
-
-  '@apollo/server-gateway-interface@1.1.1':
-    resolution: {integrity: sha512-pGwCl/po6+rxRmDMFgozKQo2pbsSwE91TpsDBAOgf74CRDPXHHtM88wbwjab0wMMZh95QfR45GGyDIdhY24bkQ==}
-    deprecated: '@apollo/server-gateway-interface v1 is part of Apollo Server v4, which is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v2 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.'
-    peerDependencies:
-      graphql: 14.x || 15.x || 16.x
-
-  '@apollo/server-gateway-interface@2.0.0':
-    resolution: {integrity: sha512-3HEMD6fSantG2My3jWkb9dvfkF9vJ4BDLRjMgsnD790VINtuPaEp+h3Hg9HOHiWkML6QsOhnaRqZ+gvhp3y8Nw==}
-    peerDependencies:
-      graphql: 14.x || 15.x || 16.x
-
-  '@apollo/server@5.4.0':
-    resolution: {integrity: sha512-E0/2C5Rqp7bWCjaDh4NzYuEPDZ+dltTf2c0FI6GCKJA6GBetVferX3h1//1rS4+NxD36wrJsGGJK+xyT/M3ysg==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      graphql: ^16.11.0
-
-  '@apollo/subgraph@2.13.1':
-    resolution: {integrity: sha512-SmFYNd/0uzVt9OyyofSMydgYpzDRPF2gyVY0a32xb2RTCtnNpGnCMaOd9kN9V5Tm31Zspcbqycj1l64zMu0egQ==}
-    engines: {node: '>=14.15.0'}
-    peerDependencies:
-      graphql: ^16.5.0
-
-  '@apollo/usage-reporting-protobuf@4.1.1':
-    resolution: {integrity: sha512-u40dIUePHaSKVshcedO7Wp+mPiZsaU6xjv9J+VyxpoU/zL6Jle+9zWeG98tr/+SZ0nZ4OXhrbb8SNr0rAPpIDA==}
-
-  '@apollo/utils.createhash@2.0.2':
-    resolution: {integrity: sha512-UkS3xqnVFLZ3JFpEmU/2cM2iKJotQXMoSTgxXsfQgXLC5gR1WaepoXagmYnPSA7Q/2cmnyTYK5OgAgoC4RULPg==}
-    engines: {node: '>=14'}
-
-  '@apollo/utils.createhash@3.0.1':
-    resolution: {integrity: sha512-CKrlySj4eQYftBE5MJ8IzKwIibQnftDT7yGfsJy5KSEEnLlPASX0UTpbKqkjlVEwPPd4mEwI7WOM7XNxEuO05A==}
-    engines: {node: '>=16'}
-
-  '@apollo/utils.dropunuseddefinitions@2.0.1':
-    resolution: {integrity: sha512-EsPIBqsSt2BwDsv8Wu76LK5R1KtsVkNoO4b0M5aK0hx+dGg9xJXuqlr7Fo34Dl+y83jmzn+UvEW+t1/GP2melA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      graphql: 14.x || 15.x || 16.x
-
-  '@apollo/utils.fetcher@2.0.1':
-    resolution: {integrity: sha512-jvvon885hEyWXd4H6zpWeN3tl88QcWnHp5gWF5OPF34uhvoR+DFqcNxs9vrRaBBSY3qda3Qe0bdud7tz2zGx1A==}
-    engines: {node: '>=14'}
-
-  '@apollo/utils.fetcher@3.1.0':
-    resolution: {integrity: sha512-Z3QAyrsQkvrdTuHAFwWDNd+0l50guwoQUoaDQssLOjkmnmVuvXlJykqlEJolio+4rFwBnWdoY1ByFdKaQEcm7A==}
-    engines: {node: '>=16'}
-
-  '@apollo/utils.isnodelike@2.0.1':
-    resolution: {integrity: sha512-w41XyepR+jBEuVpoRM715N2ZD0xMD413UiJx8w5xnAZD2ZkSJnMJBoIzauK83kJpSgNuR6ywbV29jG9NmxjK0Q==}
-    engines: {node: '>=14'}
-
-  '@apollo/utils.isnodelike@3.0.0':
-    resolution: {integrity: sha512-xrjyjfkzunZ0DeF6xkHaK5IKR8F1FBq6qV+uZ+h9worIF/2YSzA0uoBxGv6tbTeo9QoIQnRW4PVFzGix5E7n/g==}
-    engines: {node: '>=16'}
-
-  '@apollo/utils.keyvaluecache@2.1.1':
-    resolution: {integrity: sha512-qVo5PvUUMD8oB9oYvq4ViCjYAMWnZ5zZwEjNF37L2m1u528x5mueMlU+Cr1UinupCgdB78g+egA1G98rbJ03Vw==}
-    engines: {node: '>=14'}
-
-  '@apollo/utils.keyvaluecache@4.0.0':
-    resolution: {integrity: sha512-mKw1myRUkQsGPNB+9bglAuhviodJ2L2MRYLTafCMw5BIo7nbvCPNCkLnIHjZ1NOzH7SnMAr5c9LmXiqsgYqLZw==}
-    engines: {node: '>=20'}
-
-  '@apollo/utils.logger@2.0.1':
-    resolution: {integrity: sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==}
-    engines: {node: '>=14'}
-
-  '@apollo/utils.logger@3.0.0':
-    resolution: {integrity: sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg==}
-    engines: {node: '>=16'}
-
-  '@apollo/utils.printwithreducedwhitespace@2.0.1':
-    resolution: {integrity: sha512-9M4LUXV/fQBh8vZWlLvb/HyyhjJ77/I5ZKu+NBWV/BmYGyRmoEP9EVAy7LCVoY3t8BDcyCAGfxJaLFCSuQkPUg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      graphql: 14.x || 15.x || 16.x
-
-  '@apollo/utils.removealiases@2.0.1':
-    resolution: {integrity: sha512-0joRc2HBO4u594Op1nev+mUF6yRnxoUH64xw8x3bX7n8QBDYdeYgY4tF0vJReTy+zdn2xv6fMsquATSgC722FA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      graphql: 14.x || 15.x || 16.x
-
-  '@apollo/utils.sortast@2.0.1':
-    resolution: {integrity: sha512-eciIavsWpJ09za1pn37wpsCGrQNXUhM0TktnZmHwO+Zy9O4fu/WdB4+5BvVhFiZYOXvfjzJUcc+hsIV8RUOtMw==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      graphql: 14.x || 15.x || 16.x
-
-  '@apollo/utils.stripsensitiveliterals@2.0.1':
-    resolution: {integrity: sha512-QJs7HtzXS/JIPMKWimFnUMK7VjkGQTzqD9bKD1h3iuPAqLsxd0mUNVbkYOPTsDhUKgcvUOfOqOJWYohAKMvcSA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      graphql: 14.x || 15.x || 16.x
-
-  '@apollo/utils.usagereporting@2.1.0':
-    resolution: {integrity: sha512-LPSlBrn+S17oBy5eWkrRSGb98sWmnEzo3DPTZgp8IQc8sJe0prDgDuppGq4NeQlpoqEHz0hQeYHAOA0Z3aQsxQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      graphql: 14.x || 15.x || 16.x
-
-  '@apollo/utils.withrequired@3.0.0':
-    resolution: {integrity: sha512-aaxeavfJ+RHboh7c2ofO5HHtQobGX4AgUujXP4CXpREHp9fQ9jPi6K9T1jrAKe7HIipoP0OJ1gd6JamSkFIpvA==}
-    engines: {node: '>=16'}
-
   '@ardatan/relay-compiler@12.0.0':
     resolution: {integrity: sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==}
     hasBin: true
@@ -3051,13 +2915,6 @@ packages:
     hasBin: true
     peerDependencies:
       graphql: '*'
-
-  '@as-integrations/express4@1.1.2':
-    resolution: {integrity: sha512-PGeMcwoOKdYnZ4LtsmM7aLNoel3tbK8wKnfyahdRau1qb7wLbuaXB35zg3w34Ov4bm3WJtO3yzd8Bw5jVE+aIQ==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@apollo/server': ^4.0.0 || ^5.0.0
-      express: ^4.0.0
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -4945,10 +4802,6 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
-  '@gar/promise-retry@1.0.2':
-    resolution: {integrity: sha512-Lm/ZLhDZcBECta3TmCQSngiQykFdfw+QtI1/GYMsZd4l3nG+P8WLB16XuS7WaBGLQ+9E+cOcWQsth9cayuGt8g==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
@@ -5314,6 +5167,18 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
+  '@graphql-yoga/logger@2.0.1':
+    resolution: {integrity: sha512-Nv0BoDGLMg9QBKy9cIswQ3/6aKaKjlTh87x3GiBg2Z4RrjyrM48DvOOK0pJh1C1At+b0mUIM67cwZcFTDLN4sA==}
+    engines: {node: '>=18.0.0'}
+
+  '@graphql-yoga/subscription@5.0.5':
+    resolution: {integrity: sha512-oCMWOqFs6QV96/NZRt/ZhTQvzjkGB4YohBOpKM4jH/lDT4qb7Lex/aGCxpi/JD9njw3zBBtMqxbaC22+tFHVvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@graphql-yoga/typed-event-target@3.0.2':
+    resolution: {integrity: sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA==}
+    engines: {node: '>=18.0.0'}
+
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
     engines: {node: '>=12.10.0'}
@@ -5660,9 +5525,6 @@ packages:
     resolution: {integrity: sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@josephg/resolvable@1.0.1':
-    resolution: {integrity: sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==}
-
   '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0':
     resolution: {integrity: sha512-qYDdL7fPwLRI+bJNurVcis+tNgJmvWjH4YTBGXTA8xMuxFrnAz6E5o35iyzyKbq5J5Lr8mJGfrR5GXl+WGwhgQ==}
     peerDependencies:
@@ -5955,16 +5817,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@npmcli/agent@4.0.0':
-    resolution: {integrity: sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   '@npmcli/fs@1.1.1':
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
-
-  '@npmcli/fs@5.0.0':
-    resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@npmcli/move-file@1.1.2':
     resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
@@ -8990,9 +8844,6 @@ packages:
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
 
-  '@types/long@4.0.2':
-    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
-
   '@types/luxon@3.7.1':
     resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
 
@@ -9027,9 +8878,6 @@ packages:
 
   '@types/mysql@2.15.26':
     resolution: {integrity: sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==}
-
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
   '@types/node@17.0.45':
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
@@ -9659,6 +9507,10 @@ packages:
     resolution: {integrity: sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==}
     engines: {node: '>=18.0.0'}
 
+  '@whatwg-node/events@0.1.2':
+    resolution: {integrity: sha512-ApcWxkrs1WmEMS2CaLLFUEem/49erT3sxIVjpzU5f6zmVcnijtDSrhoK2zVobOIikZJdH63jdAXOrvjf6eOUNQ==}
+    engines: {node: '>=18.0.0'}
+
   '@whatwg-node/fetch@0.10.13':
     resolution: {integrity: sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q==}
     engines: {node: '>=18.0.0'}
@@ -9670,6 +9522,10 @@ packages:
   '@whatwg-node/promise-helpers@1.3.2':
     resolution: {integrity: sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==}
     engines: {node: '>=16.0.0'}
+
+  '@whatwg-node/server@0.10.18':
+    resolution: {integrity: sha512-kMwLlxUbduttIgaPdSkmEarFpP+mSY8FEm+QWMBRJwxOHWkri+cxd8KZHO9EMrB9vgUuz+5WEaCawaL5wGVoXg==}
+    engines: {node: '>=18.0.0'}
 
   '@wry/caches@1.0.1':
     resolution: {integrity: sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==}
@@ -10038,9 +9894,6 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
-
-  async-retry@1.3.3:
-    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -10489,10 +10342,6 @@ packages:
   cacache@15.3.0:
     resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
     engines: {node: '>= 10'}
-
-  cacache@20.0.3:
-    resolution: {integrity: sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   cacheable-lookup@6.1.0:
     resolution: {integrity: sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==}
@@ -11431,10 +11280,6 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
-  deep-equal@2.2.3:
-    resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
-    engines: {node: '>= 0.4'}
-
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -11835,9 +11680,6 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-
-  es-get-iterator@1.1.3:
-    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
 
   es-iterator-helpers@1.2.2:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
@@ -12593,10 +12435,6 @@ packages:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
 
-  fs-minipass@3.0.3:
-    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
   fs-native-extensions@1.4.5:
     resolution: {integrity: sha512-ekV0T//iDm4AvhOcuPaHpxub4DI7HvY5ucLJVDvi7T2J+NZkQ9S6MuvgP0yeQvoqNUaAGyLjVYb1905BF9bpmg==}
 
@@ -12887,6 +12725,12 @@ packages:
         optional: true
       ws:
         optional: true
+
+  graphql-yoga@5.18.1:
+    resolution: {integrity: sha512-GiDSlvibfY/vyurbkBOKMO+adF6bTCzKr80FYWta59s1Lx87oVo8T6Nu/0hrxrGv0SrAUkqUpcpr4Ee7XlYmBw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      graphql: ^15.2.0 || ^16.0.0
 
   graphql@16.12.0:
     resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
@@ -13972,10 +13816,6 @@ packages:
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
-  js-levenshtein@1.1.6:
-    resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
-    engines: {node: '>=0.10.0'}
-
   js-md4@0.3.2:
     resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
 
@@ -14481,13 +14321,6 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
-  loglevel@1.9.2:
-    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
-    engines: {node: '>= 0.6.0'}
-
-  long@4.0.0:
-    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
-
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -14578,10 +14411,6 @@ packages:
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
-
-  make-fetch-happen@15.0.4:
-    resolution: {integrity: sha512-vM2sG+wbVeVGYcCm16mM3d5fuem9oC28n436HjsGO3LcxoTI8LNVa4rwZDn3f76+cWyT4GGJDxjTYU1I2nr6zw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   make-fetch-happen@9.1.0:
     resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
@@ -14997,17 +14826,9 @@ packages:
     resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
     engines: {node: '>= 8'}
 
-  minipass-collect@2.0.1:
-    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minipass-fetch@1.4.1:
     resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
     engines: {node: '>=8'}
-
-  minipass-fetch@5.0.2:
-    resolution: {integrity: sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   minipass-flush@1.0.5:
     resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
@@ -15019,10 +14840,6 @@ packages:
 
   minipass-sized@1.0.3:
     resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
-    engines: {node: '>=8'}
-
-  minipass-sized@2.0.0:
-    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
     engines: {node: '>=8'}
 
   minipass@3.3.6:
@@ -15228,9 +15045,6 @@ packages:
   node-abi@3.87.0:
     resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
     engines: {node: '>=10'}
-
-  node-abort-controller@3.1.1:
-    resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -15584,10 +15398,6 @@ packages:
   p-map@4.0.0:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
-
-  p-map@7.0.4:
-    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
-    engines: {node: '>=18'}
 
   p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
@@ -17685,10 +17495,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  ssri@13.0.1:
-    resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   ssri@8.0.1:
     resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
     engines: {node: '>= 8'}
@@ -18238,10 +18044,6 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
 
-  ts-graphviz@1.8.2:
-    resolution: {integrity: sha512-5YhbFoHmjxa7pgQLkB07MtGnGJ/yhvjmc9uhsnDBEICME6gkPf83SBwLDQqGDoCa3XzUMWLk1AU2Wn1u1naDtA==}
-    engines: {node: '>=14.16'}
-
   ts-invariant@0.10.3:
     resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
     engines: {node: '>=8'}
@@ -18484,16 +18286,8 @@ packages:
   unique-filename@1.1.1:
     resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
 
-  unique-filename@5.0.0:
-    resolution: {integrity: sha512-2RaJTAvAb4owyjllTfXzFClJ7WsGxlykkPvCr9pA//LD9goVq+m4PPAeBgNodGZ7nSrntT/auWpJ6Y5IFXcfjg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   unique-slug@2.0.2:
     resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
-
-  unique-slug@6.0.0:
-    resolution: {integrity: sha512-4Lup7Ezn8W3d52/xBhZBVdx323ckxa7DEvd9kPQHppTkLoJXw6ltrBCyj5pnrxj0qKDxYMJ56CoxNuFCscdTiw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   unique-string@3.0.0:
     resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
@@ -19570,10 +19364,6 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@apollo/cache-control-types@1.0.3(graphql@16.12.0)':
-    dependencies:
-      graphql: 16.12.0
-
   '@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(graphql@16.12.0)(ws@8.19.0))(graphql@16.12.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
@@ -19596,196 +19386,6 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
     transitivePeerDependencies:
       - '@types/react'
-
-  '@apollo/composition@2.13.1(graphql@16.12.0)':
-    dependencies:
-      '@apollo/federation-internals': 2.13.1(graphql@16.12.0)
-      '@apollo/query-graphs': 2.13.1(graphql@16.12.0)
-      graphql: 16.12.0
-
-  '@apollo/federation-internals@2.13.1(graphql@16.12.0)':
-    dependencies:
-      '@types/uuid': 9.0.8
-      chalk: 4.1.2
-      graphql: 16.12.0
-      js-levenshtein: 1.1.6
-      uuid: 9.0.1
-
-  '@apollo/gateway@2.13.1(encoding@0.1.13)(graphql@16.12.0)':
-    dependencies:
-      '@apollo/composition': 2.13.1(graphql@16.12.0)
-      '@apollo/federation-internals': 2.13.1(graphql@16.12.0)
-      '@apollo/query-planner': 2.13.1(graphql@16.12.0)
-      '@apollo/server-gateway-interface': 1.1.1(graphql@16.12.0)
-      '@apollo/usage-reporting-protobuf': 4.1.1
-      '@apollo/utils.createhash': 2.0.2
-      '@apollo/utils.fetcher': 2.0.1
-      '@apollo/utils.isnodelike': 2.0.1
-      '@apollo/utils.keyvaluecache': 2.1.1
-      '@apollo/utils.logger': 2.0.1
-      '@josephg/resolvable': 1.0.1
-      '@opentelemetry/api': 1.9.0
-      '@types/node-fetch': 2.6.13
-      async-retry: 1.3.3
-      graphql: 16.12.0
-      loglevel: 1.9.2
-      make-fetch-happen: 15.0.4
-      node-abort-controller: 3.1.1
-      node-fetch: 2.7.0(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  '@apollo/protobufjs@1.2.7':
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
-      '@types/long': 4.0.2
-      long: 4.0.0
-
-  '@apollo/query-graphs@2.13.1(graphql@16.12.0)':
-    dependencies:
-      '@apollo/federation-internals': 2.13.1(graphql@16.12.0)
-      deep-equal: 2.2.3
-      graphql: 16.12.0
-      ts-graphviz: 1.8.2
-      uuid: 9.0.1
-
-  '@apollo/query-planner@2.13.1(graphql@16.12.0)':
-    dependencies:
-      '@apollo/federation-internals': 2.13.1(graphql@16.12.0)
-      '@apollo/query-graphs': 2.13.1(graphql@16.12.0)
-      '@apollo/utils.keyvaluecache': 2.1.1
-      chalk: 4.1.2
-      deep-equal: 2.2.3
-      graphql: 16.12.0
-      pretty-format: 29.7.0
-
-  '@apollo/server-gateway-interface@1.1.1(graphql@16.12.0)':
-    dependencies:
-      '@apollo/usage-reporting-protobuf': 4.1.1
-      '@apollo/utils.fetcher': 2.0.1
-      '@apollo/utils.keyvaluecache': 2.1.1
-      '@apollo/utils.logger': 2.0.1
-      graphql: 16.12.0
-
-  '@apollo/server-gateway-interface@2.0.0(graphql@16.12.0)':
-    dependencies:
-      '@apollo/usage-reporting-protobuf': 4.1.1
-      '@apollo/utils.fetcher': 3.1.0
-      '@apollo/utils.keyvaluecache': 4.0.0
-      '@apollo/utils.logger': 3.0.0
-      graphql: 16.12.0
-
-  '@apollo/server@5.4.0(graphql@16.12.0)':
-    dependencies:
-      '@apollo/cache-control-types': 1.0.3(graphql@16.12.0)
-      '@apollo/server-gateway-interface': 2.0.0(graphql@16.12.0)
-      '@apollo/usage-reporting-protobuf': 4.1.1
-      '@apollo/utils.createhash': 3.0.1
-      '@apollo/utils.fetcher': 3.1.0
-      '@apollo/utils.isnodelike': 3.0.0
-      '@apollo/utils.keyvaluecache': 4.0.0
-      '@apollo/utils.logger': 3.0.0
-      '@apollo/utils.usagereporting': 2.1.0(graphql@16.12.0)
-      '@apollo/utils.withrequired': 3.0.0
-      '@graphql-tools/schema': 10.0.31(graphql@16.12.0)
-      async-retry: 1.3.3
-      body-parser: 2.2.2
-      content-type: 1.0.5
-      cors: 2.8.6
-      finalhandler: 2.1.1
-      graphql: 16.12.0
-      loglevel: 1.9.2
-      lru-cache: 11.2.6
-      negotiator: 1.0.0
-      uuid: 11.1.0
-      whatwg-mimetype: 4.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@apollo/subgraph@2.13.1(graphql@16.12.0)':
-    dependencies:
-      '@apollo/cache-control-types': 1.0.3(graphql@16.12.0)
-      '@apollo/federation-internals': 2.13.1(graphql@16.12.0)
-      graphql: 16.12.0
-
-  '@apollo/usage-reporting-protobuf@4.1.1':
-    dependencies:
-      '@apollo/protobufjs': 1.2.7
-
-  '@apollo/utils.createhash@2.0.2':
-    dependencies:
-      '@apollo/utils.isnodelike': 2.0.1
-      sha.js: 2.4.12
-
-  '@apollo/utils.createhash@3.0.1':
-    dependencies:
-      '@apollo/utils.isnodelike': 3.0.0
-      sha.js: 2.4.12
-
-  '@apollo/utils.dropunuseddefinitions@2.0.1(graphql@16.12.0)':
-    dependencies:
-      graphql: 16.12.0
-
-  '@apollo/utils.fetcher@2.0.1': {}
-
-  '@apollo/utils.fetcher@3.1.0': {}
-
-  '@apollo/utils.isnodelike@2.0.1': {}
-
-  '@apollo/utils.isnodelike@3.0.0': {}
-
-  '@apollo/utils.keyvaluecache@2.1.1':
-    dependencies:
-      '@apollo/utils.logger': 2.0.1
-      lru-cache: 7.18.3
-
-  '@apollo/utils.keyvaluecache@4.0.0':
-    dependencies:
-      '@apollo/utils.logger': 3.0.0
-      lru-cache: 11.2.6
-
-  '@apollo/utils.logger@2.0.1': {}
-
-  '@apollo/utils.logger@3.0.0': {}
-
-  '@apollo/utils.printwithreducedwhitespace@2.0.1(graphql@16.12.0)':
-    dependencies:
-      graphql: 16.12.0
-
-  '@apollo/utils.removealiases@2.0.1(graphql@16.12.0)':
-    dependencies:
-      graphql: 16.12.0
-
-  '@apollo/utils.sortast@2.0.1(graphql@16.12.0)':
-    dependencies:
-      graphql: 16.12.0
-      lodash.sortby: 4.7.0
-
-  '@apollo/utils.stripsensitiveliterals@2.0.1(graphql@16.12.0)':
-    dependencies:
-      graphql: 16.12.0
-
-  '@apollo/utils.usagereporting@2.1.0(graphql@16.12.0)':
-    dependencies:
-      '@apollo/usage-reporting-protobuf': 4.1.1
-      '@apollo/utils.dropunuseddefinitions': 2.0.1(graphql@16.12.0)
-      '@apollo/utils.printwithreducedwhitespace': 2.0.1(graphql@16.12.0)
-      '@apollo/utils.removealiases': 2.0.1(graphql@16.12.0)
-      '@apollo/utils.sortast': 2.0.1(graphql@16.12.0)
-      '@apollo/utils.stripsensitiveliterals': 2.0.1(graphql@16.12.0)
-      graphql: 16.12.0
-
-  '@apollo/utils.withrequired@3.0.0': {}
 
   '@ardatan/relay-compiler@12.0.0(encoding@0.1.13)(graphql@16.12.0)':
     dependencies:
@@ -19826,11 +19426,6 @@ snapshots:
       signedsource: 1.0.0
     transitivePeerDependencies:
       - encoding
-
-  '@as-integrations/express4@1.1.2(@apollo/server@5.4.0(graphql@16.12.0))(express@4.22.1)':
-    dependencies:
-      '@apollo/server': 5.4.0(graphql@16.12.0)
-      express: 4.22.1
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -20005,7 +19600,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -20057,7 +19652,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -20850,7 +20445,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -22538,7 +22133,7 @@ snapshots:
   '@eslint/config-array@0.21.1':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -22554,7 +22149,7 @@ snapshots:
   '@eslint/eslintrc@3.3.4':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -22594,10 +22189,6 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   '@floating-ui/utils@0.2.10': {}
-
-  '@gar/promise-retry@1.0.2':
-    dependencies:
-      retry: 0.13.1
 
   '@gar/promisify@1.1.3':
     optional: true
@@ -23382,6 +22973,22 @@ snapshots:
     dependencies:
       graphql: 16.12.0
 
+  '@graphql-yoga/logger@2.0.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@graphql-yoga/subscription@5.0.5':
+    dependencies:
+      '@graphql-yoga/typed-event-target': 3.0.2
+      '@repeaterjs/repeater': 3.0.6
+      '@whatwg-node/events': 0.1.2
+      tslib: 2.8.1
+
+  '@graphql-yoga/typed-event-target@3.0.2':
+    dependencies:
+      '@repeaterjs/repeater': 3.0.6
+      tslib: 2.8.1
+
   '@grpc/grpc-js@1.14.3':
     dependencies:
       '@grpc/proto-loader': 0.8.0
@@ -24027,8 +23634,6 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@josephg/resolvable@1.0.1': {}
-
   '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       glob: 10.5.0
@@ -24412,25 +24017,11 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@npmcli/agent@4.0.0':
-    dependencies:
-      agent-base: 7.1.4
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      lru-cache: 11.2.6
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@npmcli/fs@1.1.1':
     dependencies:
       '@gar/promisify': 1.1.3
       semver: 7.7.4
     optional: true
-
-  '@npmcli/fs@5.0.0':
-    dependencies:
-      semver: 7.7.4
 
   '@npmcli/move-file@1.1.2':
     dependencies:
@@ -26259,7 +25850,7 @@ snapshots:
       '@prefresh/vite': 2.4.12(preact@10.28.4)(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.0)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       picocolors: 1.1.1
       vite: 7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-prerender-plugin: 0.5.12(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -26351,8 +25942,8 @@ snapshots:
 
   '@puppeteer/browsers@2.13.0':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      extract-zip: 2.0.1(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
+      extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
       semver: 7.7.4
@@ -26367,7 +25958,7 @@ snapshots:
   '@pyroscope/nodejs@0.4.10(express@4.22.1)':
     dependencies:
       '@datadog/pprof': 5.13.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       p-limit: 7.3.0
       regenerator-runtime: 0.14.1
       source-map: 0.7.6
@@ -26379,7 +25970,7 @@ snapshots:
   '@pyroscope/nodejs@0.4.10(express@5.2.1)':
     dependencies:
       '@datadog/pprof': 5.13.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       p-limit: 7.3.0
       regenerator-runtime: 0.14.1
       source-map: 0.7.6
@@ -27640,7 +27231,7 @@ snapshots:
       '@swc-node/sourcemap-support': 0.5.1
       '@swc/core': 1.11.31(@swc/helpers@0.5.19)
       colorette: 2.0.20
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       oxc-resolver: 5.3.0
       pirates: 4.0.7
       tslib: 2.8.1
@@ -27874,7 +27465,7 @@ snapshots:
   '@theguild/federation-composition@0.21.3(graphql@16.12.0)':
     dependencies:
       constant-case: 3.0.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       graphql: 16.12.0
       json5: 2.2.3
       lodash.sortby: 4.7.0
@@ -28092,8 +27683,6 @@ snapshots:
 
   '@types/lodash@4.17.24': {}
 
-  '@types/long@4.0.2': {}
-
   '@types/luxon@3.7.1': {}
 
   '@types/mdast@4.0.4':
@@ -28127,11 +27716,6 @@ snapshots:
   '@types/mysql@2.15.26':
     dependencies:
       '@types/node': 25.3.1
-
-  '@types/node-fetch@2.6.13':
-    dependencies:
-      '@types/node': 25.3.1
-      form-data: 4.0.5
 
   '@types/node@17.0.45': {}
 
@@ -28338,7 +27922,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -28348,7 +27932,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -28367,7 +27951,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.3(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -28382,7 +27966,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -28482,7 +28066,7 @@ snapshots:
       '@verdaccio/core': 8.0.0-next-8.29
       '@verdaccio/loaders': 8.0.0-next-8.19
       '@verdaccio/signature': 8.0.0-next-8.21
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       lodash: 4.17.21
       verdaccio-htpasswd: 13.0.0-next-8.29
     transitivePeerDependencies:
@@ -28496,7 +28080,7 @@ snapshots:
   '@verdaccio/config@8.0.0-next-8.29':
     dependencies:
       '@verdaccio/core': 8.0.0-next-8.29
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       js-yaml: 4.1.1
       lodash: 4.17.21
     transitivePeerDependencies:
@@ -28532,7 +28116,7 @@ snapshots:
     dependencies:
       '@verdaccio/core': 8.0.0-next-8.29
       '@verdaccio/logger': 8.0.0-next-8.29
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       got-cjs: 12.5.4
       handlebars: 4.7.8
     transitivePeerDependencies:
@@ -28541,7 +28125,7 @@ snapshots:
   '@verdaccio/loaders@8.0.0-next-8.19':
     dependencies:
       '@verdaccio/core': 8.0.0-next-8.29
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -28564,7 +28148,7 @@ snapshots:
       '@verdaccio/core': 8.0.0-next-8.29
       '@verdaccio/logger-prettify': 8.0.0-next-8.4
       colorette: 2.0.20
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -28589,7 +28173,7 @@ snapshots:
       '@verdaccio/config': 8.0.0-next-8.29
       '@verdaccio/core': 8.0.0-next-8.29
       '@verdaccio/url': 13.0.0-next-8.29
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       express: 4.22.1
       express-rate-limit: 5.5.1
       lodash: 4.17.21
@@ -28603,7 +28187,7 @@ snapshots:
     dependencies:
       '@verdaccio/config': 8.0.0-next-8.29
       '@verdaccio/core': 8.0.0-next-8.29
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       jsonwebtoken: 9.0.3
     transitivePeerDependencies:
       - supports-color
@@ -28614,7 +28198,7 @@ snapshots:
     dependencies:
       '@verdaccio/core': 8.0.0-next-8.29
       '@verdaccio/url': 13.0.0-next-8.29
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gunzip-maybe: 1.4.2
       tar-stream: 3.1.7
     transitivePeerDependencies:
@@ -28627,7 +28211,7 @@ snapshots:
   '@verdaccio/url@13.0.0-next-8.29':
     dependencies:
       '@verdaccio/core': 8.0.0-next-8.29
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       validator: 13.15.26
     transitivePeerDependencies:
       - supports-color
@@ -28740,7 +28324,7 @@ snapshots:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
       ast-v8-to-istanbul: 0.3.11
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
@@ -28984,6 +28568,10 @@ snapshots:
       '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
 
+  '@whatwg-node/events@0.1.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@whatwg-node/fetch@0.10.13':
     dependencies:
       '@whatwg-node/node-fetch': 0.8.5
@@ -28998,6 +28586,14 @@ snapshots:
 
   '@whatwg-node/promise-helpers@1.3.2':
     dependencies:
+      tslib: 2.8.1
+
+  '@whatwg-node/server@0.10.18':
+    dependencies:
+      '@envelop/instrumentation': 1.0.0
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/fetch': 0.10.13
+      '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
 
   '@wry/caches@1.0.1':
@@ -29105,7 +28701,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -29373,10 +28969,6 @@ snapshots:
   astring@1.9.0: {}
 
   async-function@1.0.0: {}
-
-  async-retry@1.3.3:
-    dependencies:
-      retry: 0.13.1
 
   async@3.2.6: {}
 
@@ -29786,7 +29378,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -29979,20 +29571,6 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
     optional: true
-
-  cacache@20.0.3:
-    dependencies:
-      '@npmcli/fs': 5.0.0
-      fs-minipass: 3.0.3
-      glob: 13.0.6
-      lru-cache: 11.2.6
-      minipass: 7.1.3
-      minipass-collect: 2.0.1
-      minipass-flush: 1.0.5
-      minipass-pipeline: 1.2.4
-      p-map: 7.0.4
-      ssri: 13.0.1
-      unique-filename: 5.0.0
 
   cacheable-lookup@6.1.0: {}
 
@@ -30346,7 +29924,7 @@ snapshots:
   cmd-ts@0.15.0:
     dependencies:
       chalk: 5.6.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       didyoumean: 1.2.2
       strip-ansi: 7.1.2
     transitivePeerDependencies:
@@ -31042,27 +30620,6 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
-  deep-equal@2.2.3:
-    dependencies:
-      array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.8
-      es-get-iterator: 1.1.3
-      get-intrinsic: 1.3.0
-      is-arguments: 1.2.0
-      is-array-buffer: 3.0.5
-      is-date-object: 1.1.0
-      is-regex: 1.2.1
-      is-shared-array-buffer: 1.0.4
-      isarray: 2.0.5
-      object-is: 1.1.6
-      object-keys: 1.1.1
-      object.assign: 4.1.7
-      regexp.prototype.flags: 1.5.4
-      side-channel: 1.1.0
-      which-boxed-primitive: 1.1.1
-      which-collection: 1.0.2
-      which-typed-array: 1.1.20
-
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -31149,7 +30706,7 @@ snapshots:
   detect-port@1.6.1:
     dependencies:
       address: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -31538,18 +31095,6 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-get-iterator@1.1.3:
-    dependencies:
-      call-bind: 1.0.8
-      get-intrinsic: 1.3.0
-      has-symbols: 1.1.0
-      is-arguments: 1.2.0
-      is-map: 2.0.3
-      is-set: 2.0.3
-      is-string: 1.1.1
-      isarray: 2.0.5
-      stop-iteration-iterator: 1.1.0
-
   es-iterator-helpers@1.2.2:
     dependencies:
       call-bind: 1.0.8
@@ -31683,14 +31228,14 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.25.12):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       esbuild: 0.25.12
     transitivePeerDependencies:
       - supports-color
 
   esbuild-register@3.6.0(esbuild@0.27.3):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       esbuild: 0.27.3
     transitivePeerDependencies:
       - supports-color
@@ -31895,7 +31440,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -32165,7 +31710,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -32201,6 +31746,16 @@ snapshots:
       is-extendable: 0.1.1
 
   extend@3.0.2: {}
+
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
 
   extract-zip@2.0.1(supports-color@8.1.1):
     dependencies:
@@ -32333,7 +31888,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -32485,10 +32040,6 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
-  fs-minipass@3.0.3:
-    dependencies:
-      minipass: 7.1.3
-
   fs-native-extensions@1.4.5(bare-url@2.3.2):
     dependencies:
       require-addon: 1.2.0(bare-url@2.3.2)
@@ -32612,7 +32163,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.2.0
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -32871,6 +32422,22 @@ snapshots:
       graphql: 16.12.0
     optionalDependencies:
       ws: 8.19.0
+
+  graphql-yoga@5.18.1(graphql@16.12.0):
+    dependencies:
+      '@envelop/core': 5.5.1
+      '@envelop/instrumentation': 1.0.0
+      '@graphql-tools/executor': 1.5.1(graphql@16.12.0)
+      '@graphql-tools/schema': 10.0.31(graphql@16.12.0)
+      '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
+      '@graphql-yoga/logger': 2.0.1
+      '@graphql-yoga/subscription': 5.0.5
+      '@whatwg-node/fetch': 0.10.13
+      '@whatwg-node/promise-helpers': 1.3.2
+      '@whatwg-node/server': 0.10.18
+      graphql: 16.12.0
+      lru-cache: 10.4.3
+      tslib: 2.8.1
 
   graphql@16.12.0: {}
 
@@ -33201,7 +32768,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -33209,7 +32776,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -33253,14 +32820,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -33282,7 +32849,7 @@ snapshots:
       '@types/node': 17.0.45
       chalk: 4.1.2
       change-case: 3.1.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       degit: 2.8.4
       ejs: 3.1.10
       enquirer: 2.4.1
@@ -33816,7 +33383,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -33825,7 +33392,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -34492,8 +34059,6 @@ snapshots:
 
   jose@6.1.3: {}
 
-  js-levenshtein@1.1.6: {}
-
   js-md4@0.3.2: {}
 
   js-tokens@10.0.0: {}
@@ -34987,10 +34552,6 @@ snapshots:
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
 
-  loglevel@1.9.2: {}
-
-  long@4.0.0: {}
-
   long@5.3.2: {}
 
   longest-streak@3.1.0: {}
@@ -35073,22 +34634,6 @@ snapshots:
       semver: 7.7.4
 
   make-error@1.3.6: {}
-
-  make-fetch-happen@15.0.4:
-    dependencies:
-      '@gar/promise-retry': 1.0.2
-      '@npmcli/agent': 4.0.0
-      cacache: 20.0.3
-      http-cache-semantics: 4.2.0
-      minipass: 7.1.3
-      minipass-fetch: 5.0.2
-      minipass-flush: 1.0.5
-      minipass-pipeline: 1.2.4
-      negotiator: 1.0.0
-      proc-log: 6.1.0
-      ssri: 13.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   make-fetch-happen@9.1.0:
     dependencies:
@@ -35688,7 +35233,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -35802,10 +35347,6 @@ snapshots:
       minipass: 3.3.6
     optional: true
 
-  minipass-collect@2.0.1:
-    dependencies:
-      minipass: 7.1.3
-
   minipass-fetch@1.4.1:
     dependencies:
       minipass: 3.3.6
@@ -35815,30 +35356,20 @@ snapshots:
       encoding: 0.1.13
     optional: true
 
-  minipass-fetch@5.0.2:
-    dependencies:
-      minipass: 7.1.3
-      minipass-sized: 2.0.0
-      minizlib: 3.1.0
-    optionalDependencies:
-      iconv-lite: 0.7.2
-
   minipass-flush@1.0.5:
     dependencies:
       minipass: 3.3.6
+    optional: true
 
   minipass-pipeline@1.2.4:
     dependencies:
       minipass: 3.3.6
+    optional: true
 
   minipass-sized@1.0.3:
     dependencies:
       minipass: 3.3.6
     optional: true
-
-  minipass-sized@2.0.0:
-    dependencies:
-      minipass: 7.1.3
 
   minipass@3.3.6:
     dependencies:
@@ -36061,8 +35592,6 @@ snapshots:
   node-abi@3.87.0:
     dependencies:
       semver: 7.7.4
-
-  node-abort-controller@3.1.1: {}
 
   node-addon-api@7.1.1: {}
 
@@ -36625,8 +36154,6 @@ snapshots:
     dependencies:
       aggregate-error: 3.1.0
 
-  p-map@7.0.4: {}
-
   p-queue@6.6.2:
     dependencies:
       eventemitter3: 4.0.7
@@ -36648,7 +36175,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       get-uri: 6.0.5
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -37594,7 +37121,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -37655,7 +37182,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.13.0
       chromium-bidi: 14.0.0(devtools-protocol@0.0.1566079)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       devtools-protocol: 0.0.1566079
       typed-query-selector: 2.12.1
       webdriver-bidi-protocol: 0.4.1
@@ -38333,7 +37860,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -38464,7 +37991,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -38599,7 +38126,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -38633,7 +38160,7 @@ snapshots:
     dependencies:
       '@types/debug': 4.1.12
       '@types/validator': 13.15.10
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       dottie: 2.0.7
       inflection: 1.13.4
       lodash: 4.17.23
@@ -38893,7 +38420,7 @@ snapshots:
   socks-proxy-agent@6.2.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -38902,7 +38429,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -39013,7 +38540,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -39024,7 +38551,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -39077,10 +38604,6 @@ snapshots:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
-
-  ssri@13.0.1:
-    dependencies:
-      minipass: 7.1.3
 
   ssri@8.0.1:
     dependencies:
@@ -39319,7 +38842,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.5
       formidable: 3.5.4
@@ -39676,8 +39199,6 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-graphviz@1.8.2: {}
-
   ts-invariant@0.10.3:
     dependencies:
       tslib: 2.8.1
@@ -39911,18 +39432,10 @@ snapshots:
       unique-slug: 2.0.2
     optional: true
 
-  unique-filename@5.0.0:
-    dependencies:
-      unique-slug: 6.0.0
-
   unique-slug@2.0.2:
     dependencies:
       imurmurhash: 0.1.4
     optional: true
-
-  unique-slug@6.0.0:
-    dependencies:
-      imurmurhash: 0.1.4
 
   unique-string@3.0.0:
     dependencies:
@@ -40196,7 +39709,7 @@ snapshots:
       '@verdaccio/file-locking': 13.0.0-next-8.6
       apache-md5: 1.1.8
       bcryptjs: 2.4.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.0
       unix-crypt-td-js: 1.1.4
     transitivePeerDependencies:
@@ -40225,7 +39738,7 @@ snapshots:
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       compression: 1.8.1
       cors: 2.8.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       envinfo: 7.15.0
       express: 4.22.1
       lodash: 4.17.23
@@ -40303,7 +39816,7 @@ snapshots:
   vite-node@3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -40324,7 +39837,7 @@ snapshots:
   vite-node@3.2.4(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -40400,7 +39913,7 @@ snapshots:
 
   vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -40467,7 +39980,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
@@ -40512,7 +40025,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,10 +48,12 @@ catalog:
   "@graphql-codegen/typescript-graphql-request": 6.4.0
   "@graphql-codegen/typescript-operations": 5.0.7
   "@graphql-codegen/typescript-resolvers": 5.1.5
+  "@graphql-tools/merge": 9.1.7
   "@graphql-tools/schema": 10.0.31
   "@graphql-tools/utils": 11.0.0
   "@graphql-tools/graphql-file-loader": 8.1.9
   "@graphql-tools/load": 8.1.8
+  "graphql-yoga": 5.18.1
   "@types/bun": 1.3.8
   "ts-morph": 27.0.2
   "semver": 7.7.4

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -208,6 +208,58 @@ tsx docs-create.ts 1 -o 100 -b 10 --async
 | `--percentiles`       | `-p`  | Show p50/p90/p95/p99 stats                                                  |
 | `--show-action-types` | `-a`  | Show action names in min/max timings                                        |
 
+### `docs-create-direct.ts` — Create documents bypassing Apollo/GraphQL
+
+A diagnostic variant of `docs-create.ts` that bypasses Apollo entirely. Documents are created via GraphQL, but mutations are sent directly to Express endpoints that call the reactor client with no GraphQL parsing, schema validation, or federation overhead.
+
+Use this to isolate whether observed latency growth originates inside the reactor or inside the Apollo/GraphQL stack:
+
+- If client round-trip stays flat here but grows with `docs-create.ts` → Apollo is the bottleneck.
+- If both grow → the bottleneck is inside the reactor itself.
+
+```bash
+# Basic run: 1 doc, 25 operations x 1000 loops
+tsx docs-create-direct.ts 1 -o 25 -l 1000
+
+# Async mode (fire-and-forget; polls jobStatus for E2E latency)
+tsx docs-create-direct.ts 1 -o 25 -l 1000 --async
+
+# Target an existing document
+tsx docs-create-direct.ts --doc-id abc123 -o 25 -l 100
+
+# Custom endpoints
+tsx docs-create-direct.ts 1 -o 25 --endpoint http://localhost:4001/graphql \
+  --direct-endpoint http://localhost:4001/reactor/mutate
+
+# Save output to a timestamped file
+tsx docs-create-direct.ts 1 -o 25 -l 100 --file
+
+# Show percentiles and action type names
+tsx docs-create-direct.ts 1 -o 25 -l 100 --percentiles --show-action-types
+```
+
+| Flag                  | Short | Description                                                                         |
+| --------------------- | ----- | ----------------------------------------------------------------------------------- |
+| `N` (positional)      |       | Number of documents to create (default: 1)                                          |
+| `--operations`        | `-o`  | Operations per loop (default: 0)                                                    |
+| `--op-loops`          | `-l`  | Loops per document (default: 1)                                                     |
+| `--batch-size`        | `-b`  | Operations per request (default: 1)                                                 |
+| `--doc-id`            | `-d`  | Use existing document(s), can be repeated                                           |
+| `--endpoint`          |       | GraphQL endpoint for document creation (default: `http://localhost:4001/graphql`)   |
+| `--direct-endpoint`   |       | Express sync endpoint (default: `http://localhost:4001/reactor/mutate`)             |
+| `--async`             |       | Use async endpoint; returns jobId immediately and polls `jobStatus` for E2E latency |
+| `--async-timeout`     |       | Max ms to wait for a polled job to reach terminal status (default: `30000`)         |
+| `--file`              |       | Write output to a timestamped file (default name: `docs-create-direct.txt`)         |
+| `--output`            | `-O`  | Write output to a specific file (no timestamp prefix)                               |
+| `--verbose`           | `-v`  | Show detailed per-operation timings                                                 |
+| `--percentiles`       | `-p`  | Show p50/p90/p95/p99 stats                                                          |
+| `--show-action-types` | `-a`  | Show action names in min/max timings                                                |
+
+The script uses two Express endpoints added to the reactor-api server:
+
+- `POST /reactor/mutate` — calls `execute()`, blocks until READ_READY (sync, mirrors non-async GraphQL mutation)
+- `POST /reactor/mutate-async` — calls `executeAsync()`, returns `{ jobId }` immediately (used by `--async`)
+
 ### `docs-count.ts` — Count documents (fast)
 
 Counts documents using the `totalCount` GraphQL field (single request per type).
@@ -386,6 +438,7 @@ docker compose -f scripts/profiling/docker-compose.yml up otel-collector prometh
 
 | Metric                                          | Description                                 |
 | ----------------------------------------------- | ------------------------------------------- |
+| `reactor_queue_wait_duration_milliseconds`      | Queue wait: PENDING → RUNNING               |
 | `reactor_executor_job_duration_milliseconds`    | Execution time: RUNNING → WRITE_READY       |
 | `reactor_job_total_duration_milliseconds`       | Full lifecycle: PENDING → READ_READY/FAILED |
 | `reactor_readmodel_index_duration_milliseconds` | Indexing time: WRITE_READY → READ_READY     |
@@ -418,6 +471,9 @@ histogram_quantile(0.99, rate(reactor_job_total_duration_milliseconds_bucket[30s
 histogram_quantile(0.99, rate(reactor_job_total_duration_milliseconds_bucket[2m]))
 histogram_quantile(0.50, rate(reactor_job_total_duration_milliseconds_bucket[2m]))
 
+# Average queue wait time (PENDING to RUNNING) — confirms or rules out queue-depth regressions
+rate(reactor_queue_wait_duration_milliseconds_sum[1m]) / rate(reactor_queue_wait_duration_milliseconds_count[1m])
+
 # Average executor time vs read-model indexing time
 rate(reactor_executor_job_duration_milliseconds_sum[1m]) / rate(reactor_executor_job_duration_milliseconds_count[1m])
 rate(reactor_readmodel_index_duration_milliseconds_sum[1m]) / rate(reactor_readmodel_index_duration_milliseconds_count[1m])
@@ -442,6 +498,28 @@ docker compose -f scripts/profiling/docker-compose.yml up -d --wait
 # Flame graphs: http://localhost:4040
 # Metrics:      http://localhost:9090
 ```
+
+### Isolate Apollo/GraphQL overhead vs reactor overhead
+
+Run both `docs-create.ts` and `docs-create-direct.ts` against the same switchboard to attribute latency growth to the correct layer:
+
+```bash
+# Terminal 1: start switchboard
+./scripts/profiling/switchboard-pyroscope.sh \
+  --postgres "postgresql://postgres:postgres@localhost:5432/postgres"
+
+# Terminal 2: GraphQL path (via Apollo)
+tsx docs-create.ts 1 -o 25 -l 1000 --async -p
+
+# Terminal 3: direct Express path (bypasses Apollo)
+tsx docs-create-direct.ts 1 -o 25 -l 1000 --async -p
+
+# Cleanup
+tsx docs-reset.ts
+```
+
+If `docs-create.ts` latency grows but `docs-create-direct.ts` stays flat → Apollo/GraphQL is the bottleneck.
+If both grow at the same rate → the bottleneck is inside the reactor.
 
 ### End-to-end switchboard benchmark
 

--- a/scripts/profiling/docs-create-direct.ts
+++ b/scripts/profiling/docs-create-direct.ts
@@ -3,12 +3,16 @@
  * Diagnostic variant of docs-create.ts that bypasses Apollo/GraphQL entirely.
  *
  * Documents are still created via GraphQL. Mutations are sent directly to
- * POST /reactor/mutate-async, which calls reactorClient.executeAsync() with
- * no GraphQL parsing, schema validation, or federation overhead.
+ * Express endpoints that call the reactor client with no GraphQL parsing,
+ * schema validation, or federation overhead:
  *
- * The endpoint returns { jobId, durationMs } where durationMs is the
- * server-side time inside executeAsync(). The script also records the full
- * client round-trip so both can be compared against the GraphQL path.
+ *   POST /reactor/mutate        — calls execute(), blocks until READ_READY
+ *                                 (mirrors non-async GraphQL mutation)
+ *   POST /reactor/mutate-async  — calls executeAsync(), returns jobId
+ *                                 immediately (mirrors --async GraphQL mode)
+ *
+ * --async mode derives the async endpoint from --direct-endpoint by appending
+ * "-async", so a single flag controls both.
  *
  * If client round-trip stays flat but docs-create.ts (GraphQL) grows,
  * Apollo is the bottleneck. If both grow, the bottleneck is inside the
@@ -22,7 +26,7 @@ import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
 const DEFAULT_GRAPHQL_ENDPOINT = "http://localhost:4001/graphql";
-const DEFAULT_DIRECT_ENDPOINT = "http://localhost:4001/reactor/mutate-async";
+const DEFAULT_DIRECT_ENDPOINT = "http://localhost:4001/reactor/mutate";
 const GRAPHQL_TIMEOUT_MS = 30_000;
 
 // Mirror the same action cycle as docs-create.ts, using native action format.
@@ -83,7 +87,11 @@ interface CreateDocumentResponse {
   DocumentModel_createEmptyDocument: { id: string };
 }
 
-interface DirectMutateResponse {
+interface DirectMuteSyncResponse {
+  durationMs: number;
+}
+
+interface DirectMuteAsyncResponse {
   jobId: string;
   durationMs: number;
 }
@@ -184,13 +192,13 @@ async function createDocument(client: GraphQLClient): Promise<string> {
   return DocumentModel_createEmptyDocument.id;
 }
 
-async function sendDirectMutation(
-  directEndpoint: string,
+async function sendMutate(
+  endpoint: string,
   documentId: string,
   branch: string,
   actions: unknown[],
-): Promise<DirectMutateResponse> {
-  const res = await fetch(directEndpoint, {
+): Promise<DirectMuteSyncResponse> {
+  const res = await fetch(endpoint, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ documentId, branch, actions }),
@@ -200,7 +208,26 @@ async function sendDirectMutation(
     const body = await res.text();
     throw new Error(`HTTP ${res.status}: ${body}`);
   }
-  return res.json() as Promise<DirectMutateResponse>;
+  return res.json() as Promise<DirectMuteSyncResponse>;
+}
+
+async function sendMutateAsync(
+  endpoint: string,
+  documentId: string,
+  branch: string,
+  actions: unknown[],
+): Promise<DirectMuteAsyncResponse> {
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ documentId, branch, actions }),
+    signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`HTTP ${res.status}: ${body}`);
+  }
+  return res.json() as Promise<DirectMuteAsyncResponse>;
 }
 
 type RequestDescriptor = {
@@ -240,7 +267,7 @@ function buildRequests(
 }
 
 async function performOperations(
-  directEndpoint: string,
+  syncEndpoint: string,
   documentId: string,
   docIndex: number,
   operationCount: number,
@@ -267,8 +294,8 @@ async function performOperations(
 
   for (const req of requests) {
     const t0 = performance.now();
-    const response = await sendDirectMutation(
-      directEndpoint,
+    const response = await sendMutate(
+      syncEndpoint,
       documentId,
       branch,
       req.actions,
@@ -436,12 +463,14 @@ Options:
                             (can be specified multiple times, skips document creation)
   --endpoint <url>          GraphQL endpoint for document creation and job polling
                             (default: ${DEFAULT_GRAPHQL_ENDPOINT})
-  --direct-endpoint <url>   Direct Express endpoint for mutations
+  --direct-endpoint <url>   Sync Express endpoint: POST /reactor/mutate
                             (default: ${DEFAULT_DIRECT_ENDPOINT})
+                            The async endpoint is derived automatically by
+                            appending "-async" to this URL.
   --branch <name>           Document branch (default: main)
-  --async [N]               Poll every Nth request for E2E latency via GraphQL
-                            jobStatus (default N=100). Dispatch timing is always
-                            measured; this adds READ_READY round-trip measurement.
+  --async [N]               Use POST /reactor/mutate-async and poll every Nth
+                            request for E2E latency via GraphQL jobStatus
+                            (default N=100).
   --async-timeout <ms>      Max ms to wait for a polled job to reach a terminal
                             status (default: 30000)
   --verbose, -v             Show detailed per-request timings
@@ -641,9 +670,15 @@ async function main() {
     console.log(
       `GraphQL endpoint (doc creation / job polling): ${graphqlEndpoint}`,
     );
-    console.log(
-      `Direct endpoint  (mutations):                  ${directEndpoint}`,
-    );
+    if (asyncMutate) {
+      console.log(
+        `Direct endpoint  (mutations, async):           ${directEndpoint}-async`,
+      );
+    } else {
+      console.log(
+        `Direct endpoint  (mutations, sync):            ${directEndpoint}`,
+      );
+    }
 
     const gqlClient = new GraphQLClient(graphqlEndpoint);
     const useExistingDocs = docIds.length > 0;
@@ -735,8 +770,8 @@ async function main() {
             for (const req of requests) {
               globalReqNum++;
               const dispatchedAt = performance.now();
-              const response = await sendDirectMutation(
-                directEndpoint,
+              const response = await sendMutateAsync(
+                directEndpoint + "-async",
                 docId,
                 branch,
                 req.actions,
@@ -842,7 +877,7 @@ async function main() {
             };
 
             const result = await performOperations(
-              directEndpoint,
+              directEndpoint, // sync endpoint: /reactor/mutate
               docId,
               docNum,
               operations,

--- a/scripts/profiling/docs-create-direct.ts
+++ b/scripts/profiling/docs-create-direct.ts
@@ -252,7 +252,11 @@ function buildRequests(
 
     for (let j = i; j < batchEnd; j++) {
       const config = ACTION_CONFIGS[(j + 1) % ACTION_CONFIGS.length];
-      actions.push(config.buildAction(docIndex, j + 1));
+      actions.push({
+        id: crypto.randomUUID(),
+        timestampUtcMs: new Date().toISOString(),
+        ...config.buildAction(docIndex, j + 1),
+      });
       actionTypes.push(config.name);
     }
 

--- a/scripts/profiling/docs-create-direct.ts
+++ b/scripts/profiling/docs-create-direct.ts
@@ -1,0 +1,761 @@
+#!/usr/bin/env tsx
+/**
+ * Diagnostic variant of docs-create.ts that bypasses Apollo/GraphQL entirely.
+ *
+ * Documents are still created via GraphQL. Mutations are sent directly to
+ * POST /reactor/mutate-async, which calls reactorClient.executeAsync() with
+ * no GraphQL parsing, schema validation, or federation overhead.
+ *
+ * The endpoint returns { jobId, durationMs } where durationMs is the
+ * server-side time inside executeAsync(). The script also records the full
+ * client round-trip so both can be compared to the GraphQL path.
+ *
+ * If client round-trip stays flat but the GraphQL path grows, Apollo is the
+ * bottleneck. If both grow, the bottleneck is inside the reactor itself.
+ *
+ * Usage: tsx docs-create-direct.ts [N] [options]
+ */
+
+import { GraphQLClient } from "graphql-request";
+import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+const DEFAULT_GRAPHQL_ENDPOINT = "http://localhost:4001/graphql";
+const DEFAULT_DIRECT_ENDPOINT = "http://localhost:4001/reactor/mutate-async";
+const GRAPHQL_TIMEOUT_MS = 30_000;
+
+// Mirror the same action cycle as docs-create.ts, using native action format.
+const ACTION_CONFIGS = [
+  {
+    name: "setModelName",
+    buildAction: (docIndex: number, opIndex: number) => ({
+      type: "SET_MODEL_NAME",
+      scope: "global",
+      input: { name: `Model-${docIndex}-op${opIndex}` },
+    }),
+  },
+  {
+    name: "setModelDescription",
+    buildAction: (docIndex: number, opIndex: number) => ({
+      type: "SET_MODEL_DESCRIPTION",
+      scope: "global",
+      input: {
+        description: `Description for document ${docIndex}, operation ${opIndex}`,
+      },
+    }),
+  },
+  {
+    name: "setAuthorName",
+    buildAction: (docIndex: number, opIndex: number) => ({
+      type: "SET_AUTHOR_NAME",
+      scope: "global",
+      input: { authorName: `Author-${docIndex}-op${opIndex}` },
+    }),
+  },
+  {
+    name: "setAuthorWebsite",
+    buildAction: (docIndex: number, opIndex: number) => ({
+      type: "SET_AUTHOR_WEBSITE",
+      scope: "global",
+      input: { authorWebsite: `https://example-${docIndex}-${opIndex}.com` },
+    }),
+  },
+  {
+    name: "setModelExtension",
+    buildAction: (_docIndex: number, opIndex: number) => ({
+      type: "SET_MODEL_EXTENSION",
+      scope: "global",
+      input: { extension: `.ext${opIndex}` },
+    }),
+  },
+  {
+    name: "setModelId",
+    buildAction: (docIndex: number, opIndex: number) => ({
+      type: "SET_MODEL_ID",
+      scope: "global",
+      input: { id: `org/model-${docIndex}-v${opIndex}` },
+    }),
+  },
+];
+
+interface CreateDocumentResponse {
+  DocumentModel_createEmptyDocument: { id: string };
+}
+
+interface DirectMutateResponse {
+  jobId: string;
+  durationMs: number;
+}
+
+interface MemoryStats {
+  heapUsed: number;
+  heapTotal: number;
+  rss: number;
+}
+
+interface Percentiles {
+  p50: number;
+  p90: number;
+  p95: number;
+  p99: number;
+}
+
+interface RequestTiming {
+  reqIndex: number;
+  clientMs: number;
+  serverMs: number;
+  actionType: string;
+}
+
+interface LoopResult {
+  minClient: RequestTiming | null;
+  maxClient: RequestTiming | null;
+  minServer: RequestTiming | null;
+  maxServer: RequestTiming | null;
+  clientDurations: number[];
+  serverDurations: number[];
+}
+
+function getMemoryStats(): MemoryStats {
+  const mem = process.memoryUsage();
+  return { heapUsed: mem.heapUsed, heapTotal: mem.heapTotal, rss: mem.rss };
+}
+
+function formatBytes(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+function formatMemory(stats: MemoryStats): string {
+  return `heap: ${formatBytes(stats.heapUsed)}/${formatBytes(stats.heapTotal)}, rss: ${formatBytes(stats.rss)}`;
+}
+
+function calculatePercentiles(durations: number[]): Percentiles | null {
+  if (durations.length === 0) return null;
+  const sorted = [...durations].sort((a, b) => a - b);
+  const percentile = (p: number): number => {
+    const pos = (p / 100) * (sorted.length - 1);
+    const lower = Math.floor(pos);
+    const upper = Math.ceil(pos);
+    const weight = pos - lower;
+    if (lower === upper) return sorted[lower];
+    return Math.round(sorted[lower] * (1 - weight) + sorted[upper] * weight);
+  };
+  return {
+    p50: percentile(50),
+    p90: percentile(90),
+    p95: percentile(95),
+    p99: percentile(99),
+  };
+}
+
+function formatPercentiles(p: Percentiles): string {
+  return `p50: ${p.p50}ms, p90: ${p.p90}ms, p95: ${p.p95}ms, p99: ${p.p99}ms`;
+}
+
+async function createDocument(client: GraphQLClient): Promise<string> {
+  const { DocumentModel_createEmptyDocument } =
+    await client.request<CreateDocumentResponse>({
+      document: `mutation CreateDocument { DocumentModel_createEmptyDocument { id } }`,
+      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
+    });
+  return DocumentModel_createEmptyDocument.id;
+}
+
+async function sendDirectMutation(
+  directEndpoint: string,
+  documentId: string,
+  branch: string,
+  actions: unknown[],
+): Promise<DirectMutateResponse> {
+  const res = await fetch(directEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ documentId, branch, actions }),
+    signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`HTTP ${res.status}: ${body}`);
+  }
+  return res.json() as Promise<DirectMutateResponse>;
+}
+
+async function performDirectOperations(
+  directEndpoint: string,
+  documentId: string,
+  docIndex: number,
+  operationCount: number,
+  batchSize: number,
+  branch: string,
+  onProgress: (
+    reqNum: number,
+    totalReqs: number,
+    clientMs: number,
+    serverMs: number,
+    batchCount: number,
+  ) => void,
+): Promise<LoopResult> {
+  const result: LoopResult = {
+    minClient: null,
+    maxClient: null,
+    minServer: null,
+    maxServer: null,
+    clientDurations: [],
+    serverDurations: [],
+  };
+
+  const totalReqs = Math.ceil(operationCount / batchSize);
+  let reqNum = 0;
+
+  for (let i = 0; i < operationCount; i += batchSize) {
+    reqNum++;
+    const batchEnd = Math.min(i + batchSize, operationCount);
+    const batchCount = batchEnd - i;
+    const actions: unknown[] = [];
+    const actionTypes: string[] = [];
+
+    for (let j = i; j < batchEnd; j++) {
+      const config = ACTION_CONFIGS[(j + 1) % ACTION_CONFIGS.length];
+      actions.push(config.buildAction(docIndex, j + 1));
+      actionTypes.push(config.name);
+    }
+
+    const actionType =
+      batchCount === 1 ? actionTypes[0] : `batch(${batchCount})`;
+
+    const t0 = performance.now();
+    const response = await sendDirectMutation(
+      directEndpoint,
+      documentId,
+      branch,
+      actions,
+    );
+    const clientMs = performance.now() - t0;
+    const serverMs = response.durationMs;
+
+    result.clientDurations.push(clientMs / batchCount);
+    result.serverDurations.push(serverMs / batchCount);
+
+    const timing: RequestTiming = {
+      reqIndex: batchEnd,
+      clientMs: clientMs / batchCount,
+      serverMs: serverMs / batchCount,
+      actionType,
+    };
+
+    if (
+      result.minClient === null ||
+      timing.clientMs < result.minClient.clientMs
+    )
+      result.minClient = timing;
+    if (
+      result.maxClient === null ||
+      timing.clientMs > result.maxClient.clientMs
+    )
+      result.maxClient = timing;
+    if (
+      result.minServer === null ||
+      timing.serverMs < result.minServer.serverMs
+    )
+      result.minServer = timing;
+    if (
+      result.maxServer === null ||
+      timing.serverMs > result.maxServer.serverMs
+    )
+      result.maxServer = timing;
+
+    onProgress(reqNum, totalReqs, clientMs, serverMs, batchCount);
+  }
+
+  return result;
+}
+
+function parseArgs(args: string[]): {
+  count: number;
+  operations: number;
+  opLoops: number;
+  batchSize: number;
+  graphqlEndpoint: string;
+  directEndpoint: string;
+  branch: string;
+  docIds: string[];
+  verbose: boolean;
+  percentiles: boolean;
+  output: string | undefined;
+  outputTimestamp: boolean;
+} {
+  let count = 10;
+  let operations = 0;
+  let opLoops = 1;
+  let batchSize = 1;
+  let graphqlEndpoint = DEFAULT_GRAPHQL_ENDPOINT;
+  let directEndpoint = DEFAULT_DIRECT_ENDPOINT;
+  let branch = "main";
+  const docIds: string[] = [];
+  let verbose = false;
+  let percentiles = false;
+  let output: string | undefined;
+  let outputTimestamp = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--endpoint" && args[i + 1]) {
+      graphqlEndpoint = args[++i];
+    } else if (arg === "--direct-endpoint" && args[i + 1]) {
+      directEndpoint = args[++i];
+    } else if (arg === "--branch" && args[i + 1]) {
+      branch = args[++i];
+    } else if ((arg === "--operations" || arg === "-o") && args[i + 1]) {
+      operations = Number(args[++i]);
+    } else if ((arg === "--op-loops" || arg === "-l") && args[i + 1]) {
+      opLoops = Number(args[++i]);
+    } else if ((arg === "--batch-size" || arg === "-b") && args[i + 1]) {
+      batchSize = Number(args[++i]);
+    } else if ((arg === "--doc-id" || arg === "-d") && args[i + 1]) {
+      docIds.push(args[++i]);
+    } else if (arg === "--verbose" || arg === "-v") {
+      verbose = true;
+    } else if (arg === "--percentiles" || arg === "-p") {
+      percentiles = true;
+    } else if ((arg === "--output" || arg === "-O") && args[i + 1]) {
+      output = args[++i];
+      outputTimestamp = false;
+    } else if (arg === "--file") {
+      const nextArg = args[i + 1];
+      if (nextArg && !nextArg.startsWith("-")) {
+        output = nextArg;
+        i++;
+      } else {
+        output = "docs-create-direct.txt";
+      }
+      outputTimestamp = true;
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(`
+Usage: tsx docs-create-direct.ts [N] [options]
+
+Bypasses Apollo and calls POST /reactor/mutate-async directly.
+Use this to isolate whether Apollo overhead is causing latency growth.
+
+Arguments:
+  N                         Number of documents to create (default: 10)
+
+Options:
+  --operations, -o <M>      Number of operations per loop (default: 0)
+  --op-loops, -l <L>        Number of operation loops per document (default: 1)
+  --batch-size, -b <N>      Actions per direct request (default: 1)
+  --doc-id, -d <id>         Use existing document(s), skip creation
+                            (can be specified multiple times)
+  --endpoint <url>          GraphQL endpoint for document creation
+                            (default: ${DEFAULT_GRAPHQL_ENDPOINT})
+  --direct-endpoint <url>   Direct Express endpoint for mutations
+                            (default: ${DEFAULT_DIRECT_ENDPOINT})
+  --branch <name>           Document branch (default: main)
+  --verbose, -v             Show per-request client and server timings
+  --percentiles, -p         Show percentile statistics (p50/p90/p95/p99)
+  --file [name]             Write output to a timestamped file
+  --output, -O <file>       Write output to a specific file
+  --help, -h                Show this help message
+
+Timings reported:
+  client ms  Full round-trip from before fetch() to after response
+  server ms  Time inside executeAsync() as reported by the endpoint
+
+Examples:
+  tsx docs-create-direct.ts 1 -o 25 -l 1000
+  tsx docs-create-direct.ts --doc-id <id> -o 25 -l 1000
+  tsx docs-create-direct.ts 1 -o 25 -l 1000 --verbose
+`);
+      process.exit(0);
+    } else if (!isNaN(Number(arg)) && arg.trim() !== "") {
+      count = Number(arg);
+    } else {
+      console.error(`Error: Unrecognized argument: ${arg}`);
+      console.error("Use --help for usage information.");
+      process.exit(1);
+    }
+  }
+
+  if (docIds.length === 0 && count < 1) {
+    console.error(
+      "Error: Document count must be >= 1 when --doc-id is not provided.",
+    );
+    process.exit(1);
+  }
+  if (isNaN(operations) || operations < 0) {
+    console.error("Error: --operations must be a non-negative integer.");
+    process.exit(1);
+  }
+  if (isNaN(opLoops) || opLoops < 1) {
+    console.error("Error: --op-loops must be >= 1.");
+    process.exit(1);
+  }
+  if (isNaN(batchSize) || batchSize < 1) {
+    console.error("Error: --batch-size must be >= 1.");
+    process.exit(1);
+  }
+  if (operations === 0 && opLoops > 1) {
+    console.warn("Warning: --op-loops has no effect when operations is 0.");
+  }
+  if (docIds.length > 0 && operations === 0) {
+    console.warn(
+      "Warning: --doc-id specified but no operations to perform (use --operations).",
+    );
+  }
+
+  return {
+    count,
+    operations,
+    opLoops,
+    batchSize,
+    graphqlEndpoint,
+    directEndpoint,
+    branch,
+    docIds,
+    verbose,
+    percentiles,
+    output,
+    outputTimestamp,
+  };
+}
+
+async function main() {
+  const {
+    count,
+    operations,
+    opLoops,
+    batchSize,
+    graphqlEndpoint,
+    directEndpoint,
+    branch,
+    docIds,
+    verbose,
+    percentiles: showPercentiles,
+    output: outputFile,
+    outputTimestamp,
+  } = parseArgs(process.argv.slice(2));
+
+  // Set up output file tee if requested
+  let outputStream: WriteStream | undefined;
+  let pendingLine = "";
+  const origStdoutWrite = process.stdout.write.bind(process.stdout);
+  const origStderrWrite = process.stderr.write.bind(process.stderr);
+
+  if (outputFile) {
+    const outputPath = outputTimestamp
+      ? join(
+          dirname(outputFile),
+          `${new Date().toISOString().replace(/[:.]/g, "-")}-${basename(outputFile)}`,
+        )
+      : outputFile;
+    mkdirSync(dirname(outputPath), { recursive: true });
+    console.log(`Writing output to: ${outputPath}`);
+    outputStream = createWriteStream(outputPath);
+
+    const fileWrite = (chunk: string | Uint8Array) => {
+      const text =
+        typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+      const parts = text.split("\n");
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        if (i === parts.length - 1) {
+          pendingLine = part.split("\r").at(-1) ?? "";
+        } else {
+          outputStream!.write(
+            pendingLine + (part.split("\r").at(-1) ?? "") + "\n",
+          );
+          pendingLine = "";
+        }
+      }
+    };
+
+    type WriteCallback = (error?: Error | null) => void;
+    process.stdout.write = (
+      chunk: string | Uint8Array,
+      encodingOrCallback?: BufferEncoding | WriteCallback,
+      callback?: WriteCallback,
+    ): boolean => {
+      fileWrite(chunk);
+      const encoding =
+        typeof encodingOrCallback === "string" ? encodingOrCallback : undefined;
+      const cb =
+        typeof encodingOrCallback === "function"
+          ? encodingOrCallback
+          : callback;
+      return origStdoutWrite(chunk, encoding, cb);
+    };
+
+    process.stderr.write = (
+      chunk: string | Uint8Array,
+      encodingOrCallback?: BufferEncoding | WriteCallback,
+      callback?: WriteCallback,
+    ): boolean => {
+      fileWrite(chunk);
+      const encoding =
+        typeof encodingOrCallback === "string" ? encodingOrCallback : undefined;
+      const cb =
+        typeof encodingOrCallback === "function"
+          ? encodingOrCallback
+          : callback;
+      return origStderrWrite(chunk, encoding, cb);
+    };
+  }
+
+  try {
+    console.log(
+      `Command: tsx docs-create-direct.ts ${process.argv.slice(2).join(" ")}`,
+    );
+    console.log(`GraphQL endpoint: ${graphqlEndpoint}`);
+    console.log(`Direct endpoint:  ${directEndpoint}`);
+
+    const gqlClient = new GraphQLClient(graphqlEndpoint);
+    const useExistingDocs = docIds.length > 0;
+
+    const initialMemory = getMemoryStats();
+    console.log(`\nInitial memory: ${formatMemory(initialMemory)}`);
+
+    const overallStart = performance.now();
+    let documentIds: string[];
+
+    if (useExistingDocs) {
+      documentIds = docIds;
+      console.log(`\nUsing ${documentIds.length} existing document(s):`);
+      documentIds.forEach((id) => console.log(`  - ${id}`));
+    } else {
+      console.log(`\nPhase 1: Creating ${count} documents via GraphQL...`);
+      const createStart = performance.now();
+      documentIds = [];
+      for (let i = 0; i < count; i++) {
+        const id = await createDocument(gqlClient);
+        documentIds.push(id);
+        process.stdout.write(`\r  Progress: ${i + 1}/${count}`);
+      }
+      const createMs = performance.now() - createStart;
+      console.log(
+        `\n  Created ${count} documents in ${(createMs / 1000).toFixed(2)}s (avg: ${(createMs / count).toFixed(0)}ms/doc)`,
+      );
+      console.log(`  Memory: ${formatMemory(getMemoryStats())}`);
+    }
+
+    if (operations > 0) {
+      const docCount = documentIds.length;
+      const loopLabel = opLoops > 1 ? ` x ${opLoops} loops` : "";
+      const batchLabel = batchSize > 1 ? ` (batch size: ${batchSize})` : "";
+      const phaseLabel = useExistingDocs ? "Operations" : "Phase 2";
+      console.log(
+        `\n${phaseLabel}: Performing ${operations} operations${loopLabel}${batchLabel} on each document (direct)...`,
+      );
+
+      const opsStart = performance.now();
+      const totalOps = docCount * operations * opLoops;
+
+      let overallMinClient: {
+        docId: string;
+        docNum: number;
+        loop: number;
+        timing: RequestTiming;
+      } | null = null;
+      let overallMaxClient: {
+        docId: string;
+        docNum: number;
+        loop: number;
+        timing: RequestTiming;
+      } | null = null;
+      let overallMinServer: {
+        docId: string;
+        docNum: number;
+        loop: number;
+        timing: RequestTiming;
+      } | null = null;
+      let overallMaxServer: {
+        docId: string;
+        docNum: number;
+        loop: number;
+        timing: RequestTiming;
+      } | null = null;
+
+      const allClientDurations: number[] = [];
+      const allServerDurations: number[] = [];
+
+      for (let i = 0; i < documentIds.length; i++) {
+        const docNum = i + 1;
+        const docId = documentIds[i];
+
+        for (let loop = 1; loop <= opLoops; loop++) {
+          const loopStart = performance.now();
+          const loopPrefix = opLoops > 1 ? `loop ${loop}/${opLoops}: ` : "";
+          const totalReqs = Math.ceil(operations / batchSize);
+
+          if (verbose) {
+            console.log(`  [${docNum}/${docCount}] ${docId} ${loopPrefix}:`);
+          }
+
+          const onProgress = (
+            reqNum: number,
+            _totalReqs: number,
+            clientMs: number,
+            serverMs: number,
+            batchCount: number,
+          ) => {
+            const batchInfo = batchCount > 1 ? ` (${batchCount} ops)` : "";
+            if (verbose) {
+              console.log(
+                `    req ${reqNum}: client=${clientMs.toFixed(1)}ms server=${serverMs.toFixed(1)}ms${batchInfo}`,
+              );
+            } else {
+              process.stdout.write(
+                `\r  [${docNum}/${docCount}] ${docId}: ${loopPrefix}${reqNum}/${totalReqs} reqs`,
+              );
+            }
+          };
+
+          const loopResult = await performDirectOperations(
+            directEndpoint,
+            docId,
+            docNum,
+            operations,
+            batchSize,
+            branch,
+            onProgress,
+          );
+
+          if (loopResult.minClient) {
+            if (
+              overallMinClient === null ||
+              loopResult.minClient.clientMs < overallMinClient.timing.clientMs
+            )
+              overallMinClient = {
+                docId,
+                docNum,
+                loop,
+                timing: loopResult.minClient,
+              };
+          }
+          if (loopResult.maxClient) {
+            if (
+              overallMaxClient === null ||
+              loopResult.maxClient.clientMs > overallMaxClient.timing.clientMs
+            )
+              overallMaxClient = {
+                docId,
+                docNum,
+                loop,
+                timing: loopResult.maxClient,
+              };
+          }
+          if (loopResult.minServer) {
+            if (
+              overallMinServer === null ||
+              loopResult.minServer.serverMs < overallMinServer.timing.serverMs
+            )
+              overallMinServer = {
+                docId,
+                docNum,
+                loop,
+                timing: loopResult.minServer,
+              };
+          }
+          if (loopResult.maxServer) {
+            if (
+              overallMaxServer === null ||
+              loopResult.maxServer.serverMs > overallMaxServer.timing.serverMs
+            )
+              overallMaxServer = {
+                docId,
+                docNum,
+                loop,
+                timing: loopResult.maxServer,
+              };
+          }
+
+          if (showPercentiles) {
+            allClientDurations.push(...loopResult.clientDurations);
+            allServerDurations.push(...loopResult.serverDurations);
+          }
+
+          const loopMs = performance.now() - loopStart;
+          const avgClientMs = (
+            loopResult.clientDurations.reduce((a, b) => a + b, 0) /
+            loopResult.clientDurations.length
+          ).toFixed(1);
+          const avgServerMs = (
+            loopResult.serverDurations.reduce((a, b) => a + b, 0) /
+            loopResult.serverDurations.length
+          ).toFixed(1);
+
+          const minMaxStr =
+            loopResult.minClient && loopResult.maxClient
+              ? `, client min/max: ${loopResult.minClient.clientMs.toFixed(1)}/${loopResult.maxClient.clientMs.toFixed(1)}ms`
+              : "";
+          const serverMinMaxStr =
+            loopResult.minServer && loopResult.maxServer
+              ? `, server min/max: ${loopResult.minServer.serverMs.toFixed(1)}/${loopResult.maxServer.serverMs.toFixed(1)}ms`
+              : "";
+
+          const loopPercentiles = showPercentiles
+            ? calculatePercentiles(loopResult.clientDurations)
+            : null;
+          const percentilesStr = loopPercentiles
+            ? `\n      client ${formatPercentiles(loopPercentiles)}`
+            : "";
+
+          if (verbose) {
+            console.log(
+              `    Done: ${(loopMs / 1000).toFixed(2)}s, avg client=${avgClientMs}ms/op server=${avgServerMs}ms/op${minMaxStr}${serverMinMaxStr}${percentilesStr}`,
+            );
+          } else {
+            process.stdout.write(
+              ` (${(loopMs / 1000).toFixed(2)}s, client avg=${avgClientMs}ms server avg=${avgServerMs}ms${minMaxStr})${percentilesStr}\n`,
+            );
+          }
+        }
+      }
+
+      const opsMs = performance.now() - opsStart;
+      const avgMsPerOp = (opsMs / totalOps).toFixed(0);
+      const overallMinMaxStr =
+        overallMinClient && overallMaxClient
+          ? `, client min: ${overallMinClient.timing.clientMs.toFixed(1)}ms, max: ${overallMaxClient.timing.clientMs.toFixed(1)}ms`
+          : "";
+      const overallServerStr =
+        overallMinServer && overallMaxServer
+          ? `, server min: ${overallMinServer.timing.serverMs.toFixed(1)}ms, max: ${overallMaxServer.timing.serverMs.toFixed(1)}ms`
+          : "";
+
+      console.log(
+        `  Completed ${totalOps} operations in ${(opsMs / 1000).toFixed(2)}s (avg client: ${avgMsPerOp}ms/op${overallMinMaxStr}${overallServerStr})`,
+      );
+
+      if (showPercentiles) {
+        const cp = calculatePercentiles(allClientDurations);
+        const sp = calculatePercentiles(allServerDurations);
+        if (cp) console.log(`  Client percentiles: ${formatPercentiles(cp)}`);
+        if (sp) console.log(`  Server percentiles: ${formatPercentiles(sp)}`);
+      }
+
+      console.log(`  Memory: ${formatMemory(getMemoryStats())}`);
+    }
+
+    const finalMemory = getMemoryStats();
+    const totalDuration = ((performance.now() - overallStart) / 1000).toFixed(
+      2,
+    );
+    const heapDelta = finalMemory.heapUsed - initialMemory.heapUsed;
+    const rssDelta = finalMemory.rss - initialMemory.rss;
+    console.log(`\nDone! Total time: ${totalDuration}s`);
+    console.log(
+      `Memory delta: heap: ${heapDelta >= 0 ? "+" : ""}${formatBytes(heapDelta)}, rss: ${rssDelta >= 0 ? "+" : ""}${formatBytes(rssDelta)}`,
+    );
+  } finally {
+    if (outputStream) {
+      process.stdout.write = origStdoutWrite;
+      process.stderr.write = origStderrWrite;
+      if (pendingLine) outputStream.write(pendingLine + "\n");
+      outputStream.end();
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error("Error:", error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/profiling/docs-create-direct.ts
+++ b/scripts/profiling/docs-create-direct.ts
@@ -8,10 +8,11 @@
  *
  * The endpoint returns { jobId, durationMs } where durationMs is the
  * server-side time inside executeAsync(). The script also records the full
- * client round-trip so both can be compared to the GraphQL path.
+ * client round-trip so both can be compared against the GraphQL path.
  *
- * If client round-trip stays flat but the GraphQL path grows, Apollo is the
- * bottleneck. If both grow, the bottleneck is inside the reactor itself.
+ * If client round-trip stays flat but docs-create.ts (GraphQL) grows,
+ * Apollo is the bottleneck. If both grow, the bottleneck is inside the
+ * reactor itself.
  *
  * Usage: tsx docs-create-direct.ts [N] [options]
  */
@@ -100,21 +101,43 @@ interface Percentiles {
   p99: number;
 }
 
+// Mirrors OperationTiming from docs-create.ts, extended with server-side timing.
 interface RequestTiming {
-  reqIndex: number;
+  opIndex: number;
   clientMs: number;
   serverMs: number;
   actionType: string;
 }
 
-interface LoopResult {
-  minClient: RequestTiming | null;
-  maxClient: RequestTiming | null;
-  minServer: RequestTiming | null;
-  maxServer: RequestTiming | null;
+// Mirrors OperationsResult from docs-create.ts, with dual timing arrays.
+interface OperationsResult {
+  minOp: RequestTiming | null;
+  maxOp: RequestTiming | null;
   clientDurations: number[];
   serverDurations: number[];
 }
+
+interface JobStatusResponse {
+  jobStatus: { status: string; completedAt: string | null };
+}
+
+interface SampledJob {
+  jobId: string;
+  dispatchedAt: number;
+  batchEnd: number;
+  batchCount: number;
+  actionType: string;
+  loopNum: number;
+  reqNum: number;
+}
+
+const JOB_STATUS_QUERY = `
+  query GetJobStatus($jobId: String!) {
+    jobStatus(jobId: $jobId) { status completedAt }
+  }
+`;
+const TERMINAL_JOB_STATUSES = new Set(["WRITE_READY", "READ_READY", "FAILED"]);
+const JOB_POLL_INTERVAL_MS = 5;
 
 function getMemoryStats(): MemoryStats {
   const mem = process.memoryUsage();
@@ -180,35 +203,21 @@ async function sendDirectMutation(
   return res.json() as Promise<DirectMutateResponse>;
 }
 
-async function performDirectOperations(
-  directEndpoint: string,
+type RequestDescriptor = {
+  actions: unknown[];
+  batchEnd: number;
+  batchCount: number;
+  actionType: string;
+};
+
+function buildRequests(
   documentId: string,
   docIndex: number,
   operationCount: number,
   batchSize: number,
-  branch: string,
-  onProgress: (
-    reqNum: number,
-    totalReqs: number,
-    clientMs: number,
-    serverMs: number,
-    batchCount: number,
-  ) => void,
-): Promise<LoopResult> {
-  const result: LoopResult = {
-    minClient: null,
-    maxClient: null,
-    minServer: null,
-    maxServer: null,
-    clientDurations: [],
-    serverDurations: [],
-  };
-
-  const totalReqs = Math.ceil(operationCount / batchSize);
-  let reqNum = 0;
-
+): RequestDescriptor[] {
+  const requests: RequestDescriptor[] = [];
   for (let i = 0; i < operationCount; i += batchSize) {
-    reqNum++;
     const batchEnd = Math.min(i + batchSize, operationCount);
     const batchCount = batchEnd - i;
     const actions: unknown[] = [];
@@ -220,54 +229,106 @@ async function performDirectOperations(
       actionTypes.push(config.name);
     }
 
-    const actionType =
-      batchCount === 1 ? actionTypes[0] : `batch(${batchCount})`;
+    requests.push({
+      actions,
+      batchEnd,
+      batchCount,
+      actionType: batchCount === 1 ? actionTypes[0] : `batch(${batchCount})`,
+    });
+  }
+  return requests;
+}
 
+async function performOperations(
+  directEndpoint: string,
+  documentId: string,
+  docIndex: number,
+  operationCount: number,
+  batchSize: number,
+  branch: string,
+  onProgress: (
+    opNum: number,
+    clientMs: number,
+    serverMs: number,
+    batchCount: number,
+  ) => void,
+): Promise<OperationsResult> {
+  let minOp: RequestTiming | null = null;
+  let maxOp: RequestTiming | null = null;
+  const clientDurations: number[] = [];
+  const serverDurations: number[] = [];
+
+  const requests = buildRequests(
+    documentId,
+    docIndex,
+    operationCount,
+    batchSize,
+  );
+
+  for (const req of requests) {
     const t0 = performance.now();
     const response = await sendDirectMutation(
       directEndpoint,
       documentId,
       branch,
-      actions,
+      req.actions,
     );
     const clientMs = performance.now() - t0;
     const serverMs = response.durationMs;
+    const perOpClientMs = clientMs / req.batchCount;
+    const perOpServerMs = serverMs / req.batchCount;
 
-    result.clientDurations.push(clientMs / batchCount);
-    result.serverDurations.push(serverMs / batchCount);
+    for (let j = 0; j < req.batchCount; j++) {
+      clientDurations.push(perOpClientMs);
+      serverDurations.push(perOpServerMs);
+    }
 
     const timing: RequestTiming = {
-      reqIndex: batchEnd,
-      clientMs: clientMs / batchCount,
-      serverMs: serverMs / batchCount,
-      actionType,
+      opIndex: req.batchEnd,
+      clientMs: perOpClientMs,
+      serverMs: perOpServerMs,
+      actionType: req.actionType,
     };
 
-    if (
-      result.minClient === null ||
-      timing.clientMs < result.minClient.clientMs
-    )
-      result.minClient = timing;
-    if (
-      result.maxClient === null ||
-      timing.clientMs > result.maxClient.clientMs
-    )
-      result.maxClient = timing;
-    if (
-      result.minServer === null ||
-      timing.serverMs < result.minServer.serverMs
-    )
-      result.minServer = timing;
-    if (
-      result.maxServer === null ||
-      timing.serverMs > result.maxServer.serverMs
-    )
-      result.maxServer = timing;
+    if (minOp === null || perOpClientMs < minOp.clientMs) minOp = timing;
+    if (maxOp === null || perOpClientMs > maxOp.clientMs) maxOp = timing;
 
-    onProgress(reqNum, totalReqs, clientMs, serverMs, batchCount);
+    onProgress(req.batchEnd, clientMs, serverMs, req.batchCount);
   }
 
-  return result;
+  return { minOp, maxOp, clientDurations, serverDurations };
+}
+
+async function pollJobAsync(
+  gqlClient: GraphQLClient,
+  job: SampledJob,
+  timeoutMs: number,
+): Promise<{ totalMs: number; timedOut: boolean }> {
+  const deadline = performance.now() + timeoutMs;
+  let timedOut = false;
+  while (true) {
+    if (performance.now() >= deadline) {
+      timedOut = true;
+      process.stderr.write(
+        `\nWarning: job ${job.jobId} (req ${job.reqNum}) did not reach a terminal status within ${timeoutMs}ms — giving up.\n`,
+      );
+      break;
+    }
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, JOB_POLL_INTERVAL_MS),
+    );
+    const { jobStatus } = await gqlClient.request<JobStatusResponse>({
+      document: JOB_STATUS_QUERY,
+      variables: { jobId: job.jobId },
+      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
+    });
+    if (
+      TERMINAL_JOB_STATUSES.has(jobStatus.status) ||
+      jobStatus.completedAt !== null
+    )
+      break;
+  }
+  return { totalMs: performance.now() - job.dispatchedAt, timedOut };
 }
 
 function parseArgs(args: string[]): {
@@ -279,8 +340,12 @@ function parseArgs(args: string[]): {
   directEndpoint: string;
   branch: string;
   docIds: string[];
+  asyncMutate: boolean;
+  asyncPollRate: number;
+  asyncTimeoutMs: number;
   verbose: boolean;
   percentiles: boolean;
+  showActionTypes: boolean;
   output: string | undefined;
   outputTimestamp: boolean;
 } {
@@ -292,8 +357,12 @@ function parseArgs(args: string[]): {
   let directEndpoint = DEFAULT_DIRECT_ENDPOINT;
   let branch = "main";
   const docIds: string[] = [];
+  let asyncMutate = false;
+  let asyncPollRate = 100;
+  let asyncTimeoutMs = 30_000;
   let verbose = false;
   let percentiles = false;
+  let showActionTypes = false;
   let output: string | undefined;
   let outputTimestamp = false;
 
@@ -313,10 +382,28 @@ function parseArgs(args: string[]): {
       batchSize = Number(args[++i]);
     } else if ((arg === "--doc-id" || arg === "-d") && args[i + 1]) {
       docIds.push(args[++i]);
+    } else if (arg === "--async") {
+      asyncMutate = true;
+      const nextArg = args[i + 1];
+      if (nextArg && !nextArg.startsWith("-")) {
+        const n = Number(nextArg);
+        if (isNaN(n) || n <= 0 || !Number.isInteger(n)) {
+          console.error(
+            `Error: --async N must be a positive integer, got: ${nextArg}`,
+          );
+          process.exit(1);
+        }
+        asyncPollRate = n;
+        i++;
+      }
+    } else if (arg === "--async-timeout" && args[i + 1]) {
+      asyncTimeoutMs = Number(args[++i]);
     } else if (arg === "--verbose" || arg === "-v") {
       verbose = true;
     } else if (arg === "--percentiles" || arg === "-p") {
       percentiles = true;
+    } else if (arg === "--show-action-types" || arg === "-a") {
+      showActionTypes = true;
     } else if ((arg === "--output" || arg === "-O") && args[i + 1]) {
       output = args[++i];
       outputTimestamp = false;
@@ -335,6 +422,7 @@ Usage: tsx docs-create-direct.ts [N] [options]
 
 Bypasses Apollo and calls POST /reactor/mutate-async directly.
 Use this to isolate whether Apollo overhead is causing latency growth.
+Documents are still created via GraphQL.
 
 Arguments:
   N                         Number of documents to create (default: 10)
@@ -343,27 +431,36 @@ Options:
   --operations, -o <M>      Number of operations per loop (default: 0)
   --op-loops, -l <L>        Number of operation loops per document (default: 1)
   --batch-size, -b <N>      Actions per direct request (default: 1)
-  --doc-id, -d <id>         Use existing document(s), skip creation
-                            (can be specified multiple times)
-  --endpoint <url>          GraphQL endpoint for document creation
+                            Use higher values to measure per-request overhead
+  --doc-id, -d <id>         Use existing document(s) instead of creating new ones
+                            (can be specified multiple times, skips document creation)
+  --endpoint <url>          GraphQL endpoint for document creation and job polling
                             (default: ${DEFAULT_GRAPHQL_ENDPOINT})
   --direct-endpoint <url>   Direct Express endpoint for mutations
                             (default: ${DEFAULT_DIRECT_ENDPOINT})
   --branch <name>           Document branch (default: main)
-  --verbose, -v             Show per-request client and server timings
-  --percentiles, -p         Show percentile statistics (p50/p90/p95/p99)
-  --file [name]             Write output to a timestamped file
-  --output, -O <file>       Write output to a specific file
+  --async [N]               Poll every Nth request for E2E latency via GraphQL
+                            jobStatus (default N=100). Dispatch timing is always
+                            measured; this adds READ_READY round-trip measurement.
+  --async-timeout <ms>      Max ms to wait for a polled job to reach a terminal
+                            status (default: 30000)
+  --verbose, -v             Show detailed per-request timings
+  --percentiles, -p         Show percentile statistics (p50, p90, p95, p99)
+  --show-action-types, -a   Show action type names in min/max timings
+  --file [name]             Write output to a timestamped file (default: docs-create-direct.txt)
+  --output, -O <file>       Write output to a specific file (no timestamp prefix)
   --help, -h                Show this help message
 
 Timings reported:
-  client ms  Full round-trip from before fetch() to after response
+  client ms  Full HTTP round-trip from before fetch() to after response
   server ms  Time inside executeAsync() as reported by the endpoint
+  async ms   Wall-clock from before dispatch to job reaching READ_READY (--async only)
 
 Examples:
   tsx docs-create-direct.ts 1 -o 25 -l 1000
+  tsx docs-create-direct.ts 1 -o 25 -l 1000 --async
   tsx docs-create-direct.ts --doc-id <id> -o 25 -l 1000
-  tsx docs-create-direct.ts 1 -o 25 -l 1000 --verbose
+  tsx docs-create-direct.ts 1 -o 25 -l 1000 --verbose --percentiles
 `);
       process.exit(0);
     } else if (!isNaN(Number(arg)) && arg.trim() !== "") {
@@ -377,28 +474,54 @@ Examples:
 
   if (docIds.length === 0 && count < 1) {
     console.error(
-      "Error: Document count must be >= 1 when --doc-id is not provided.",
+      "Error: Document count must be a positive integer (>= 1) when --doc-id is not provided.",
     );
     process.exit(1);
   }
   if (isNaN(operations) || operations < 0) {
-    console.error("Error: --operations must be a non-negative integer.");
+    console.error(
+      "Error: Invalid operations value: must be a non-negative integer.",
+    );
     process.exit(1);
   }
   if (isNaN(opLoops) || opLoops < 1) {
-    console.error("Error: --op-loops must be >= 1.");
+    console.error(
+      "Error: Invalid op-loops value: must be a positive integer (>= 1).",
+    );
     process.exit(1);
   }
   if (isNaN(batchSize) || batchSize < 1) {
-    console.error("Error: --batch-size must be >= 1.");
+    console.error(
+      "Error: Invalid batch-size value: must be a positive integer (>= 1).",
+    );
+    process.exit(1);
+  }
+  if (
+    isNaN(asyncTimeoutMs) ||
+    asyncTimeoutMs < 1 ||
+    !Number.isInteger(asyncTimeoutMs)
+  ) {
+    console.error(
+      "Error: Invalid --async-timeout value: must be a positive integer (ms).",
+    );
     process.exit(1);
   }
   if (operations === 0 && opLoops > 1) {
-    console.warn("Warning: --op-loops has no effect when operations is 0.");
+    console.warn(
+      `Warning: --op-loops=${opLoops} has no effect when operations is 0.`,
+    );
+  }
+  if (operations === 0 && batchSize > 1) {
+    console.warn(
+      `Warning: --batch-size=${batchSize} has no effect when operations is 0.`,
+    );
+  }
+  if (operations === 0 && asyncMutate) {
+    console.warn(`Warning: --async has no effect when operations is 0.`);
   }
   if (docIds.length > 0 && operations === 0) {
     console.warn(
-      "Warning: --doc-id specified but no operations to perform (use --operations).",
+      `Warning: --doc-id specified but no operations to perform (use --operations).`,
     );
   }
 
@@ -411,8 +534,12 @@ Examples:
     directEndpoint,
     branch,
     docIds,
+    asyncMutate,
+    asyncPollRate,
+    asyncTimeoutMs,
     verbose,
     percentiles,
+    showActionTypes,
     output,
     outputTimestamp,
   };
@@ -428,8 +555,12 @@ async function main() {
     directEndpoint,
     branch,
     docIds,
+    asyncMutate,
+    asyncPollRate,
+    asyncTimeoutMs,
     verbose,
     percentiles: showPercentiles,
+    showActionTypes,
     output: outputFile,
     outputTimestamp,
   } = parseArgs(process.argv.slice(2));
@@ -455,14 +586,17 @@ async function main() {
       const text =
         typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
       const parts = text.split("\n");
+
       for (let i = 0; i < parts.length; i++) {
         const part = parts[i];
+
         if (i === parts.length - 1) {
-          pendingLine = part.split("\r").at(-1) ?? "";
+          const crParts = part.split("\r");
+          pendingLine = crParts[crParts.length - 1];
         } else {
-          outputStream!.write(
-            pendingLine + (part.split("\r").at(-1) ?? "") + "\n",
-          );
+          const crParts = part.split("\r");
+          const finalPart = crParts[crParts.length - 1];
+          outputStream!.write(pendingLine + finalPart + "\n");
           pendingLine = "";
         }
       }
@@ -504,8 +638,12 @@ async function main() {
     console.log(
       `Command: tsx docs-create-direct.ts ${process.argv.slice(2).join(" ")}`,
     );
-    console.log(`GraphQL endpoint: ${graphqlEndpoint}`);
-    console.log(`Direct endpoint:  ${directEndpoint}`);
+    console.log(
+      `GraphQL endpoint (doc creation / job polling): ${graphqlEndpoint}`,
+    );
+    console.log(
+      `Direct endpoint  (mutations):                  ${directEndpoint}`,
+    );
 
     const gqlClient = new GraphQLClient(graphqlEndpoint);
     const useExistingDocs = docIds.length > 0;
@@ -513,7 +651,7 @@ async function main() {
     const initialMemory = getMemoryStats();
     console.log(`\nInitial memory: ${formatMemory(initialMemory)}`);
 
-    const overallStart = performance.now();
+    const overallStartTime = performance.now();
     let documentIds: string[];
 
     if (useExistingDocs) {
@@ -522,18 +660,23 @@ async function main() {
       documentIds.forEach((id) => console.log(`  - ${id}`));
     } else {
       console.log(`\nPhase 1: Creating ${count} documents via GraphQL...`);
-      const createStart = performance.now();
+      const createStartTime = performance.now();
       documentIds = [];
+
       for (let i = 0; i < count; i++) {
         const id = await createDocument(gqlClient);
         documentIds.push(id);
         process.stdout.write(`\r  Progress: ${i + 1}/${count}`);
       }
-      const createMs = performance.now() - createStart;
+
+      const createDurationMs = performance.now() - createStartTime;
+      const createDuration = (createDurationMs / 1000).toFixed(2);
+      const msPerDoc = (createDurationMs / count).toFixed(0);
+      const phase1Memory = getMemoryStats();
       console.log(
-        `\n  Created ${count} documents in ${(createMs / 1000).toFixed(2)}s (avg: ${(createMs / count).toFixed(0)}ms/doc)`,
+        `\n  Created ${count} documents in ${createDuration}s (avg: ${msPerDoc}ms/doc)`,
       );
-      console.log(`  Memory: ${formatMemory(getMemoryStats())}`);
+      console.log(`  Memory: ${formatMemory(phase1Memory)}`);
     }
 
     if (operations > 0) {
@@ -544,201 +687,271 @@ async function main() {
       console.log(
         `\n${phaseLabel}: Performing ${operations} operations${loopLabel}${batchLabel} on each document (direct)...`,
       );
-
-      const opsStart = performance.now();
+      const opsStartTime = performance.now();
       const totalOps = docCount * operations * opLoops;
 
-      let overallMinClient: {
+      let overallMinOp: {
         docId: string;
         docNum: number;
         loop: number;
         timing: RequestTiming;
       } | null = null;
-      let overallMaxClient: {
+      let overallMaxOp: {
         docId: string;
         docNum: number;
         loop: number;
         timing: RequestTiming;
       } | null = null;
-      let overallMinServer: {
-        docId: string;
-        docNum: number;
-        loop: number;
-        timing: RequestTiming;
-      } | null = null;
-      let overallMaxServer: {
-        docId: string;
-        docNum: number;
-        loop: number;
-        timing: RequestTiming;
-      } | null = null;
-
       const allClientDurations: number[] = [];
       const allServerDurations: number[] = [];
+      let timedOutCount = 0;
+      let sampledJobCount = 0;
 
       for (let i = 0; i < documentIds.length; i++) {
         const docNum = i + 1;
         const docId = documentIds[i];
 
-        for (let loop = 1; loop <= opLoops; loop++) {
-          const loopStart = performance.now();
-          const loopPrefix = opLoops > 1 ? `loop ${loop}/${opLoops}: ` : "";
-          const totalReqs = Math.ceil(operations / batchSize);
+        if (asyncMutate && operations > 0) {
+          const totalRequests = opLoops * Math.ceil(operations / batchSize);
+          const pollPromises: Promise<{
+            totalMs: number;
+            timedOut: boolean;
+            job: SampledJob;
+          }>[] = [];
+          let globalReqNum = 0;
 
-          if (verbose) {
-            console.log(`  [${docNum}/${docCount}] ${docId} ${loopPrefix}:`);
+          // Dispatch sequentially; start polling each sampled job immediately
+          // (fire-and-forget into pollPromises) so results stream to stdout as
+          // each poll resolves during dispatch rather than bursting at the end.
+          for (let loop = 1; loop <= opLoops; loop++) {
+            const loopDispatchStart = performance.now();
+            const requests = buildRequests(
+              docId,
+              docNum,
+              operations,
+              batchSize,
+            );
+
+            for (const req of requests) {
+              globalReqNum++;
+              const dispatchedAt = performance.now();
+              const response = await sendDirectMutation(
+                directEndpoint,
+                docId,
+                branch,
+                req.actions,
+              );
+              const jobId = response.jobId;
+              if (!jobId) {
+                throw new Error(
+                  `Missing jobId in response for request ${globalReqNum}`,
+                );
+              }
+
+              if (
+                globalReqNum % asyncPollRate === 0 ||
+                globalReqNum === totalRequests
+              ) {
+                const job: SampledJob = {
+                  jobId,
+                  dispatchedAt,
+                  batchEnd: req.batchEnd,
+                  batchCount: req.batchCount,
+                  actionType: req.actionType,
+                  loopNum: loop,
+                  reqNum: globalReqNum,
+                };
+                pollPromises.push(
+                  pollJobAsync(gqlClient, job, asyncTimeoutMs).then((r) => {
+                    const ms = Math.round(r.totalMs);
+                    if (r.timedOut) {
+                      process.stdout.write(
+                        `\r  [${docNum}/${docCount}] ${docId}: op ${job.reqNum}/${totalRequests} TIMED OUT after ${ms}ms\n`,
+                      );
+                    } else {
+                      process.stdout.write(
+                        `\r  [${docNum}/${docCount}] ${docId}: op ${job.reqNum}/${totalRequests} (${ms}ms)\n`,
+                      );
+                    }
+                    return { ...r, job };
+                  }),
+                );
+              }
+              if (!verbose) {
+                process.stdout.write(
+                  `\r  [${docNum}/${docCount}] ${docId}: dispatching ${globalReqNum}/${totalRequests}...`,
+                );
+              }
+            }
+
+            const loopDispatchMs = Math.round(
+              performance.now() - loopDispatchStart,
+            );
+            const msPerOp = Math.round(loopDispatchMs / operations);
+            process.stdout.write(
+              `\r  [${docNum}/${docCount}] ${docId}: loop ${loop}/${opLoops} dispatched in ${loopDispatchMs}ms (${msPerOp}ms/op)\n`,
+            );
           }
 
-          const onProgress = (
-            reqNum: number,
-            _totalReqs: number,
-            clientMs: number,
-            serverMs: number,
-            batchCount: number,
-          ) => {
-            const batchInfo = batchCount > 1 ? ` (${batchCount} ops)` : "";
+          // Wait for any polls still in flight after dispatch completes, then aggregate
+          const allPollResults = await Promise.all(pollPromises);
+          for (const { totalMs, timedOut, job } of allPollResults) {
+            if (timedOut) {
+              timedOutCount++;
+              continue;
+            }
+            sampledJobCount++;
+            const perOpMs = totalMs / job.batchCount;
+            const timing: RequestTiming = {
+              opIndex: job.batchEnd,
+              clientMs: perOpMs,
+              serverMs: 0,
+              actionType: job.actionType,
+            };
+            if (overallMinOp === null || perOpMs < overallMinOp.timing.clientMs)
+              overallMinOp = { docId, docNum, loop: job.loopNum, timing };
+            if (overallMaxOp === null || perOpMs > overallMaxOp.timing.clientMs)
+              overallMaxOp = { docId, docNum, loop: job.loopNum, timing };
+            if (showPercentiles) allClientDurations.push(perOpMs);
+          }
+        } else {
+          for (let loop = 1; loop <= opLoops; loop++) {
+            const loopStartTime = performance.now();
+            const loopPrefix = opLoops > 1 ? `loop ${loop}/${opLoops}: ` : "";
+
+            if (verbose) {
+              console.log(`  [${docNum}/${docCount}] ${docId} ${loopPrefix}:`);
+            }
+
+            const onProgress = (
+              opNum: number,
+              clientMs: number,
+              serverMs: number,
+              batchCount: number,
+            ) => {
+              const batchInfo = batchCount > 1 ? ` (${batchCount} ops)` : "";
+              if (verbose) {
+                console.log(
+                  `    op ${opNum}/${operations}: client=${clientMs.toFixed(1)}ms server=${serverMs.toFixed(1)}ms${batchInfo}`,
+                );
+              } else {
+                process.stdout.write(
+                  `\r  [${docNum}/${docCount}] ${docId}: ${loopPrefix}${opNum}/${operations} ops`,
+                );
+              }
+            };
+
+            const result = await performOperations(
+              directEndpoint,
+              docId,
+              docNum,
+              operations,
+              batchSize,
+              branch,
+              onProgress,
+            );
+
+            if (
+              result.minOp &&
+              (overallMinOp === null ||
+                result.minOp.clientMs < overallMinOp.timing.clientMs)
+            ) {
+              overallMinOp = { docId, docNum, loop, timing: result.minOp };
+            }
+            if (
+              result.maxOp &&
+              (overallMaxOp === null ||
+                result.maxOp.clientMs > overallMaxOp.timing.clientMs)
+            ) {
+              overallMaxOp = { docId, docNum, loop, timing: result.maxOp };
+            }
+            if (showPercentiles) {
+              allClientDurations.push(...result.clientDurations);
+              allServerDurations.push(...result.serverDurations);
+            }
+
+            const loopDurationMs = performance.now() - loopStartTime;
+            const loopDuration = (loopDurationMs / 1000).toFixed(2);
+            const msPerOp = (loopDurationMs / operations).toFixed(0);
+
+            const minMaxClient =
+              result.minOp && result.maxOp
+                ? showActionTypes
+                  ? `, client min: ${result.minOp.clientMs.toFixed(1)}ms (${result.minOp.actionType}), max: ${result.maxOp.clientMs.toFixed(1)}ms (${result.maxOp.actionType})`
+                  : `, client min: ${result.minOp.clientMs.toFixed(1)}ms, max: ${result.maxOp.clientMs.toFixed(1)}ms`
+                : "";
+            const minMaxServer =
+              result.minOp && result.maxOp
+                ? showActionTypes
+                  ? `, server min: ${result.minOp.serverMs.toFixed(1)}ms (${result.minOp.actionType}), max: ${result.maxOp.serverMs.toFixed(1)}ms (${result.maxOp.actionType})`
+                  : `, server min: ${result.minOp.serverMs.toFixed(1)}ms, max: ${result.maxOp.serverMs.toFixed(1)}ms`
+                : "";
+
+            const loopClientPercentiles = showPercentiles
+              ? calculatePercentiles(result.clientDurations)
+              : null;
+            const loopServerPercentiles = showPercentiles
+              ? calculatePercentiles(result.serverDurations)
+              : null;
+            const percentilesStr = loopClientPercentiles
+              ? `\n      client ${formatPercentiles(loopClientPercentiles)}` +
+                (loopServerPercentiles
+                  ? `\n      server ${formatPercentiles(loopServerPercentiles)}`
+                  : "")
+              : "";
+
             if (verbose) {
               console.log(
-                `    req ${reqNum}: client=${clientMs.toFixed(1)}ms server=${serverMs.toFixed(1)}ms${batchInfo}`,
+                `    Done: ${loopDuration}s, ${msPerOp}ms/op${minMaxClient}${minMaxServer}${percentilesStr}`,
               );
             } else {
               process.stdout.write(
-                `\r  [${docNum}/${docCount}] ${docId}: ${loopPrefix}${reqNum}/${totalReqs} reqs`,
+                ` (${loopDuration}s, ${msPerOp}ms/op${minMaxClient}${minMaxServer})${percentilesStr}\n`,
               );
             }
-          };
-
-          const loopResult = await performDirectOperations(
-            directEndpoint,
-            docId,
-            docNum,
-            operations,
-            batchSize,
-            branch,
-            onProgress,
-          );
-
-          if (loopResult.minClient) {
-            if (
-              overallMinClient === null ||
-              loopResult.minClient.clientMs < overallMinClient.timing.clientMs
-            )
-              overallMinClient = {
-                docId,
-                docNum,
-                loop,
-                timing: loopResult.minClient,
-              };
-          }
-          if (loopResult.maxClient) {
-            if (
-              overallMaxClient === null ||
-              loopResult.maxClient.clientMs > overallMaxClient.timing.clientMs
-            )
-              overallMaxClient = {
-                docId,
-                docNum,
-                loop,
-                timing: loopResult.maxClient,
-              };
-          }
-          if (loopResult.minServer) {
-            if (
-              overallMinServer === null ||
-              loopResult.minServer.serverMs < overallMinServer.timing.serverMs
-            )
-              overallMinServer = {
-                docId,
-                docNum,
-                loop,
-                timing: loopResult.minServer,
-              };
-          }
-          if (loopResult.maxServer) {
-            if (
-              overallMaxServer === null ||
-              loopResult.maxServer.serverMs > overallMaxServer.timing.serverMs
-            )
-              overallMaxServer = {
-                docId,
-                docNum,
-                loop,
-                timing: loopResult.maxServer,
-              };
-          }
-
-          if (showPercentiles) {
-            allClientDurations.push(...loopResult.clientDurations);
-            allServerDurations.push(...loopResult.serverDurations);
-          }
-
-          const loopMs = performance.now() - loopStart;
-          const avgClientMs = (
-            loopResult.clientDurations.reduce((a, b) => a + b, 0) /
-            loopResult.clientDurations.length
-          ).toFixed(1);
-          const avgServerMs = (
-            loopResult.serverDurations.reduce((a, b) => a + b, 0) /
-            loopResult.serverDurations.length
-          ).toFixed(1);
-
-          const minMaxStr =
-            loopResult.minClient && loopResult.maxClient
-              ? `, client min/max: ${loopResult.minClient.clientMs.toFixed(1)}/${loopResult.maxClient.clientMs.toFixed(1)}ms`
-              : "";
-          const serverMinMaxStr =
-            loopResult.minServer && loopResult.maxServer
-              ? `, server min/max: ${loopResult.minServer.serverMs.toFixed(1)}/${loopResult.maxServer.serverMs.toFixed(1)}ms`
-              : "";
-
-          const loopPercentiles = showPercentiles
-            ? calculatePercentiles(loopResult.clientDurations)
-            : null;
-          const percentilesStr = loopPercentiles
-            ? `\n      client ${formatPercentiles(loopPercentiles)}`
-            : "";
-
-          if (verbose) {
-            console.log(
-              `    Done: ${(loopMs / 1000).toFixed(2)}s, avg client=${avgClientMs}ms/op server=${avgServerMs}ms/op${minMaxStr}${serverMinMaxStr}${percentilesStr}`,
-            );
-          } else {
-            process.stdout.write(
-              ` (${(loopMs / 1000).toFixed(2)}s, client avg=${avgClientMs}ms server avg=${avgServerMs}ms${minMaxStr})${percentilesStr}\n`,
-            );
           }
         }
       }
 
-      const opsMs = performance.now() - opsStart;
-      const avgMsPerOp = (opsMs / totalOps).toFixed(0);
-      const overallMinMaxStr =
-        overallMinClient && overallMaxClient
-          ? `, client min: ${overallMinClient.timing.clientMs.toFixed(1)}ms, max: ${overallMaxClient.timing.clientMs.toFixed(1)}ms`
+      const opsDurationMs = performance.now() - opsStartTime;
+      const opsDuration = (opsDurationMs / 1000).toFixed(2);
+      const avgMsPerOp = (opsDurationMs / totalOps).toFixed(0);
+      const phase2Memory = getMemoryStats();
+
+      const overallMinMax =
+        overallMinOp && overallMaxOp
+          ? showActionTypes
+            ? `, min: ${overallMinOp.timing.clientMs.toFixed(1)}ms (${overallMinOp.timing.actionType}), max: ${overallMaxOp.timing.clientMs.toFixed(1)}ms (${overallMaxOp.timing.actionType})`
+            : `, min: ${overallMinOp.timing.clientMs.toFixed(1)}ms, max: ${overallMaxOp.timing.clientMs.toFixed(1)}ms`
           : "";
-      const overallServerStr =
-        overallMinServer && overallMaxServer
-          ? `, server min: ${overallMinServer.timing.serverMs.toFixed(1)}ms, max: ${overallMaxServer.timing.serverMs.toFixed(1)}ms`
+      const timedOutStr =
+        timedOutCount > 0 ? `, timed-out jobs: ${timedOutCount}` : "";
+      const sampledStr =
+        sampledJobCount > 0
+          ? ` (stats from ${sampledJobCount} sampled jobs)`
           : "";
 
       console.log(
-        `  Completed ${totalOps} operations in ${(opsMs / 1000).toFixed(2)}s (avg client: ${avgMsPerOp}ms/op${overallMinMaxStr}${overallServerStr})`,
+        `  Completed ${totalOps} operations in ${opsDuration}s (avg: ${avgMsPerOp}ms/op${overallMinMax}${timedOutStr})${sampledStr}`,
       );
 
-      if (showPercentiles) {
+      if (showPercentiles && allClientDurations.length > 0) {
         const cp = calculatePercentiles(allClientDurations);
-        const sp = calculatePercentiles(allServerDurations);
         if (cp) console.log(`  Client percentiles: ${formatPercentiles(cp)}`);
-        if (sp) console.log(`  Server percentiles: ${formatPercentiles(sp)}`);
+        if (!asyncMutate && allServerDurations.length > 0) {
+          const sp = calculatePercentiles(allServerDurations);
+          if (sp) console.log(`  Server percentiles: ${formatPercentiles(sp)}`);
+        }
       }
 
-      console.log(`  Memory: ${formatMemory(getMemoryStats())}`);
+      console.log(`  Memory: ${formatMemory(phase2Memory)}`);
     }
 
     const finalMemory = getMemoryStats();
-    const totalDuration = ((performance.now() - overallStart) / 1000).toFixed(
-      2,
-    );
+    const totalDuration = (
+      (performance.now() - overallStartTime) /
+      1000
+    ).toFixed(2);
     const heapDelta = finalMemory.heapUsed - initialMemory.heapUsed;
     const rssDelta = finalMemory.rss - initialMemory.rss;
     console.log(`\nDone! Total time: ${totalDuration}s`);
@@ -749,7 +962,9 @@ async function main() {
     if (outputStream) {
       process.stdout.write = origStdoutWrite;
       process.stderr.write = origStderrWrite;
-      if (pendingLine) outputStream.write(pendingLine + "\n");
+      if (pendingLine) {
+        outputStream.write(pendingLine + "\n");
+      }
       outputStream.end();
     }
   }


### PR DESCRIPTION
- Add reactor.queue.wait.duration histogram (PENDING→RUNNING) to OTel instrumentation to expose queue buildup in future profiling runs
- Add per-step debug timing to mutateDocumentAsync resolver (authCheck, assertOps, execute) to pinpoint where client-observed latency grows
- Add covering index idx_operation_doc_branch_scope_index on Operation(documentId, branch, scope, index) via migration 015 to convert the correlated MAX(index) subquery in getRevisions() from O(N) to O(log N)