### PR TITLE
Add MercuriusGatewayAdapter implementing IGatewayAdapter

### DIFF
--- a/packages/reactor-api/package.json
+++ b/packages/reactor-api/package.json
@@ -70,6 +70,8 @@
     "@powerhousedao/shared": "workspace:*",
     "@renown/sdk": "workspace:*",
     "@fastify/cors": "^11.0.1",
+    "@mercuriusjs/gateway": "^5.2.0",
+    "mercurius": "^16.8.0",
     "@fastify/formbody": "^8.0.1",
     "@fastify/middie": "^9.0.1",
     "body-parser": "^1.20.3",

--- a/packages/reactor-api/src/graphql/gateway/adapter-gateway-mercurius.ts
+++ b/packages/reactor-api/src/graphql/gateway/adapter-gateway-mercurius.ts
@@ -169,6 +169,19 @@ async function buildMercuriusApp(
     schema,
     graphiql: false,
     context: makeContextFn(contextFactory, logger),
+    // Override _Service.sdl to rewrite "type Query/Mutation/Subscription {"
+    // as "extend type …  {" so that @mercuriusjs/gateway v5 (which follows the
+    // Federation v1 convention of using extensionTypeMap) correctly maps root
+    // operation fields to this service during query planning.
+    resolvers: {
+      _Service: {
+        sdl: (parent: { sdl?: string }) =>
+          (parent.sdl ?? "").replace(
+            /\btype\s+(Query|Mutation|Subscription)\s*\{/g,
+            "extend type $1 {",
+          ),
+      },
+    },
   } satisfies MercuriusOptions);
 
   await app.ready();

--- a/packages/reactor-api/src/graphql/gateway/adapter-gateway-mercurius.ts
+++ b/packages/reactor-api/src/graphql/gateway/adapter-gateway-mercurius.ts
@@ -1,0 +1,246 @@
+import type { MercuriusGatewayOptions } from "@mercuriusjs/gateway";
+import mercuriusGateway from "@mercuriusjs/gateway";
+import Fastify from "fastify";
+import type {
+  FastifyInstance,
+  FastifyPluginCallback,
+  FastifyReply,
+  FastifyRequest,
+} from "fastify";
+import mercurius from "mercurius";
+import type { MercuriusOptions } from "mercurius";
+import type { ILogger } from "document-model";
+import type { GraphQLSchema } from "graphql";
+import type http from "node:http";
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { WebSocketServer } from "ws";
+import type { Context } from "../types.js";
+import { useServer } from "../websocket.js";
+import type {
+  FetchHandler,
+  GatewayContextFactory,
+  IGatewayAdapter,
+  SubgraphDefinition,
+  WsContextFactory,
+  WsDisposer,
+} from "./types.js";
+
+/**
+ * Threads the original Fetch API Request through Mercurius's internal
+ * fastify.inject() call so that contextFactory (which uses the auth WeakMap
+ * from auth-middleware.ts) receives the same Request object that auth
+ * middleware populated before calling the handler.
+ */
+const requestAls = new AsyncLocalStorage<Request>();
+
+// @mercuriusjs/gateway exports a plain `(instance, opts) => void` rather than
+// a typed FastifyPluginCallback — cast once here.
+// The gateway plugin's accepted options are the intersection of the base
+// MercuriusOptions and MercuriusGatewayOptions (mirroring the unexported
+// MercuriusFederationOptions type in the package).
+type GatewayPluginOptions = MercuriusOptions & MercuriusGatewayOptions;
+const mercuriusGatewayPlugin =
+  mercuriusGateway as unknown as FastifyPluginCallback<GatewayPluginOptions>;
+
+export class MercuriusGatewayAdapter implements IGatewayAdapter<Context> {
+  readonly #logger: ILogger;
+  readonly #subgraphApps: FastifyInstance[] = [];
+
+  #supergraphApp: FastifyInstance | null = null;
+  #getSubgraphs: (() => SubgraphDefinition[]) | null = null;
+  #supergraphContextFactory: GatewayContextFactory<Context> | null = null;
+
+  constructor(logger: ILogger) {
+    this.#logger = logger;
+  }
+
+  async start(_httpServer: http.Server): Promise<void> {
+    // Mercurius instances are started lazily in createHandler /
+    // createSupergraphHandler — nothing to do here.
+  }
+
+  async createHandler(
+    schema: GraphQLSchema,
+    contextFactory: GatewayContextFactory<Context>,
+  ): Promise<FetchHandler> {
+    const app = await buildMercuriusApp(schema, contextFactory, this.#logger);
+    this.#subgraphApps.push(app);
+    return buildFetchHandler(app);
+  }
+
+  async createSupergraphHandler(
+    getSubgraphs: () => SubgraphDefinition[],
+    _httpServer: http.Server,
+    contextFactory: GatewayContextFactory<Context>,
+  ): Promise<FetchHandler> {
+    if (this.#supergraphApp) {
+      throw new Error("Supergraph is already running");
+    }
+    this.#getSubgraphs = getSubgraphs;
+    this.#supergraphContextFactory = contextFactory;
+    this.#supergraphApp = await buildGatewayApp(
+      getSubgraphs(),
+      contextFactory,
+      this.#logger,
+    );
+
+    // Capture `this` so the returned handler always delegates to the *current*
+    // #supergraphApp, allowing updateSupergraph() to swap it atomically.
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const adapter = this;
+    return (request: Request): Promise<Response> => {
+      if (!adapter.#supergraphApp) {
+        return Promise.resolve(
+          new Response("Gateway not ready", { status: 503 }),
+        );
+      }
+      return requestAls.run(request, () =>
+        injectRequest(adapter.#supergraphApp!, request),
+      );
+    };
+  }
+
+  async updateSupergraph(): Promise<void> {
+    if (!this.#getSubgraphs || !this.#supergraphContextFactory) return;
+    const newApp = await buildGatewayApp(
+      this.#getSubgraphs(),
+      this.#supergraphContextFactory,
+      this.#logger,
+    );
+    const oldApp = this.#supergraphApp;
+    // Swap atomically — in-flight requests on the old app finish normally.
+    this.#supergraphApp = newApp;
+    if (oldApp) await oldApp.close();
+  }
+
+  attachWebSocket(
+    wsServer: WebSocketServer,
+    schema: GraphQLSchema,
+    contextFactory: WsContextFactory<Context>,
+  ): WsDisposer {
+    // Use graphql-ws directly; Mercurius's own subscription transport is
+    // Fastify-specific and not applicable here.
+    return useServer(
+      {
+        schema,
+        context: async (ctx: { connectionParams?: Record<string, unknown> }) =>
+          contextFactory(ctx.connectionParams ?? {}),
+      },
+      wsServer,
+    );
+  }
+
+  async stop(): Promise<void> {
+    await Promise.all(this.#subgraphApps.map((app) => app.close()));
+    this.#subgraphApps.length = 0;
+    if (this.#supergraphApp) {
+      await this.#supergraphApp.close();
+      this.#supergraphApp = null;
+    }
+    this.#getSubgraphs = null;
+    this.#supergraphContextFactory = null;
+  }
+}
+
+// ── Fastify instance factories ────────────────────────────────────────────────
+
+function makeContextFn(
+  contextFactory: GatewayContextFactory<Context>,
+  logger: ILogger,
+) {
+  return (_req: FastifyRequest, _reply: FastifyReply) => {
+    const request = requestAls.getStore();
+    if (!request) {
+      logger.error("[mercurius] No Fetch Request in AsyncLocalStorage");
+      throw new Error("No Fetch Request in AsyncLocalStorage");
+    }
+    return contextFactory(request);
+  };
+}
+
+async function buildMercuriusApp(
+  schema: GraphQLSchema,
+  contextFactory: GatewayContextFactory<Context>,
+  logger: ILogger,
+): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+
+  await app.register(mercurius, {
+    schema,
+    graphiql: false,
+    context: makeContextFn(contextFactory, logger),
+  } satisfies MercuriusOptions);
+
+  await app.ready();
+  return app;
+}
+
+/**
+ * Builds a Mercurius federation gateway that composes the given subgraph
+ * services. Each service URL must be reachable so that the gateway can fetch
+ * its SDL via `_service { sdl }` (Apollo Federation protocol).
+ */
+async function buildGatewayApp(
+  subgraphs: SubgraphDefinition[],
+  contextFactory: GatewayContextFactory<Context>,
+  logger: ILogger,
+): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+
+  await app.register(mercuriusGatewayPlugin, {
+    gateway: {
+      services: subgraphs.map((s) => ({ name: s.name, url: s.url })),
+    },
+    graphiql: false,
+    context: makeContextFn(contextFactory, logger),
+  });
+
+  await app.ready();
+  return app;
+}
+
+// ── Fetch API bridge ──────────────────────────────────────────────────────────
+
+function buildFetchHandler(app: FastifyInstance): FetchHandler {
+  return (request: Request): Promise<Response> =>
+    requestAls.run(request, () => injectRequest(app, request));
+}
+
+async function injectRequest(
+  app: FastifyInstance,
+  request: Request,
+): Promise<Response> {
+  const body =
+    request.method !== "GET" && request.method !== "HEAD"
+      ? await request.text()
+      : undefined;
+
+  const headers: Record<string, string> = {};
+  request.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  const response = await app.inject({
+    method: request.method as
+      | "DELETE"
+      | "GET"
+      | "HEAD"
+      | "OPTIONS"
+      | "PATCH"
+      | "POST"
+      | "PUT",
+    url: "/graphql",
+    headers,
+    payload: body,
+  });
+
+  const responseHeaders: Record<string, string> = {};
+  for (const [key, value] of Object.entries(response.headers)) {
+    if (value !== undefined) responseHeaders[key] = String(value);
+  }
+
+  return new Response(response.payload, {
+    status: response.statusCode,
+    headers: responseHeaders,
+  });
+}

--- a/packages/reactor-api/src/graphql/gateway/adapter-http-fastify.ts
+++ b/packages/reactor-api/src/graphql/gateway/adapter-http-fastify.ts
@@ -206,7 +206,14 @@ export class FastifyHttpAdapter implements IHttpAdapter {
 
     // Single catch-all route — all dispatching is done via the Maps above so
     // that routes registered after listen() are picked up automatically.
-    instance.all("/*", (req, reply) => this.#dispatch(req, reply));
+    // OPTIONS is excluded because @fastify/cors registers its own OPTIONS /*
+    // handler for preflight; including it here would cause a duplicate-route
+    // conflict at startup.
+    instance.route({
+      method: ["DELETE", "GET", "HEAD", "PATCH", "POST", "PUT"],
+      url: "/*",
+      handler: (req, reply) => this.#dispatch(req, reply),
+    });
 
     await instance.ready();
 
@@ -244,7 +251,10 @@ export class FastifyHttpAdapter implements IHttpAdapter {
     }
 
     // 3. Fetch routes (GraphQL handlers, SSE, etc.).
-    for (const entry of this.#fetchRoutes) {
+    // Iterate in reverse so that the last-mounted handler wins when the same
+    // path is mounted more than once (e.g. supergraph remount after reload).
+    for (let i = this.#fetchRoutes.length - 1; i >= 0; i--) {
+      const entry = this.#fetchRoutes[i]!;
       if (entry.matcher(pathname)) {
         return serveFetchHandler(entry.handler, req, reply);
       }

--- a/packages/reactor-api/src/graphql/gateway/factory.ts
+++ b/packages/reactor-api/src/graphql/gateway/factory.ts
@@ -1,11 +1,12 @@
 import type { ILogger } from "document-model";
 import type { Context } from "../types.js";
 import { ApolloGatewayAdapter } from "./adapter-gateway-apollo.js";
+import { MercuriusGatewayAdapter } from "./adapter-gateway-mercurius.js";
 import { createExpressHttpAdapter } from "./adapter-http-express.js";
 import { createFastifyHttpAdapter } from "./adapter-http-fastify.js";
 import type { IGatewayAdapter, IHttpAdapter } from "./types.js";
 
-export type GatewayAdapterType = "apollo";
+export type GatewayAdapterType = "apollo" | "mercurius";
 export type HttpAdapterType = "express" | "fastify";
 
 export function createGatewayAdapter(
@@ -15,6 +16,8 @@ export function createGatewayAdapter(
   switch (type) {
     case "apollo":
       return new ApolloGatewayAdapter(logger);
+    case "mercurius":
+      return new MercuriusGatewayAdapter(logger);
   }
 }
 

--- a/packages/reactor-api/test/gateway/adapter-gateway-mercurius.test.ts
+++ b/packages/reactor-api/test/gateway/adapter-gateway-mercurius.test.ts
@@ -1,0 +1,32 @@
+import { vi } from "vitest";
+import { MercuriusGatewayAdapter } from "../../src/graphql/gateway/adapter-gateway-mercurius.js";
+import {
+  runGatewayAdapterContractTests,
+  type GatewayAdapterHarness,
+} from "./gateway-adapter-contract.js";
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+const silentLogger = {
+  level: "error" as const,
+  verbose: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  errorHandler: vi.fn(),
+  child: () => silentLogger,
+};
+
+// ─── run the shared contract suite against MercuriusGatewayAdapter ───────────
+
+runGatewayAdapterContractTests(
+  "MercuriusGatewayAdapter",
+  async (): Promise<GatewayAdapterHarness> => {
+    const adapter = new MercuriusGatewayAdapter(silentLogger);
+    return {
+      adapter,
+      close: () => adapter.stop(),
+    };
+  },
+);

--- a/packages/reactor-api/test/gateway/adapter-http-fastify.test.ts
+++ b/packages/reactor-api/test/gateway/adapter-http-fastify.test.ts
@@ -1,0 +1,28 @@
+import { FastifyHttpAdapter } from "../../src/graphql/gateway/adapter-http-fastify.js";
+import {
+  runHttpAdapterContractTests,
+  type HttpAdapterHarness,
+} from "./http-adapter-contract.js";
+
+// ─── Fastify harness factory ──────────────────────────────────────────────────
+
+async function createFastifyHarness(): Promise<HttpAdapterHarness> {
+  const adapter = new FastifyHttpAdapter();
+  adapter.setupMiddleware({});
+
+  const httpServer = await adapter.listen(0);
+  const addr = httpServer.address() as { port: number };
+
+  return {
+    adapter,
+    url: `http://127.0.0.1:${addr.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        httpServer.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+// ─── run the shared contract suite against FastifyHttpAdapter ─────────────────
+
+runHttpAdapterContractTests("FastifyHttpAdapter", createFastifyHarness);

--- a/packages/reactor-api/vitest.config.ts
+++ b/packages/reactor-api/vitest.config.ts
@@ -11,10 +11,7 @@ export default defineConfig({
     },
   },
   test: {
-    exclude: [
-      "**/node_modules/**",
-      "**/dist/test/fault-injection-sync.test.js",
-    ],
+    exclude: ["**/node_modules/**", "**/dist/**"],
     deps: {
       optimizer: {
         web: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1158,7 +1158,7 @@ importers:
         version: 6.0.0(graphql@16.12.0)
       '@graphql-codegen/cli':
         specifier: 'catalog:'
-        version: 6.1.1(@parcel/watcher@2.5.6)(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(encoding@0.1.13)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        version: 6.1.1(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@parcel/watcher@2.5.6)(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(encoding@0.1.13)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@graphql-codegen/typescript':
         specifier: 'catalog:'
         version: 5.0.7(encoding@0.1.13)(graphql@16.12.0)
@@ -1749,6 +1749,9 @@ importers:
       '@fastify/middie':
         specifier: ^9.0.1
         version: 9.3.1
+      '@mercuriusjs/gateway':
+        specifier: ^5.2.0
+        version: 5.2.0(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(crossws@0.3.5)(utf-8-validate@6.0.6)
       '@opentelemetry/auto-instrumentations-node':
         specifier: ^0.57.1
         version: 0.57.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
@@ -1841,7 +1844,7 @@ importers:
         version: 0.3.2(graphql@16.12.0)
       graphql-ws:
         specifier: 'catalog:'
-        version: 6.0.7(crossws@0.3.5)(graphql@16.12.0)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        version: 6.0.7(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(crossws@0.3.5)(graphql@16.12.0)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       knex:
         specifier: 'catalog:'
         version: 3.1.0(better-sqlite3@12.6.2)(mysql2@3.17.2)(mysql@2.18.1)(pg@8.18.0)(sqlite3@5.1.7)(tedious@19.2.1(@azure/core-client@1.10.1))
@@ -1854,6 +1857,9 @@ importers:
       kysely-knex:
         specifier: 'catalog:'
         version: 0.2.0(knex@3.1.0(pg@8.18.0))(kysely@0.28.11)
+      mercurius:
+        specifier: ^16.8.0
+        version: 16.8.0(bufferutil@4.1.0)(graphql@16.12.0)(utf-8-validate@6.0.6)
       path-to-regexp:
         specifier: ^8.3.0
         version: 8.3.0
@@ -1872,7 +1878,7 @@ importers:
     devDependencies:
       '@graphql-codegen/cli':
         specifier: 'catalog:'
-        version: 6.1.1(@parcel/watcher@2.5.6)(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(encoding@0.1.13)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        version: 6.1.1(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@parcel/watcher@2.5.6)(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(encoding@0.1.13)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@graphql-codegen/typescript':
         specifier: 'catalog:'
         version: 5.0.7(encoding@0.1.13)(graphql@16.12.0)
@@ -1987,7 +1993,7 @@ importers:
     devDependencies:
       '@graphql-codegen/cli':
         specifier: 'catalog:'
-        version: 6.1.1(@parcel/watcher@2.5.6)(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(encoding@0.1.13)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        version: 6.1.1(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(encoding@0.1.13)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@graphql-codegen/typescript':
         specifier: 'catalog:'
         version: 5.0.7(encoding@0.1.13)(graphql@16.12.0)
@@ -2305,7 +2311,7 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: ^3.11.8
-        version: 3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(crossws@0.3.5)(graphql@16.12.0)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(graphql@16.12.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(crossws@0.3.5)(graphql@16.12.0)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(graphql@16.12.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@heroicons/react':
         specifier: ^2.1.5
         version: 2.2.0(react@19.2.4)
@@ -2485,7 +2491,7 @@ importers:
         version: 6.0.0(graphql@16.12.0)
       '@graphql-codegen/cli':
         specifier: 'catalog:'
-        version: 6.1.1(@parcel/watcher@2.5.6)(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(encoding@0.1.13)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        version: 6.1.1(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@parcel/watcher@2.5.6)(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(encoding@0.1.13)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@graphql-codegen/typescript':
         specifier: 'catalog:'
         version: 5.0.7(encoding@0.1.13)(graphql@16.12.0)
@@ -2617,7 +2623,7 @@ importers:
         version: 2.6.0(graphql@16.12.0)
       graphql-ws:
         specifier: 'catalog:'
-        version: 6.0.7(crossws@0.3.5)(graphql@16.12.0)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        version: 6.0.7(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(crossws@0.3.5)(graphql@16.12.0)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@vitest/browser-playwright@4.1.1)(happy-dom@20.8.8(bufferutil@4.1.0)(utf-8-validate@6.0.6))(jsdom@24.1.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -5259,6 +5265,9 @@ packages:
     resolution: {integrity: sha512-It0Sne6P3szg7JIi6CgKbvTZoMjxBZhcv91ZrqrNuaZQfB5WoqYYbzCUOq89YR+VY8juY9M1vDWmDDa2TzfXCw==}
     engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
+  '@fastify/accept-negotiator@2.0.1':
+    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
+
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
@@ -5280,6 +5289,9 @@ packages:
   '@fastify/forwarded@3.0.1':
     resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
 
+  '@fastify/merge-json-schemas@0.1.1':
+    resolution: {integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==}
+
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
 
@@ -5288,6 +5300,15 @@ packages:
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/send@4.1.0':
+    resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
+
+  '@fastify/static@9.0.0':
+    resolution: {integrity: sha512-r64H8Woe/vfilg5RTy7lwWlE8ZZcTrc3kebYFMEUBrMqlydhQyoiExQXdYAy2REVpST/G35+stAM8WYp1WGmMA==}
+
+  '@fastify/websocket@11.2.0':
+    resolution: {integrity: sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==}
 
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
@@ -6226,6 +6247,10 @@ packages:
   '@lit/reactive-element@2.1.2':
     resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
 
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
+
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
@@ -6259,6 +6284,18 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@mercuriusjs/federation@5.1.0':
+    resolution: {integrity: sha512-F2eJNySdqiWvNSFEVe8wPodw8aiTfpcSn/XQfqQ3h67HUc2R76NI+YZp5YL3JV/9I73y30CfCxJ5hza4nRXcMw==}
+
+  '@mercuriusjs/gateway@5.2.0':
+    resolution: {integrity: sha512-o9dmAzfj9K25XO+SzNn0UawgyTVzkPQS5bA7gPmyPWnzpA4z0LesY3ZL13cFMu+Us4NUklU4qUZDBJFbNiP8+w==}
+
+  '@mercuriusjs/subscription-client@2.0.0':
+    resolution: {integrity: sha512-rjYVWfFa0Z6L1OjQ3akp5RrFZ2dnlgF+sfnZ7AjGJgj5vrIvv/S4UFYIWmdrRjVaxJwPvBLJVHiY0fDqnFjWEQ==}
+    engines: {node: '>=20.16.0'}
+    peerDependencies:
+      graphql: ^16.0.0
 
   '@metamask/json-rpc-engine@8.0.2':
     resolution: {integrity: sha512-IoQPmql8q7ABLruW7i4EYVHWUbF74yrp63bRuXV5Zf9BQwcn5H9Ww1eLtROYvI1bUXwOiHZ6qT5CWTrDc/t/AA==}
@@ -13584,6 +13621,9 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-json-stringify@5.16.1:
+    resolution: {integrity: sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==}
+
   fast-json-stringify@6.3.0:
     resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
 
@@ -13600,6 +13640,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-uri@2.4.0:
+    resolution: {integrity: sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -13612,6 +13655,9 @@ packages:
 
   fastify@5.8.4:
     resolution: {integrity: sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==}
+
+  fastparallel@2.4.1:
+    resolution: {integrity: sha512-qUmhxPgNHmvRjZKBFUNI0oZuuH9OlSIOXmJ98lhKPxMZZ7zS/Fi0wRHOihDSz0R1YiIOjxzOY4bq65YTcdBi2Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -14114,6 +14160,11 @@ packages:
     peerDependenciesMeta:
       cosmiconfig-toml-loader:
         optional: true
+
+  graphql-jit@0.8.7:
+    resolution: {integrity: sha512-KGzCrsxQPfEiXOUIJCexWKiWF6ycjO89kAO6SdO8OWRGwYXbG0hsLuTnbFfMq0gj7d7/ib/Gh7jtst7FHZEEjw==}
+    peerDependencies:
+      graphql: '>=15'
 
   graphql-language-service@5.5.0:
     resolution: {integrity: sha512-9EvWrLLkF6Y5e29/2cmFoAO6hBPPAZlCyjznmpR11iFtRydfkss+9m6x+htA8h7YznGam+TtJwS6JuwoWWgb2Q==}
@@ -15376,6 +15427,9 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-ref-resolver@1.0.1:
+    resolution: {integrity: sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==}
+
   json-schema-ref-resolver@3.0.0:
     resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
 
@@ -16031,6 +16085,12 @@ packages:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
     engines: {node: '>=16.10'}
 
+  mercurius@16.8.0:
+    resolution: {integrity: sha512-b0ZxtmqgqH8GBvXxs5wITLNZdTOVd7FzkuvUkUgg0waEM1UD8buDcl0RVrqH745WOpGRqID2ltWRVfNeLIXh5w==}
+    engines: {node: ^20.9.0 || >=22.0.0}
+    peerDependencies:
+      graphql: ^16.0.0
+
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
@@ -16518,6 +16578,10 @@ packages:
 
   monocart-locator@1.0.2:
     resolution: {integrity: sha512-v8W5hJLcWMIxLCcSi/MHh+VeefI+ycFmGz23Froer9QzWjrbg4J3gFJBuI/T1VLNoYxF47bVPPxq8ZlNX4gVCw==}
+
+  mqemitter@7.1.0:
+    resolution: {integrity: sha512-GnBDNz3lxmllW201ne0mrmdy5tPOTnc79jjVcsfUa2LG2pUGeyGWVeiae6ZysfC/64XrYOqCKRAQYrB7pGyBVQ==}
+    engines: {node: '>=20'}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -18186,6 +18250,10 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
+  qlobber@8.0.1:
+    resolution: {integrity: sha512-O+Wd1chXj5YE1DwmD+ae0bXiSLehmnS3czlC1R9FL/Nt/3q8uMS1bIHmg2lJfCoiimCxClWM8AAuJrF0EvNiog==}
+    engines: {node: '>= 16'}
+
   qrcode@1.5.3:
     resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
     engines: {node: '>=10.13.0'}
@@ -18240,6 +18308,10 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  quick-lru@7.3.0:
+    resolution: {integrity: sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==}
+    engines: {node: '>=18'}
 
   quickbit-native@2.4.8:
     resolution: {integrity: sha512-FcCcqI+nIAWGknqhtrYT5TSD7t/N+Xd8ctM+2PrIIBuwOi5hx0SxAvuPtzLIEMfT/2h9+fhBakUe2uALOHX6yw==}
@@ -18988,6 +19060,9 @@ packages:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
 
+  secure-json-parse@3.0.2:
+    resolution: {integrity: sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w==}
+
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -19178,6 +19253,9 @@ packages:
   simple-update-notifier@2.0.0:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
+
+  single-user-cache@2.1.0:
+    resolution: {integrity: sha512-Wmu+uIEkabMoQPpJTOYhEsE6h/XjnjIhtuB1+tynxeO/hQxwQD0hIDq/ad65P1Tw9wt9f5SKnUe+63m6TMB4Uw==}
 
   sirv@2.0.4:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
@@ -19841,6 +19919,10 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tiny-lru@11.4.7:
+    resolution: {integrity: sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==}
+    engines: {node: '>=12'}
+
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
@@ -20227,6 +20309,10 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici@7.24.6:
+    resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
+    engines: {node: '>=20.18.1'}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -20490,6 +20576,9 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-strict@1.0.1:
+    resolution: {integrity: sha512-IeiWvvEXfW5ltKVMkxq6FvNf2LojMKvB2OCeja6+ct24S1XOmQw2dGr2JyndwACWAGJva9B7yPHwAmeA9QCqAQ==}
 
   use-sync-external-store@1.2.0:
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
@@ -21533,7 +21622,7 @@ snapshots:
     dependencies:
       graphql: 16.12.0
 
-  '@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(crossws@0.3.5)(graphql@16.12.0)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(graphql@16.12.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(crossws@0.3.5)(graphql@16.12.0)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(graphql@16.12.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
       '@wry/caches': 1.0.1
@@ -21550,7 +21639,7 @@ snapshots:
       tslib: 2.8.1
       zen-observable-ts: 1.2.5
     optionalDependencies:
-      graphql-ws: 6.0.7(crossws@0.3.5)(graphql@16.12.0)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      graphql-ws: 6.0.7(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(crossws@0.3.5)(graphql@16.12.0)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     transitivePeerDependencies:
@@ -24950,6 +25039,8 @@ snapshots:
 
   '@faker-js/faker@10.3.0': {}
 
+  '@fastify/accept-negotiator@2.0.1': {}
+
   '@fastify/ajv-compiler@4.0.5':
     dependencies:
       ajv: 8.18.0
@@ -24976,6 +25067,10 @@ snapshots:
 
   '@fastify/forwarded@3.0.1': {}
 
+  '@fastify/merge-json-schemas@0.1.1':
+    dependencies:
+      fast-deep-equal: 3.1.3
+
   '@fastify/merge-json-schemas@0.2.1':
     dependencies:
       dequal: 2.0.3
@@ -24992,6 +25087,32 @@ snapshots:
     dependencies:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
+
+  '@fastify/send@4.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      escape-html: 1.0.3
+      fast-decode-uri-component: 1.0.1
+      http-errors: 2.0.1
+      mime: 3.0.0
+
+  '@fastify/static@9.0.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 1.0.1
+      fastify-plugin: 5.1.0
+      fastq: 1.20.1
+      glob: 13.0.6
+
+  '@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+    dependencies:
+      duplexify: 4.1.3
+      fastify-plugin: 5.1.0
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@floating-ui/core@1.7.4':
     dependencies:
@@ -25023,7 +25144,7 @@ snapshots:
       graphql: 16.12.0
       tslib: 2.6.3
 
-  '@graphql-codegen/cli@6.1.1(@parcel/watcher@2.5.6)(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(encoding@0.1.13)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@graphql-codegen/cli@6.1.1(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@parcel/watcher@2.5.6)(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(encoding@0.1.13)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/template': 7.28.6
@@ -25038,7 +25159,7 @@ snapshots:
       '@graphql-tools/graphql-file-loader': 8.1.9(graphql@16.12.0)
       '@graphql-tools/json-file-loader': 8.0.26(graphql@16.12.0)
       '@graphql-tools/load': 8.1.8(graphql@16.12.0)
-      '@graphql-tools/url-loader': 9.0.6(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
+      '@graphql-tools/url-loader': 9.0.6(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
       '@inquirer/prompts': 7.10.1(@types/node@25.2.3)
       '@whatwg-node/fetch': 0.10.13
@@ -25047,7 +25168,7 @@ snapshots:
       debounce: 2.2.0
       detect-indent: 6.1.0
       graphql: 16.12.0
-      graphql-config: 5.1.5(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      graphql-config: 5.1.5(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       is-glob: 4.0.3
       jiti: 2.6.1
       json-to-pretty-yaml: 1.2.2
@@ -25074,7 +25195,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@graphql-codegen/cli@6.1.1(@parcel/watcher@2.5.6)(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(encoding@0.1.13)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@graphql-codegen/cli@6.1.1(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(encoding@0.1.13)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/template': 7.28.6
@@ -25089,7 +25210,7 @@ snapshots:
       '@graphql-tools/graphql-file-loader': 8.1.9(graphql@16.12.0)
       '@graphql-tools/json-file-loader': 8.0.26(graphql@16.12.0)
       '@graphql-tools/load': 8.1.8(graphql@16.12.0)
-      '@graphql-tools/url-loader': 9.0.6(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
+      '@graphql-tools/url-loader': 9.0.6(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
       '@inquirer/prompts': 7.10.1(@types/node@25.5.0)
       '@whatwg-node/fetch': 0.10.13
@@ -25098,7 +25219,7 @@ snapshots:
       debounce: 2.2.0
       detect-indent: 6.1.0
       graphql: 16.12.0
-      graphql-config: 5.1.5(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      graphql-config: 5.1.5(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       is-glob: 4.0.3
       jiti: 2.6.1
       json-to-pretty-yaml: 1.2.2
@@ -25419,13 +25540,13 @@ snapshots:
       '@graphql-tools/utils': 11.0.0(graphql@16.12.0)
       graphql: 16.12.0
 
-  '@graphql-tools/executor-graphql-ws@2.0.7(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)':
+  '@graphql-tools/executor-graphql-ws@2.0.7(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@graphql-tools/executor-common': 0.0.6(graphql@16.12.0)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
       '@whatwg-node/disposablestack': 0.0.6
       graphql: 16.12.0
-      graphql-ws: 6.0.7(crossws@0.3.5)(graphql@16.12.0)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      graphql-ws: 6.0.7(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(crossws@0.3.5)(graphql@16.12.0)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       isomorphic-ws: 5.0.0(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       tslib: 2.8.1
       ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -25435,13 +25556,13 @@ snapshots:
       - crossws
       - utf-8-validate
 
-  '@graphql-tools/executor-graphql-ws@3.1.4(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)':
+  '@graphql-tools/executor-graphql-ws@3.1.4(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@graphql-tools/executor-common': 1.0.6(graphql@16.12.0)
       '@graphql-tools/utils': 11.0.0(graphql@16.12.0)
       '@whatwg-node/disposablestack': 0.0.6
       graphql: 16.12.0
-      graphql-ws: 6.0.7(crossws@0.3.5)(graphql@16.12.0)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      graphql-ws: 6.0.7(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(crossws@0.3.5)(graphql@16.12.0)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       isows: 1.0.7(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       tslib: 2.8.1
       ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -25665,9 +25786,9 @@ snapshots:
       graphql: 16.12.0
       tslib: 2.8.1
 
-  '@graphql-tools/url-loader@8.0.33(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)':
+  '@graphql-tools/url-loader@8.0.33(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)':
     dependencies:
-      '@graphql-tools/executor-graphql-ws': 2.0.7(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
+      '@graphql-tools/executor-graphql-ws': 2.0.7(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
       '@graphql-tools/executor-http': 1.3.3(@types/node@25.2.3)(graphql@16.12.0)
       '@graphql-tools/executor-legacy-ws': 1.1.25(bufferutil@4.1.0)(graphql@16.12.0)(utf-8-validate@6.0.6)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
@@ -25687,9 +25808,9 @@ snapshots:
       - crossws
       - utf-8-validate
 
-  '@graphql-tools/url-loader@8.0.33(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)':
+  '@graphql-tools/url-loader@8.0.33(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)':
     dependencies:
-      '@graphql-tools/executor-graphql-ws': 2.0.7(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
+      '@graphql-tools/executor-graphql-ws': 2.0.7(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
       '@graphql-tools/executor-http': 1.3.3(@types/node@25.5.0)(graphql@16.12.0)
       '@graphql-tools/executor-legacy-ws': 1.1.25(bufferutil@4.1.0)(graphql@16.12.0)(utf-8-validate@6.0.6)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
@@ -25709,9 +25830,9 @@ snapshots:
       - crossws
       - utf-8-validate
 
-  '@graphql-tools/url-loader@9.0.6(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)':
+  '@graphql-tools/url-loader@9.0.6(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)':
     dependencies:
-      '@graphql-tools/executor-graphql-ws': 3.1.4(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
+      '@graphql-tools/executor-graphql-ws': 3.1.4(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
       '@graphql-tools/executor-http': 3.1.0(@types/node@25.2.3)(graphql@16.12.0)
       '@graphql-tools/executor-legacy-ws': 1.1.25(bufferutil@4.1.0)(graphql@16.12.0)(utf-8-validate@6.0.6)
       '@graphql-tools/utils': 11.0.0(graphql@16.12.0)
@@ -25731,9 +25852,9 @@ snapshots:
       - crossws
       - utf-8-validate
 
-  '@graphql-tools/url-loader@9.0.6(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)':
+  '@graphql-tools/url-loader@9.0.6(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)':
     dependencies:
-      '@graphql-tools/executor-graphql-ws': 3.1.4(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
+      '@graphql-tools/executor-graphql-ws': 3.1.4(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
       '@graphql-tools/executor-http': 3.1.0(@types/node@25.5.0)(graphql@16.12.0)
       '@graphql-tools/executor-legacy-ws': 1.1.25(bufferutil@4.1.0)(graphql@16.12.0)(utf-8-validate@6.0.6)
       '@graphql-tools/utils': 11.0.0(graphql@16.12.0)
@@ -26671,6 +26792,8 @@ snapshots:
       '@lit-labs/ssr-dom-shim': 1.5.1
     optional: true
 
+  '@lukeed/ms@2.0.2': {}
+
   '@marijn/find-cluster-break@1.0.2': {}
 
   '@marp-team/marp-cli@4.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
@@ -26753,6 +26876,45 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
       react: 19.2.4
+
+  '@mercuriusjs/federation@5.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@fastify/error': 4.2.0
+      graphql: 16.12.0
+      mercurius: 16.8.0(bufferutil@4.1.0)(graphql@16.12.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@mercuriusjs/gateway@5.2.0(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(crossws@0.3.5)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@mercuriusjs/federation': 5.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@mercuriusjs/subscription-client': 2.0.0(bufferutil@4.1.0)(graphql@16.12.0)(utf-8-validate@6.0.6)
+      fastify-plugin: 5.1.0
+      graphql: 16.12.0
+      graphql-ws: 6.0.7(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(crossws@0.3.5)(graphql@16.12.0)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      mercurius: 16.8.0(bufferutil@4.1.0)(graphql@16.12.0)(utf-8-validate@6.0.6)
+      p-map: 7.0.4
+      single-user-cache: 2.1.0
+      tiny-lru: 11.4.7
+      undici: 7.24.6
+      use-strict: 1.0.1
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - '@fastify/websocket'
+      - bufferutil
+      - crossws
+      - utf-8-validate
+
+  '@mercuriusjs/subscription-client@2.0.0(bufferutil@4.1.0)(graphql@16.12.0)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@fastify/error': 4.2.0
+      graphql: 16.12.0
+      secure-json-parse: 3.0.2
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@metamask/json-rpc-engine@8.0.2':
     dependencies:
@@ -35488,7 +35650,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       stream-shift: 1.0.3
-    optional: true
 
   eastasianwidth@0.2.0: {}
 
@@ -36538,6 +36699,16 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-json-stringify@5.16.1:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.1.1
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-deep-equal: 3.1.3
+      fast-uri: 2.4.0
+      json-schema-ref-resolver: 1.0.1
+      rfdc: 1.4.1
+
   fast-json-stringify@6.3.0:
     dependencies:
       '@fastify/merge-json-schemas': 0.2.1
@@ -36557,6 +36728,8 @@ snapshots:
     optional: true
 
   fast-safe-stringify@2.1.1: {}
+
+  fast-uri@2.4.0: {}
 
   fast-uri@3.1.0: {}
 
@@ -36581,6 +36754,11 @@ snapshots:
       secure-json-parse: 4.1.0
       semver: 7.7.4
       toad-cache: 3.7.0
+
+  fastparallel@2.4.1:
+    dependencies:
+      reusify: 1.1.0
+      xtend: 4.0.2
 
   fastq@1.20.1:
     dependencies:
@@ -37154,13 +37332,13 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  graphql-config@5.1.5(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6):
+  graphql-config@5.1.5(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6):
     dependencies:
       '@graphql-tools/graphql-file-loader': 8.1.9(graphql@16.12.0)
       '@graphql-tools/json-file-loader': 8.0.26(graphql@16.12.0)
       '@graphql-tools/load': 8.1.8(graphql@16.12.0)
       '@graphql-tools/merge': 9.1.7(graphql@16.12.0)
-      '@graphql-tools/url-loader': 8.0.33(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
+      '@graphql-tools/url-loader': 8.0.33(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/node@25.2.3)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
       cosmiconfig: 8.3.6(typescript@5.9.3)
       graphql: 16.12.0
@@ -37177,13 +37355,13 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  graphql-config@5.1.5(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6):
+  graphql-config@5.1.5(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(typescript@5.9.3)(utf-8-validate@6.0.6):
     dependencies:
       '@graphql-tools/graphql-file-loader': 8.1.9(graphql@16.12.0)
       '@graphql-tools/json-file-loader': 8.0.26(graphql@16.12.0)
       '@graphql-tools/load': 8.1.8(graphql@16.12.0)
       '@graphql-tools/merge': 9.1.7(graphql@16.12.0)
-      '@graphql-tools/url-loader': 8.0.33(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
+      '@graphql-tools/url-loader': 8.0.33(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/node@25.5.0)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@6.0.6)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
       cosmiconfig: 8.3.6(typescript@5.9.3)
       graphql: 16.12.0
@@ -37199,6 +37377,16 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
+
+  graphql-jit@0.8.7(graphql@16.12.0):
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
+      fast-json-stringify: 5.16.1
+      generate-function: 2.3.1
+      graphql: 16.12.0
+      lodash.memoize: 4.1.2
+      lodash.merge: 4.6.2
+      lodash.mergewith: 4.6.2
 
   graphql-language-service@5.5.0(graphql@16.12.0):
     dependencies:
@@ -37255,17 +37443,19 @@ snapshots:
     optionalDependencies:
       '@types/express': 5.0.6
 
-  graphql-ws@6.0.7(crossws@0.3.5)(graphql@16.12.0)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  graphql-ws@6.0.7(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(crossws@0.3.5)(graphql@16.12.0)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
       graphql: 16.12.0
     optionalDependencies:
+      '@fastify/websocket': 11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       crossws: 0.3.5
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
-  graphql-ws@6.0.7(crossws@0.3.5)(graphql@16.12.0)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  graphql-ws@6.0.7(@fastify/websocket@11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(crossws@0.3.5)(graphql@16.12.0)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
       graphql: 16.12.0
     optionalDependencies:
+      '@fastify/websocket': 11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       crossws: 0.3.5
       ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
@@ -39026,6 +39216,10 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-ref-resolver@1.0.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+
   json-schema-ref-resolver@3.0.0:
     dependencies:
       dequal: 2.0.3
@@ -39855,6 +40049,27 @@ snapshots:
       map-or-similar: 1.5.0
 
   meow@12.1.1: {}
+
+  mercurius@16.8.0(bufferutil@4.1.0)(graphql@16.12.0)(utf-8-validate@6.0.6):
+    dependencies:
+      '@fastify/error': 4.2.0
+      '@fastify/static': 9.0.0
+      '@fastify/websocket': 11.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      fastify-plugin: 5.1.0
+      graphql: 16.12.0
+      graphql-jit: 0.8.7(graphql@16.12.0)
+      mqemitter: 7.1.0
+      p-map: 4.0.0
+      quick-lru: 7.3.0
+      readable-stream: 4.7.0
+      safe-stable-stringify: 2.5.0
+      secure-json-parse: 4.1.0
+      single-user-cache: 2.1.0
+      tiny-lru: 11.4.7
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   merge-descriptors@1.0.3: {}
 
@@ -40801,6 +41016,11 @@ snapshots:
       monocart-locator: 1.0.2
 
   monocart-locator@1.0.2: {}
+
+  mqemitter@7.1.0:
+    dependencies:
+      fastparallel: 2.4.1
+      qlobber: 8.0.1
 
   mri@1.2.0: {}
 
@@ -42811,6 +43031,8 @@ snapshots:
 
   pvutils@1.1.5: {}
 
+  qlobber@8.0.1: {}
+
   qrcode@1.5.3:
     dependencies:
       dijkstrajs: 1.0.3
@@ -42860,6 +43082,8 @@ snapshots:
   quick-format-unescaped@4.0.4: {}
 
   quick-lru@5.1.1: {}
+
+  quick-lru@7.3.0: {}
 
   quickbit-native@2.4.8(bare-url@2.3.2):
     dependencies:
@@ -43947,6 +44171,8 @@ snapshots:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
 
+  secure-json-parse@3.0.2: {}
+
   secure-json-parse@4.1.0: {}
 
   seedrandom@3.0.5: {}
@@ -44223,6 +44449,10 @@ snapshots:
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.7.4
+
+  single-user-cache@2.1.0:
+    dependencies:
+      safe-stable-stringify: 2.5.0
 
   sirv@2.0.4:
     dependencies:
@@ -45029,6 +45259,8 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tiny-lru@11.4.7: {}
+
   tiny-warning@1.0.3: {}
 
   tinybench@2.9.0: {}
@@ -45379,6 +45611,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici@7.24.6: {}
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
@@ -45631,6 +45865,8 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  use-strict@1.0.1: {}
 
   use-sync-external-store@1.2.0(react@19.2.4):
     dependencies:


### PR DESCRIPTION
Uses Mercurius + @mercuriusjs/gateway as an alternative to Apollo Server:

- createHandler: registers Mercurius on an isolated Fastify instance and bridges requests via fastify.inject(), returning a standard FetchHandler
- createSupergraphHandler: uses @mercuriusjs/gateway (Apollo Federation compatible) to compose subgraph services; subgraph URLs are fetched at startup via the _service { sdl } protocol
- updateSupergraph: atomically swaps the gateway Fastify instance so in-flight requests on the old instance drain normally
- attachWebSocket: reuses graphql-ws directly (same as Apollo adapter)
- AsyncLocalStorage threads the original Fetch Request through inject() so contextFactory receives the same Request that auth middleware populated in the WeakMap — no auth context is lost across the bridge
- factory.ts: GatewayAdapterType now includes "mercurius"