### PR TITLE
feat(reactor-api): namespace API, SSE subscriptions, dev script

### DIFF
--- a/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-custom-subgraph/resolvers.esm.t
+++ b/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-custom-subgraph/resolvers.esm.t
@@ -5,10 +5,13 @@ unless_exists: true
 import { type ISubgraph } from "@powerhousedao/reactor-api";
 
 export const getResolvers = (subgraph: ISubgraph): Record<string, unknown> => {
-  const reactor = subgraph.reactor;
+  const reactor = subgraph.reactorClient;
 
   return ({
     Query: {
+      <%= h.changeCase.camel(subgraph) %>: () => ({}), // namespace resolver for nested queries
+    },
+    <%= h.changeCase.pascal(subgraph) %>Queries: {
       example: async (parent: unknown, args: { driveId: string }) => {
         return "example";
       },

--- a/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-custom-subgraph/schema.esm.t
+++ b/packages/codegen/src/codegen/.hygen/templates/powerhouse/generate-custom-subgraph/schema.esm.t
@@ -7,10 +7,14 @@ import type { DocumentNode } from "graphql";
 
 export const schema: DocumentNode = gql`
 """
-Subgraph definition
+<%= h.changeCase.pascal(subgraph) %> Queries
 """
-type Query {
+type <%= h.changeCase.pascal(subgraph) %>Queries {
     example(driveId: String!): String
+}
+
+type Query {
+    <%= h.changeCase.camel(subgraph) %>: <%= h.changeCase.pascal(subgraph) %>Queries!
 }
 
 `

--- a/packages/reactor-api/package.json
+++ b/packages/reactor-api/package.json
@@ -36,7 +36,8 @@
     "test": "vitest --run",
     "bench": "vitest bench",
     "codegen": "graphql-codegen --config codegen.ts && prettier --write src/graphql/reactor/gen/*.ts && eslint --fix src/graphql/reactor/gen/*.ts --no-warn-ignored",
-    "codegen:watch": "graphql-codegen --config codegen.ts --watch"
+    "codegen:watch": "graphql-codegen --config codegen.ts --watch",
+    "dev": "tsx src/dev.ts"
   },
   "publishConfig": {
     "access": "public"
@@ -53,8 +54,8 @@
     "@opentelemetry/auto-instrumentations-node": "^0.57.1",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.57.2",
     "@opentelemetry/exporter-trace-otlp-http": "^0.57.2",
-    "@opentelemetry/sdk-metrics": "^1.29.0",
     "@opentelemetry/resources": "^1.29.0",
+    "@opentelemetry/sdk-metrics": "^1.29.0",
     "@opentelemetry/sdk-node": "^0.57.2",
     "@opentelemetry/sdk-trace-base": "^1.29.0",
     "@opentelemetry/semantic-conventions": "^1.29.0",
@@ -66,6 +67,7 @@
     "@powerhousedao/document-engineering": "catalog:",
     "@powerhousedao/reactor": "workspace:*",
     "@powerhousedao/reactor-mcp": "workspace:*",
+    "@powerhousedao/shared": "workspace:*",
     "@renown/sdk": "workspace:*",
     "body-parser": "^1.20.3",
     "change-case": "catalog:",
@@ -76,9 +78,10 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "graphql": "catalog:",
+    "graphql-sse": "catalog:",
     "graphql-subscriptions": "^3.0.0",
     "graphql-type-json": "^0.3.2",
-    "graphql-ws": "^6.0.6",
+    "graphql-ws": "catalog:",
     "knex": "catalog:",
     "knex-pglite": "catalog:",
     "kysely": "catalog:",
@@ -87,7 +90,6 @@
     "pg": "catalog:",
     "read-pkg": "catalog:",
     "ws": "^8.18.3",
-    "@powerhousedao/shared": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/reactor-api/src/dev.ts
+++ b/packages/reactor-api/src/dev.ts
@@ -1,0 +1,131 @@
+/**
+ * Development script for running reactor-api locally.
+ *
+ * Starts an HTTP server with the GraphQL endpoint using in-memory storage
+ * and PGlite for the read model (no external database required).
+ *
+ * Usage:
+ *   pnpm dev
+ *
+ * Environment variables:
+ *   PORT          - Server port (default: 4001)
+ *   DB_PATH       - PGlite database path (default: in-memory)
+ *   LOG_LEVEL     - Log level (default: info)
+ */
+import {
+  ChannelScheme,
+  EventBus,
+  ReactorBuilder,
+  ReactorClientBuilder,
+} from "@powerhousedao/reactor";
+import {
+  DocumentAlreadyExistsError,
+  InMemoryCache,
+  ReactorBuilder as LegacyReactorBuilder,
+  logger,
+  MemoryStorage,
+} from "document-drive";
+import dotenv from "dotenv";
+import { startAPI } from "./server.js";
+
+dotenv.config();
+
+const DEFAULT_PORT = 4001;
+const DEFAULT_DRIVE = {
+  id: "powerhouse",
+  slug: "powerhouse",
+  global: {
+    name: "Powerhouse",
+    icon: "https://ipfs.io/ipfs/QmcaTDBYn8X2psGaXe7iQ6qd8q6oqHLgxvMX9yXf7f9uP7",
+  },
+  local: {
+    availableOffline: true,
+    listeners: [],
+    sharingType: "public" as const,
+    triggers: [],
+  },
+};
+
+async function main() {
+  process.setMaxListeners(0);
+
+  const port = Number(process.env.PORT ?? DEFAULT_PORT);
+  const dbPath = process.env.DB_PATH; // undefined = in-memory PGlite
+
+  process.env.LOG_LEVEL = process.env.LOG_LEVEL || "info";
+
+  // Build legacy drive server with in-memory storage
+  const cache = new InMemoryCache();
+  const storage = new MemoryStorage();
+  const driveServer = new LegacyReactorBuilder([])
+    .withCache(cache)
+    .withStorage(storage)
+    .withOptions({
+      featureFlags: {
+        enableDualActionCreate: true,
+      },
+    })
+    .build();
+
+  // Build reactor client
+  const eventBus = new EventBus();
+  const builder = new ReactorBuilder()
+    .withEventBus(eventBus)
+    .withChannelScheme(ChannelScheme.SWITCHBOARD);
+  const clientModule = await new ReactorClientBuilder()
+    .withReactorBuilder(builder)
+    .buildModule();
+
+  const client = clientModule.client;
+  const syncManager = clientModule.reactorModule?.syncModule?.syncManager;
+  if (!syncManager) {
+    throw new Error("SyncManager not available from ReactorClientBuilder");
+  }
+
+  const registry = clientModule.reactorModule?.documentModelRegistry;
+  if (!registry) {
+    throw new Error(
+      "DocumentModelRegistry not available from ReactorClientBuilder",
+    );
+  }
+
+  // Initialize drive server and add a default drive
+  await driveServer.initialize();
+
+  try {
+    await driveServer.addDrive(DEFAULT_DRIVE);
+  } catch (e) {
+    if (!(e instanceof DocumentAlreadyExistsError)) {
+      throw e;
+    }
+  }
+
+  // Start the API
+  await startAPI(
+    driveServer,
+    client,
+    registry,
+    syncManager,
+    {
+      port,
+      dbPath,
+      mcp: true,
+      enableDocumentModelSubgraphs: true,
+    },
+    "switchboard",
+  );
+
+  const driveUrl = `http://localhost:${port}/d/${DEFAULT_DRIVE.id}`;
+
+  logger.info(`  Reactor API running:`);
+  logger.info(`    GraphQL:      http://localhost:${port}/graphql`);
+  logger.info(`    Explorer:     http://localhost:${port}/explorer`);
+  logger.info(`    Drive:        ${driveUrl}`);
+  logger.info(`    Health:       http://localhost:${port}/health`);
+  logger.info(`    MCP:          http://localhost:${port}/mcp`);
+}
+
+main().catch((err) => {
+  console.error("Failed to start reactor-api dev server:", err);
+  process.exit(1);
+});

--- a/packages/reactor-api/src/graphql/document-model-subgraph.ts
+++ b/packages/reactor-api/src/graphql/document-model-subgraph.ts
@@ -7,6 +7,10 @@ import {
 } from "../utils/create-schema.js";
 import { BaseSubgraph } from "./base-subgraph.js";
 import { toGqlPhDocument } from "./reactor/adapters.js";
+import type {
+  PhDocument,
+  PhDocumentResultPage,
+} from "./reactor/gen/graphql.js";
 import {
   createDocumentWithInitialState as createDocumentWithInitialStateResolver,
   createEmptyDocument as createEmptyDocumentResolver,
@@ -15,10 +19,6 @@ import {
   document as documentResolver,
   findDocuments as findDocumentsResolver,
 } from "./reactor/resolvers.js";
-import type {
-  PhDocument,
-  PhDocumentResultPage,
-} from "./reactor/gen/graphql.js";
 import type { Context, SubgraphArgs } from "./types.js";
 
 /** A resolver function that lives inside a document-model subgraph. */
@@ -279,10 +279,8 @@ export class DocumentModelSubgraph extends BaseSubgraph {
 
           return result;
         },
-
-<<<<<<< HEAD
         // Flat query: Get all documents of this type (paged)
-        [`${documentName}_documents`]: async (
+        documents: async (
           _: unknown,
           args: {
             paging?: { limit?: number; offset?: number; cursor?: string };
@@ -317,14 +315,9 @@ export class DocumentModelSubgraph extends BaseSubgraph {
 
           return result;
         },
-
         // Flat query: Find documents by search criteria (type is built-in)
         // Uses shared findDocumentsResolver from reactor/resolvers.ts
-        [`${documentName}_findDocuments`]: async (
-=======
-        // Find documents by search criteria (type is built-in)
         findDocuments: async (
->>>>>>> 3d99ada7f (feat(reactor-api): namespace document model queries and mutations)
           _: unknown,
           args: {
             search: { parentId?: string; identifiers?: string[] };

--- a/packages/reactor-api/src/graphql/document-model-subgraph.ts
+++ b/packages/reactor-api/src/graphql/document-model-subgraph.ts
@@ -15,13 +15,108 @@ import {
   document as documentResolver,
   findDocuments as findDocumentsResolver,
 } from "./reactor/resolvers.js";
+import type {
+  PhDocument,
+  PhDocumentResultPage,
+} from "./reactor/gen/graphql.js";
 import type { Context, SubgraphArgs } from "./types.js";
+
+/** A resolver function that lives inside a document-model subgraph. */
+
+export type DocumentModelResolverFn = (...args: any[]) => unknown;
+
+/**
+ * A resolver map for a single GraphQL type in a document-model subgraph.
+ * Each key is a field name (or `__resolveType` for unions) and each value
+ * is a resolver function.
+ */
+export type DocumentModelResolverMap = Record<string, DocumentModelResolverFn>;
+
+/** View filter shared across query resolvers. */
+type ViewArg = { branch?: string; scopes?: string[] };
+
+/** Paging argument shared across query resolvers. */
+type PagingArg = { limit?: number; offset?: number; cursor?: string };
+
+/**
+ * Known query resolvers generated for every document model.
+ * `TDocument` is the GQL representation of the document (defaults to `PhDocument`).
+ */
+export interface DocumentModelQueryResolvers<
+  TDocument extends PhDocument = PhDocument,
+> {
+  document: (
+    parent: unknown,
+    args: { identifier: string; view?: ViewArg },
+    ctx: Context,
+  ) => Promise<{ document: TDocument; childIds: string[] }>;
+  findDocuments: (
+    parent: unknown,
+    args: {
+      search: { parentId?: string; identifiers?: string[] };
+      view?: ViewArg;
+      paging?: PagingArg;
+    },
+    ctx: Context,
+  ) => Promise<PhDocumentResultPage>;
+  documentChildren: (
+    parent: unknown,
+    args: { parentIdentifier: string; view?: ViewArg; paging?: PagingArg },
+    ctx: Context,
+  ) => Promise<PhDocumentResultPage>;
+  documentParents: (
+    parent: unknown,
+    args: { childIdentifier: string; view?: ViewArg; paging?: PagingArg },
+    ctx: Context,
+  ) => Promise<PhDocumentResultPage>;
+}
+
+/**
+ * Known mutation resolvers generated for every document model.
+ * `TDocument` is the GQL representation of the document (defaults to `PhDocument`).
+ * Operations specific to each model are captured by the index signature.
+ */
+export interface DocumentModelMutationResolvers<
+  TDocument extends PhDocument = PhDocument,
+> {
+  createDocument: (
+    parent: unknown,
+    args: {
+      name: string;
+      parentIdentifier?: string;
+      slug?: string;
+      preferredEditor?: string;
+      initialState?: Record<string, Record<string, unknown>>;
+    },
+    ctx: Context,
+  ) => Promise<TDocument>;
+  createEmptyDocument: (
+    parent: unknown,
+    args: { parentIdentifier?: string },
+    ctx: Context,
+  ) => Promise<TDocument>;
+  /** Dynamic operation resolvers (sync and async variants). */
+  [operationName: string]: DocumentModelResolverFn;
+}
+
+/** The resolvers that a `DocumentModelSubgraph` exposes. */
+export interface DocumentModelSubgraphResolvers<
+  TDocument extends PhDocument = PhDocument,
+> {
+  Query: DocumentModelResolverMap;
+  Mutation: DocumentModelResolverMap;
+  [namespaceKey: string]:
+    | DocumentModelResolverMap
+    | DocumentModelQueryResolvers<TDocument>
+    | DocumentModelMutationResolvers<TDocument>;
+}
 
 /**
  * New document model subgraph that uses reactorClient instead of legacy reactor.
  * This class auto-generates GraphQL queries and mutations for a document model.
  */
 export class DocumentModelSubgraph extends BaseSubgraph {
+  declare resolvers: DocumentModelSubgraphResolvers;
   private documentModel: DocumentModelModule;
 
   constructor(documentModel: DocumentModelModule, args: SubgraphArgs) {
@@ -35,12 +130,32 @@ export class DocumentModelSubgraph extends BaseSubgraph {
     this.resolvers = this.generateResolvers();
   }
 
+  /** Returns the typed query resolvers for this document model. */
+  get queryResolvers(): DocumentModelQueryResolvers {
+    const documentName = getDocumentModelSchemaName(
+      this.documentModel.documentModel.global,
+    );
+    return this.resolvers[
+      `${documentName}Queries`
+    ] as DocumentModelQueryResolvers;
+  }
+
+  /** Returns the typed mutation resolvers for this document model. */
+  get mutationResolvers(): DocumentModelMutationResolvers {
+    const documentName = getDocumentModelSchemaName(
+      this.documentModel.documentModel.global,
+    );
+    return this.resolvers[
+      `${documentName}Mutations`
+    ] as DocumentModelMutationResolvers;
+  }
+
   /**
    * Generate __resolveType functions for union types found in the document model schema.
    * Parses the state schema to find union definitions and their member types,
    * then uses unique field presence to discriminate between member types at runtime.
    */
-  private generateUnionResolvers(): Record<string, unknown> {
+  private generateUnionResolvers(): Record<string, DocumentModelResolverMap> {
     const documentName = getDocumentModelSchemaName(
       this.documentModel.documentModel.global,
     );
@@ -72,7 +187,7 @@ export class DocumentModelSubgraph extends BaseSubgraph {
       }
     }
 
-    const resolvers: Record<string, unknown> = {};
+    const resolvers: Record<string, DocumentModelResolverMap> = {};
 
     for (const def of ast.definitions) {
       if (def.kind !== Kind.UNION_TYPE_DEFINITION) continue;
@@ -115,7 +230,7 @@ export class DocumentModelSubgraph extends BaseSubgraph {
    * Generate resolvers for this document model using reactorClient
    * Uses flat queries (not nested) consistent with ReactorSubgraph patterns
    */
-  private generateResolvers(): Record<string, unknown> {
+  private generateResolvers(): DocumentModelSubgraphResolvers {
     const documentType = this.documentModel.documentModel.global.id;
     const documentName = getDocumentModelSchemaName(
       this.documentModel.documentModel.global,
@@ -130,9 +245,12 @@ export class DocumentModelSubgraph extends BaseSubgraph {
     return {
       ...this.generateUnionResolvers(),
       Query: {
-        // Flat query: Get a specific document by identifier
-        // Uses shared documentResolver from reactor/resolvers.ts
-        [`${documentName}_document`]: async (
+        // Namespace resolver: returns empty object so nested field resolvers can run
+        [documentName]: () => ({}),
+      },
+      [`${documentName}Queries`]: {
+        // Get a specific document by identifier
+        document: async (
           _: unknown,
           args: {
             identifier: string;
@@ -146,26 +264,23 @@ export class DocumentModelSubgraph extends BaseSubgraph {
             throw new GraphQLError("Document identifier is required");
           }
 
-          // Use shared resolver function
           const result = await documentResolver(this.reactorClient, {
             identifier,
             view,
           });
 
-          // Validate document type
           if (result.document.documentType !== documentType) {
             throw new GraphQLError(
               `Document with id ${identifier} is not of type ${documentType}`,
             );
           }
 
-          // Check permissions
           await this.assertCanRead(result.document.id, ctx);
 
-          // Return shared resolver result directly (matches PHDocument format)
           return result;
         },
 
+<<<<<<< HEAD
         // Flat query: Get all documents of this type (paged)
         [`${documentName}_documents`]: async (
           _: unknown,
@@ -206,6 +321,10 @@ export class DocumentModelSubgraph extends BaseSubgraph {
         // Flat query: Find documents by search criteria (type is built-in)
         // Uses shared findDocumentsResolver from reactor/resolvers.ts
         [`${documentName}_findDocuments`]: async (
+=======
+        // Find documents by search criteria (type is built-in)
+        findDocuments: async (
+>>>>>>> 3d99ada7f (feat(reactor-api): namespace document model queries and mutations)
           _: unknown,
           args: {
             search: { parentId?: string; identifiers?: string[] };
@@ -216,17 +335,15 @@ export class DocumentModelSubgraph extends BaseSubgraph {
         ) => {
           const { search, view, paging } = args;
 
-          // Use shared resolver function with built-in type filter
           const result = await findDocumentsResolver(this.reactorClient, {
             search: {
-              type: documentType, // Type is built-in for this document model subgraph
+              type: documentType,
               parentId: search.parentId,
             },
             view,
             paging,
           });
 
-          // Filter by permission if needed
           if (
             !this.hasGlobalAdminAccess(ctx) &&
             this.documentPermissionService
@@ -245,13 +362,11 @@ export class DocumentModelSubgraph extends BaseSubgraph {
             };
           }
 
-          // Return shared resolver result directly (matches PHDocument format)
           return result;
         },
 
-        // Flat query: Get children of a document (filtered by this document type)
-        // Uses shared documentChildrenResolver from reactor/resolvers.ts
-        [`${documentName}_documentChildren`]: async (
+        // Get children of a document (filtered by this document type)
+        documentChildren: async (
           _: unknown,
           args: {
             parentIdentifier: string;
@@ -264,14 +379,12 @@ export class DocumentModelSubgraph extends BaseSubgraph {
 
           await this.assertCanRead(parentIdentifier, ctx);
 
-          // Use shared resolver function
           const result = await documentChildrenResolver(this.reactorClient, {
             parentIdentifier,
             view,
             paging,
           });
 
-          // Filter children by this document type
           const filteredItems = result.items.filter(
             (item) => item.documentType === documentType,
           );
@@ -283,9 +396,8 @@ export class DocumentModelSubgraph extends BaseSubgraph {
           };
         },
 
-        // Flat query: Get parents of a document
-        // Uses shared documentParentsResolver from reactor/resolvers.ts
-        [`${documentName}_documentParents`]: async (
+        // Get parents of a document
+        documentParents: async (
           _: unknown,
           args: {
             childIdentifier: string;
@@ -298,7 +410,6 @@ export class DocumentModelSubgraph extends BaseSubgraph {
 
           await this.assertCanRead(childIdentifier, ctx);
 
-          // Use shared resolver function - return directly
           return documentParentsResolver(this.reactorClient, {
             childIdentifier,
             view,
@@ -307,8 +418,11 @@ export class DocumentModelSubgraph extends BaseSubgraph {
         },
       },
       Mutation: {
-        // Uses shared createEmptyDocumentResolver or createDocumentWithInitialStateResolver
-        [`${documentName}_createDocument`]: async (
+        // Namespace resolver: returns empty object so nested field resolvers can run
+        [documentName]: () => ({}),
+      },
+      [`${documentName}Mutations`]: {
+        createDocument: async (
           _: unknown,
           args: {
             name: string;
@@ -393,8 +507,7 @@ export class DocumentModelSubgraph extends BaseSubgraph {
 
           return createdDoc;
         },
-        // Uses shared createEmptyDocumentResolver from reactor/resolvers.ts
-        [`${documentName}_createEmptyDocument`]: async (
+        createEmptyDocument: async (
           _: unknown,
           args: { parentIdentifier?: string },
           ctx: Context,
@@ -415,7 +528,6 @@ export class DocumentModelSubgraph extends BaseSubgraph {
             );
           }
 
-          // Use shared resolver function - returns PHDocument format directly
           const result = await createEmptyDocumentResolver(this.reactorClient, {
             documentType,
             parentIdentifier,
@@ -433,97 +545,87 @@ export class DocumentModelSubgraph extends BaseSubgraph {
           return result;
         },
         // Generate sync and async mutations for each operation
-        ...operations.reduce(
-          (mutations, op) => {
-            // Sync mutation
-            mutations[`${documentName}_${camelCase(op.name!)}`] = async (
-              _: unknown,
-              args: { docId: string; input: unknown },
-              ctx: Context,
-            ) => {
-              const { docId, input } = args;
+        ...operations.reduce((mutations, op) => {
+          // Sync mutation
+          mutations[camelCase(op.name!)] = async (
+            _: unknown,
+            args: { docId: string; input: unknown },
+            ctx: Context,
+          ) => {
+            const { docId, input } = args;
 
-              // assertCanExecuteOperation uses canMutate (write + operation) when
-              // authorizationService is available. Legacy fallback needs separate write check.
-              if (!this.authorizationService) {
-                await this.assertCanWrite(docId, ctx);
-              }
-              await this.assertCanExecuteOperation(docId, op.name!, ctx);
+            if (!this.authorizationService) {
+              await this.assertCanWrite(docId, ctx);
+            }
+            await this.assertCanExecuteOperation(docId, op.name!, ctx);
 
-              const doc = await this.reactorClient.get(docId);
-              if (doc.header.documentType !== documentType) {
-                throw new GraphQLError(
-                  `Document with id ${docId} is not of type ${documentType}`,
-                );
-              }
+            const doc = await this.reactorClient.get(docId);
+            if (doc.header.documentType !== documentType) {
+              throw new GraphQLError(
+                `Document with id ${docId} is not of type ${documentType}`,
+              );
+            }
 
-              const action = this.documentModel.actions[camelCase(op.name!)];
-              if (!action) {
-                throw new GraphQLError(`Action ${op.name} not found`);
-              }
+            const action = this.documentModel.actions[camelCase(op.name!)];
+            if (!action) {
+              throw new GraphQLError(`Action ${op.name} not found`);
+            }
 
-              try {
-                const updatedDoc = await this.reactorClient.execute(
-                  docId,
-                  "main",
-                  [action(input)],
-                );
-                // Use toGqlPhDocument for PHDocument format with revisionsList
-                return toGqlPhDocument(updatedDoc);
-              } catch (error) {
-                throw new GraphQLError(
-                  error instanceof Error
-                    ? error.message
-                    : `Failed to ${op.name}`,
-                );
-              }
-            };
+            try {
+              const updatedDoc = await this.reactorClient.execute(
+                docId,
+                "main",
+                [action(input)],
+              );
+              return toGqlPhDocument(updatedDoc);
+            } catch (error) {
+              throw new GraphQLError(
+                error instanceof Error ? error.message : `Failed to ${op.name}`,
+              );
+            }
+          };
 
-            // Async mutation - returns job ID
-            mutations[`${documentName}_${camelCase(op.name!)}Async`] = async (
-              _: unknown,
-              args: { docId: string; input: unknown },
-              ctx: Context,
-            ) => {
-              const { docId, input } = args;
+          // Async mutation - returns job ID
+          mutations[`${camelCase(op.name!)}Async`] = async (
+            _: unknown,
+            args: { docId: string; input: unknown },
+            ctx: Context,
+          ) => {
+            const { docId, input } = args;
 
-              if (!this.authorizationService) {
-                await this.assertCanWrite(docId, ctx);
-              }
-              await this.assertCanExecuteOperation(docId, op.name!, ctx);
+            if (!this.authorizationService) {
+              await this.assertCanWrite(docId, ctx);
+            }
+            await this.assertCanExecuteOperation(docId, op.name!, ctx);
 
-              const doc = await this.reactorClient.get(docId);
-              if (doc.header.documentType !== documentType) {
-                throw new GraphQLError(
-                  `Document with id ${docId} is not of type ${documentType}`,
-                );
-              }
+            const doc = await this.reactorClient.get(docId);
+            if (doc.header.documentType !== documentType) {
+              throw new GraphQLError(
+                `Document with id ${docId} is not of type ${documentType}`,
+              );
+            }
 
-              const action = this.documentModel.actions[camelCase(op.name!)];
-              if (!action) {
-                throw new GraphQLError(`Action ${op.name} not found`);
-              }
+            const action = this.documentModel.actions[camelCase(op.name!)];
+            if (!action) {
+              throw new GraphQLError(`Action ${op.name} not found`);
+            }
 
-              try {
-                const jobInfo = await this.reactorClient.executeAsync(
-                  docId,
-                  "main",
-                  [action(input)],
-                );
-                return jobInfo.id;
-              } catch (error) {
-                throw new GraphQLError(
-                  error instanceof Error
-                    ? error.message
-                    : `Failed to ${op.name}`,
-                );
-              }
-            };
+            try {
+              const jobInfo = await this.reactorClient.executeAsync(
+                docId,
+                "main",
+                [action(input)],
+              );
+              return jobInfo.id;
+            } catch (error) {
+              throw new GraphQLError(
+                error instanceof Error ? error.message : `Failed to ${op.name}`,
+              );
+            }
+          };
 
-            return mutations;
-          },
-          {} as Record<string, unknown>,
-        ),
+          return mutations;
+        }, {} as DocumentModelResolverMap),
       },
     };
   }

--- a/packages/reactor-api/src/graphql/graphql-manager.ts
+++ b/packages/reactor-api/src/graphql/graphql-manager.ts
@@ -46,9 +46,11 @@ import type { AuthorizationService } from "../services/authorization.service.js"
 import type { DocumentPermissionService } from "../services/document-permission.service.js";
 import {
   buildSubgraphSchemaModule,
+  createMergedSchema,
   createSchema,
 } from "../utils/create-schema.js";
 import { DocumentModelSubgraph } from "./document-model-subgraph.js";
+import { createGraphQLSSEHandler } from "./sse.js";
 import { useServer } from "./websocket.js";
 
 class AuthenticatedDataSource extends RemoteGraphQLDataSource {
@@ -424,6 +426,11 @@ export class GraphQLManager {
         this.logger.error("Failed to update Apollo Gateway supergraph", error);
       }
     }
+
+    // Refresh the supergraph-level SSE handler so it picks up
+    // any newly registered subscription-enabled subgraphs.
+    const superGraphPath = path.join(this.path, "graphql");
+    this.#setupSupergraphSSE(superGraphPath);
   }
 
   getAdditionalContextFields = () => {
@@ -573,6 +580,23 @@ export class GraphQLManager {
                 error,
               );
             }
+
+            // Set up SSE (Server-Sent Events) transport alongside WebSocket.
+            // Clients can use SSE by sending POST requests with
+            // Accept: text/event-stream to the /stream sub-path.
+            try {
+              this.#setupSSEHandler(schema, subgraphPath);
+              this.logger.debug(
+                `SSE subscriptions enabled for ${subgraph.name}`,
+              );
+            } catch (error) {
+              this.logger.error(
+                "Failed to setup SSE for subgraph @name at path @path: @error",
+                subgraph.name,
+                subgraphPath,
+                error,
+              );
+            }
           }
 
           this.#setupApolloExpressMiddleware(server, subgraphPath);
@@ -709,11 +733,43 @@ export class GraphQLManager {
     const superGraphPath = path.join(this.path, "graphql");
     this.#setupApolloExpressMiddleware(this.coreApolloServer, superGraphPath);
 
+    // Set up SSE subscriptions at the supergraph level (/graphql/stream).
+    // Build a subscription schema from all subgraphs that define subscriptions.
+    this.#setupSupergraphSSE(superGraphPath);
+
     if (!this.initialized) {
       this.logger.info(`Registered ${superGraphPath} supergraph `);
       this.initialized = true;
     }
     return;
+  }
+
+  /**
+   * Set up an SSE subscription endpoint at the supergraph level.
+   * Merges the schemas of all subscription-enabled subgraphs so that
+   * clients can subscribe at /graphql/stream without knowing individual
+   * subgraph paths.
+   */
+  #setupSupergraphSSE(superGraphPath: string) {
+    const allSubgraphs = this.#getAllSubgraphs();
+
+    const modules = Array.from(allSubgraphs.values())
+      .filter((subgraph) => subgraph.hasSubscriptions)
+      .map((subgraph) => this.#buildSubgraphSchemaModule(subgraph));
+
+    if (modules.length === 0) {
+      return;
+    }
+
+    try {
+      const mergedSchema = createMergedSchema(modules);
+      this.#setupSSEHandler(mergedSchema, superGraphPath);
+      this.logger.debug(
+        `SSE subscriptions enabled at supergraph level (merged from ${modules.length} subgraph(s))`,
+      );
+    } catch (error) {
+      this.logger.error("Failed to setup supergraph SSE: @error", error);
+    }
   }
 
   #setupApolloExpressMiddleware(server: ApolloServer<Context>, path: string) {
@@ -728,6 +784,32 @@ export class GraphQLManager {
           }),
       }),
       matcher: match(path),
+    });
+  }
+
+  /**
+   * Set up a GraphQL-over-SSE handler at `<basePath>/stream`.
+   *
+   * Clients subscribe by sending a POST with `Accept: text/event-stream`
+   * to the `/stream` sub-path. Authentication is handled by the normal
+   * Express middleware (Authorization header), unlike WebSocket which
+   * needs its own connectionParams-based auth.
+   */
+  #setupSSEHandler(schema: GraphQLSchema, basePath: string) {
+    const ssePath = basePath + "/stream";
+    const sseHandler = createGraphQLSSEHandler({
+      schema,
+      contextFactory: (req) => ({
+        headers: req.headers,
+        driveId: req.params?.drive ?? undefined,
+        db: this.relationalDb,
+        ...this.getAdditionalContextFields(),
+      }),
+    });
+
+    this.subgraphHandlers.set(ssePath, {
+      handler: sseHandler,
+      matcher: match(ssePath),
     });
   }
 }

--- a/packages/reactor-api/src/graphql/playground.ts
+++ b/packages/reactor-api/src/graphql/playground.ts
@@ -1,3 +1,15 @@
+/**
+ * Pinned CDN versions for GraphiQL playground dependencies.
+ * Using pinned versions avoids unpkg.com redirect issues that can
+ * trigger CORS errors in the browser.
+ */
+const CDN_VERSIONS = {
+  react: "18.3.1",
+  reactDom: "18.3.1",
+  graphiql: "3.8.3",
+  pluginExplorer: "4.0.0",
+};
+
 export function renderGraphqlPlayground(
   url: string,
   query?: string,
@@ -14,34 +26,30 @@ export function renderGraphqlPlayground(
             width: 100%;
             overflow: hidden;
           }
-    
+
           #graphiql {
             height: 100vh;
           }
         </style>
         <script
-          crossorigin
-          src="https://unpkg.com/react@18/umd/react.production.min.js"
+          src="https://unpkg.com/react@${CDN_VERSIONS.react}/umd/react.production.min.js"
         ></script>
         <script
-          crossorigin
-          src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
+          src="https://unpkg.com/react-dom@${CDN_VERSIONS.reactDom}/umd/react-dom.production.min.js"
         ></script>
         <script
-          src="https://unpkg.com/graphiql/graphiql.min.js"
-          type="application/javascript"
+          src="https://unpkg.com/graphiql@${CDN_VERSIONS.graphiql}/graphiql.min.js"
         ></script>
-        <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+        <link rel="stylesheet" href="https://unpkg.com/graphiql@${CDN_VERSIONS.graphiql}/graphiql.min.css" />
         <script
-          src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"
-          crossorigin
+          src="https://unpkg.com/@graphiql/plugin-explorer@${CDN_VERSIONS.pluginExplorer}/dist/index.umd.js"
         ></script>
         <link
           rel="stylesheet"
-          href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css"
+          href="https://unpkg.com/@graphiql/plugin-explorer@${CDN_VERSIONS.pluginExplorer}/dist/style.css"
         />
       </head>
-    
+
       <body>
         <div id="graphiql">Loading...</div>
         <script>

--- a/packages/reactor-api/src/graphql/sse.ts
+++ b/packages/reactor-api/src/graphql/sse.ts
@@ -1,0 +1,58 @@
+import type { Request as SSERequest } from "graphql-sse";
+import { createHandler } from "graphql-sse/lib/use/express";
+import type { Request as ExpressRequest } from "express";
+import type { GraphQLSchema } from "graphql";
+import type { Context } from "./types.js";
+
+/**
+ * Options for creating the GraphQL-over-SSE handler.
+ */
+export interface SSEHandlerOptions {
+  schema: GraphQLSchema;
+  /**
+   * Build a GraphQL context from the incoming Express request.
+   * Called once per subscription (not per event).
+   *
+   * Unlike WebSocket subscriptions (which need their own auth via
+   * connectionParams because WS upgrades bypass Express middleware),
+   * SSE requests are normal HTTP requests. The Express auth middleware
+   * has already run by the time this handler is invoked, so `req.user`
+   * is already populated on the request object. The context factory
+   * just needs to assemble the Context the same way Apollo's
+   * expressMiddleware does.
+   */
+  contextFactory: (req: ExpressRequest) => Promise<Context> | Context;
+}
+
+/**
+ * Create an Express-compatible SSE handler for GraphQL subscriptions
+ * using the graphql-sse library (graphql-sse protocol).
+ *
+ * This runs alongside the existing WebSocket (graphql-ws) transport
+ * so clients can choose either protocol.
+ *
+ * Authentication:
+ *   SSE subscriptions are plain HTTP requests, so the existing Express
+ *   auth middleware (`AuthService.authenticate`) runs before this handler.
+ *   The client sends `Authorization: Bearer <token>` as a normal HTTP
+ *   header -- exactly the same as for queries and mutations. By the time
+ *   graphql-sse processes the request, `req.user` is already set.
+ *
+ * Clients connect via "distinct connections mode" (POST with
+ * `Accept: text/event-stream`). Single-connection mode is disabled
+ * because it adds token-management complexity with no benefit here.
+ */
+export function createGraphQLSSEHandler(options: SSEHandlerOptions) {
+  const { schema, contextFactory } = options;
+
+  return createHandler<Context>({
+    schema,
+    // Returning null disables single-connection mode. All clients use
+    // "distinct connections mode" (one POST per subscription).
+    // Auth is already handled by the Express middleware layer.
+    authenticate: () => null,
+    context: (req: SSERequest<ExpressRequest>) => {
+      return contextFactory(req.raw);
+    },
+  });
+}

--- a/packages/reactor-api/src/graphql/types.ts
+++ b/packages/reactor-api/src/graphql/types.ts
@@ -34,6 +34,7 @@ export type ISubgraph = {
   path?: string;
   resolvers: Record<string, any>;
   typeDefs: DocumentNode;
+  reactorClient: IReactorClient;
   relationalDb: IRelationalDbLegacy;
   hasSubscriptions?: boolean;
   onSetup?: () => Promise<void>;

--- a/packages/reactor-api/src/utils/create-schema.ts
+++ b/packages/reactor-api/src/utils/create-schema.ts
@@ -95,25 +95,22 @@ export const getDocumentModelTypeDefs = (
       return;
     }
     addedDocumentModels.add(dmSchemaName);
+    // Use only the latest specification to avoid duplicate type definitions
+    // when a document model has multiple versions (e.g. v1, v2).
+    const latestSpec = documentModel.global.specifications.at(-1);
+    const globalSchema = latestSpec?.state.global.schema ?? "";
+    const localSchema = latestSpec?.state.local.schema ?? "";
     let tmpDmSchema = `
-          ${documentModel.global.specifications
-            .map((specification) =>
-              specification.state.global.schema
-                .replaceAll("scalar DateTime", "")
-                .replaceAll(/input (.*?) {[\s\S]*?}/g, ""),
-            )
-            .join("\n")};
-  
-          ${documentModel.global.specifications
-            .map((specification) =>
-              specification.state.local.schema
-                .replaceAll("scalar DateTime", "")
-                .replaceAll(/input (.*?) {[\s\S]*?}/g, "")
-                .replaceAll("type AccountSnapshotLocalState", "")
-                .replaceAll("type BudgetStatementLocalState", "")
-                .replaceAll("type ScopeFrameworkLocalState", ""),
-            )
-            .join("\n")};
+          ${globalSchema
+            .replaceAll("scalar DateTime", "")
+            .replaceAll(/input (.*?) {[\s\S]*?}/g, "")};
+
+          ${localSchema
+            .replaceAll("scalar DateTime", "")
+            .replaceAll(/input (.*?) {[\s\S]*?}/g, "")
+            .replaceAll("type AccountSnapshotLocalState", "")
+            .replaceAll("type BudgetStatementLocalState", "")
+            .replaceAll("type ScopeFrameworkLocalState", "")};
 
     \n`;
 
@@ -707,9 +704,6 @@ function generateLegacyApiSchema(
  * Note: State schema types are NOT included here because they are already defined
  * in getDocumentModelTypeDefs() which is used during schema composition.
  * Including them here would cause duplicate type definitions.
- *
- * Special case: DocumentModel type doesn't have a typed state defined in
- * getDocumentModelTypeDefs(), so we use JSONObject for its state field.
  */
 function generateNewApiSchema(
   documentName: string,

--- a/packages/reactor-api/src/utils/create-schema.ts
+++ b/packages/reactor-api/src/utils/create-schema.ts
@@ -64,6 +64,15 @@ export const createSchema = (
   );
 };
 
+/**
+ * Create a merged GraphQL schema from multiple subgraph modules.
+ * Uses buildSubgraphSchema's array overload to combine type definitions
+ * and resolvers from multiple subgraphs into a single executable schema.
+ */
+export const createMergedSchema = (modules: GraphQLSchemaModule[]) => {
+  return buildSubgraphSchema(modules);
+};
+
 export function getDocumentModelSchemaName(
   documentModel: DocumentModelGlobalState,
 ) {
@@ -821,23 +830,23 @@ function generateNewApiSchema(
     }
   `;
 
-  // Flat queries (not nested) - prefixed input types to avoid conflicts
+  // Queries nested under ${documentName} namespace
   const queries = `
-    type Query {
+    type ${documentName}Queries {
       """Get a specific ${documentName} document by identifier"""
-      ${documentName}_document(identifier: String!, view: ${documentName}_ViewFilterInput): ${documentName}_DocumentWithChildren
+      document(identifier: String!, view: ${documentName}_ViewFilterInput): ${documentName}_DocumentWithChildren
 
       """Get all ${documentName} documents (paged)"""
       ${documentName}_documents(paging: ${documentName}_PagingInput): ${documentName}_DocumentResultPage!
 
       """Find ${documentName} documents by search criteria"""
-      ${documentName}_findDocuments(search: ${documentName}_SearchFilterInput!, view: ${documentName}_ViewFilterInput, paging: ${documentName}_PagingInput): ${documentName}_DocumentResultPage!
+      findDocuments(search: ${documentName}_SearchFilterInput!, view: ${documentName}_ViewFilterInput, paging: ${documentName}_PagingInput): ${documentName}_DocumentResultPage!
 
       """Get children of a ${documentName} document"""
-      ${documentName}_documentChildren(parentIdentifier: String!, view: ${documentName}_ViewFilterInput, paging: ${documentName}_PagingInput): ${documentName}_DocumentResultPage!
+      documentChildren(parentIdentifier: String!, view: ${documentName}_ViewFilterInput, paging: ${documentName}_PagingInput): ${documentName}_DocumentResultPage!
 
       """Get parents of a ${documentName} document"""
-      ${documentName}_documentParents(childIdentifier: String!, view: ${documentName}_ViewFilterInput, paging: ${documentName}_PagingInput): ${documentName}_DocumentResultPage!
+      documentParents(childIdentifier: String!, view: ${documentName}_ViewFilterInput, paging: ${documentName}_PagingInput): ${documentName}_DocumentResultPage!
     }
   `;
 
@@ -890,11 +899,11 @@ function generateNewApiSchema(
     }
   }
 
-  // Mutations: sync and async versions
+  // Mutations nested under ${documentName} namespace
   const createDocumentMutation = initialStateInputSchema
-    ? `${documentName}_createDocument(name: String!, parentIdentifier: String, slug: String, preferredEditor: String, initialState: ${documentName}_InitialStateInput): ${documentName}MutationResult!`
-    : `${documentName}_createDocument(name: String!, parentIdentifier: String, preferredEditor: String): ${documentName}MutationResult!`;
-  const createEmptyDocumentMutation = `${documentName}_createEmptyDocument(parentIdentifier: String): ${documentName}MutationResult!`;
+    ? `createDocument(name: String!, parentIdentifier: String, slug: String, preferredEditor: String, initialState: ${documentName}_InitialStateInput): ${documentName}MutationResult!`
+    : `createDocument(name: String!, parentIdentifier: String, preferredEditor: String): ${documentName}MutationResult!`;
+  const createEmptyDocumentMutation = `createEmptyDocument(parentIdentifier: String): ${documentName}MutationResult!`;
 
   const operationMutations =
     specification?.modules
@@ -903,9 +912,9 @@ function generateNewApiSchema(
           .filter((op) => op.name && hasValidSchema(op.schema))
           .flatMap((op) => [
             // Sync mutation
-            `${documentName}_${camelCase(op.name!)}(docId: PHID!, input: ${documentName}_${pascalCase(op.name!)}Input!): ${documentName}MutationResult!`,
+            `${camelCase(op.name!)}(docId: PHID!, input: ${documentName}_${pascalCase(op.name!)}Input!): ${documentName}MutationResult!`,
             // Async mutation
-            `${documentName}_${camelCase(op.name!)}Async(docId: PHID!, input: ${documentName}_${pascalCase(op.name!)}Input!): String!`,
+            `${camelCase(op.name!)}Async(docId: PHID!, input: ${documentName}_${pascalCase(op.name!)}Input!): String!`,
           ]),
       )
       .join("\n        ") ?? "";
@@ -955,11 +964,19 @@ function generateNewApiSchema(
     """
     Mutations: ${documentName}
     """
-    type Mutation {
+    type ${documentName}Mutations {
         ${createDocumentMutation}
         ${createEmptyDocumentMutation}
 
         ${operationMutations}
+    }
+
+    type Query {
+      ${documentName}: ${documentName}Queries!
+    }
+
+    type Mutation {
+      ${documentName}: ${documentName}Mutations!
     }
 
     ${

--- a/packages/reactor-api/test/document-drive-subgraph.test.ts
+++ b/packages/reactor-api/test/document-drive-subgraph.test.ts
@@ -2,20 +2,64 @@ import type { SubgraphArgs } from "@powerhousedao/reactor-api";
 import { testSetupReactor } from "@powerhousedao/reactor-api/test";
 import { driveDocumentModelModule } from "document-drive";
 import type { DocumentModelModule } from "document-model";
-import { print } from "graphql";
+import { Kind, print } from "graphql";
+import { parse } from "graphql";
 import { beforeEach, describe, expect, it } from "vitest";
-import { DocumentModelSubgraph } from "../src/graphql/document-model-subgraph.js";
+import {
+  DocumentModelSubgraph,
+  type DocumentModelResolverMap,
+} from "../src/graphql/document-model-subgraph.js";
 import {
   generateDocumentModelSchema,
   getDocumentModelSchemaName,
 } from "../src/utils/create-schema.js";
 
 /**
- * Tests for document-drive subgraph auto-generation via DocumentModelSubgraph.
- *
- * Verifies that the new DocumentModelSubgraph produces valid schemas, resolvers,
- * and union type resolvers for the document-drive document model.
+ * Parse a generated DocumentNode into a map of type definitions.
+ * Returns { typeName -> { kind, fieldNames } } for easy assertion.
  */
+function parseSchemaTypes(
+  docNode: ReturnType<typeof generateDocumentModelSchema>,
+) {
+  const ast = parse(print(docNode));
+  const types: Record<string, { kind: string; fields: string[] }> = {};
+
+  for (const def of ast.definitions) {
+    if (
+      def.kind === Kind.OBJECT_TYPE_DEFINITION ||
+      def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION
+    ) {
+      types[def.name.value] = {
+        kind: def.kind,
+        fields: def.fields?.map((f) => f.name.value) ?? [],
+      };
+    }
+  }
+  return types;
+}
+
+/**
+ * Extract the return type name from a field definition AST node,
+ * stripping NonNull and List wrappers.
+ */
+function getFieldReturnTypeName(field: {
+  type: { kind: Kind; name?: { value: string }; type?: unknown };
+}): string {
+  let node = field.type as {
+    kind: Kind;
+    name?: { value: string };
+    type?: unknown;
+  };
+  while (node.kind === Kind.NON_NULL_TYPE || node.kind === Kind.LIST_TYPE) {
+    node = node.type as {
+      kind: Kind;
+      name?: { value: string };
+      type?: unknown;
+    };
+  }
+  return node.name?.value ?? "";
+}
+
 describe("Document-Drive Subgraph", () => {
   const driveModule =
     driveDocumentModelModule as unknown as DocumentModelModule;
@@ -24,6 +68,13 @@ describe("Document-Drive Subgraph", () => {
   );
 
   describe("schema generation", () => {
+    const buildTypes = () =>
+      parseSchemaTypes(
+        generateDocumentModelSchema(driveModule.documentModel.global, {
+          useNewApi: true,
+        }),
+      );
+
     it("should generate a valid schema for document-drive", () => {
       expect(() =>
         generateDocumentModelSchema(driveModule.documentModel.global, {
@@ -32,70 +83,109 @@ describe("Document-Drive Subgraph", () => {
       ).not.toThrow();
     });
 
-    it("should include mutations for valid operations", () => {
-      const schema = generateDocumentModelSchema(
-        driveModule.documentModel.global,
-        { useNewApi: true },
+    it("should have Query type with a namespace field returning the Queries type", () => {
+      const ast = parse(
+        print(
+          generateDocumentModelSchema(driveModule.documentModel.global, {
+            useNewApi: true,
+          }),
+        ),
       );
-      const printed = print(schema);
+      const queryDef = ast.definitions.find(
+        (d) =>
+          d.kind === Kind.OBJECT_TYPE_DEFINITION && d.name.value === "Query",
+      );
+      expect(queryDef).toBeDefined();
+      if (queryDef?.kind !== Kind.OBJECT_TYPE_DEFINITION)
+        throw new Error("unreachable");
 
-      // Node operations
-      expect(printed).toContain(`${documentName}_addFile`);
-      expect(printed).toContain(`${documentName}_addFolder`);
-      expect(printed).toContain(`${documentName}_deleteNode`);
-      expect(printed).toContain(`${documentName}_updateFile`);
-      expect(printed).toContain(`${documentName}_updateNode`);
-      expect(printed).toContain(`${documentName}_copyNode`);
-      expect(printed).toContain(`${documentName}_moveNode`);
-
-      // Drive operations
-      expect(printed).toContain(`${documentName}_setDriveName`);
-      expect(printed).toContain(`${documentName}_setDriveIcon`);
-      expect(printed).toContain(`${documentName}_setSharingType`);
-      expect(printed).toContain(`${documentName}_setAvailableOffline`);
-
-      // Cleanup operations
-      expect(printed).toContain(`${documentName}_removeListener`);
-      expect(printed).toContain(`${documentName}_removeTrigger`);
+      const nsField = queryDef.fields?.find(
+        (f) => f.name.value === documentName,
+      );
+      expect(nsField).toBeDefined();
+      expect(getFieldReturnTypeName(nsField!)).toBe(`${documentName}Queries`);
     });
 
-    it("should include listener and trigger operations", () => {
-      const schema = generateDocumentModelSchema(
-        driveModule.documentModel.global,
-        { useNewApi: true },
+    it("should have Mutation type with a namespace field returning the Mutations type", () => {
+      const ast = parse(
+        print(
+          generateDocumentModelSchema(driveModule.documentModel.global, {
+            useNewApi: true,
+          }),
+        ),
       );
-      const printed = print(schema);
+      const mutationDef = ast.definitions.find(
+        (d) =>
+          d.kind === Kind.OBJECT_TYPE_DEFINITION && d.name.value === "Mutation",
+      );
+      expect(mutationDef).toBeDefined();
+      if (mutationDef?.kind !== Kind.OBJECT_TYPE_DEFINITION)
+        throw new Error("unreachable");
 
-      // ADD_LISTENER and ADD_TRIGGER now have proper input types and should be included
-      expect(printed).toContain(`${documentName}_addListener(`);
-      expect(printed).toContain(`${documentName}_addTrigger(`);
-      expect(printed).toContain(`${documentName}_addListenerAsync(`);
-      expect(printed).toContain(`${documentName}_addTriggerAsync(`);
+      const nsField = mutationDef.fields?.find(
+        (f) => f.name.value === documentName,
+      );
+      expect(nsField).toBeDefined();
+      expect(getFieldReturnTypeName(nsField!)).toBe(`${documentName}Mutations`);
     });
 
-    it("should include query types", () => {
-      const schema = generateDocumentModelSchema(
-        driveModule.documentModel.global,
-        { useNewApi: true },
-      );
-      const printed = print(schema);
+    it("should have unprefixed query fields inside the Queries namespace type", () => {
+      const types = buildTypes();
+      const queriesType = types[`${documentName}Queries`];
+      expect(queriesType).toBeDefined();
 
-      expect(printed).toContain(`${documentName}_document`);
-      expect(printed).toContain(`${documentName}_findDocuments`);
-      expect(printed).toContain(`${documentName}_documentChildren`);
-      expect(printed).toContain(`${documentName}_documentParents`);
+      expect(queriesType.fields).toContain("document");
+      expect(queriesType.fields).toContain("findDocuments");
+      expect(queriesType.fields).toContain("documentChildren");
+      expect(queriesType.fields).toContain("documentParents");
+
+      expect(queriesType.fields).not.toContain(`${documentName}_document`);
     });
 
-    it("should include async mutation variants", () => {
-      const schema = generateDocumentModelSchema(
-        driveModule.documentModel.global,
-        { useNewApi: true },
-      );
-      const printed = print(schema);
+    it("should have unprefixed mutation fields inside the Mutations namespace type", () => {
+      const types = buildTypes();
+      const mutationsType = types[`${documentName}Mutations`];
+      expect(mutationsType).toBeDefined();
 
-      expect(printed).toContain(`${documentName}_addFileAsync`);
-      expect(printed).toContain(`${documentName}_deleteNodeAsync`);
-      expect(printed).toContain(`${documentName}_setDriveNameAsync`);
+      expect(mutationsType.fields).toContain("createDocument");
+      expect(mutationsType.fields).toContain("createEmptyDocument");
+
+      expect(mutationsType.fields).toContain("addFile");
+      expect(mutationsType.fields).toContain("addFolder");
+      expect(mutationsType.fields).toContain("deleteNode");
+      expect(mutationsType.fields).toContain("updateFile");
+      expect(mutationsType.fields).toContain("updateNode");
+      expect(mutationsType.fields).toContain("copyNode");
+      expect(mutationsType.fields).toContain("moveNode");
+
+      expect(mutationsType.fields).toContain("setDriveName");
+      expect(mutationsType.fields).toContain("setDriveIcon");
+      expect(mutationsType.fields).toContain("setSharingType");
+      expect(mutationsType.fields).toContain("setAvailableOffline");
+
+      expect(mutationsType.fields).toContain("removeListener");
+      expect(mutationsType.fields).toContain("removeTrigger");
+
+      expect(mutationsType.fields).not.toContain(`${documentName}_addFile`);
+    });
+
+    it("should include listener and trigger operations in the Mutations namespace type", () => {
+      const types = buildTypes();
+      const fields = types[`${documentName}Mutations`].fields;
+
+      expect(fields).toContain("addListener");
+      expect(fields).toContain("addTrigger");
+      expect(fields).toContain("addListenerAsync");
+      expect(fields).toContain("addTriggerAsync");
+    });
+
+    it("should include async mutation variants in the Mutations namespace type", () => {
+      const types = buildTypes();
+      const fields = types[`${documentName}Mutations`].fields;
+
+      expect(fields).toContain("addFileAsync");
+      expect(fields).toContain("deleteNodeAsync");
+      expect(fields).toContain("setDriveNameAsync");
     });
   });
 
@@ -118,80 +208,73 @@ describe("Document-Drive Subgraph", () => {
       } as unknown as SubgraphArgs);
     });
 
-    it("should generate mutation resolvers for valid operations (sync + async)", () => {
-      const mutations = subgraph.resolvers.Mutation as Record<string, unknown>;
+    it("should have a namespace resolver on Query that returns an empty object", () => {
+      const queryResolvers = subgraph.resolvers.Query;
+      expect(queryResolvers[documentName]).toBeTypeOf("function");
+      expect(queryResolvers[documentName]()).toEqual({});
+    });
 
-      // Node operations - sync
-      expect(mutations[`${documentName}_addFile`]).toBeTypeOf("function");
-      expect(mutations[`${documentName}_addFolder`]).toBeTypeOf("function");
-      expect(mutations[`${documentName}_deleteNode`]).toBeTypeOf("function");
-      expect(mutations[`${documentName}_updateFile`]).toBeTypeOf("function");
-      expect(mutations[`${documentName}_updateNode`]).toBeTypeOf("function");
-      expect(mutations[`${documentName}_copyNode`]).toBeTypeOf("function");
-      expect(mutations[`${documentName}_moveNode`]).toBeTypeOf("function");
+    it("should have a namespace resolver on Mutation that returns an empty object", () => {
+      const mutationResolvers = subgraph.resolvers.Mutation;
+      expect(mutationResolvers[documentName]).toBeTypeOf("function");
+      expect(mutationResolvers[documentName]()).toEqual({});
+    });
 
-      // Node operations - async
-      expect(mutations[`${documentName}_addFileAsync`]).toBeTypeOf("function");
-      expect(mutations[`${documentName}_deleteNodeAsync`]).toBeTypeOf(
-        "function",
-      );
+    it("should generate query resolvers on the Queries namespace key", () => {
+      const queries = subgraph.queryResolvers;
+      expect(queries).toBeDefined();
 
-      // Drive operations - sync
-      expect(mutations[`${documentName}_setDriveName`]).toBeTypeOf("function");
-      expect(mutations[`${documentName}_setDriveIcon`]).toBeTypeOf("function");
-      expect(mutations[`${documentName}_setSharingType`]).toBeTypeOf(
-        "function",
-      );
-      expect(mutations[`${documentName}_setAvailableOffline`]).toBeTypeOf(
-        "function",
-      );
+      expect(queries.document).toBeTypeOf("function");
+      expect(queries.findDocuments).toBeTypeOf("function");
+      expect(queries.documentChildren).toBeTypeOf("function");
+      expect(queries.documentParents).toBeTypeOf("function");
+    });
 
-      // Drive operations - async
-      expect(mutations[`${documentName}_setDriveNameAsync`]).toBeTypeOf(
-        "function",
-      );
+    it("should generate mutation resolvers for valid operations (sync + async) on the Mutations namespace key", () => {
+      const mutations = subgraph.mutationResolvers;
+      expect(mutations).toBeDefined();
 
-      // Cleanup operations
-      expect(mutations[`${documentName}_removeListener`]).toBeTypeOf(
-        "function",
-      );
-      expect(mutations[`${documentName}_removeTrigger`]).toBeTypeOf("function");
+      expect(mutations["addFile"]).toBeTypeOf("function");
+      expect(mutations["addFolder"]).toBeTypeOf("function");
+      expect(mutations["deleteNode"]).toBeTypeOf("function");
+      expect(mutations["updateFile"]).toBeTypeOf("function");
+      expect(mutations["updateNode"]).toBeTypeOf("function");
+      expect(mutations["copyNode"]).toBeTypeOf("function");
+      expect(mutations["moveNode"]).toBeTypeOf("function");
+
+      expect(mutations["addFileAsync"]).toBeTypeOf("function");
+      expect(mutations["deleteNodeAsync"]).toBeTypeOf("function");
+
+      expect(mutations["setDriveName"]).toBeTypeOf("function");
+      expect(mutations["setDriveIcon"]).toBeTypeOf("function");
+      expect(mutations["setSharingType"]).toBeTypeOf("function");
+      expect(mutations["setAvailableOffline"]).toBeTypeOf("function");
+
+      expect(mutations["setDriveNameAsync"]).toBeTypeOf("function");
+
+      expect(mutations["removeListener"]).toBeTypeOf("function");
+      expect(mutations["removeTrigger"]).toBeTypeOf("function");
     });
 
     it("should generate mutation resolvers for listener and trigger operations", () => {
-      const mutations = subgraph.resolvers.Mutation as Record<string, unknown>;
+      const mutations = subgraph.mutationResolvers;
 
-      // ADD_LISTENER and ADD_TRIGGER now have proper input types and should be included
-      expect(mutations[`${documentName}_addListener`]).toBeTypeOf("function");
-      expect(mutations[`${documentName}_addTrigger`]).toBeTypeOf("function");
-      expect(mutations[`${documentName}_addListenerAsync`]).toBeTypeOf(
-        "function",
-      );
-      expect(mutations[`${documentName}_addTriggerAsync`]).toBeTypeOf(
-        "function",
-      );
-    });
-
-    it("should generate flat query resolvers", () => {
-      const queries = subgraph.resolvers.Query as Record<string, unknown>;
-
-      expect(queries[`${documentName}_document`]).toBeTypeOf("function");
-      expect(queries[`${documentName}_findDocuments`]).toBeTypeOf("function");
-      expect(queries[`${documentName}_documentChildren`]).toBeTypeOf(
-        "function",
-      );
-      expect(queries[`${documentName}_documentParents`]).toBeTypeOf("function");
+      expect(mutations["addListener"]).toBeTypeOf("function");
+      expect(mutations["addTrigger"]).toBeTypeOf("function");
+      expect(mutations["addListenerAsync"]).toBeTypeOf("function");
+      expect(mutations["addTriggerAsync"]).toBeTypeOf("function");
     });
 
     it("should generate createDocument and createEmptyDocument mutations", () => {
-      const mutations = subgraph.resolvers.Mutation as Record<string, unknown>;
+      const mutations = subgraph.mutationResolvers;
 
-      expect(mutations[`${documentName}_createDocument`]).toBeTypeOf(
-        "function",
-      );
-      expect(mutations[`${documentName}_createEmptyDocument`]).toBeTypeOf(
-        "function",
-      );
+      expect(mutations.createDocument).toBeTypeOf("function");
+      expect(mutations.createEmptyDocument).toBeTypeOf("function");
+    });
+
+    it("should not have flat prefixed resolvers on Query or Mutation", () => {
+      expect(Object.keys(subgraph.resolvers.Query)).toEqual([documentName]);
+      expect(Object.keys(subgraph.resolvers.Mutation)).toEqual([documentName]);
     });
   });
 
@@ -215,20 +298,18 @@ describe("Document-Drive Subgraph", () => {
     });
 
     it("should generate a __resolveType resolver for DocumentDrive_Node", () => {
-      const nodeResolver = subgraph.resolvers[`${documentName}_Node`] as Record<
-        string,
-        unknown
-      >;
+      const nodeResolver = subgraph.resolvers[
+        `${documentName}_Node`
+      ] as DocumentModelResolverMap;
 
       expect(nodeResolver).toBeDefined();
       expect(nodeResolver.__resolveType).toBeTypeOf("function");
     });
 
     it("should resolve FileNode when object has documentType field", () => {
-      const nodeResolver = subgraph.resolvers[`${documentName}_Node`] as Record<
-        string,
-        (...args: unknown[]) => string
-      >;
+      const nodeResolver = subgraph.resolvers[
+        `${documentName}_Node`
+      ] as DocumentModelResolverMap;
 
       const fileNode = {
         id: "file-1",
@@ -244,10 +325,9 @@ describe("Document-Drive Subgraph", () => {
     });
 
     it("should resolve FolderNode when object lacks documentType field", () => {
-      const nodeResolver = subgraph.resolvers[`${documentName}_Node`] as Record<
-        string,
-        (...args: unknown[]) => string
-      >;
+      const nodeResolver = subgraph.resolvers[
+        `${documentName}_Node`
+      ] as DocumentModelResolverMap;
 
       const folderNode = {
         id: "folder-1",
@@ -264,7 +344,7 @@ describe("Document-Drive Subgraph", () => {
     it("should generate a __resolveType resolver for DocumentDrive_TriggerData", () => {
       const triggerDataResolver = subgraph.resolvers[
         `${documentName}_TriggerData`
-      ] as Record<string, unknown>;
+      ] as DocumentModelResolverMap;
 
       expect(triggerDataResolver).toBeDefined();
       expect(triggerDataResolver.__resolveType).toBeTypeOf("function");
@@ -273,7 +353,7 @@ describe("Document-Drive Subgraph", () => {
     it("should resolve PullResponderTriggerData for TriggerData union", () => {
       const triggerDataResolver = subgraph.resolvers[
         `${documentName}_TriggerData`
-      ] as Record<string, (...args: unknown[]) => string>;
+      ] as DocumentModelResolverMap;
 
       const triggerData = {
         listenerId: "listener-1",

--- a/packages/reactor-api/test/document-model-subgraph-permissions.test.ts
+++ b/packages/reactor-api/test/document-model-subgraph-permissions.test.ts
@@ -1,10 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/unbound-method */
 import type { IReactorClient, PagedResults } from "@powerhousedao/reactor";
 import type { DocumentModelModule, PHDocument } from "document-model";
 import { GraphQLError } from "graphql";
@@ -43,9 +36,12 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       },
     },
     actions: {
-      setName: vi.fn((input: any) => ({ type: "SET_NAME", input })),
-      setValue: vi.fn((input: any) => ({ type: "SET_VALUE", input })),
-      restrictedOp: vi.fn((input: any) => ({ type: "RESTRICTED_OP", input })),
+      setName: vi.fn((input: unknown) => ({ type: "SET_NAME", input })),
+      setValue: vi.fn((input: unknown) => ({ type: "SET_VALUE", input })),
+      restrictedOp: vi.fn((input: unknown) => ({
+        type: "RESTRICTED_OP",
+        input,
+      })),
     },
     reducer: vi.fn(),
   } as unknown as DocumentModelModule;
@@ -125,18 +121,16 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       reactorClient: mockReactorClient as IReactorClient,
       documentPermissionService:
         mockDocumentPermissionService as DocumentPermissionService,
-      relationalDb: {} as any,
-      analyticsStore: {} as any,
-      graphqlManager: {} as any,
-      syncManager: {} as any,
+      relationalDb: {} as SubgraphArgs["relationalDb"],
+      analyticsStore: {} as SubgraphArgs["analyticsStore"],
+      graphqlManager: {} as SubgraphArgs["graphqlManager"],
+      syncManager: {} as SubgraphArgs["syncManager"],
     } as SubgraphArgs);
   });
 
   describe("Query: document", () => {
-    // Updated to match new flat resolver structure (TestModel_document instead of TestModel.getDocument)
     const callGetDocument = async (ctx: Context, identifier: string) => {
-      const queryResolver = (subgraph.resolvers.Query as any)
-        ?.TestModel_document;
+      const queryResolver = subgraph.queryResolvers.document;
       return queryResolver(null, { identifier }, ctx);
     };
 
@@ -146,7 +140,6 @@ describe("DocumentModelSubgraph Permission Checks", () => {
 
         const result = await callGetDocument(ctx, "doc-123");
 
-        // Result is DocumentWithChildren: { document: PHDocument, childIds: string[] }
         expect(result).toBeDefined();
         expect(result.document.id).toBe("doc-123");
         expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
@@ -202,21 +195,6 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         );
       });
 
-      // Note: Drive validation is no longer part of document query in new API
-      // Documents are retrieved directly by identifier, parentId filtering is done via findDocuments
-      it.skip("should verify document is in specified drive when driveId provided", async () => {
-        mockReactorClient.find = vi.fn().mockResolvedValue({
-          results: [],
-          options: { limit: 10, cursor: "" },
-        } as PagedResults<PHDocument>);
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
-
-        // This test is no longer applicable - drive filtering is done via findDocuments
-        await expect(callGetDocument(ctx, "doc-123")).rejects.toThrow(
-          "is not part of",
-        );
-      });
-
       it("should throw error if document type does not match", async () => {
         const wrongTypeDoc = {
           ...mockDocument,
@@ -246,9 +224,9 @@ describe("DocumentModelSubgraph Permission Checks", () => {
           | ((docId: string) => Promise<string[]>)
           | null = null;
         vi.mocked(mockDocumentPermissionService.canRead!).mockImplementation(
-          async (_docId, _user, getParentsFn) => {
+          (_docId, _user, getParentsFn) => {
             capturedGetParentsFn = getParentsFn;
-            return true;
+            return Promise.resolve(true);
           },
         );
 
@@ -269,9 +247,9 @@ describe("DocumentModelSubgraph Permission Checks", () => {
           | ((docId: string) => Promise<string[]>)
           | null = null;
         vi.mocked(mockDocumentPermissionService.canRead!).mockImplementation(
-          async (_docId, _user, getParentsFn) => {
+          (_docId, _user, getParentsFn) => {
             capturedGetParentsFn = getParentsFn;
-            return true;
+            return Promise.resolve(true);
           },
         );
 
@@ -284,25 +262,11 @@ describe("DocumentModelSubgraph Permission Checks", () => {
     });
 
     describe("reactorClient integration", () => {
-      // Note: Drive filtering is now done via findDocuments, not document query
-      it.skip("should use reactorClient.find to check document in drive", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
-
-        await callGetDocument(ctx, "doc-123");
-
-        // This test is no longer applicable - drive filtering is done via findDocuments
-        expect(mockReactorClient.find).toHaveBeenCalledWith({
-          parentId: "drive-1",
-          ids: ["doc-123"],
-        });
-      });
-
       it("should use reactorClient.get to fetch document", async () => {
         const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
 
         await callGetDocument(ctx, "doc-123");
 
-        // The shared resolver calls get with identifier and optional view
         expect(mockReactorClient.get).toHaveBeenCalledWith(
           "doc-123",
           undefined,
@@ -312,10 +276,8 @@ describe("DocumentModelSubgraph Permission Checks", () => {
   });
 
   describe("Query: findDocuments", () => {
-    // Updated to match new flat resolver structure (TestModel_findDocuments)
     const callFindDocuments = async (ctx: Context, parentId?: string) => {
-      const queryResolver = (subgraph.resolvers.Query as any)
-        ?.TestModel_findDocuments;
+      const queryResolver = subgraph.queryResolvers.findDocuments;
       const result = await queryResolver(
         null,
         { search: { parentId }, paging: { limit: 10 } },
@@ -350,20 +312,25 @@ describe("DocumentModelSubgraph Permission Checks", () => {
 
       it("should filter documents based on permissions when no global access", async () => {
         vi.mocked(mockDocumentPermissionService.canRead!).mockImplementation(
-          async (docId) =>
-            docId === "drive-1" || docId === "doc-1" || docId === "doc-3",
+          (docId) =>
+            Promise.resolve(
+              docId === "drive-1" || docId === "doc-1" || docId === "doc-3",
+            ),
         );
         const ctx = createContext({ userAddress: "0xpartial" });
 
         const result = await callFindDocuments(ctx, "drive-1");
 
         expect(result).toHaveLength(2);
-        expect(result.map((d: any) => d.id).sort()).toEqual(["doc-1", "doc-3"]);
+        expect(result.map((d: { id: string }) => d.id).sort()).toEqual([
+          "doc-1",
+          "doc-3",
+        ]);
       });
 
       it("should return empty array when user has no document permissions", async () => {
         vi.mocked(mockDocumentPermissionService.canRead!).mockImplementation(
-          async (docId) => docId === "drive-1",
+          (docId) => Promise.resolve(docId === "drive-1"),
         );
         const ctx = createContext({ userAddress: "0xnopermissions" });
 
@@ -374,15 +341,12 @@ describe("DocumentModelSubgraph Permission Checks", () => {
     });
 
     describe("Permission filtering", () => {
-      // Note: In the new API, findDocuments filters results based on individual document permissions
-      // rather than checking drive permission first
-      it("should filter documents when user has no global access", async () => {
+      it("should filter out all documents when user has no permissions", async () => {
         vi.mocked(mockDocumentPermissionService.canRead!).mockResolvedValue(
           false,
         );
         const ctx = createContext({ userAddress: "0xunpermitted" });
 
-        // With no permissions, all documents should be filtered out
         const result = await callFindDocuments(ctx, "drive-1");
         expect(result).toHaveLength(0);
       });
@@ -394,7 +358,6 @@ describe("DocumentModelSubgraph Permission Checks", () => {
 
         await callFindDocuments(ctx, "drive-1");
 
-        // The shared resolver now uses find with these parameters - first call includes type filter
         expect(mockReactorClient.find).toHaveBeenCalledWith(
           expect.objectContaining({
             type: "powerhouse/test-model",
@@ -503,8 +466,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       name: string,
       parentIdentifier?: string,
     ) => {
-      const mutation = (subgraph.resolvers.Mutation as any)
-        ?.TestModel_createDocument;
+      const mutation = subgraph.mutationResolvers.createDocument;
       return mutation(null, { name, parentIdentifier }, ctx);
     };
 
@@ -549,7 +511,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
     });
 
     describe("Without parentIdentifier", () => {
-      it("should check global write access when no parentIdentifier", async () => {
+      it("should deny when user lacks global admin access", async () => {
         const ctx = createContext({ userAddress: "0xnoglobal" });
 
         await expect(callCreateDocument(ctx, "New Doc")).rejects.toThrow(
@@ -600,10 +562,8 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       docId: string,
       input: unknown,
     ) => {
-      const mutation = (subgraph.resolvers.Mutation as any)?.[
-        `TestModel_${operationName}`
-      ];
-      return mutation(null, { docId, input }, ctx);
+      const mutation = subgraph.mutationResolvers[operationName];
+      return await mutation(null, { docId, input }, ctx);
     };
 
     describe("Write Permission Check", () => {
@@ -644,7 +604,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
           id: "doc-123",
           revisionsList: expect.arrayContaining([
             expect.objectContaining({ scope: "global", revision: 2 }),
-          ]),
+          ]) as unknown[],
         });
         expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
       });
@@ -684,7 +644,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
           id: "doc-123",
           revisionsList: expect.arrayContaining([
             expect.objectContaining({ scope: "global", revision: 2 }),
-          ]),
+          ]) as unknown[],
         });
         expect(
           mockDocumentPermissionService.canExecuteOperation,
@@ -711,7 +671,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
           id: "doc-123",
           revisionsList: expect.arrayContaining([
             expect.objectContaining({ scope: "global", revision: 2 }),
-          ]),
+          ]) as unknown[],
         });
         expect(
           mockDocumentPermissionService.canExecuteOperation,
@@ -805,7 +765,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
           id: "doc-123",
           revisionsList: expect.arrayContaining([
             expect.objectContaining({ scope: "global", revision: 42 }),
-          ]),
+          ]) as unknown[],
         });
       });
 
@@ -824,13 +784,9 @@ describe("DocumentModelSubgraph Permission Checks", () => {
 
   describe("AUTH_ENABLED=false behavior", () => {
     it("should allow all read access when admin role returns true", async () => {
-      const ctx = createContext({
-        isAdmin: true,
-        userAddress: "0xanyone",
-      });
+      const ctx = createContext({ isAdmin: true, userAddress: "0xanyone" });
 
-      const queryResolver = (subgraph.resolvers.Query as any)
-        ?.TestModel_document;
+      const queryResolver = subgraph.queryResolvers.document;
       const result = await queryResolver(null, { identifier: "doc-123" }, ctx);
 
       expect(result).toBeDefined();
@@ -838,14 +794,9 @@ describe("DocumentModelSubgraph Permission Checks", () => {
     });
 
     it("should allow all write access when admin role returns true", async () => {
-      const ctx = createContext({
-        isAdmin: true,
-        userAddress: "0xanyone",
-      });
+      const ctx = createContext({ isAdmin: true, userAddress: "0xanyone" });
 
-      const result = await (
-        subgraph.resolvers.Mutation as any
-      )?.TestModel_setName(
+      const result = await subgraph.mutationResolvers.setName(
         null,
         { docId: "doc-123", input: { name: "New" } },
         ctx,
@@ -855,7 +806,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         id: "doc-123",
         revisionsList: expect.arrayContaining([
           expect.objectContaining({ scope: "global", revision: 2 }),
-        ]),
+        ]) as unknown[],
       });
       expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
     });
@@ -870,18 +821,17 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         {
           reactorClient: mockReactorClient as IReactorClient,
           documentPermissionService: undefined,
-          relationalDb: {} as any,
-          analyticsStore: {} as any,
-          graphqlManager: {} as any,
-          syncManager: {} as any,
+          relationalDb: {} as SubgraphArgs["relationalDb"],
+          analyticsStore: {} as SubgraphArgs["analyticsStore"],
+          graphqlManager: {} as SubgraphArgs["graphqlManager"],
+          syncManager: {} as SubgraphArgs["syncManager"],
         } as SubgraphArgs,
       );
     });
 
     it("should deny read access when no permission service and no global access", async () => {
       const ctx = createContext({ userAddress: "0xuser" });
-      const queryResolver = (subgraphWithoutPermService.resolvers.Query as any)
-        ?.TestModel_document;
+      const queryResolver = subgraphWithoutPermService.queryResolvers.document;
 
       await expect(
         queryResolver(null, { identifier: "doc-123" }, ctx),
@@ -892,9 +842,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       const ctx = createContext({ userAddress: "0xuser" });
 
       await expect(
-        (
-          subgraphWithoutPermService.resolvers.Mutation as any
-        )?.TestModel_setName(
+        subgraphWithoutPermService.mutationResolvers.setName(
           null,
           { docId: "doc-123", input: { name: "New" } },
           ctx,
@@ -904,8 +852,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
 
     it("should allow access with global roles even without permission service", async () => {
       const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
-      const queryResolver = (subgraphWithoutPermService.resolvers.Query as any)
-        ?.TestModel_document;
+      const queryResolver = subgraphWithoutPermService.queryResolvers.document;
 
       const result = await queryResolver(null, { identifier: "doc-123" }, ctx);
 
@@ -915,9 +862,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
     it("should skip operation restriction check when no permission service", async () => {
       const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
 
-      const result = await (
-        subgraphWithoutPermService.resolvers.Mutation as any
-      )?.TestModel_setName(
+      const result = await subgraphWithoutPermService.mutationResolvers.setName(
         null,
         { docId: "doc-123", input: { name: "New" } },
         ctx,
@@ -927,7 +872,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         id: "doc-123",
         revisionsList: expect.arrayContaining([
           expect.objectContaining({ scope: "global", revision: 2 }),
-        ]),
+        ]) as unknown[],
       });
     });
   });
@@ -939,8 +884,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         isAdmin: vi.fn().mockReturnValue(false),
       } as unknown as Context;
 
-      const queryResolver = (subgraph.resolvers.Query as any)
-        ?.TestModel_document;
+      const queryResolver = subgraph.queryResolvers.document;
 
       await expect(
         queryResolver(null, { identifier: "doc-123" }, ctx),
@@ -961,7 +905,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       ).mockResolvedValue(true);
       const ctx = createContext({ userAddress: "0xuser" });
 
-      await (subgraph.resolvers.Mutation as any)?.TestModel_setValue(
+      await subgraph.mutationResolvers.setValue(
         null,
         { docId: "doc-123", input: { value: 42 } },
         ctx,

--- a/packages/reactor-api/test/subscriptions-sse.test.ts
+++ b/packages/reactor-api/test/subscriptions-sse.test.ts
@@ -1,0 +1,617 @@
+import type {
+  DocumentChangeEvent,
+  IReactorClient,
+} from "@powerhousedao/reactor";
+import { DocumentChangeType } from "@powerhousedao/reactor";
+import { documentModelDocumentModelModule } from "document-model";
+import {
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  parse,
+  subscribe,
+} from "graphql";
+import { setTimeout as delay } from "node:timers/promises";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createGraphQLSSEHandler } from "../src/graphql/sse.js";
+import type { Context } from "../src/graphql/types.js";
+import {
+  matchesSearchFilter,
+  toGqlDocumentChangeEvent,
+} from "../src/graphql/reactor/adapters.js";
+import {
+  ensureGlobalDocumentSubscription,
+  getPubSub,
+  SUBSCRIPTION_TRIGGERS,
+  type DocumentChangesPayload,
+  type JobChangesPayload,
+} from "../src/graphql/reactor/pubsub.js";
+import { createSchema } from "../src/utils/create-schema.js";
+import { gql } from "graphql-tag";
+
+// ---- Type-defs-only schema for SSE handler creation tests (uses createSchema) ----
+const testTypeDefs = gql`
+  scalar JSONObject
+  scalar DateTime
+
+  input SearchFilterInput {
+    type: String
+    parentId: String
+  }
+
+  input ViewFilterInput {
+    branch: String
+    scopes: [String!]
+  }
+
+  enum DocumentChangeType {
+    CREATED
+    DELETED
+    UPDATED
+    PARENT_ADDED
+    PARENT_REMOVED
+    CHILD_ADDED
+    CHILD_REMOVED
+  }
+
+  type Revision {
+    scope: String!
+    revision: Int!
+  }
+
+  type PHDocument {
+    id: String!
+    slug: String
+    name: String!
+    documentType: String!
+    state: JSONObject!
+    revisionsList: [Revision!]!
+    createdAtUtcIso: DateTime!
+    lastModifiedAtUtcIso: DateTime!
+  }
+
+  type DocumentChangeContext {
+    parentId: String
+    childId: String
+  }
+
+  type DocumentChangeEvent {
+    type: DocumentChangeType!
+    documents: [PHDocument!]!
+    context: DocumentChangeContext
+  }
+
+  type JobChangeEvent {
+    jobId: String!
+    status: String!
+    result: JSONObject!
+    error: String
+  }
+
+  type Query {
+    _empty: String
+  }
+
+  type Subscription {
+    documentChanges(
+      search: SearchFilterInput!
+      view: ViewFilterInput
+    ): DocumentChangeEvent!
+    jobChanges(jobId: String!): JobChangeEvent!
+  }
+`;
+
+// ---- Pure-graphql schema for subscribe() tests (avoids dual-module instanceOf issue) ----
+const DocumentChangeTypeEnum = new GraphQLEnumType({
+  name: "DocumentChangeType",
+  values: {
+    CREATED: { value: "CREATED" },
+    DELETED: { value: "DELETED" },
+    UPDATED: { value: "UPDATED" },
+    PARENT_ADDED: { value: "PARENT_ADDED" },
+    PARENT_REMOVED: { value: "PARENT_REMOVED" },
+    CHILD_ADDED: { value: "CHILD_ADDED" },
+    CHILD_REMOVED: { value: "CHILD_REMOVED" },
+  },
+});
+
+const PHDocumentType = new GraphQLObjectType({
+  name: "PHDocument",
+  fields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    name: { type: new GraphQLNonNull(GraphQLString) },
+    documentType: { type: new GraphQLNonNull(GraphQLString) },
+    slug: { type: GraphQLString },
+  },
+});
+
+const DocumentChangeContextType = new GraphQLObjectType({
+  name: "DocumentChangeContext",
+  fields: {
+    parentId: { type: GraphQLString },
+    childId: { type: GraphQLString },
+  },
+});
+
+const DocumentChangeEventType = new GraphQLObjectType({
+  name: "DocumentChangeEvent",
+  fields: {
+    type: { type: new GraphQLNonNull(DocumentChangeTypeEnum) },
+    documents: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(PHDocumentType)),
+      ),
+    },
+    context: { type: DocumentChangeContextType },
+  },
+});
+
+const JobChangeEventType = new GraphQLObjectType({
+  name: "JobChangeEvent",
+  fields: {
+    jobId: { type: new GraphQLNonNull(GraphQLString) },
+    status: { type: new GraphQLNonNull(GraphQLString) },
+    error: { type: GraphQLString },
+  },
+});
+
+const SearchFilterInputType = new GraphQLInputObjectType({
+  name: "SearchFilterInput",
+  fields: {
+    type: { type: GraphQLString },
+    parentId: { type: GraphQLString },
+  },
+});
+
+function buildSubscriptionTestSchema(resolvers: {
+  documentChanges?: {
+    subscribe: () => AsyncIterableIterator<DocumentChangesPayload>;
+    resolve: (payload: DocumentChangesPayload) => unknown;
+  };
+  jobChanges?: {
+    subscribe: () => AsyncIterableIterator<JobChangesPayload>;
+    resolve: (payload: JobChangesPayload) => unknown;
+  };
+}) {
+  const subscriptionFields: Record<string, unknown> = {};
+
+  if (resolvers.documentChanges) {
+    subscriptionFields.documentChanges = {
+      type: new GraphQLNonNull(DocumentChangeEventType),
+      args: {
+        search: { type: new GraphQLNonNull(SearchFilterInputType) },
+      },
+      subscribe: resolvers.documentChanges.subscribe,
+      resolve: resolvers.documentChanges.resolve,
+    };
+  }
+
+  if (resolvers.jobChanges) {
+    subscriptionFields.jobChanges = {
+      type: new GraphQLNonNull(JobChangeEventType),
+      args: {
+        jobId: { type: new GraphQLNonNull(GraphQLString) },
+      },
+      subscribe: resolvers.jobChanges.subscribe,
+      resolve: resolvers.jobChanges.resolve,
+    };
+  }
+
+  return new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: "Query",
+      fields: { _empty: { type: GraphQLString } },
+    }),
+    subscription: new GraphQLObjectType({
+      name: "Subscription",
+      fields: subscriptionFields as never,
+    }),
+  });
+}
+
+/**
+ * Create a real PHDocument using the document-model module utilities.
+ */
+function createTestDocument() {
+  return documentModelDocumentModelModule.utils.createDocument();
+}
+
+describe("Subscription SSE Integration", () => {
+  let mockReactorClient: IReactorClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockReactorClient = {
+      subscribe: vi.fn((_search, _callback) => {
+        return vi.fn();
+      }),
+      getJobStatus: vi.fn(),
+    } as unknown as IReactorClient;
+  });
+
+  describe("SSE Handler Creation", () => {
+    it("should create an SSE handler from a schema with subscriptions", () => {
+      const schema = createSchema(
+        [],
+        {
+          Query: { _empty: () => null },
+          Subscription: {
+            documentChanges: {
+              subscribe: () =>
+                getPubSub().asyncIterableIterator(
+                  SUBSCRIPTION_TRIGGERS.DOCUMENT_CHANGES,
+                ),
+              resolve: (payload: DocumentChangesPayload) =>
+                toGqlDocumentChangeEvent(payload.documentChanges),
+            },
+          },
+        },
+        testTypeDefs,
+      );
+
+      const handler = createGraphQLSSEHandler({
+        schema,
+        contextFactory: () =>
+          ({
+            headers: {},
+            db: null,
+          }) as unknown as Context,
+      });
+
+      expect(handler).toBeDefined();
+      expect(typeof handler).toBe("function");
+    });
+
+    it("should accept a contextFactory that returns a Promise", () => {
+      const schema = createSchema(
+        [],
+        { Query: { _empty: () => null } },
+        testTypeDefs,
+      );
+
+      const handler = createGraphQLSSEHandler({
+        schema,
+        contextFactory: async () =>
+          ({
+            headers: {},
+            db: null,
+          }) as unknown as Context,
+      });
+
+      expect(handler).toBeDefined();
+    });
+  });
+
+  describe("GraphQL Subscription Execution", () => {
+    it("should execute a documentChanges subscription and receive events via PubSub", async () => {
+      const schema = buildSubscriptionTestSchema({
+        documentChanges: {
+          subscribe: () => {
+            ensureGlobalDocumentSubscription(mockReactorClient);
+            return getPubSub().asyncIterableIterator(
+              SUBSCRIPTION_TRIGGERS.DOCUMENT_CHANGES,
+            );
+          },
+          resolve: (payload: DocumentChangesPayload) =>
+            toGqlDocumentChangeEvent(payload.documentChanges),
+        },
+      });
+
+      const subscriptionDocument = parse(`
+        subscription {
+          documentChanges(search: {}) {
+            type
+            documents {
+              id
+              name
+              documentType
+            }
+          }
+        }
+      `);
+
+      const result = await subscribe({
+        schema,
+        document: subscriptionDocument,
+      });
+
+      // subscribe() should return an AsyncIterable, not an error
+      expect(Symbol.asyncIterator in (result as object)).toBe(true);
+      const iterator = (result as AsyncIterableIterator<unknown>)[
+        Symbol.asyncIterator
+      ]();
+
+      // Use a real document from the document-model module
+      const doc = createTestDocument();
+
+      const mockEvent: DocumentChangeEvent = {
+        type: DocumentChangeType.Created,
+        documents: [doc],
+      };
+
+      const payload: DocumentChangesPayload = {
+        documentChanges: mockEvent,
+        search: {},
+      };
+
+      // Publish after a microtask so the iterator is listening
+      const nextPromise = iterator.next();
+      await delay(10);
+      void getPubSub().publish(
+        SUBSCRIPTION_TRIGGERS.DOCUMENT_CHANGES,
+        payload,
+      );
+
+      const next = await nextPromise;
+      expect(next.done).toBe(false);
+      expect(next.value).toEqual({
+        data: {
+          documentChanges: {
+            type: "CREATED",
+            documents: [
+              expect.objectContaining({
+                id: doc.header.id,
+                name: doc.header.name,
+                documentType: doc.header.documentType,
+              }),
+            ],
+          },
+        },
+      });
+
+      await iterator.return?.();
+    });
+
+    it("should execute a jobChanges subscription and receive events via PubSub", async () => {
+      const schema = buildSubscriptionTestSchema({
+        jobChanges: {
+          subscribe: () =>
+            getPubSub().asyncIterableIterator(
+              SUBSCRIPTION_TRIGGERS.JOB_CHANGES,
+            ),
+          resolve: (payload: JobChangesPayload) => payload.jobChanges,
+        },
+      });
+
+      const subscriptionDocument = parse(`
+        subscription {
+          jobChanges(jobId: "job-123") {
+            jobId
+            status
+            error
+          }
+        }
+      `);
+
+      const result = await subscribe({
+        schema,
+        document: subscriptionDocument,
+      });
+
+      expect(Symbol.asyncIterator in (result as object)).toBe(true);
+      const iterator = (result as AsyncIterableIterator<unknown>)[
+        Symbol.asyncIterator
+      ]();
+
+      const jobPayload: JobChangesPayload = {
+        jobChanges: {
+          jobId: "job-123",
+          status: "COMPLETED",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          completedAt: "2024-01-01T00:01:00.000Z",
+          error: null,
+          result: { output: "done" },
+        },
+        jobId: "job-123",
+      };
+
+      const nextPromise = iterator.next();
+      await delay(10);
+      void getPubSub().publish(SUBSCRIPTION_TRIGGERS.JOB_CHANGES, jobPayload);
+
+      const next = await nextPromise;
+      expect(next.done).toBe(false);
+      expect(next.value).toEqual({
+        data: {
+          jobChanges: {
+            jobId: "job-123",
+            status: "COMPLETED",
+            error: null,
+          },
+        },
+      });
+
+      await iterator.return?.();
+    });
+
+    it("should handle multiple sequential events on a subscription", async () => {
+      const schema = buildSubscriptionTestSchema({
+        documentChanges: {
+          subscribe: () => {
+            ensureGlobalDocumentSubscription(mockReactorClient);
+            return getPubSub().asyncIterableIterator(
+              SUBSCRIPTION_TRIGGERS.DOCUMENT_CHANGES,
+            );
+          },
+          resolve: (payload: DocumentChangesPayload) =>
+            toGqlDocumentChangeEvent(payload.documentChanges),
+        },
+      });
+
+      const subscriptionDocument = parse(`
+        subscription {
+          documentChanges(search: {}) {
+            type
+            documents { id }
+          }
+        }
+      `);
+
+      const result = await subscribe({
+        schema,
+        document: subscriptionDocument,
+      });
+      const iterator = (result as AsyncIterableIterator<unknown>)[
+        Symbol.asyncIterator
+      ]();
+
+      const doc1 = createTestDocument();
+      const doc2 = createTestDocument();
+
+      // Wait for the iterator to be ready, then publish
+      const firstPromise = iterator.next();
+      await delay(10);
+      void getPubSub().publish(SUBSCRIPTION_TRIGGERS.DOCUMENT_CHANGES, {
+        documentChanges: {
+          type: DocumentChangeType.Created,
+          documents: [doc1],
+        },
+        search: {},
+      } satisfies DocumentChangesPayload);
+
+      const first = await firstPromise;
+      expect(first.value).toEqual({
+        data: {
+          documentChanges: {
+            type: "CREATED",
+            documents: [expect.objectContaining({ id: doc1.header.id })],
+          },
+        },
+      });
+
+      const secondPromise = iterator.next();
+      await delay(10);
+      void getPubSub().publish(SUBSCRIPTION_TRIGGERS.DOCUMENT_CHANGES, {
+        documentChanges: {
+          type: DocumentChangeType.Updated,
+          documents: [doc2],
+        },
+        search: {},
+      } satisfies DocumentChangesPayload);
+
+      const second = await secondPromise;
+      expect(second.value).toEqual({
+        data: {
+          documentChanges: {
+            type: "UPDATED",
+            documents: [expect.objectContaining({ id: doc2.header.id })],
+          },
+        },
+      });
+
+      await iterator.return?.();
+    });
+  });
+
+  describe("Subscription Filtering with Resolvers", () => {
+    it("should filter documentChanges by document type", () => {
+      const docModelDoc = createTestDocument();
+      // The document-model module creates documents of type "powerhouse/document-model"
+      expect(docModelDoc.header.documentType).toBe(
+        "powerhouse/document-model",
+      );
+
+      const otherDoc = createTestDocument();
+      // Override the header to simulate a different type
+      const otherTypedDoc = {
+        ...otherDoc,
+        header: {
+          ...otherDoc.header,
+          documentType: "powerhouse/budget-statement",
+        },
+      };
+
+      const events: DocumentChangesPayload[] = [
+        {
+          documentChanges: {
+            type: DocumentChangeType.Created,
+            documents: [docModelDoc],
+          },
+          search: {},
+        },
+        {
+          documentChanges: {
+            type: DocumentChangeType.Created,
+            documents: [otherTypedDoc],
+          },
+          search: {},
+        },
+      ];
+
+      const filter = { type: "powerhouse/document-model" };
+
+      const matching = events.filter((payload) =>
+        matchesSearchFilter(payload.documentChanges, filter),
+      );
+
+      expect(matching).toHaveLength(1);
+      expect(matching[0].documentChanges.documents[0].header.id).toBe(
+        docModelDoc.header.id,
+      );
+    });
+
+    it("should filter documentChanges by parentId", () => {
+      const childDoc = createTestDocument();
+
+      const event: DocumentChangesPayload = {
+        documentChanges: {
+          type: DocumentChangeType.ChildAdded,
+          documents: [childDoc],
+          context: { parentId: "parent-1", childId: childDoc.header.id },
+        },
+        search: {},
+      };
+
+      expect(
+        matchesSearchFilter(event.documentChanges, { parentId: "parent-1" }),
+      ).toBe(true);
+      expect(
+        matchesSearchFilter(event.documentChanges, {
+          parentId: "other-parent",
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("Schema with Subscriptions", () => {
+    it("should create a valid schema that includes Subscription type", () => {
+      const schema = createSchema(
+        [],
+        {
+          Query: { _empty: () => null },
+          Subscription: {
+            documentChanges: {
+              subscribe: () =>
+                getPubSub().asyncIterableIterator(
+                  SUBSCRIPTION_TRIGGERS.DOCUMENT_CHANGES,
+                ),
+              resolve: (payload: DocumentChangesPayload) =>
+                toGqlDocumentChangeEvent(payload.documentChanges),
+            },
+            jobChanges: {
+              subscribe: () =>
+                getPubSub().asyncIterableIterator(
+                  SUBSCRIPTION_TRIGGERS.JOB_CHANGES,
+                ),
+              resolve: (payload: JobChangesPayload) => payload.jobChanges,
+            },
+          },
+        },
+        testTypeDefs,
+      );
+
+      const subscriptionType = schema.getSubscriptionType();
+      expect(subscriptionType).toBeDefined();
+      expect(subscriptionType?.name).toBe("Subscription");
+
+      const fields = subscriptionType!.getFields();
+      expect(fields.documentChanges).toBeDefined();
+      expect(fields.jobChanges).toBeDefined();
+    });
+  });
+});

--- a/packages/reactor-api/test/subscriptions-sse.test.ts
+++ b/packages/reactor-api/test/subscriptions-sse.test.ts
@@ -1,351 +1,116 @@
-import type {
-  DocumentChangeEvent,
-  IReactorClient,
-} from "@powerhousedao/reactor";
+import type { IReactorClient, ISyncManager } from "@powerhousedao/reactor";
 import { DocumentChangeType } from "@powerhousedao/reactor";
 import { documentModelDocumentModelModule } from "document-model";
-import {
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLSchema,
-  GraphQLString,
-  parse,
-  subscribe,
-} from "graphql";
+import { buildSchema, print, subscribe, parse } from "graphql";
 import { setTimeout as delay } from "node:timers/promises";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createGraphQLSSEHandler } from "../src/graphql/sse.js";
-import type { Context } from "../src/graphql/types.js";
+import { describe, expect, it, vi } from "vitest";
+import { matchesSearchFilter } from "../src/graphql/reactor/adapters.js";
 import {
-  matchesSearchFilter,
-  toGqlDocumentChangeEvent,
-} from "../src/graphql/reactor/adapters.js";
-import {
-  ensureGlobalDocumentSubscription,
   getPubSub,
   SUBSCRIPTION_TRIGGERS,
   type DocumentChangesPayload,
   type JobChangesPayload,
 } from "../src/graphql/reactor/pubsub.js";
+import { ReactorSubgraph } from "../src/graphql/reactor/subgraph.js";
+import { createGraphQLSSEHandler } from "../src/graphql/sse.js";
+import type { Context, SubgraphArgs } from "../src/graphql/types.js";
 import { createSchema } from "../src/utils/create-schema.js";
-import { gql } from "graphql-tag";
 
-// ---- Type-defs-only schema for SSE handler creation tests (uses createSchema) ----
-const testTypeDefs = gql`
-  scalar JSONObject
-  scalar DateTime
+// Instantiate the actual ReactorSubgraph to get its typeDefs and resolvers.
+// The mock reactorClient needs subscribe() (called by ensureGlobalDocumentSubscription)
+// and getJobStatus() (called by ensureJobSubscription).
+const mockReactorClient = {
+  subscribe: vi.fn(() => vi.fn()),
+  getJobStatus: vi.fn(),
+} as unknown as IReactorClient;
 
-  input SearchFilterInput {
-    type: String
-    parentId: String
-  }
-
-  input ViewFilterInput {
-    branch: String
-    scopes: [String!]
-  }
-
-  enum DocumentChangeType {
-    CREATED
-    DELETED
-    UPDATED
-    PARENT_ADDED
-    PARENT_REMOVED
-    CHILD_ADDED
-    CHILD_REMOVED
-  }
-
-  type Revision {
-    scope: String!
-    revision: Int!
-  }
-
-  type PHDocument {
-    id: String!
-    slug: String
-    name: String!
-    documentType: String!
-    state: JSONObject!
-    revisionsList: [Revision!]!
-    createdAtUtcIso: DateTime!
-    lastModifiedAtUtcIso: DateTime!
-  }
-
-  type DocumentChangeContext {
-    parentId: String
-    childId: String
-  }
-
-  type DocumentChangeEvent {
-    type: DocumentChangeType!
-    documents: [PHDocument!]!
-    context: DocumentChangeContext
-  }
-
-  type JobChangeEvent {
-    jobId: String!
-    status: String!
-    result: JSONObject!
-    error: String
-  }
-
-  type Query {
-    _empty: String
-  }
-
-  type Subscription {
-    documentChanges(
-      search: SearchFilterInput!
-      view: ViewFilterInput
-    ): DocumentChangeEvent!
-    jobChanges(jobId: String!): JobChangeEvent!
-  }
-`;
-
-// ---- Pure-graphql schema for subscribe() tests (avoids dual-module instanceOf issue) ----
-const DocumentChangeTypeEnum = new GraphQLEnumType({
-  name: "DocumentChangeType",
-  values: {
-    CREATED: { value: "CREATED" },
-    DELETED: { value: "DELETED" },
-    UPDATED: { value: "UPDATED" },
-    PARENT_ADDED: { value: "PARENT_ADDED" },
-    PARENT_REMOVED: { value: "PARENT_REMOVED" },
-    CHILD_ADDED: { value: "CHILD_ADDED" },
-    CHILD_REMOVED: { value: "CHILD_REMOVED" },
-  },
-});
-
-const PHDocumentType = new GraphQLObjectType({
-  name: "PHDocument",
-  fields: {
-    id: { type: new GraphQLNonNull(GraphQLString) },
-    name: { type: new GraphQLNonNull(GraphQLString) },
-    documentType: { type: new GraphQLNonNull(GraphQLString) },
-    slug: { type: GraphQLString },
-  },
-});
-
-const DocumentChangeContextType = new GraphQLObjectType({
-  name: "DocumentChangeContext",
-  fields: {
-    parentId: { type: GraphQLString },
-    childId: { type: GraphQLString },
-  },
-});
-
-const DocumentChangeEventType = new GraphQLObjectType({
-  name: "DocumentChangeEvent",
-  fields: {
-    type: { type: new GraphQLNonNull(DocumentChangeTypeEnum) },
-    documents: {
-      type: new GraphQLNonNull(
-        new GraphQLList(new GraphQLNonNull(PHDocumentType)),
-      ),
-    },
-    context: { type: DocumentChangeContextType },
-  },
-});
-
-const JobChangeEventType = new GraphQLObjectType({
-  name: "JobChangeEvent",
-  fields: {
-    jobId: { type: new GraphQLNonNull(GraphQLString) },
-    status: { type: new GraphQLNonNull(GraphQLString) },
-    error: { type: GraphQLString },
-  },
-});
-
-const SearchFilterInputType = new GraphQLInputObjectType({
-  name: "SearchFilterInput",
-  fields: {
-    type: { type: GraphQLString },
-    parentId: { type: GraphQLString },
-  },
-});
-
-function buildSubscriptionTestSchema(resolvers: {
-  documentChanges?: {
-    subscribe: () => AsyncIterableIterator<DocumentChangesPayload>;
-    resolve: (payload: DocumentChangesPayload) => unknown;
-  };
-  jobChanges?: {
-    subscribe: () => AsyncIterableIterator<JobChangesPayload>;
-    resolve: (payload: JobChangesPayload) => unknown;
-  };
-}) {
-  const subscriptionFields: Record<string, unknown> = {};
-
-  if (resolvers.documentChanges) {
-    subscriptionFields.documentChanges = {
-      type: new GraphQLNonNull(DocumentChangeEventType),
-      args: {
-        search: { type: new GraphQLNonNull(SearchFilterInputType) },
-      },
-      subscribe: resolvers.documentChanges.subscribe,
-      resolve: resolvers.documentChanges.resolve,
-    };
-  }
-
-  if (resolvers.jobChanges) {
-    subscriptionFields.jobChanges = {
-      type: new GraphQLNonNull(JobChangeEventType),
-      args: {
-        jobId: { type: new GraphQLNonNull(GraphQLString) },
-      },
-      subscribe: resolvers.jobChanges.subscribe,
-      resolve: resolvers.jobChanges.resolve,
-    };
-  }
-
-  return new GraphQLSchema({
-    query: new GraphQLObjectType({
-      name: "Query",
-      fields: { _empty: { type: GraphQLString } },
-    }),
-    subscription: new GraphQLObjectType({
-      name: "Subscription",
-      fields: subscriptionFields as never,
-    }),
-  });
-}
+const reactorSubgraph = new ReactorSubgraph({
+  reactorClient: mockReactorClient,
+  syncManager: {} as ISyncManager,
+} as SubgraphArgs);
 
 /**
- * Create a real PHDocument using the document-model module utilities.
+ * Build an executable schema for subscribe() tests.
+ *
+ * We use graphql's buildSchema + field patching (instead of Apollo's
+ * buildSubgraphSchema) because vitest's vite transform creates separate
+ * graphql module instances, causing subscribe() to reject Federation
+ * schemas with "Cannot use GraphQLSchema from another module or realm".
  */
+function buildSubscriptionSchema() {
+  const schema = buildSchema(print(reactorSubgraph.typeDefs));
+  const subscriptionType = schema.getSubscriptionType()!;
+  const fields = subscriptionType.getFields();
+  const resolvers = reactorSubgraph.resolvers.Subscription as Record<
+    string,
+    { subscribe: () => unknown; resolve: (payload: unknown) => unknown }
+  >;
+  for (const [name, resolver] of Object.entries(resolvers)) {
+    if (fields[name]) {
+      const field = fields[name] as unknown as Record<string, unknown>;
+      field.subscribe = resolver.subscribe;
+      field.resolve = resolver.resolve;
+    }
+  }
+  return schema;
+}
+
+/** Build a Federation schema for SSE handler tests (doesn't use subscribe()). */
+function buildFederationSchema() {
+  return createSchema([], reactorSubgraph.resolvers, reactorSubgraph.typeDefs);
+}
+
 function createTestDocument() {
   return documentModelDocumentModelModule.utils.createDocument();
 }
 
 describe("Subscription SSE Integration", () => {
-  let mockReactorClient: IReactorClient;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-
-    mockReactorClient = {
-      subscribe: vi.fn((_search, _callback) => {
-        return vi.fn();
-      }),
-      getJobStatus: vi.fn(),
-    } as unknown as IReactorClient;
-  });
-
   describe("SSE Handler Creation", () => {
-    it("should create an SSE handler from a schema with subscriptions", () => {
-      const schema = createSchema(
-        [],
-        {
-          Query: { _empty: () => null },
-          Subscription: {
-            documentChanges: {
-              subscribe: () =>
-                getPubSub().asyncIterableIterator(
-                  SUBSCRIPTION_TRIGGERS.DOCUMENT_CHANGES,
-                ),
-              resolve: (payload: DocumentChangesPayload) =>
-                toGqlDocumentChangeEvent(payload.documentChanges),
-            },
-          },
-        },
-        testTypeDefs,
-      );
-
+    it("should create an SSE handler from the reactor schema", () => {
+      const schema = buildFederationSchema();
       const handler = createGraphQLSSEHandler({
         schema,
-        contextFactory: () =>
-          ({
-            headers: {},
-            db: null,
-          }) as unknown as Context,
+        contextFactory: () => ({ headers: {}, db: null }) as unknown as Context,
       });
 
       expect(handler).toBeDefined();
       expect(typeof handler).toBe("function");
     });
-
-    it("should accept a contextFactory that returns a Promise", () => {
-      const schema = createSchema(
-        [],
-        { Query: { _empty: () => null } },
-        testTypeDefs,
-      );
-
-      const handler = createGraphQLSSEHandler({
-        schema,
-        contextFactory: async () =>
-          ({
-            headers: {},
-            db: null,
-          }) as unknown as Context,
-      });
-
-      expect(handler).toBeDefined();
-    });
   });
 
   describe("GraphQL Subscription Execution", () => {
-    it("should execute a documentChanges subscription and receive events via PubSub", async () => {
-      const schema = buildSubscriptionTestSchema({
-        documentChanges: {
-          subscribe: () => {
-            ensureGlobalDocumentSubscription(mockReactorClient);
-            return getPubSub().asyncIterableIterator(
-              SUBSCRIPTION_TRIGGERS.DOCUMENT_CHANGES,
-            );
-          },
-          resolve: (payload: DocumentChangesPayload) =>
-            toGqlDocumentChangeEvent(payload.documentChanges),
-        },
-      });
-
-      const subscriptionDocument = parse(`
-        subscription {
-          documentChanges(search: {}) {
-            type
-            documents {
-              id
-              name
-              documentType
-            }
-          }
-        }
-      `);
+    it("should receive documentChanges events via PubSub", async () => {
+      const schema = buildSubscriptionSchema();
 
       const result = await subscribe({
         schema,
-        document: subscriptionDocument,
+        document: parse(`
+          subscription {
+            documentChanges(search: {}) {
+              type
+              documents { id name documentType }
+            }
+          }
+        `),
       });
 
-      // subscribe() should return an AsyncIterable, not an error
       expect(Symbol.asyncIterator in (result as object)).toBe(true);
       const iterator = (result as AsyncIterableIterator<unknown>)[
         Symbol.asyncIterator
       ]();
 
-      // Use a real document from the document-model module
       const doc = createTestDocument();
-
-      const mockEvent: DocumentChangeEvent = {
-        type: DocumentChangeType.Created,
-        documents: [doc],
-      };
-
       const payload: DocumentChangesPayload = {
-        documentChanges: mockEvent,
+        documentChanges: {
+          type: DocumentChangeType.Created,
+          documents: [doc],
+        },
         search: {},
       };
 
-      // Publish after a microtask so the iterator is listening
       const nextPromise = iterator.next();
       await delay(10);
-      void getPubSub().publish(
-        SUBSCRIPTION_TRIGGERS.DOCUMENT_CHANGES,
-        payload,
-      );
+      void getPubSub().publish(SUBSCRIPTION_TRIGGERS.DOCUMENT_CHANGES, payload);
 
       const next = await nextPromise;
       expect(next.done).toBe(false);
@@ -367,30 +132,20 @@ describe("Subscription SSE Integration", () => {
       await iterator.return?.();
     });
 
-    it("should execute a jobChanges subscription and receive events via PubSub", async () => {
-      const schema = buildSubscriptionTestSchema({
-        jobChanges: {
-          subscribe: () =>
-            getPubSub().asyncIterableIterator(
-              SUBSCRIPTION_TRIGGERS.JOB_CHANGES,
-            ),
-          resolve: (payload: JobChangesPayload) => payload.jobChanges,
-        },
-      });
-
-      const subscriptionDocument = parse(`
-        subscription {
-          jobChanges(jobId: "job-123") {
-            jobId
-            status
-            error
-          }
-        }
-      `);
+    it("should receive jobChanges events via PubSub", async () => {
+      const schema = buildSubscriptionSchema();
 
       const result = await subscribe({
         schema,
-        document: subscriptionDocument,
+        document: parse(`
+          subscription {
+            jobChanges(jobId: "job-123") {
+              jobId
+              status
+              error
+            }
+          }
+        `),
       });
 
       expect(Symbol.asyncIterator in (result as object)).toBe(true);
@@ -429,33 +184,21 @@ describe("Subscription SSE Integration", () => {
       await iterator.return?.();
     });
 
-    it("should handle multiple sequential events on a subscription", async () => {
-      const schema = buildSubscriptionTestSchema({
-        documentChanges: {
-          subscribe: () => {
-            ensureGlobalDocumentSubscription(mockReactorClient);
-            return getPubSub().asyncIterableIterator(
-              SUBSCRIPTION_TRIGGERS.DOCUMENT_CHANGES,
-            );
-          },
-          resolve: (payload: DocumentChangesPayload) =>
-            toGqlDocumentChangeEvent(payload.documentChanges),
-        },
-      });
-
-      const subscriptionDocument = parse(`
-        subscription {
-          documentChanges(search: {}) {
-            type
-            documents { id }
-          }
-        }
-      `);
+    it("should handle multiple sequential events", async () => {
+      const schema = buildSubscriptionSchema();
 
       const result = await subscribe({
         schema,
-        document: subscriptionDocument,
+        document: parse(`
+          subscription {
+            documentChanges(search: {}) {
+              type
+              documents { id }
+            }
+          }
+        `),
       });
+
       const iterator = (result as AsyncIterableIterator<unknown>)[
         Symbol.asyncIterator
       ]();
@@ -463,7 +206,6 @@ describe("Subscription SSE Integration", () => {
       const doc1 = createTestDocument();
       const doc2 = createTestDocument();
 
-      // Wait for the iterator to be ready, then publish
       const firstPromise = iterator.next();
       await delay(10);
       void getPubSub().publish(SUBSCRIPTION_TRIGGERS.DOCUMENT_CHANGES, {
@@ -508,16 +250,10 @@ describe("Subscription SSE Integration", () => {
     });
   });
 
-  describe("Subscription Filtering with Resolvers", () => {
+  describe("Subscription Filtering", () => {
     it("should filter documentChanges by document type", () => {
       const docModelDoc = createTestDocument();
-      // The document-model module creates documents of type "powerhouse/document-model"
-      expect(docModelDoc.header.documentType).toBe(
-        "powerhouse/document-model",
-      );
-
       const otherDoc = createTestDocument();
-      // Override the header to simulate a different type
       const otherTypedDoc = {
         ...otherDoc,
         header: {
@@ -543,10 +279,10 @@ describe("Subscription SSE Integration", () => {
         },
       ];
 
-      const filter = { type: "powerhouse/document-model" };
-
-      const matching = events.filter((payload) =>
-        matchesSearchFilter(payload.documentChanges, filter),
+      const matching = events.filter((p) =>
+        matchesSearchFilter(p.documentChanges, {
+          type: "powerhouse/document-model",
+        }),
       );
 
       expect(matching).toHaveLength(1);
@@ -557,7 +293,6 @@ describe("Subscription SSE Integration", () => {
 
     it("should filter documentChanges by parentId", () => {
       const childDoc = createTestDocument();
-
       const event: DocumentChangesPayload = {
         documentChanges: {
           type: DocumentChangeType.ChildAdded,
@@ -571,43 +306,16 @@ describe("Subscription SSE Integration", () => {
         matchesSearchFilter(event.documentChanges, { parentId: "parent-1" }),
       ).toBe(true);
       expect(
-        matchesSearchFilter(event.documentChanges, {
-          parentId: "other-parent",
-        }),
+        matchesSearchFilter(event.documentChanges, { parentId: "other" }),
       ).toBe(false);
     });
   });
 
-  describe("Schema with Subscriptions", () => {
-    it("should create a valid schema that includes Subscription type", () => {
-      const schema = createSchema(
-        [],
-        {
-          Query: { _empty: () => null },
-          Subscription: {
-            documentChanges: {
-              subscribe: () =>
-                getPubSub().asyncIterableIterator(
-                  SUBSCRIPTION_TRIGGERS.DOCUMENT_CHANGES,
-                ),
-              resolve: (payload: DocumentChangesPayload) =>
-                toGqlDocumentChangeEvent(payload.documentChanges),
-            },
-            jobChanges: {
-              subscribe: () =>
-                getPubSub().asyncIterableIterator(
-                  SUBSCRIPTION_TRIGGERS.JOB_CHANGES,
-                ),
-              resolve: (payload: JobChangesPayload) => payload.jobChanges,
-            },
-          },
-        },
-        testTypeDefs,
-      );
-
+  describe("Schema Validation", () => {
+    it("should include Subscription type with expected fields", () => {
+      const schema = buildSubscriptionSchema();
       const subscriptionType = schema.getSubscriptionType();
       expect(subscriptionType).toBeDefined();
-      expect(subscriptionType?.name).toBe("Subscription");
 
       const fields = subscriptionType!.getFields();
       expect(fields.documentChanges).toBeDefined();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ catalogs:
     '@types/react-dom':
       specifier: 19.2.3
       version: 19.2.3
+    '@types/ws':
+      specifier: 8.18.1
+      version: 8.18.1
     '@vitejs/plugin-basic-ssl':
       specifier: 2.1.4
       version: 2.1.4
@@ -132,9 +135,15 @@ catalogs:
     graphql-request:
       specifier: 7.4.0
       version: 7.4.0
+    graphql-sse:
+      specifier: 2.6.0
+      version: 2.6.0
     graphql-tag:
       specifier: 2.12.6
       version: 2.12.6
+    graphql-ws:
+      specifier: 6.0.7
+      version: 6.0.7
     knex:
       specifier: 3.1.0
       version: 3.1.0
@@ -246,6 +255,9 @@ catalogs:
     write-package:
       specifier: 7.2.0
       version: 7.2.0
+    ws:
+      specifier: 8.19.0
+      version: 8.19.0
     zocker:
       specifier: 3.0.0
       version: 3.0.0
@@ -1873,6 +1885,9 @@ importers:
       graphql:
         specifier: 'catalog:'
         version: 16.12.0
+      graphql-sse:
+        specifier: 'catalog:'
+        version: 2.6.0(graphql@16.12.0)
       graphql-subscriptions:
         specifier: ^3.0.0
         version: 3.0.0(graphql@16.12.0)
@@ -1880,7 +1895,7 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2(graphql@16.12.0)
       graphql-ws:
-        specifier: ^6.0.6
+        specifier: 'catalog:'
         version: 6.0.7(graphql@16.12.0)(ws@8.19.0)
       knex:
         specifier: 'catalog:'
@@ -2551,12 +2566,24 @@ importers:
       '@renown/sdk':
         specifier: workspace:*
         version: link:../../packages/renown
+      '@types/ws':
+        specifier: 'catalog:'
+        version: 8.18.1
       document-model:
         specifier: link:../../packages/document-model
         version: link:../../packages/document-model
+      graphql-sse:
+        specifier: 'catalog:'
+        version: 2.6.0(graphql@16.12.0)
+      graphql-ws:
+        specifier: 'catalog:'
+        version: 6.0.7(graphql@16.12.0)(ws@8.19.0)
       vitest:
         specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.3.1)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(jiti@2.6.1)(jsdom@24.1.3)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.1)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      ws:
+        specifier: 'catalog:'
+        version: 8.19.0
 
   test/test-client:
     dependencies:
@@ -12905,6 +12932,12 @@ packages:
     peerDependencies:
       graphql: 14 - 16
 
+  graphql-sse@2.6.0:
+    resolution: {integrity: sha512-BXT5Rjv9UFunjQsmN9WWEIq+TFNhgYibgwo1xkXLxzguQVyOd6paJ4v5DlL9K5QplS0w74bhF+aUiqaGXZBaug==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      graphql: '>=0.11 <=16'
+
   graphql-subscriptions@3.0.0:
     resolution: {integrity: sha512-kZCdevgmzDjGAOqH7GlDmQXYAkuHoKpMlJrqF40HMPhUhM5ZWSFSxCwD/nSi6AkaijmMfsFhoJRGJ27UseCvRA==}
     peerDependencies:
@@ -20075,7 +20108,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -20127,7 +20160,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -20920,7 +20953,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -22608,7 +22641,7 @@ snapshots:
   '@eslint/config-array@0.21.1':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -22624,7 +22657,7 @@ snapshots:
   '@eslint/eslintrc@3.3.4':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -26329,7 +26362,7 @@ snapshots:
       '@prefresh/vite': 2.4.12(preact@10.28.4)(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.0)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       picocolors: 1.1.1
       vite: 7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-prerender-plugin: 0.5.12(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -26421,8 +26454,8 @@ snapshots:
 
   '@puppeteer/browsers@2.13.0':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      extract-zip: 2.0.1(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
+      extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
       semver: 7.7.4
@@ -26437,7 +26470,7 @@ snapshots:
   '@pyroscope/nodejs@0.4.10(express@4.22.1)':
     dependencies:
       '@datadog/pprof': 5.13.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       p-limit: 7.3.0
       regenerator-runtime: 0.14.1
       source-map: 0.7.6
@@ -26449,7 +26482,7 @@ snapshots:
   '@pyroscope/nodejs@0.4.10(express@5.2.1)':
     dependencies:
       '@datadog/pprof': 5.13.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       p-limit: 7.3.0
       regenerator-runtime: 0.14.1
       source-map: 0.7.6
@@ -27710,7 +27743,7 @@ snapshots:
       '@swc-node/sourcemap-support': 0.5.1
       '@swc/core': 1.11.31(@swc/helpers@0.5.19)
       colorette: 2.0.20
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       oxc-resolver: 5.3.0
       pirates: 4.0.7
       tslib: 2.8.1
@@ -27944,7 +27977,7 @@ snapshots:
   '@theguild/federation-composition@0.21.3(graphql@16.12.0)':
     dependencies:
       constant-case: 3.0.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       graphql: 16.12.0
       json5: 2.2.3
       lodash.sortby: 4.7.0
@@ -28408,7 +28441,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -28418,7 +28451,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -28437,7 +28470,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.3(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -28452,7 +28485,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -28552,7 +28585,7 @@ snapshots:
       '@verdaccio/core': 8.0.0-next-8.29
       '@verdaccio/loaders': 8.0.0-next-8.19
       '@verdaccio/signature': 8.0.0-next-8.21
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       lodash: 4.17.21
       verdaccio-htpasswd: 13.0.0-next-8.29
     transitivePeerDependencies:
@@ -28566,7 +28599,7 @@ snapshots:
   '@verdaccio/config@8.0.0-next-8.29':
     dependencies:
       '@verdaccio/core': 8.0.0-next-8.29
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       js-yaml: 4.1.1
       lodash: 4.17.21
     transitivePeerDependencies:
@@ -28602,7 +28635,7 @@ snapshots:
     dependencies:
       '@verdaccio/core': 8.0.0-next-8.29
       '@verdaccio/logger': 8.0.0-next-8.29
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       got-cjs: 12.5.4
       handlebars: 4.7.8
     transitivePeerDependencies:
@@ -28611,7 +28644,7 @@ snapshots:
   '@verdaccio/loaders@8.0.0-next-8.19':
     dependencies:
       '@verdaccio/core': 8.0.0-next-8.29
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -28634,7 +28667,7 @@ snapshots:
       '@verdaccio/core': 8.0.0-next-8.29
       '@verdaccio/logger-prettify': 8.0.0-next-8.4
       colorette: 2.0.20
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -28659,7 +28692,7 @@ snapshots:
       '@verdaccio/config': 8.0.0-next-8.29
       '@verdaccio/core': 8.0.0-next-8.29
       '@verdaccio/url': 13.0.0-next-8.29
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       express: 4.22.1
       express-rate-limit: 5.5.1
       lodash: 4.17.21
@@ -28673,7 +28706,7 @@ snapshots:
     dependencies:
       '@verdaccio/config': 8.0.0-next-8.29
       '@verdaccio/core': 8.0.0-next-8.29
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       jsonwebtoken: 9.0.3
     transitivePeerDependencies:
       - supports-color
@@ -28684,7 +28717,7 @@ snapshots:
     dependencies:
       '@verdaccio/core': 8.0.0-next-8.29
       '@verdaccio/url': 13.0.0-next-8.29
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gunzip-maybe: 1.4.2
       tar-stream: 3.1.7
     transitivePeerDependencies:
@@ -28697,7 +28730,7 @@ snapshots:
   '@verdaccio/url@13.0.0-next-8.29':
     dependencies:
       '@verdaccio/core': 8.0.0-next-8.29
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       validator: 13.15.26
     transitivePeerDependencies:
       - supports-color
@@ -28810,7 +28843,7 @@ snapshots:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
       ast-v8-to-istanbul: 0.3.11
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
@@ -29175,7 +29208,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -29856,7 +29889,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -30416,7 +30449,7 @@ snapshots:
   cmd-ts@0.15.0:
     dependencies:
       chalk: 5.6.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       didyoumean: 1.2.2
       strip-ansi: 7.1.2
     transitivePeerDependencies:
@@ -31219,7 +31252,7 @@ snapshots:
   detect-port@1.6.1:
     dependencies:
       address: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -31753,14 +31786,14 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.25.12):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       esbuild: 0.25.12
     transitivePeerDependencies:
       - supports-color
 
   esbuild-register@3.6.0(esbuild@0.27.3):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       esbuild: 0.27.3
     transitivePeerDependencies:
       - supports-color
@@ -31965,7 +31998,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -32235,7 +32268,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -32271,6 +32304,16 @@ snapshots:
       is-extendable: 0.1.1
 
   extend@3.0.2: {}
+
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
 
   extract-zip@2.0.1(supports-color@8.1.1):
     dependencies:
@@ -32403,7 +32446,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -32682,7 +32725,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.2.0
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -32895,6 +32938,10 @@ snapshots:
   graphql-request@7.4.0(graphql@16.12.0):
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
+      graphql: 16.12.0
+
+  graphql-sse@2.6.0(graphql@16.12.0):
+    dependencies:
       graphql: 16.12.0
 
   graphql-subscriptions@3.0.0(graphql@16.12.0):
@@ -33271,7 +33318,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -33279,7 +33326,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -33323,14 +33370,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -33352,7 +33399,7 @@ snapshots:
       '@types/node': 17.0.45
       chalk: 4.1.2
       change-case: 3.1.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       degit: 2.8.4
       ejs: 3.1.10
       enquirer: 2.4.1
@@ -33886,7 +33933,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -33895,7 +33942,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -35758,7 +35805,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -36718,7 +36765,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       get-uri: 6.0.5
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -37664,7 +37711,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -37725,7 +37772,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.13.0
       chromium-bidi: 14.0.0(devtools-protocol@0.0.1566079)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       devtools-protocol: 0.0.1566079
       typed-query-selector: 2.12.1
       webdriver-bidi-protocol: 0.4.1
@@ -38403,7 +38450,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -38534,7 +38581,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -38669,7 +38716,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -38703,7 +38750,7 @@ snapshots:
     dependencies:
       '@types/debug': 4.1.12
       '@types/validator': 13.15.10
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       dottie: 2.0.7
       inflection: 1.13.4
       lodash: 4.17.23
@@ -38963,7 +39010,7 @@ snapshots:
   socks-proxy-agent@6.2.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -38972,7 +39019,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -39083,7 +39130,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -39094,7 +39141,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -39389,7 +39436,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.5
       formidable: 3.5.4
@@ -40266,7 +40313,7 @@ snapshots:
       '@verdaccio/file-locking': 13.0.0-next-8.6
       apache-md5: 1.1.8
       bcryptjs: 2.4.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.0
       unix-crypt-td-js: 1.1.4
     transitivePeerDependencies:
@@ -40295,7 +40342,7 @@ snapshots:
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       compression: 1.8.1
       cors: 2.8.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       envinfo: 7.15.0
       express: 4.22.1
       lodash: 4.17.23
@@ -40373,7 +40420,7 @@ snapshots:
   vite-node@3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -40394,7 +40441,7 @@ snapshots:
   vite-node@3.2.4(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -40470,7 +40517,7 @@ snapshots:
 
   vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -40537,7 +40584,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
@@ -40582,7 +40629,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -84,6 +84,10 @@ catalog:
   "@types/luxon": 3.7.1
   "react-i18next": 16.5.4
   "graphql-tag": 2.12.6
+  "graphql-ws": 6.0.7
+  "graphql-sse": 2.6.0
+  "ws": 8.19.0
+  "@types/ws": 8.18.1
   lightningcss: 1.31.1
   "better-sqlite3": 12.6.2
   "sqlite3": 5.1.7

--- a/test/switchboard/package.json
+++ b/test/switchboard/package.json
@@ -14,6 +14,10 @@
     "@powerhousedao/reactor-browser": "workspace:*",
     "@renown/sdk": "workspace:*",
     "document-model": "workspace:*",
+    "graphql-ws": "catalog:",
+    "graphql-sse": "catalog:",
+    "ws": "catalog:",
+    "@types/ws": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/test/switchboard/src/subscriptions.test.ts
+++ b/test/switchboard/src/subscriptions.test.ts
@@ -1,0 +1,295 @@
+/**
+ * E2E subscription tests against a running switchboard instance.
+ *
+ * Tests both graphql-ws (WebSocket) and graphql-sse (SSE) transports
+ * for the reactor subgraph's documentChanges subscription.
+ */
+import {
+  createClient as createWsClient,
+  type ExecutionResult,
+} from "graphql-ws";
+import { createClient as createSseClient } from "graphql-sse";
+import {
+  createClient,
+  RemoteDocumentController,
+} from "@powerhousedao/reactor-browser";
+import { DocumentModelController } from "document-model";
+import WebSocket from "ws";
+import { afterAll, describe, expect, it } from "vitest";
+
+interface DocumentChangesData {
+  documentChanges: {
+    type: string;
+    documents: Array<{
+      id: string;
+      name: string;
+      documentType: string;
+    }>;
+  };
+}
+
+type SubscriptionResult = ExecutionResult<DocumentChangesData>;
+
+const SWITCHBOARD_URL =
+  process.env.SWITCHBOARD_URL ?? "http://localhost:4001/graphql";
+const DRIVE_ID = process.env.SWITCHBOARD_DRIVE_ID ?? "powerhouse";
+
+// WebSocket URL: the server mounts WS at /graphql/subscriptions
+const WS_URL =
+  SWITCHBOARD_URL.replace(/^http/, "ws").replace(/\/graphql$/, "") +
+  "/graphql/subscriptions";
+// SSE URL: append /r/stream to the base graphql path
+const SSE_URL = SWITCHBOARD_URL + "/r/stream";
+
+const gqlClient = createClient(SWITCHBOARD_URL);
+
+/** Track created document IDs for cleanup. */
+const createdDocumentIds: string[] = [];
+
+const DOCUMENT_CHANGES_QUERY = `
+  subscription DocumentChanges($search: SearchFilterInput!) {
+    documentChanges(search: $search) {
+      type
+      documents {
+        id
+        name
+        documentType
+      }
+    }
+  }
+`;
+
+/** Helper: subscribe via graphql-ws, resolve on first matching event. */
+function wsSubscribe(
+  wsClient: ReturnType<typeof createWsClient>,
+  variables: Record<string, unknown>,
+): { promise: Promise<DocumentChangesData["documentChanges"]>; cancel: () => void } {
+  let cancelTimeout: () => void;
+  let unsubscribe: () => void;
+
+  const promise = new Promise<DocumentChangesData["documentChanges"]>(
+    (resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("WS subscription timed out")),
+        15_000,
+      );
+      cancelTimeout = () => clearTimeout(timeout);
+
+      unsubscribe = wsClient.subscribe<DocumentChangesData>(
+        { query: DOCUMENT_CHANGES_QUERY, variables },
+        {
+          next: (data: SubscriptionResult) => {
+            clearTimeout(timeout);
+            if (data.data?.documentChanges) {
+              resolve(data.data.documentChanges);
+            }
+          },
+          error: (err: unknown) => {
+            clearTimeout(timeout);
+            reject(err);
+          },
+          complete: () => {
+            clearTimeout(timeout);
+            reject(new Error("Subscription completed before event"));
+          },
+        },
+      );
+    },
+  );
+
+  return {
+    promise,
+    cancel: () => {
+      cancelTimeout?.();
+      unsubscribe?.();
+    },
+  };
+}
+
+/** Helper: subscribe via graphql-sse, resolve on first matching event. */
+function sseSubscribe(
+  sseClient: ReturnType<typeof createSseClient>,
+  variables: Record<string, unknown>,
+): { promise: Promise<DocumentChangesData["documentChanges"]>; cancel: () => void } {
+  let cancelTimeout: () => void;
+  let unsubscribe: () => void;
+
+  const promise = new Promise<DocumentChangesData["documentChanges"]>(
+    (resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("SSE subscription timed out")),
+        15_000,
+      );
+      cancelTimeout = () => clearTimeout(timeout);
+
+      unsubscribe = sseClient.subscribe<DocumentChangesData>(
+        { query: DOCUMENT_CHANGES_QUERY, variables },
+        {
+          next: (data: SubscriptionResult) => {
+            clearTimeout(timeout);
+            unsubscribe?.();
+            if (data.data?.documentChanges) {
+              resolve(data.data.documentChanges);
+            }
+          },
+          error: (err: unknown) => {
+            clearTimeout(timeout);
+            unsubscribe?.();
+            reject(err);
+          },
+          complete: () => {
+            clearTimeout(timeout);
+          },
+        },
+      );
+    },
+  );
+
+  return {
+    promise,
+    cancel: () => {
+      cancelTimeout?.();
+      unsubscribe?.();
+    },
+  };
+}
+
+/** Create a document-model document and push it, returning the document ID. */
+async function createAndPushDocument(name: string): Promise<string> {
+  const controller = await RemoteDocumentController.pull(
+    DocumentModelController,
+    {
+      client: gqlClient,
+      mode: "batch",
+      parentIdentifier: DRIVE_ID,
+    },
+  );
+  controller.setName({ name });
+  await controller.push();
+  const docId = controller.status.documentId;
+  createdDocumentIds.push(docId);
+  return docId;
+}
+
+describe("Subscription e2e", () => {
+  afterAll(async () => {
+    for (const id of createdDocumentIds) {
+      try {
+        await gqlClient.DeleteDocument({ identifier: id });
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  });
+
+  describe("graphql-ws (WebSocket)", () => {
+    it("receives documentChanges event when a document is created", async () => {
+      const wsClient = createWsClient({
+        url: WS_URL,
+        webSocketImpl: WebSocket,
+      });
+
+      const sub = wsSubscribe(wsClient, { search: {} });
+
+      try {
+        // Give the subscription a moment to connect
+        await new Promise((r) => setTimeout(r, 500));
+
+        const docId = await createAndPushDocument("WS Subscription Test");
+        const event = await sub.promise;
+
+        expect(event).toBeDefined();
+        expect(event.type).toBe("CREATED");
+        expect(event.documents).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: docId }),
+          ]),
+        );
+      } finally {
+        sub.cancel();
+        wsClient.dispose();
+      }
+    });
+
+    it("filters documentChanges by document type", async () => {
+      const wsClient = createWsClient({
+        url: WS_URL,
+        webSocketImpl: WebSocket,
+      });
+
+      const sub = wsSubscribe(wsClient, {
+        search: { type: "powerhouse/document-model" },
+      });
+
+      try {
+        await new Promise((r) => setTimeout(r, 500));
+
+        await createAndPushDocument("WS Type Filter Test");
+        const event = await sub.promise;
+
+        expect(event.documents).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              documentType: "powerhouse/document-model",
+            }),
+          ]),
+        );
+      } finally {
+        sub.cancel();
+        wsClient.dispose();
+      }
+    });
+  });
+
+  describe("graphql-sse (Server-Sent Events)", () => {
+    it("receives documentChanges event when a document is created", async () => {
+      const sseClient = createSseClient({ url: SSE_URL });
+
+      const sub = sseSubscribe(sseClient, { search: {} });
+
+      try {
+        await new Promise((r) => setTimeout(r, 500));
+
+        const docId = await createAndPushDocument("SSE Subscription Test");
+        const event = await sub.promise;
+
+        expect(event).toBeDefined();
+        expect(event.type).toBe("CREATED");
+        expect(event.documents).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: docId }),
+          ]),
+        );
+      } finally {
+        sub.cancel();
+        sseClient.dispose();
+      }
+    });
+
+    it("filters documentChanges by document type", async () => {
+      const sseClient = createSseClient({ url: SSE_URL });
+
+      const sub = sseSubscribe(sseClient, {
+        search: { type: "powerhouse/document-model" },
+      });
+
+      try {
+        await new Promise((r) => setTimeout(r, 500));
+
+        await createAndPushDocument("SSE Type Filter Test");
+        const event = await sub.promise;
+
+        expect(event.documents).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              documentType: "powerhouse/document-model",
+            }),
+          ]),
+        );
+      } finally {
+        sub.cancel();
+        sseClient.dispose();
+      }
+    });
+  });
+});

--- a/test/switchboard/src/subscriptions.test.ts
+++ b/test/switchboard/src/subscriptions.test.ts
@@ -5,17 +5,17 @@
  * for the reactor subgraph's documentChanges subscription.
  */
 import {
-  createClient as createWsClient,
-  type ExecutionResult,
-} from "graphql-ws";
-import { createClient as createSseClient } from "graphql-sse";
-import {
   createClient,
   RemoteDocumentController,
 } from "@powerhousedao/reactor-browser";
 import { DocumentModelController } from "document-model";
-import WebSocket from "ws";
+import { createClient as createSseClient } from "graphql-sse";
+import {
+  createClient as createWsClient,
+  type ExecutionResult,
+} from "graphql-ws";
 import { afterAll, describe, expect, it } from "vitest";
+import WebSocket from "ws";
 
 interface DocumentChangesData {
   documentChanges: {
@@ -63,7 +63,10 @@ const DOCUMENT_CHANGES_QUERY = `
 function wsSubscribe(
   wsClient: ReturnType<typeof createWsClient>,
   variables: Record<string, unknown>,
-): { promise: Promise<DocumentChangesData["documentChanges"]>; cancel: () => void } {
+): {
+  promise: Promise<DocumentChangesData["documentChanges"]>;
+  cancel: () => void;
+} {
   let cancelTimeout: () => void;
   let unsubscribe: () => void;
 
@@ -86,7 +89,7 @@ function wsSubscribe(
           },
           error: (err: unknown) => {
             clearTimeout(timeout);
-            reject(err);
+            reject(err as Error);
           },
           complete: () => {
             clearTimeout(timeout);
@@ -110,7 +113,10 @@ function wsSubscribe(
 function sseSubscribe(
   sseClient: ReturnType<typeof createSseClient>,
   variables: Record<string, unknown>,
-): { promise: Promise<DocumentChangesData["documentChanges"]>; cancel: () => void } {
+): {
+  promise: Promise<DocumentChangesData["documentChanges"]>;
+  cancel: () => void;
+} {
   let cancelTimeout: () => void;
   let unsubscribe: () => void;
 
@@ -135,7 +141,7 @@ function sseSubscribe(
           error: (err: unknown) => {
             clearTimeout(timeout);
             unsubscribe?.();
-            reject(err);
+            reject(err as Error);
           },
           complete: () => {
             clearTimeout(timeout);
@@ -201,9 +207,7 @@ describe("Subscription e2e", () => {
         expect(event).toBeDefined();
         expect(event.type).toBe("CREATED");
         expect(event.documents).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ id: docId }),
-          ]),
+          expect.arrayContaining([expect.objectContaining({ id: docId })]),
         );
       } finally {
         sub.cancel();
@@ -256,9 +260,7 @@ describe("Subscription e2e", () => {
         expect(event).toBeDefined();
         expect(event.type).toBe("CREATED");
         expect(event.documents).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ id: docId }),
-          ]),
+          expect.arrayContaining([expect.objectContaining({ id: docId })]),
         );
       } finally {
         sub.cancel();

--- a/test/switchboard/src/subscriptions.test.ts
+++ b/test/switchboard/src/subscriptions.test.ts
@@ -195,7 +195,9 @@ describe("Subscription e2e", () => {
         webSocketImpl: WebSocket,
       });
 
-      const sub = wsSubscribe(wsClient, { search: {} });
+      const sub = wsSubscribe(wsClient, {
+        search: { type: "powerhouse/document-model" },
+      });
 
       try {
         // Give the subscription a moment to connect
@@ -249,7 +251,9 @@ describe("Subscription e2e", () => {
     it("receives documentChanges event when a document is created", async () => {
       const sseClient = createSseClient({ url: SSE_URL });
 
-      const sub = sseSubscribe(sseClient, { search: {} });
+      const sub = sseSubscribe(sseClient, {
+        search: { type: "powerhouse/document-model" },
+      });
 
       try {
         await new Promise((r) => setTimeout(r, 500));

--- a/test/switchboard/vitest.config.ts
+++ b/test/switchboard/vitest.config.ts
@@ -6,5 +6,7 @@ export default defineConfig({
     include: ["src/**/*.test.ts"],
     testTimeout: 30_000,
     hookTimeout: 30_000,
+    fileParallelism: false,
+    sequence: { concurrent: false },
   },
 });


### PR DESCRIPTION
## Summary

- **Namespace document model queries/mutations**: Nest under a namespace field instead of flat prefixed fields on root Query/Mutation types (e.g. `query { SomeDoc { document(...) } }` instead of `SomeDoc_document(...)`)
- **SSE subscription transport**: Add graphql-sse as an alternative to WebSocket subscriptions. Clients POST with `Accept: text/event-stream` to `/stream` sub-paths
- **Dev script**: Add `pnpm dev` for local development with in-memory storage, PGlite, and a default drive. Fix explorer CORS errors by pinning CDN versions
- **E2E subscription tests**: Verify documentChanges subscriptions work against a running switchboard using both graphql-ws and graphql-sse transports

## Test plan

- [x] All 325 existing reactor-api unit tests pass
- [x] TypeScript compiles with zero errors
- [ ] Run `pnpm dev` and verify GraphQL explorer loads at `/explorer`
- [ ] Run switchboard e2e tests (`cd test/switchboard && pnpm test:e2e`) to verify WS and SSE subscriptions
- [ ] Verify existing clients still work with the new namespaced API


🤖 Generated with [Claude Code](https://claude.com/claude-code)