### PR TITLE
feat(registry): add publish notifications via SSE and webhooks

### DIFF
--- a/packages/reactor-browser/README.md
+++ b/packages/reactor-browser/README.md
@@ -29,6 +29,7 @@ This document contains all documentation comments for the hooks exported from `p
 - [Timeline Revision](#timeline-revision)
 - [Use Get Switchboard Link](#use-get-switchboard-link)
 - [Vetra Packages](#vetra-packages)
+- [Registry Client](./src/registry/README.md)
 
 ---
 
@@ -503,4 +504,3 @@ Gets the value of an item in the global document config for a given key.
 
 Strongly typed, inferred from type definition for the key.
 
----

--- a/packages/reactor-browser/src/registry/README.md
+++ b/packages/reactor-browser/src/registry/README.md
@@ -1,0 +1,47 @@
+# Registry Client
+
+Client for interacting with a Powerhouse package registry. Provides methods to query packages and subscribe to real-time publish notifications via SSE.
+
+```ts
+import { RegistryClient } from "@powerhousedao/reactor-browser";
+
+const client = new RegistryClient("http://localhost:8080/-/cdn/");
+```
+
+## `getPackages`
+
+Returns all packages from the registry.
+
+```ts
+const packages = await client.getPackages();
+// [{ name, description, version, category, publisher, publisherUrl }, ...]
+```
+
+## `getPackagesByDocumentType`
+
+Returns package names that contain the specified document type.
+
+```ts
+const names = await client.getPackagesByDocumentType("powerhouse/document-model");
+```
+
+## `searchPackages`
+
+Client-side search through all packages by name or description.
+
+```ts
+const results = await client.searchPackages("vetra");
+```
+
+## `onPublish`
+
+Subscribes to real-time publish notifications via Server-Sent Events. Calls the callback whenever a package is published. Returns an unsubscribe function.
+
+```ts
+const unsubscribe = client.onPublish((event) => {
+  console.log(`${event.packageName}@${event.version} published`);
+});
+
+// later...
+unsubscribe();
+```

--- a/packages/reactor-browser/src/registry/client.ts
+++ b/packages/reactor-browser/src/registry/client.ts
@@ -1,19 +1,6 @@
 import type { PackageInfo } from "@powerhousedao/shared/registry";
 import { getPackages, getPackagesByDocumentType } from "./fetchers.js";
-import type { RegistryPackageInfo } from "./types.js";
-
-interface PackageInfoFromApi {
-  name: string;
-  manifest?: {
-    description?: string;
-    version?: string;
-    category?: string;
-    publisher?: {
-      name?: string;
-      url?: string;
-    };
-  };
-}
+import type { PublishEvent, RegistryPackageInfo } from "./types.js";
 
 function cdnUrlToApiUrl(cdnUrl: string): string {
   return cdnUrl.replace(/\/-\/cdn\/?$/, "");
@@ -55,5 +42,18 @@ export class RegistryClient {
         pkg.name.toLowerCase().includes(lowerQuery) ||
         pkg.description?.toLowerCase().includes(lowerQuery),
     );
+  }
+
+  onPublish(callback: (event: PublishEvent) => void): () => void {
+    const eventSource = new EventSource(`${this.apiUrl}/-/events`);
+
+    eventSource.addEventListener("publish", (e: MessageEvent<string>) => {
+      const data = JSON.parse(e.data) as PublishEvent;
+      callback(data);
+    });
+
+    return () => {
+      eventSource.close();
+    };
   }
 }

--- a/packages/reactor-browser/src/registry/index.ts
+++ b/packages/reactor-browser/src/registry/index.ts
@@ -1,3 +1,3 @@
 export { RegistryClient } from "./client.js";
 export * from "./fetchers.js";
-export type { RegistryPackageInfo } from "./types.js";
+export type { PublishEvent, RegistryPackageInfo } from "./types.js";

--- a/packages/reactor-browser/src/registry/types.ts
+++ b/packages/reactor-browser/src/registry/types.ts
@@ -6,3 +6,8 @@ export interface RegistryPackageInfo {
   publisher?: string;
   publisherUrl?: string;
 }
+
+export interface PublishEvent {
+  packageName: string;
+  version: string | null;
+}

--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -2,53 +2,11 @@
 
 Powerhouse package registry built on Verdaccio. Serves as both an npm registry and a CDN for Powerhouse package bundles (ESM) for dynamic `import()` in browsers and Node.js.
 
-## Quick Start
-
-### CLI
-
-```sh
-ph-registry --port 8080 --storage-dir ./storage --cdn-cache-dir ./cdn-cache
-```
-
-Options:
-
-| Option | Env Variable | Default | Description |
-|---|---|---|---|
-| `--port` | `PORT` | `8080` | Port to listen on |
-| `--storage-dir` | `REGISTRY_STORAGE` | `./storage` | Verdaccio storage directory |
-| `--cdn-cache-dir` | `REGISTRY_CDN_CACHE` | `./cdn-cache` | CDN cache directory for extracted package bundles |
-| `--uplink` | `REGISTRY_UPLINK` | — | Upstream npm registry URL |
-| `--web-enabled` | `REGISTRY_WEB` | `true` | Enable Verdaccio web UI |
-| `--s3-bucket` | `S3_BUCKET` | — | S3 bucket for storage |
-| `--s3-endpoint` | `S3_ENDPOINT` | — | S3 endpoint URL |
-| `--s3-region` | `S3_REGION` | — | S3 region |
-| `--s3-access-key-id` | `S3_ACCESS_KEY_ID` | — | S3 access key |
-| `--s3-secret-access-key` | `S3_SECRET_ACCESS_KEY` | — | S3 secret key |
-| `--s3-key-prefix` | `S3_KEY_PREFIX` | — | S3 key prefix |
-| `--s3-force-path-style` | `S3_FORCE_PATH_STYLE` | `true` | Force S3 path-style URLs |
-
-### Library
-
-```ts
-import express from "express";
-import { createPowerhouseRouter, createPublishHook } from "@powerhousedao/registry";
-import type { RegistryConfig } from "@powerhousedao/registry";
-
-const config: RegistryConfig = {
-  port: 8080,
-  storagePath: "./storage",
-  cdnCachePath: "./cdn-cache",
-};
-
-const app = express();
-app.use(createPowerhouseRouter(config));
-app.use(createPublishHook(config));
-app.listen(8080);
-```
-
 ## API
 
-### `GET /packages`
+### Packages
+
+#### `GET /packages`
 
 Returns a JSON array of all discovered packages. Supports filtering by document type:
 
@@ -56,17 +14,78 @@ Returns a JSON array of all discovered packages. Supports filtering by document 
 GET /packages?documentType=powerhouse/package
 ```
 
-### `GET /packages/by-document-type?type=<documentType>`
+#### `GET /packages/by-document-type?type=<documentType>`
 
 Returns an array of package names that contain the specified document type.
 
-### `GET /packages/<packageName>`
+#### `GET /packages/<packageName>`
 
 Returns info for a single package (supports scoped names like `@powerhousedao/vetra`).
 
-### `GET /-/cdn/<packageName>/<filePath>`
+### CDN
+
+#### `GET /-/cdn/<packageName>/<filePath>`
 
 Serves files from the CDN cache. On first request, fetches and extracts the tarball from Verdaccio. Looks for files in the package root, then `cdn/`, `dist/cdn/`, and `dist/` subdirectories.
+
+### Publish Notifications
+
+When a package is published, the registry can notify subscribers in real time via Server-Sent Events (SSE) and webhooks.
+
+#### SSE — `GET /-/events`
+
+Opens a persistent SSE connection. The server sends:
+
+- `connected` event on initial connection
+- `publish` event whenever a package is published, with payload:
+
+```json
+{ "packageName": "@scope/pkg", "version": "1.0.0" }
+```
+
+Example (browser):
+
+```ts
+const source = new EventSource("http://localhost:8080/-/events");
+source.addEventListener("publish", (e) => {
+  const { packageName, version } = JSON.parse(e.data);
+  console.log(`${packageName}@${version} published`);
+});
+```
+
+#### Webhooks
+
+Webhooks are persisted to disk and survive restarts. Predefined webhooks can also be provided via configuration.
+
+##### `GET /-/webhooks`
+
+Returns all registered webhooks (predefined + dynamic).
+
+##### `POST /-/webhooks`
+
+Registers a new webhook. Body:
+
+```json
+{ "endpoint": "https://example.com/hook", "headers": { "X-Token": "secret" } }
+```
+
+`headers` is optional. Returns `201` on success. Duplicate endpoints are ignored.
+
+##### `DELETE /-/webhooks`
+
+Removes a dynamic webhook. Body:
+
+```json
+{ "endpoint": "https://example.com/hook" }
+```
+
+Returns `204` on success, `404` if not found. Predefined webhooks cannot be removed.
+
+When a package is published, each webhook receives a POST with:
+
+```json
+{ "packageName": "@scope/pkg", "version": "1.0.0" }
+```
 
 ### npm Protocol
 
@@ -78,18 +97,28 @@ All standard npm registry operations (publish, install, etc.) are handled by Ver
 npm publish --registry http://localhost:8080/
 ```
 
-On publish, the CDN cache for that package is automatically invalidated so the next CDN request fetches the new version.
+On publish, the CDN cache for that package is automatically invalidated and the new version is extracted immediately.
 
-## CDN Cache Structure
+## CLI
 
-```
-cdn-cache/
-  @scope/
-    package-name/
-      1.0.0/
-        powerhouse.manifest.json
-        index.js
-        ...
+```sh
+ph-registry --port 8080 --storage-dir ./storage --cdn-cache-dir ./cdn-cache
 ```
 
-Packages are extracted from npm tarballs on first CDN request and cached locally.
+Options:
+
+| Option | Env Variable | Default | Description |
+|---|---|---|---|
+| `--port` | `PORT` | `8080` | Port to listen on |
+| `--storage-dir` | `REGISTRY_STORAGE` | `./storage` | Verdaccio storage directory |
+| `--cdn-cache-dir` | `REGISTRY_CDN_CACHE` | `./cdn-cache` | CDN cache directory |
+| `--uplink` | `REGISTRY_UPLINK` | — | Upstream npm registry URL |
+| `--web-enabled` | `REGISTRY_WEB` | `true` | Enable Verdaccio web UI |
+| `--webhook` | `REGISTRY_WEBHOOKS` | — | Comma-separated webhook URLs to notify on publish |
+| `--s3-bucket` | `S3_BUCKET` | — | S3 bucket for storage |
+| `--s3-endpoint` | `S3_ENDPOINT` | — | S3 endpoint URL |
+| `--s3-region` | `S3_REGION` | — | S3 region |
+| `--s3-access-key-id` | `S3_ACCESS_KEY_ID` | — | S3 access key |
+| `--s3-secret-access-key` | `S3_SECRET_ACCESS_KEY` | — | S3 secret key |
+| `--s3-key-prefix` | `S3_KEY_PREFIX` | — | S3 key prefix |
+| `--s3-force-path-style` | `S3_FORCE_PATH_STYLE` | `true` | Force S3 path-style URLs |

--- a/packages/registry/cli.ts
+++ b/packages/registry/cli.ts
@@ -90,6 +90,13 @@ export const registryCommand = command({
       defaultValue: () => process.env.REGISTRY_WEB !== "false",
       defaultValueIsSerializable: true,
     }),
+    webhooks: option({
+      long: "webhook",
+      type: optional(string),
+      description: "Comma-separated webhook URLs to notify on publish",
+      defaultValue: () => process.env.REGISTRY_WEBHOOKS,
+      defaultValueIsSerializable: true,
+    }),
   },
   handler: async (args) => {
     console.log(args);

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -1,11 +1,21 @@
 export { CdnCache } from "./cdn.js";
 export { createPowerhouseRouter, createPublishHook } from "./middleware.js";
 export {
+  NotificationManager,
+  SSEChannel,
+  WebhookChannel,
+} from "./notifications/index.js";
+export type {
+  NotificationChannel,
+  PublishEvent,
+} from "./notifications/index.js";
+export {
   findPackagesByDocumentType,
   loadPackage,
   scanPackages,
 } from "./packages.js";
 export type {
+  NotifyConfig,
   PackageInfo,
   PowerhouseManifest,
   PowerhouseManifestApp,
@@ -14,5 +24,6 @@ export type {
   RegistryConfig,
   RegistryOptions,
   S3Config,
+  WebhookConfig,
 } from "./types.js";
 export { buildVerdaccioConfig } from "./verdaccio-config.js";

--- a/packages/registry/src/middleware.ts
+++ b/packages/registry/src/middleware.ts
@@ -1,8 +1,15 @@
-import type { NextFunction, Request, Response } from "express";
+import express, {
+  type NextFunction,
+  type Request,
+  type Response,
+} from "express";
 import { Router } from "express";
 import fs from "node:fs";
 import path from "node:path";
 import { CdnCache } from "./cdn.js";
+import type { NotificationChannel } from "./notifications/types.js";
+import type { SSEChannel } from "./notifications/sse.js";
+import type { WebhookChannel } from "./notifications/webhook.js";
 import {
   findPackagesByDocumentType,
   loadPackage,
@@ -26,7 +33,11 @@ function getContentType(filePath: string): string {
   return MIME_TYPES[ext] ?? "application/octet-stream";
 }
 
-export function createPowerhouseRouter(config: RegistryConfig): Router {
+export function createPowerhouseRouter(
+  config: RegistryConfig,
+  sse: SSEChannel,
+  webhooks: WebhookChannel,
+): Router {
   const cdn = new CdnCache(
     `http://localhost:${config.port}`,
     config.cdnCachePath,
@@ -38,6 +49,47 @@ export function createPowerhouseRouter(config: RegistryConfig): Router {
     res.setHeader("Access-Control-Allow-Origin", "*");
     next();
   });
+
+  // SSE endpoint for publish notifications
+  router.get("/-/events", (_req: Request, res: Response) => {
+    sse.addClient(res);
+  });
+
+  // Webhook management
+  router.get("/-/webhooks", (_req: Request, res: Response) => {
+    res.json(webhooks.getWebhooks());
+  });
+
+  router.post("/-/webhooks", express.json(), (req: Request, res: Response) => {
+    const { endpoint, headers } = req.body as {
+      endpoint?: string;
+      headers?: Record<string, string>;
+    };
+    if (!endpoint) {
+      res.status(400).json({ error: "Missing required field: endpoint" });
+      return;
+    }
+    webhooks.addWebhook({ endpoint, headers });
+    res.status(201).json({ endpoint, headers });
+  });
+
+  router.delete(
+    "/-/webhooks",
+    express.json(),
+    (req: Request, res: Response) => {
+      const { endpoint } = req.body as { endpoint?: string };
+      if (!endpoint) {
+        res.status(400).json({ error: "Missing required field: endpoint" });
+        return;
+      }
+      const removed = webhooks.removeWebhook(endpoint);
+      if (!removed) {
+        res.status(404).json({ error: "Webhook not found" });
+        return;
+      }
+      res.status(204).end();
+    },
+  );
 
   // Package listing API
   router.get("/packages", (req: Request, res: Response) => {
@@ -120,7 +172,10 @@ export function createPowerhouseRouter(config: RegistryConfig): Router {
   return router;
 }
 
-export function createPublishHook(config: RegistryConfig) {
+export function createPublishHook(
+  config: RegistryConfig,
+  notifications: NotificationChannel,
+) {
   const cdn = new CdnCache(
     `http://localhost:${config.port}`,
     config.cdnCachePath,
@@ -154,8 +209,14 @@ export function createPublishHook(config: RegistryConfig) {
                 console.log(
                   `[registry] Extracting ${packageName}@${version} to CDN cache`,
                 );
-                return cdn.extractTarball(packageName, version);
+                return cdn
+                  .extractTarball(packageName, version)
+                  .then(() => version);
               }
+              return null;
+            })
+            .then((version) => {
+              notifications.notifyPublish({ packageName, version });
             })
             .catch((err) => {
               console.error(

--- a/packages/registry/src/notifications/index.ts
+++ b/packages/registry/src/notifications/index.ts
@@ -1,0 +1,4 @@
+export { NotificationManager } from "./manager.js";
+export { SSEChannel } from "./sse.js";
+export type { NotificationChannel, PublishEvent } from "./types.js";
+export { WebhookChannel } from "./webhook.js";

--- a/packages/registry/src/notifications/manager.ts
+++ b/packages/registry/src/notifications/manager.ts
@@ -1,0 +1,15 @@
+import type { NotificationChannel, PublishEvent } from "./types.js";
+
+export class NotificationManager implements NotificationChannel {
+  #channels: NotificationChannel[];
+
+  constructor(channels: NotificationChannel[]) {
+    this.#channels = channels;
+  }
+
+  notifyPublish(event: PublishEvent): void {
+    for (const channel of this.#channels) {
+      channel.notifyPublish(event);
+    }
+  }
+}

--- a/packages/registry/src/notifications/sse.ts
+++ b/packages/registry/src/notifications/sse.ts
@@ -1,0 +1,33 @@
+import type { Response } from "express";
+import type { NotificationChannel, PublishEvent } from "./types.js";
+
+export class SSEChannel implements NotificationChannel {
+  #clients = new Set<Response>();
+
+  addClient(res: Response): void {
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "Access-Control-Allow-Origin": "*",
+    });
+    res.write("event: connected\ndata: {}\n\n");
+
+    this.#clients.add(res);
+    res.on("close", () => {
+      this.#clients.delete(res);
+    });
+  }
+
+  notifyPublish(event: PublishEvent): void {
+    const payload = `event: publish\ndata: ${JSON.stringify(event)}\n\n`;
+    for (const client of this.#clients) {
+      try {
+        client.write(payload);
+      } catch (err) {
+        console.error("[registry] SSE client write failed:", err);
+        this.#clients.delete(client);
+      }
+    }
+  }
+}

--- a/packages/registry/src/notifications/types.ts
+++ b/packages/registry/src/notifications/types.ts
@@ -1,0 +1,8 @@
+export interface PublishEvent {
+  packageName: string;
+  version: string | null;
+}
+
+export interface NotificationChannel {
+  notifyPublish(event: PublishEvent): void;
+}

--- a/packages/registry/src/notifications/webhook.ts
+++ b/packages/registry/src/notifications/webhook.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { NotifyConfig, WebhookConfig } from "../types.js";
+import type { NotificationChannel, PublishEvent } from "./types.js";
+
+const WEBHOOKS_FILE = "webhooks.json";
+
+export class WebhookChannel implements NotificationChannel {
+  #predefined: WebhookConfig[];
+  #dynamic: WebhookConfig[];
+  #storagePath: string;
+
+  constructor(storagePath: string, config?: NotifyConfig) {
+    this.#storagePath = storagePath;
+    this.#predefined = config?.webhooks ?? [];
+    this.#dynamic = this.#load();
+  }
+
+  getWebhooks(): WebhookConfig[] {
+    return [...this.#predefined, ...this.#dynamic];
+  }
+
+  addWebhook(webhook: WebhookConfig): void {
+    const exists = this.getWebhooks().some(
+      (w) => w.endpoint === webhook.endpoint,
+    );
+    if (exists) return;
+    this.#dynamic.push(webhook);
+    this.#save();
+  }
+
+  removeWebhook(endpoint: string): boolean {
+    const before = this.#dynamic.length;
+    this.#dynamic = this.#dynamic.filter((w) => w.endpoint !== endpoint);
+    if (this.#dynamic.length === before) return false;
+    this.#save();
+    return true;
+  }
+
+  notifyPublish(event: PublishEvent): void {
+    for (const webhook of this.getWebhooks()) {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        ...webhook.headers,
+      };
+
+      fetch(webhook.endpoint, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(event),
+      }).catch((err: unknown) => {
+        console.error(`[registry] Webhook to ${webhook.endpoint} failed:`, err);
+      });
+    }
+  }
+
+  #filePath(): string {
+    return path.join(this.#storagePath, WEBHOOKS_FILE);
+  }
+
+  #load(): WebhookConfig[] {
+    try {
+      const raw = fs.readFileSync(this.#filePath(), "utf-8");
+      return JSON.parse(raw) as WebhookConfig[];
+    } catch {
+      return [];
+    }
+  }
+
+  #save(): void {
+    fs.mkdirSync(this.#storagePath, { recursive: true });
+    fs.writeFileSync(this.#filePath(), JSON.stringify(this.#dynamic, null, 2));
+  }
+}

--- a/packages/registry/src/run.ts
+++ b/packages/registry/src/run.ts
@@ -5,6 +5,9 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { runServer } from "verdaccio";
 import { createPowerhouseRouter, createPublishHook } from "./middleware.js";
+import { NotificationManager } from "./notifications/manager.js";
+import { SSEChannel } from "./notifications/sse.js";
+import { WebhookChannel } from "./notifications/webhook.js";
 import type { RegistryCommandArgs, RegistryConfig } from "./types.js";
 import { buildVerdaccioConfig } from "./verdaccio-config.js";
 
@@ -28,6 +31,7 @@ export async function runRegistry(args: RegistryCommandArgs) {
     cdnCacheDir,
     uplink,
     webEnabled,
+    webhooks,
     s3AccessKeyId,
     s3Bucket,
     s3Endpoint,
@@ -44,12 +48,21 @@ export async function runRegistry(args: RegistryCommandArgs) {
     cdnCachePath,
   });
 
+  const webhookConfigs = webhooks
+    ?.split(",")
+    .map((url) => url.trim())
+    .filter(Boolean)
+    .map((endpoint) => ({ endpoint }));
+
   const config: RegistryConfig = {
     port,
     storagePath,
     cdnCachePath,
     uplink,
     webEnabled,
+    ...(webhookConfigs?.length && {
+      notify: { webhooks: webhookConfigs },
+    }),
     ...(s3Bucket &&
       s3Endpoint &&
       s3Region && {
@@ -79,9 +92,13 @@ export async function runRegistry(args: RegistryCommandArgs) {
 
   const app = express();
 
+  const sseChannel = new SSEChannel();
+  const webhookChannel = new WebhookChannel(config.storagePath, config.notify);
+  const notifications = new NotificationManager([sseChannel, webhookChannel]);
+
   // Our routes take priority over Verdaccio
-  app.use(createPowerhouseRouter(config));
-  app.use(createPublishHook(config));
+  app.use(createPowerhouseRouter(config, sseChannel, webhookChannel));
+  app.use(createPublishHook(config, notifications));
 
   // Verdaccio handles everything else (npm protocol, web UI, auth)
   app.use((req, res) => verdaccioHandler(req, res));

--- a/packages/registry/src/types.ts
+++ b/packages/registry/src/types.ts
@@ -20,6 +20,17 @@ export interface S3Config {
   keyPrefix?: string;
 }
 
+export interface WebhookConfig {
+  /** Webhook URL to POST to */
+  endpoint: string;
+  /** Custom headers to include in the request */
+  headers?: Record<string, string>;
+}
+
+export interface NotifyConfig {
+  webhooks?: WebhookConfig[];
+}
+
 export interface RegistryConfig {
   port: number;
   storagePath: string;
@@ -27,6 +38,7 @@ export interface RegistryConfig {
   uplink?: string;
   webEnabled?: boolean;
   s3?: S3Config;
+  notify?: NotifyConfig;
 }
 
 export interface RegistryCommandArgs {
@@ -42,4 +54,5 @@ export interface RegistryCommandArgs {
   s3KeyPrefix?: string;
   s3ForcePathStyle: boolean;
   webEnabled: boolean;
+  webhooks?: string;
 }

--- a/packages/registry/tests/e2e.test.ts
+++ b/packages/registry/tests/e2e.test.ts
@@ -1,15 +1,116 @@
+import { execSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
 import { access, cp, mkdir, rm } from "node:fs/promises";
+import http from "node:http";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import {
   DEFAULT_PORT,
   DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME,
   DEFAULT_STORAGE_DIR_NAME,
 } from "../src/constants.js";
+import type { PublishEvent } from "../src/notifications/types.js";
 import { runRegistry } from "../src/run.js";
-import type { PowerhouseManifest } from "../src/types.js";
+import type { PowerhouseManifest, WebhookConfig } from "../src/types.js";
 
 const REGISTRY_URL = `http://localhost:${DEFAULT_PORT}`;
+const TEST_PKG_NAME = "test-pkg";
+const TEST_PKG_VERSION = "1.0.0";
+const POLL_TIMEOUT = 5000;
+const POLL_INTERVAL = 200;
+
+let authToken: string;
+
+/**
+ * Creates a test user in verdaccio and stores the auth token.
+ * Safe to call multiple times — reuses existing token or handles 409.
+ */
+async function ensureTestUser(): Promise<void> {
+  if (authToken) return;
+  const res = await fetch(`${REGISTRY_URL}/-/user/org.couchdb.user:testuser`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "testuser", password: "testpassword" }),
+  });
+  const body = (await res.json()) as { token?: string };
+  if (body.token) {
+    authToken = body.token;
+  }
+}
+
+/**
+ * Publishes a minimal package to the registry using the npm HTTP API.
+ * Creates a tarball via `npm pack`, computes the real shasum, then PUTs
+ * the publish payload directly to verdaccio.
+ */
+async function publishPackage(
+  name = TEST_PKG_NAME,
+  version = TEST_PKG_VERSION,
+): Promise<void> {
+  const { createHash } = await import("node:crypto");
+  const { readFileSync } = await import("node:fs");
+
+  const tmpDir = path.join(import.meta.dirname, ".tmp-publish");
+  execSync(`rm -rf ${tmpDir} && mkdir -p ${tmpDir}`);
+  writeFileSync(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ name, version, description: "test" }),
+  );
+
+  const tarballName = execSync("npm pack --pack-destination .", {
+    cwd: tmpDir,
+    encoding: "utf-8",
+  }).trim();
+  const tarball = readFileSync(path.join(tmpDir, tarballName));
+  execSync(`rm -rf ${tmpDir}`);
+
+  const shasum = createHash("sha1").update(tarball).digest("hex");
+  const tarballBase64 = tarball.toString("base64");
+  const shortName = name.startsWith("@") ? name.split("/")[1] : name;
+
+  const res = await fetch(`${REGISTRY_URL}/${encodeURIComponent(name)}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
+    },
+    body: JSON.stringify({
+      _id: name,
+      name,
+      "dist-tags": { latest: version },
+      versions: {
+        [version]: {
+          name,
+          version,
+          description: "test",
+          dist: {
+            tarball: `${REGISTRY_URL}/${name}/-/${shortName}-${version}.tgz`,
+            shasum,
+          },
+        },
+      },
+      _attachments: {
+        [`${shortName}-${version}.tgz`]: {
+          content_type: "application/octet-stream",
+          data: tarballBase64,
+          length: tarball.length,
+        },
+      },
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Publish failed (${res.status}): ${body}`);
+  }
+}
 
 describe("registry e2e", () => {
   let server: Awaited<ReturnType<typeof runRegistry>>;
@@ -66,6 +167,7 @@ describe("registry e2e", () => {
 
     process.chdir(path.join(testDir, "./.test-output"));
     server = await runServer();
+    await ensureTestUser();
   }, 30000);
 
   afterAll(() => {
@@ -155,4 +257,237 @@ describe("registry e2e", () => {
       expect(response.headers.get("access-control-allow-origin")).toBe("*");
     });
   });
+
+  describe("publish", () => {
+    it("publishes a package and it appears in /packages", async () => {
+      await publishPackage();
+
+      await vi.waitFor(
+        async () => {
+          const res = await fetch(`${REGISTRY_URL}/packages`);
+          const packages = (await res.json()) as Array<{ name: string }>;
+          expect(packages.some((p) => p.name === TEST_PKG_NAME)).toBe(true);
+        },
+        { timeout: POLL_TIMEOUT, interval: POLL_INTERVAL },
+      );
+    });
+
+    it("serves published package via CDN", async () => {
+      const res = await fetch(
+        `${REGISTRY_URL}/-/cdn/${TEST_PKG_NAME}/package.json`,
+      );
+      expect(res.ok).toBe(true);
+      const pkg = (await res.json()) as { name: string; version: string };
+      expect(pkg.name).toBe(TEST_PKG_NAME);
+      expect(pkg.version).toBe(TEST_PKG_VERSION);
+    });
+  });
+
+  describe("webhooks", () => {
+    const webhookEndpoint = "http://localhost:19876/hook";
+
+    afterEach(async () => {
+      // Clean up any webhooks registered during the test
+      await fetch(`${REGISTRY_URL}/-/webhooks`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ endpoint: webhookEndpoint }),
+      });
+    });
+
+    it("GET /-/webhooks returns empty array initially", async () => {
+      const res = await fetch(`${REGISTRY_URL}/-/webhooks`);
+      expect(res.ok).toBe(true);
+      const webhooks = (await res.json()) as WebhookConfig[];
+      expect(webhooks).toEqual([]);
+    });
+
+    it("POST /-/webhooks registers a webhook", async () => {
+      const res = await fetch(`${REGISTRY_URL}/-/webhooks`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ endpoint: webhookEndpoint }),
+      });
+      expect(res.status).toBe(201);
+
+      const listRes = await fetch(`${REGISTRY_URL}/-/webhooks`);
+      const webhooks = (await listRes.json()) as WebhookConfig[];
+      expect(webhooks).toEqual([{ endpoint: webhookEndpoint }]);
+    });
+
+    it("POST /-/webhooks returns 400 without endpoint", async () => {
+      const res = await fetch(`${REGISTRY_URL}/-/webhooks`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("DELETE /-/webhooks removes a webhook", async () => {
+      await fetch(`${REGISTRY_URL}/-/webhooks`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ endpoint: webhookEndpoint }),
+      });
+
+      const delRes = await fetch(`${REGISTRY_URL}/-/webhooks`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ endpoint: webhookEndpoint }),
+      });
+      expect(delRes.status).toBe(204);
+
+      const listRes = await fetch(`${REGISTRY_URL}/-/webhooks`);
+      const webhooks = (await listRes.json()) as WebhookConfig[];
+      expect(webhooks).toEqual([]);
+    });
+
+    it("DELETE /-/webhooks returns 404 for unknown endpoint", async () => {
+      const res = await fetch(`${REGISTRY_URL}/-/webhooks`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ endpoint: "http://unknown" }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("webhook receives publish notification", async () => {
+      const received: PublishEvent[] = [];
+
+      // Start a tiny HTTP server to receive webhook calls
+      const hookServer = http.createServer((req, res) => {
+        let body = "";
+        req.on("data", (chunk: Buffer) => {
+          body += chunk.toString();
+        });
+        req.on("end", () => {
+          received.push(JSON.parse(body) as PublishEvent);
+          res.writeHead(200);
+          res.end();
+        });
+      });
+      await new Promise<void>((resolve) => {
+        hookServer.listen(19876, resolve);
+      });
+
+      try {
+        // Register webhook
+        await fetch(`${REGISTRY_URL}/-/webhooks`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ endpoint: webhookEndpoint }),
+        });
+
+        // Publish a new package version to trigger the notification
+        await publishPackage("webhook-test-pkg", "1.0.0");
+
+        // Wait for webhook delivery
+        await vi.waitFor(
+          () => {
+            expect(received.length).toBe(1);
+            expect(received[0].packageName).toBe("webhook-test-pkg");
+            expect(received[0].version).toBe("1.0.0");
+          },
+          { timeout: POLL_TIMEOUT, interval: POLL_INTERVAL },
+        );
+      } finally {
+        hookServer.close();
+      }
+    });
+  });
+
+  describe("SSE", () => {
+    it("GET /-/events returns SSE stream with connected event", async () => {
+      const events = await collectSSEEvents(
+        `${REGISTRY_URL}/-/events`,
+        1,
+        2000,
+      );
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      expect(events[0].event).toBe("connected");
+    });
+
+    it("SSE receives publish event", async () => {
+      // Start collecting SSE events (connected + publish)
+      const eventsPromise = collectSSEEvents(
+        `${REGISTRY_URL}/-/events`,
+        2,
+        POLL_TIMEOUT,
+      );
+
+      // Give SSE connection time to establish
+      await new Promise((r) => setTimeout(r, 500));
+
+      // Publish triggers a notification
+      await publishPackage("sse-test-pkg", "1.0.0");
+
+      const events = await eventsPromise;
+      const publishEvents = events.filter((e) => e.event === "publish");
+      expect(publishEvents.length).toBe(1);
+      expect(publishEvents[0].data.packageName).toBe("sse-test-pkg");
+      expect(publishEvents[0].data.version).toBe("1.0.0");
+    });
+  });
 });
+
+interface SSEEvent {
+  event: string;
+  data: PublishEvent;
+}
+
+/**
+ * Opens an SSE connection, collects up to `count` events, and resolves.
+ * Aborts after `timeoutMs` with whatever events were collected.
+ */
+function collectSSEEvents(
+  url: string,
+  count: number,
+  timeoutMs: number,
+): Promise<SSEEvent[]> {
+  return new Promise((resolve) => {
+    const events: SSEEvent[] = [];
+    const controller = new AbortController();
+
+    const timeout = setTimeout(() => {
+      controller.abort();
+      resolve(events);
+    }, timeoutMs);
+
+    http
+      .get(url, { signal: controller.signal }, (res) => {
+        let buffer = "";
+        res.on("data", (chunk: Buffer) => {
+          buffer += chunk.toString();
+          // Parse complete SSE messages (terminated by \n\n)
+          const parts = buffer.split("\n\n");
+          buffer = parts.pop()!;
+          for (const part of parts) {
+            if (!part.trim()) continue;
+            const lines = part.split("\n");
+            let event = "message";
+            let data = "";
+            for (const line of lines) {
+              if (line.startsWith("event: ")) event = line.slice(7);
+              if (line.startsWith("data: ")) data = line.slice(6);
+            }
+            events.push({
+              event,
+              data: JSON.parse(data) as PublishEvent,
+            });
+            if (events.length >= count) {
+              clearTimeout(timeout);
+              controller.abort();
+              resolve(events);
+              return;
+            }
+          }
+        });
+      })
+      .on("error", () => {
+        // AbortError is expected when we close the connection
+        clearTimeout(timeout);
+        resolve(events);
+      });
+  });
+}


### PR DESCRIPTION
## Summary

- Add real-time publish notification system to the registry with two channel types:
  - **Server-Sent Events (SSE)** at `GET /-/events` for browser clients
  - **Webhooks** with CRUD API at `/-/webhooks`, persisted to disk across restarts
- Predefined webhooks configurable via `--webhook` CLI flag or `REGISTRY_WEBHOOKS` env var (comma-separated URLs)
- `NotificationChannel` interface with `SSEChannel`, `WebhookChannel`, and `NotificationManager` implementations in `src/notifications/`
- `RegistryClient.onPublish()` method in reactor-browser for browser SSE subscription
- E2e tests covering publish flow, webhook CRUD, webhook delivery, and SSE events

## Test plan

- [ ] Run `pnpm test` in `packages/registry` — 15 tests pass (3 skipped for fixture data)
- [ ] Verify SSE endpoint returns `connected` event on connection
- [ ] Verify webhooks are persisted and restored after server restart
- [ ] Verify `--webhook` CLI flag registers predefined webhooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)