### PR TITLE
fix(registry): resolve correct package version on CDN and /packages

### DIFF
--- a/packages/registry/src/cdn.ts
+++ b/packages/registry/src/cdn.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { extract } from "tar";
+import { compareSemver } from "./semver.js";
 
 export class CdnCache {
   #extractionLocks = new Map<string, Promise<void>>();
@@ -13,10 +14,11 @@ export class CdnCache {
   ) {}
 
   async getFile(packageName: string, filePath: string): Promise<string | null> {
-    // Try local CDN cache first (pre-populated or previously extracted)
+    // Always check Verdaccio for the authoritative latest version,
+    // falling back to the cached version if Verdaccio is unavailable.
     const version =
-      this.getLatestCachedVersion(packageName) ??
-      (await this.getLatestVersion(packageName));
+      (await this.getLatestVersion(packageName)) ??
+      this.getLatestCachedVersion(packageName);
     if (!version) return null;
 
     const versionDir = path.join(this.cdnCachePath, packageName, version);
@@ -69,7 +71,7 @@ export class CdnCache {
         .filter((e) => e.isDirectory())
         .map((e) => e.name);
       if (versions.length === 0) return null;
-      versions.sort();
+      versions.sort(compareSemver);
       return versions[versions.length - 1];
     } catch {
       return null;
@@ -126,6 +128,24 @@ export class CdnCache {
     const cacheDir = path.join(this.cdnCachePath, packageName);
     if (!this.isSafePath(cacheDir)) return;
     fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+
+  /** Remove all cached version directories except the specified one. */
+  pruneOldVersions(packageName: string, keepVersion: string): void {
+    const pkgDir = path.join(this.cdnCachePath, packageName);
+    try {
+      const entries = fs.readdirSync(pkgDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() && entry.name !== keepVersion) {
+          const dir = path.join(pkgDir, entry.name);
+          if (this.isSafePath(dir)) {
+            fs.rmSync(dir, { recursive: true, force: true });
+          }
+        }
+      }
+    } catch {
+      // ignore — directory may not exist yet
+    }
   }
 
   private isSafePath(filePath: string): boolean {

--- a/packages/registry/src/middleware.ts
+++ b/packages/registry/src/middleware.ts
@@ -209,9 +209,11 @@ export function createPublishHook(
                 console.log(
                   `[registry] Extracting ${packageName}@${version} to CDN cache`,
                 );
-                return cdn
-                  .extractTarball(packageName, version)
-                  .then(() => version);
+                return cdn.extractTarball(packageName, version).then(() => {
+                  // Remove any stale version directories left by racing CDN requests
+                  cdn.pruneOldVersions(packageName, version);
+                  return version;
+                });
               }
               return null;
             })

--- a/packages/registry/src/packages.ts
+++ b/packages/registry/src/packages.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { compareSemver } from "./semver.js";
 import type { PackageInfo, PowerhouseManifest } from "./types.js";
 
 function readManifest(dir: string): PowerhouseManifest | null {
@@ -28,8 +29,7 @@ function getLatestVersionDir(pkgDir: string): string | null {
   }
   const versions = entries.filter((e) => e.isDirectory()).map((e) => e.name);
   if (versions.length === 0) return null;
-  // Simple sort — latest semver-ish version last
-  versions.sort();
+  versions.sort(compareSemver);
   return path.join(pkgDir, versions[versions.length - 1]);
 }
 

--- a/packages/registry/src/semver.ts
+++ b/packages/registry/src/semver.ts
@@ -1,0 +1,27 @@
+/**
+ * Compare two semver version strings for sorting.
+ * Returns negative if a < b, positive if a > b, 0 if equal.
+ *
+ * Handles numeric component comparison (so "1.0.10" > "1.0.9")
+ * and prerelease ordering (release > prerelease).
+ */
+export function compareSemver(a: string, b: string): number {
+  const [coreA, preA] = a.split("-", 2);
+  const [coreB, preB] = b.split("-", 2);
+
+  const partsA = coreA.split(".").map(Number);
+  const partsB = coreB.split(".").map(Number);
+
+  for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
+    const na = partsA[i] ?? 0;
+    const nb = partsB[i] ?? 0;
+    if (na !== nb) return na - nb;
+  }
+
+  // Equal core versions — release (no prerelease) sorts after prerelease
+  if (!preA && preB) return 1;
+  if (preA && !preB) return -1;
+  if (preA && preB) return preA < preB ? -1 : preA > preB ? 1 : 0;
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- **Swap version resolution order** in `CdnCache.getFile`: check Verdaccio for the authoritative latest version first, fall back to filesystem cache only when Verdaccio is unavailable. Previously the cache was checked first, so once a stale version was cached it was served forever.
- **Semver-aware sorting** for version directories in both `cdn.ts` and `packages.ts` — fixes cases like `1.0.10` incorrectly sorting before `1.0.9` with the old lexicographic sort.
- **Prune stale version directories** after publish — the publish hook now removes old version dirs that racing CDN requests may have created during the extraction window.

## Test plan
- [x] Existing e2e tests pass (15 passed, 3 skipped)
- [ ] Deploy to staging and verify: publish a new version, confirm CDN and `/packages` return the updated version

🤖 Generated with [Claude Code](https://claude.com/claude-code)