### PR TITLE
fix(reactor-api): deserialize signatures in pushSyncEnvelopes

### DIFF
--- a/packages/reactor-api/src/graphql/reactor/resolvers.ts
+++ b/packages/reactor-api/src/graphql/reactor/resolvers.ts
@@ -1,19 +1,18 @@
 import {
-  batchOperationsByDocument,
   consolidateSyncOperations,
+  envelopesToSyncOperations,
   sortEnvelopesByFirstOperationTimestamp,
-  SyncOperation,
   trimMailboxFromAckOrdinal,
   type IReactorClient,
   type ISyncManager,
   type JobInfo,
-  type OperationBatch,
   type OperationFilter,
   type PagedResults,
   type PagingOptions,
   type PropagationMode,
   type RemoteFilter,
   type SearchFilter,
+  type SyncOperation,
   type ViewFilter,
 } from "@powerhousedao/reactor";
 import type {
@@ -1116,41 +1115,15 @@ export function pushSyncEnvelopes(
       continue;
     }
 
-    const operations = envelope.operations.map((op) => ({
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      operation: op.operation,
-      context: {
-        documentId: op.context.documentId,
-        documentType: op.context.documentType,
-        scope: op.context.scope,
-        branch: op.context.branch,
-        ordinal: op.context.ordinal,
-      },
-    }));
+    const syncOps = envelopesToSyncOperations(
+      envelope as Parameters<typeof envelopesToSyncOperations>[0],
+      remote.name,
+    );
 
-    const batches: OperationBatch[] = batchOperationsByDocument(operations);
-
-    for (const batch of batches) {
-      const syncOpId = `syncop-${envelope.channelMeta.id}-${Date.now()}-${crypto.randomUUID()}`;
-      const jobId = envelope.key ?? "";
-      const jobDependencies = envelope.dependsOn ?? [];
-
-      const syncOp = new SyncOperation(
-        syncOpId,
-        jobId,
-        jobDependencies,
-        remote.name,
-        batch.documentId,
-        [batch.scope],
-        batch.branch,
-        batch.operations,
-      );
-
-      if (!remoteSyncOps.has(remote)) {
-        remoteSyncOps.set(remote, []);
-      }
-      remoteSyncOps.get(remote)!.push(syncOp);
+    if (!remoteSyncOps.has(remote)) {
+      remoteSyncOps.set(remote, []);
     }
+    remoteSyncOps.get(remote)!.push(...syncOps);
   }
 
   for (const [remote, syncOps] of remoteSyncOps) {

--- a/packages/reactor-api/test/connect-switchboard-sync.test.ts
+++ b/packages/reactor-api/test/connect-switchboard-sync.test.ts
@@ -876,4 +876,68 @@ describe("Connect-Switchboard Sync", () => {
       expect(switchboardCountFinal).toBe(switchboardCountAfterSync);
     }, 30000);
   });
+
+  it("should preserve signature tuples through sync round-trip", async () => {
+    const setup = await setupConnectSwitchboard();
+    connectReactor = setup.connectReactor;
+    switchboardReactor = setup.switchboardReactor;
+    connectModule = setup.connectModule;
+    switchboardModule = setup.switchboardModule;
+    connectEventBus = setup.connectEventBus;
+    switchboardEventBus = setup.switchboardEventBus;
+    connectSyncManager = setup.connectSyncManager;
+    switchboardSyncManager = setup.switchboardSyncManager;
+    resolverBridge = setup.resolverBridge;
+
+    const document = driveDocumentModelModule.utils.createDocument();
+    const documentId = document.header.id;
+
+    await setupSyncForDrive(connectSyncManager, documentId, resolverBridge);
+
+    const createReady = waitForOperationsReady(switchboardEventBus, documentId);
+    const createJob = await connectReactor.create(document);
+    await waitForJobCompletion(connectReactor, createJob.id);
+    await createReady;
+
+    const signedAction = driveDocumentModelModule.actions.setDriveName({
+      name: "Signed Drive",
+    });
+    signedAction.context = {
+      signer: {
+        user: { address: "0xabc", networkId: "eip155", chainId: 1 },
+        app: { name: "test-app", key: "app-key-1" },
+        signatures: [["algo", "0xabc", "pubkey123", "sig456", "hash789"]],
+      },
+    };
+
+    const mutationReady = waitForOperationsReady(
+      switchboardEventBus,
+      documentId,
+    );
+    const mutateJob = await connectReactor.execute(documentId, "main", [
+      signedAction,
+    ]);
+    await waitForJobCompletion(connectReactor, mutateJob.id);
+    await mutationReady;
+
+    const switchboardOps = await switchboardReactor.getOperations(documentId, {
+      branch: "main",
+    });
+    const globalOps = switchboardOps["global"]?.results ?? [];
+    const signedOp = globalOps.find(
+      (op) => op.action.type === "SET_DRIVE_NAME",
+    );
+
+    expect(signedOp).toBeDefined();
+    const signatures = signedOp!.action.context?.signer?.signatures;
+    expect(signatures).toHaveLength(1);
+    expect(Array.isArray(signatures![0])).toBe(true);
+    expect(signatures![0]).toEqual([
+      "algo",
+      "0xabc",
+      "pubkey123",
+      "sig456",
+      "hash789",
+    ]);
+  }, 30000);
 });

--- a/packages/reactor/src/index.ts
+++ b/packages/reactor/src/index.ts
@@ -226,6 +226,7 @@ export {
   SyncStatusTracker,
   batchOperationsByDocument,
   consolidateSyncOperations,
+  envelopesToSyncOperations,
   sortEnvelopesByFirstOperationTimestamp,
   trimMailboxFromAckOrdinal,
   type ChannelConfig,

--- a/packages/reactor/src/sync/channels/index.ts
+++ b/packages/reactor/src/sync/channels/index.ts
@@ -8,4 +8,4 @@ export {
   type PollTimerConfig,
 } from "./interval-poll-timer.js";
 export { type IPollTimer } from "./poll-timer.js";
-export { envelopeToSyncOperation } from "./utils.js";
+export { envelopeToSyncOperation, envelopesToSyncOperations } from "./utils.js";

--- a/packages/reactor/src/sync/index.ts
+++ b/packages/reactor/src/sync/index.ts
@@ -50,6 +50,7 @@ export {
 export { ChannelError, PollingChannelError } from "./errors.js";
 
 export {
+  envelopesToSyncOperations,
   GqlRequestChannel,
   GqlRequestChannelFactory,
   GqlResponseChannel,


### PR DESCRIPTION
## Summary
- The `pushSyncEnvelopes` resolver was passing operations through without deserializing signature strings back to tuples. Signatures arrive as comma-separated strings from GraphQL transport (e.g. `"algo, address, pubkey, sig, hash"`) but need to be `[string, string, string, string, string]` tuples for signature verification.
- Replaced manual operation mapping and `SyncOperation` construction with `envelopesToSyncOperations()`, which already handles signature deserialization via `deserializeOperationSignatures`.
- Added integration test that verifies signature tuples survive the full Connect → Switchboard sync round-trip.

## Test plan
- [x] New test `should preserve signature tuples through sync round-trip` passes with the fix
- [x] Same test fails without the fix (`signatures[0]` is a string instead of an array)
- [x] All existing sync tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)