### PR TITLE
feat: auto-discover and install packages for unknown document types

### DIFF
--- a/apps/connect/src/components/app.tsx
+++ b/apps/connect/src/components/app.tsx
@@ -10,6 +10,7 @@ import {
   WagmiContext,
 } from "@powerhousedao/design-system/connect";
 import { useEffect } from "react";
+import { PackageInstallPrompt } from "./package-install-prompt.js";
 export const App = () => {
   // refresh page on vite preload error due to outdated chunks
   useEffect(() => {
@@ -38,6 +39,7 @@ export const App = () => {
       <WagmiContext>
         <ToastContainer position="bottom-right" containerId="connect" />
         <Router />
+        <PackageInstallPrompt />
         <Analytics />
       </WagmiContext>
     </SentryProvider>

--- a/apps/connect/src/components/modal/modals/MissingPackageModal.tsx
+++ b/apps/connect/src/components/modal/modals/MissingPackageModal.tsx
@@ -1,5 +1,8 @@
 import { useRegistryPackages } from "@powerhousedao/connect/hooks";
-import { MissingPackageModal } from "@powerhousedao/design-system/connect/index";
+import {
+  PackageInstallModal,
+  type PendingPackageInstallation,
+} from "@powerhousedao/design-system/connect/index";
 import {
   closePHModal,
   usePHModal,
@@ -17,6 +20,13 @@ export function ConnectMissingPackageModal() {
 
   if (!packageManager || !documentType) return null;
 
+  const pendingInstallations: PendingPackageInstallation[] = registryPackageList
+    .filter((rp) => rp.documentTypes.includes(documentType))
+    .map((rp) => ({
+      documentType,
+      packageName: rp.name,
+    }));
+
   async function onInstall(packageName: string) {
     const result = await packageManager?.addPackage(packageName);
     if (result?.type === "success") {
@@ -28,15 +38,9 @@ export function ConnectMissingPackageModal() {
     updateRegistryPackageStatus(packageName, "dismissed");
   }
 
-  const requiredPackages = registryPackageList.filter((rp) =>
-    rp.documentTypes.includes(documentType),
-  );
-
   return (
-    <MissingPackageModal
-      documentType={documentType}
-      requiredPackages={requiredPackages}
-      open={open}
+    <PackageInstallModal
+      pendingInstallations={pendingInstallations}
       onInstall={onInstall}
       onDismiss={onDismiss}
       onOpenChange={(status: boolean) => {

--- a/apps/connect/src/components/package-install-prompt.tsx
+++ b/apps/connect/src/components/package-install-prompt.tsx
@@ -1,0 +1,33 @@
+import {
+  PackageInstallModal,
+  type PendingPackageInstallation,
+} from "@powerhousedao/design-system/connect/index";
+import { usePackageDiscoveryService } from "@powerhousedao/reactor-browser";
+import { usePendingInstallations } from "../hooks/usePendingInstallations.js";
+
+export function PackageInstallPrompt() {
+  const pendingInstallations = usePendingInstallations();
+  const discoveryService = usePackageDiscoveryService();
+
+  if (!discoveryService || pendingInstallations.length === 0) return null;
+
+  const installations: PendingPackageInstallation[] =
+    pendingInstallations.flatMap((p) =>
+      p.packageNames.map((packageName) => ({
+        documentType: p.documentType,
+        packageName,
+      })),
+    );
+
+  return (
+    <PackageInstallModal
+      pendingInstallations={installations}
+      onInstall={(packageName) =>
+        discoveryService.approveInstallation(packageName)
+      }
+      onDismiss={(packageName) =>
+        discoveryService.dismissInstallation(packageName)
+      }
+    />
+  );
+}

--- a/apps/connect/src/hooks/index.ts
+++ b/apps/connect/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from "./useAcceptedCookies.js";
+export * from "./usePendingInstallations.js";
 export * from "./useCheckLatestVersion.js";
 export * from "./useClientErrorHandler.js";
 export * from "./useCookieBanner.js";

--- a/apps/connect/src/hooks/usePendingInstallations.ts
+++ b/apps/connect/src/hooks/usePendingInstallations.ts
@@ -1,7 +1,10 @@
-import { usePackageDiscoveryService } from "@powerhousedao/reactor-browser";
+import {
+  usePackageDiscoveryService,
+  type PendingInstallation,
+} from "@powerhousedao/reactor-browser";
 import { useSyncExternalStore } from "react";
 
-const emptyArray: [] = [];
+const emptyArray: PendingInstallation[] = [];
 
 export function usePendingInstallations() {
   const discoveryService = usePackageDiscoveryService();

--- a/apps/connect/src/hooks/usePendingInstallations.ts
+++ b/apps/connect/src/hooks/usePendingInstallations.ts
@@ -1,0 +1,12 @@
+import { usePackageDiscoveryService } from "@powerhousedao/reactor-browser";
+import { useSyncExternalStore } from "react";
+
+const emptyArray: [] = [];
+
+export function usePendingInstallations() {
+  const discoveryService = usePackageDiscoveryService();
+  return useSyncExternalStore(
+    (cb) => discoveryService?.subscribePending(cb) ?? (() => {}),
+    () => discoveryService?.getPendingInstallations() ?? emptyArray,
+  );
+}

--- a/apps/connect/src/package-discovery.ts
+++ b/apps/connect/src/package-discovery.ts
@@ -1,0 +1,266 @@
+import {
+  BrowserLocalStorage,
+  type IDocumentModelLoader,
+  type IPackageDiscoveryService,
+  type DiscoveryEvent,
+  type DiscoveryEventListener,
+  type PendingInstallation,
+} from "@powerhousedao/reactor-browser";
+import type { RegistryClient } from "@powerhousedao/reactor-browser";
+import type { DocumentModelModule } from "@powerhousedao/shared/document-model";
+import type { BrowserPackageManager } from "./package-manager.js";
+
+export type DiscoveryMode = "immediate" | "manual";
+
+type DeferredEntry = {
+  packageNames: string[];
+  resolve: (module: DocumentModelModule<any>) => void;
+  reject: (reason: unknown) => void;
+  promise: Promise<DocumentModelModule<any>>;
+};
+
+export class PackageDiscoveryService
+  implements IDocumentModelLoader, IPackageDiscoveryService
+{
+  #packageManager: BrowserPackageManager;
+  #registryClient: RegistryClient;
+  #mode: DiscoveryMode;
+
+  #deferred = new Map<string, DeferredEntry>();
+  #pending = new Map<string, PendingInstallation>();
+  #pendingMemo: PendingInstallation[] = [];
+  #pendingSubscribers = new Set<() => void>();
+  #eventSubscribers = new Set<DiscoveryEventListener>();
+  #dismissedStorage: BrowserLocalStorage<boolean>;
+  #discoveredTypes = new Map<string, string[]>();
+
+  constructor(
+    packageManager: BrowserPackageManager,
+    registryClient: RegistryClient,
+    options: { mode: DiscoveryMode; storageKey: string },
+  ) {
+    this.#packageManager = packageManager;
+    this.#registryClient = registryClient;
+    this.#mode = options.mode;
+    this.#dismissedStorage = new BrowserLocalStorage<boolean>(
+      options.storageKey + ":PH_DISMISSED_TYPES",
+    );
+  }
+
+  load(documentType: string): Promise<DocumentModelModule<any>> {
+    const existing = this.#findModuleInLoadedPackages(documentType);
+    if (existing) {
+      return Promise.resolve(existing);
+    }
+
+    if (this.#dismissedStorage.has(documentType)) {
+      return Promise.reject(
+        new Error(`Document type "${documentType}" was dismissed`),
+      );
+    }
+
+    const tracked = this.#deferred.get(documentType);
+    if (tracked) {
+      return tracked.promise;
+    }
+
+    return this.#discover(documentType);
+  }
+
+  promptInstallation(documentType: string): void {
+    const packageNames = this.#discoveredTypes.get(documentType);
+    if (!packageNames) return;
+    if (this.#pending.has(documentType)) return;
+
+    this.#discoveredTypes.delete(documentType);
+    this.#addToPending(documentType, packageNames);
+  }
+
+  async approveInstallation(packageName: string): Promise<void> {
+    const affectedTypes = this.#findTypesByPackage(packageName);
+    if (affectedTypes.length === 0) return;
+
+    const result = await this.#packageManager.addPackage(packageName);
+    if (result.type === "error") {
+      this.#emitEvent({
+        type: "installation-failed",
+        packageName,
+        error: result.error,
+      });
+      for (const documentType of affectedTypes) {
+        const entry = this.#deferred.get(documentType);
+        if (entry) {
+          entry.reject(result.error);
+          this.#deferred.delete(documentType);
+          this.#pending.delete(documentType);
+        }
+      }
+      this.#notifyPendingChanged();
+      return;
+    }
+
+    this.#emitEvent({
+      type: "installation-approved",
+      packageName,
+      documentTypes: affectedTypes,
+    });
+
+    for (const documentType of affectedTypes) {
+      const entry = this.#deferred.get(documentType);
+      if (!entry) continue;
+
+      const module = this.#findModuleInLoadedPackages(documentType);
+      if (module) {
+        entry.resolve(module);
+      } else {
+        entry.reject(
+          new Error(
+            `Package "${packageName}" installed but module for "${documentType}" not found`,
+          ),
+        );
+      }
+      this.#deferred.delete(documentType);
+      this.#pending.delete(documentType);
+    }
+    this.#notifyPendingChanged();
+  }
+
+  dismissInstallation(packageName: string): void {
+    const affectedTypes = this.#findTypesByPackage(packageName);
+    if (affectedTypes.length === 0) return;
+
+    for (const documentType of affectedTypes) {
+      this.#dismissedStorage.set(documentType, true);
+      const entry = this.#deferred.get(documentType);
+      if (entry) {
+        entry.reject(
+          new Error(`Document type "${documentType}" was dismissed`),
+        );
+      }
+      this.#deferred.delete(documentType);
+      this.#pending.delete(documentType);
+      this.#discoveredTypes.delete(documentType);
+    }
+
+    this.#emitEvent({
+      type: "installation-dismissed",
+      packageName,
+      documentTypes: affectedTypes,
+    });
+    this.#notifyPendingChanged();
+  }
+
+  getPendingInstallations(): PendingInstallation[] {
+    return this.#pendingMemo;
+  }
+
+  subscribePending(listener: () => void): () => void {
+    this.#pendingSubscribers.add(listener);
+    return () => {
+      this.#pendingSubscribers.delete(listener);
+    };
+  }
+
+  subscribeEvents(listener: DiscoveryEventListener): () => void {
+    this.#eventSubscribers.add(listener);
+    return () => {
+      this.#eventSubscribers.delete(listener);
+    };
+  }
+
+  async #discover(documentType: string): Promise<DocumentModelModule<any>> {
+    let packageNames: string[];
+    try {
+      packageNames =
+        await this.#registryClient.getPackagesByDocumentType(documentType);
+    } catch (error) {
+      this.#emitEvent({
+        type: "registry-query-failed",
+        documentType,
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+      return Promise.reject(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
+
+    if (packageNames.length === 0) {
+      return Promise.reject(
+        new Error(`No packages found for document type "${documentType}"`),
+      );
+    }
+
+    const entry = this.#createDeferredEntry(documentType, packageNames);
+
+    this.#emitEvent({
+      type: "type-discovered",
+      documentType,
+      packageNames,
+    });
+
+    if (this.#mode === "immediate") {
+      this.#addToPending(documentType, packageNames);
+    } else {
+      this.#discoveredTypes.set(documentType, packageNames);
+    }
+
+    return entry.promise;
+  }
+
+  #createDeferredEntry(
+    documentType: string,
+    packageNames: string[],
+  ): DeferredEntry {
+    let resolve!: (module: DocumentModelModule<any>) => void;
+    let reject!: (reason: unknown) => void;
+    const promise = new Promise<DocumentModelModule<any>>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    const entry: DeferredEntry = { packageNames, resolve, reject, promise };
+    this.#deferred.set(documentType, entry);
+    return entry;
+  }
+
+  #addToPending(documentType: string, packageNames: string[]): void {
+    const installation: PendingInstallation = { documentType, packageNames };
+    this.#pending.set(documentType, installation);
+    this.#emitEvent({
+      type: "installation-prompted",
+      documentType,
+      packageNames,
+    });
+    this.#notifyPendingChanged();
+  }
+
+  #findModuleInLoadedPackages(
+    documentType: string,
+  ): DocumentModelModule<any> | undefined {
+    return this.#packageManager.packages
+      .flatMap((p) => p.documentModels)
+      .find((m) => m.documentModel.global.id === documentType);
+  }
+
+  #findTypesByPackage(packageName: string): string[] {
+    const types: string[] = [];
+    for (const [documentType, entry] of this.#deferred) {
+      if (entry.packageNames.includes(packageName)) {
+        types.push(documentType);
+      }
+    }
+    return types;
+  }
+
+  #notifyPendingChanged(): void {
+    this.#pendingMemo = Array.from(this.#pending.values());
+    for (const listener of this.#pendingSubscribers) {
+      listener();
+    }
+  }
+
+  #emitEvent(event: DiscoveryEvent): void {
+    for (const listener of this.#eventSubscribers) {
+      listener(event);
+    }
+  }
+}

--- a/apps/connect/src/package-manager.ts
+++ b/apps/connect/src/package-manager.ts
@@ -81,6 +81,10 @@ export class BrowserPackageManager implements IPackageManager {
     return this.#packagesMemo;
   }
 
+  get cdnUrl(): string | null {
+    return this.#cdnUrl;
+  }
+
   getPackageSource(packageName: string) {
     // check vs the constant name we use for common packages
     if (LOCAL_PACKAGES.includes(packageName)) {

--- a/apps/connect/src/store/reactor.ts
+++ b/apps/connect/src/store/reactor.ts
@@ -15,11 +15,13 @@ import {
   extractNodeSlugFromPath,
   getDrives,
   login,
+  RegistryClient,
   refreshReactorDataClient,
   setDefaultPHGlobalConfig,
   setDocumentCache,
   setDrives,
   setFeatures,
+  setPackageDiscoveryService,
   setPHToast,
   setReactorClient,
   setReactorClientModule,
@@ -36,6 +38,7 @@ import {
 } from "@renown/sdk";
 import { logger, type DocumentModelLib } from "document-model";
 import { initFeatureFlags } from "../feature-flags.js";
+import { PackageDiscoveryService } from "../package-discovery.js";
 import { BrowserPackageManager } from "../package-manager.js";
 import { loadPackagesConfig } from "../packages.config.js";
 import { createProcessorHostModule } from "./processor-host-module.js";
@@ -122,11 +125,29 @@ export async function createReactor(localPackage?: DocumentModelLib) {
     .flatMap((pkg) => pkg.upgradeManifests)
     .filter((u) => u !== undefined);
 
+  // initialize package discovery service for auto-installing unknown document types
+  const discoveryService =
+    packageManager.cdnUrl !== null
+      ? new PackageDiscoveryService(
+          packageManager,
+          new RegistryClient(packageManager.cdnUrl),
+          {
+            mode: "immediate",
+            storageKey: phGlobalConfigFromEnv.routerBasename ?? "",
+          },
+        )
+      : undefined;
+
+  if (discoveryService) {
+    setPackageDiscoveryService(discoveryService);
+  }
+
   // create reactor v2 with all versions and upgrade manifests
   const reactorClientModule = await createBrowserReactor(
     documentModelModules,
     upgradeManifests,
     renown,
+    discoveryService,
   );
 
   // get the drives from the reactor

--- a/packages/design-system/src/connect/components/drop-zone/use-upload-tracker.ts
+++ b/packages/design-system/src/connect/components/drop-zone/use-upload-tracker.ts
@@ -107,6 +107,10 @@ function uploadsReducer(
           ...(action.payload.progress.duplicateType && {
             duplicateType: action.payload.progress.duplicateType,
           }),
+          // Update fileNode if provided (for deferred uploads after discovery)
+          ...(action.payload.progress.fileNode && {
+            fileNode: action.payload.progress.fileNode,
+          }),
         },
       };
     }

--- a/packages/design-system/src/connect/components/modal/missing-package-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/missing-package-modal.tsx
@@ -1,98 +1,137 @@
-import { Modal, PackageAnimation } from "@powerhousedao/design-system";
-import type { RegistryPackage } from "@powerhousedao/shared/registry";
-import { useState, type ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
+import { useState } from "react";
+
+import { Modal } from "@powerhousedao/design-system";
 import { twMerge } from "tailwind-merge";
 
-type Props = ComponentPropsWithoutRef<typeof Modal> & {
+const buttonStyles =
+  "min-h-[36px] text-sm font-semibold py-2 px-4 rounded-xl outline-none active:opacity-75 hover:scale-105 transform transition-all";
+
+export interface PendingPackageInstallation {
   documentType: string;
-  requiredPackages: RegistryPackage[];
-  onInstall: (packageName: string) => Promise<void>;
-  onDismiss: (packageName: string) => void;
+  packageName: string;
+}
+
+export type PackageInstallModalProps = ComponentPropsWithoutRef<
+  typeof Modal
+> & {
+  readonly pendingInstallations: PendingPackageInstallation[];
+  readonly onInstall: (packageName: string) => Promise<void>;
+  readonly onDismiss: (packageName: string) => void;
 };
-export function MissingPackageModal(props: Props) {
+
+interface GroupedInstallation {
+  packageName: string;
+  documentTypes: string[];
+}
+
+function groupByPackage(
+  installations: PendingPackageInstallation[],
+): GroupedInstallation[] {
+  const groups = new Map<string, string[]>();
+  for (const item of installations) {
+    const existing = groups.get(item.packageName) ?? [];
+    existing.push(item.documentType);
+    groups.set(item.packageName, existing);
+  }
+  return Array.from(groups.entries()).map(([packageName, documentTypes]) => ({
+    packageName,
+    documentTypes,
+  }));
+}
+
+export function PackageInstallModal(props: PackageInstallModalProps) {
   const {
-    documentType,
-    requiredPackages,
-    open,
+    pendingInstallations,
     onInstall,
     onDismiss,
-    onOpenChange,
+    overlayProps,
+    contentProps,
+    ...restProps
   } = props;
-  const [installingPackages, setInstallingPackages] = useState<string[]>([]);
 
-  function isInstalling(packageName: string) {
-    return installingPackages.includes(packageName);
+  const [installingPackages, setInstallingPackages] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const grouped = groupByPackage(pendingInstallations);
+
+  async function handleInstall(packageName: string) {
+    setInstallingPackages((prev) => new Set(prev).add(packageName));
+    try {
+      await onInstall(packageName);
+    } finally {
+      setInstallingPackages((prev) => {
+        const next = new Set(prev);
+        next.delete(packageName);
+        return next;
+      });
+    }
   }
 
-  function addInstallingPackage(packageName: string) {
-    setInstallingPackages((previous) => [
-      ...new Set([...previous, packageName]),
-    ]);
-  }
-
-  function removeInstallingPackage(packageName: string) {
-    setInstallingPackages((previous) => [
-      ...new Set(previous.filter((ip) => ip !== packageName)),
-    ]);
-  }
-
-  function handleInstall(packageName: string) {
-    addInstallingPackage(packageName);
-    onInstall(packageName).then(
-      () => {
-        removeInstallingPackage(packageName);
-      },
-      () => {
-        removeInstallingPackage(packageName);
-      },
-    );
-  }
+  if (grouped.length === 0) return null;
 
   return (
-    <Modal open={open} onOpenChange={onOpenChange}>
+    <Modal
+      open={grouped.length > 0}
+      contentProps={{
+        ...contentProps,
+        className: twMerge("rounded-3xl", contentProps?.className),
+      }}
+      overlayProps={{
+        ...overlayProps,
+        className: overlayProps?.className,
+      }}
+      {...restProps}
+    >
       <div className="w-[460px] p-6 text-slate-300">
         <div className="border-b border-slate-50 pb-2 text-2xl font-bold text-gray-800">
-          {requiredPackages.length === 1
-            ? "Package Required"
-            : "Packages Required"}
+          {grouped.length === 1 ? "Package Required" : "Packages Required"}
         </div>
         <div className="my-4 text-sm text-gray-600">
-          {requiredPackages.length === 1
+          {grouped.length === 1
             ? "A document requires a package that is not installed."
             : "Documents require packages that are not installed."}
         </div>
         <div className="flex flex-col gap-3">
-          {requiredPackages.map(({ name }) => {
+          {grouped.map(({ packageName, documentTypes }) => {
+            const installing = installingPackages.has(packageName);
             return (
-              <div key={name} className="rounded-xl bg-slate-50 p-4">
+              <div key={packageName} className="rounded-xl bg-slate-50 p-4">
                 <div className="mb-1 text-sm font-semibold text-gray-800">
-                  {name}
+                  {packageName}
                 </div>
                 <div className="mb-3 text-xs text-gray-500">
-                  Required for document type "{documentType}"
+                  Required for document type
+                  {documentTypes.length > 1 ? "s" : ""}:{" "}
+                  {documentTypes.join(", ")}
                 </div>
-                {isInstalling(name) ? (
-                  <div className="flex justify-center">
-                    <PackageAnimation animate loop color="#6b7280" size={48} />
-                  </div>
-                ) : (
-                  <div className="flex justify-end gap-2">
-                    <button
-                      type="button"
-                      onClick={() => onDismiss(name)}
-                      className="border border-slate-200 bg-white text-slate-800"
-                    >
-                      Dismiss
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => handleInstall(name)}
-                      className="bg-gray-800 text-gray-50"
-                    >
-                      Install
-                    </button>
-                  </div>
-                )}
+                <div className="flex justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onDismiss(packageName)}
+                    disabled={installing}
+                    className={twMerge(
+                      buttonStyles,
+                      "border border-slate-200 bg-white text-slate-800",
+                      installing && "cursor-not-allowed opacity-50",
+                    )}
+                  >
+                    Dismiss
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleInstall(packageName)}
+                    disabled={installing}
+                    className={twMerge(
+                      buttonStyles,
+                      "bg-gray-800 text-gray-50",
+                      installing && "cursor-not-allowed opacity-50",
+                    )}
+                  >
+                    {installing ? "Installing..." : "Install"}
+                  </button>
+                </div>
               </div>
             );
           })}

--- a/packages/design-system/src/connect/components/modal/missing-package-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/missing-package-modal.tsx
@@ -45,6 +45,8 @@ export function PackageInstallModal(props: PackageInstallModalProps) {
     pendingInstallations,
     onInstall,
     onDismiss,
+    open,
+    onOpenChange,
     overlayProps,
     contentProps,
     ...restProps
@@ -73,7 +75,15 @@ export function PackageInstallModal(props: PackageInstallModalProps) {
 
   return (
     <Modal
-      open={grouped.length > 0}
+      open={open ?? grouped.length > 0}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          for (const { packageName } of grouped) {
+            onDismiss(packageName);
+          }
+        }
+        onOpenChange?.(isOpen);
+      }}
       contentProps={{
         ...contentProps,
         className: twMerge("rounded-3xl", contentProps?.className),

--- a/packages/reactor-browser/src/actions/document.ts
+++ b/packages/reactor-browser/src/actions/document.ts
@@ -370,7 +370,32 @@ export async function addFileWithProgress(
   try {
     onProgress?.({ stage: "loading", progress: 0 });
 
-    const document = await loadFile(file);
+    // Pre-read the document type before full load so we can attempt
+    // package discovery if the module is not installed.
+    const docType = await getDocumentTypeFromFile(file);
+
+    let document: PHDocument;
+    try {
+      document = await loadFile(file);
+    } catch (loadError) {
+      const discoveryService = window.ph?.packageDiscoveryService;
+      if (discoveryService && docType) {
+        // Trigger discovery and retry without blocking the drop handler
+        void retryAfterDiscovery(
+          discoveryService,
+          docType,
+          file,
+          driveId,
+          name,
+          parentFolder,
+          onProgress,
+          documentTypes,
+          resolveConflict,
+        );
+        return;
+      }
+      throw loadError;
+    }
 
     // Check for duplicate in same location
     const duplicateCheck = await isDocumentInLocation(
@@ -505,6 +530,57 @@ export async function addFileWithProgress(
       });
     }
     throw error;
+  }
+}
+
+async function getDocumentTypeFromFile(
+  file: string | File,
+): Promise<string | undefined> {
+  try {
+    const baseDocument = await baseLoadFromInput(
+      file,
+      (state: PHDocument) => state,
+      { checkHashes: false },
+    );
+    return baseDocument.header.documentType;
+  } catch {
+    return undefined;
+  }
+}
+
+async function retryAfterDiscovery(
+  discoveryService: NonNullable<typeof window.ph>["packageDiscoveryService"],
+  documentType: string,
+  file: string | File,
+  driveId: string,
+  name?: string,
+  parentFolder?: string,
+  onProgress?: FileUploadProgressCallback,
+  documentTypes?: string[],
+  resolveConflict?: ConflictResolution,
+): Promise<void> {
+  if (!discoveryService) return;
+  try {
+    await discoveryService.load(documentType);
+  } catch {
+    onProgress?.({
+      stage: "unsupported-document-type",
+      progress: 100,
+      error: `Document type ${documentType} is not supported`,
+    });
+    return;
+  }
+  const fileNode = await addFileWithProgress(
+    file,
+    driveId,
+    name,
+    parentFolder,
+    onProgress,
+    documentTypes,
+    resolveConflict,
+  );
+  if (fileNode) {
+    onProgress?.({ stage: "complete", progress: 100, fileNode });
   }
 }
 

--- a/packages/reactor-browser/src/actions/document.ts
+++ b/packages/reactor-browser/src/actions/document.ts
@@ -378,8 +378,10 @@ export async function addFileWithProgress(
     try {
       document = await loadFile(file);
     } catch (loadError) {
+      // Only attempt discovery if the failure is due to a missing document
+      // model module, not for other errors like corrupt files or hash failures.
       const discoveryService = window.ph?.packageDiscoveryService;
-      if (discoveryService && docType) {
+      if (discoveryService && docType && !(await hasDocumentModel(docType))) {
         // Trigger discovery and retry without blocking the drop handler
         void retryAfterDiscovery(
           discoveryService,
@@ -515,7 +517,7 @@ export async function addFileWithProgress(
       },
     });
 
-    onProgress?.({ stage: "complete", progress: 100 });
+    onProgress?.({ stage: "complete", progress: 100, fileNode });
 
     return fileNode;
   } catch (error) {
@@ -530,6 +532,17 @@ export async function addFileWithProgress(
       });
     }
     throw error;
+  }
+}
+
+async function hasDocumentModel(documentType: string): Promise<boolean> {
+  const reactorClient = window.ph?.reactorClient;
+  if (!reactorClient) return false;
+  try {
+    await reactorClient.getDocumentModelModule(documentType);
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -570,7 +583,7 @@ async function retryAfterDiscovery(
     });
     return;
   }
-  const fileNode = await addFileWithProgress(
+  await addFileWithProgress(
     file,
     driveId,
     name,
@@ -579,9 +592,6 @@ async function retryAfterDiscovery(
     documentTypes,
     resolveConflict,
   );
-  if (fileNode) {
-    onProgress?.({ stage: "complete", progress: 100, fileNode });
-  }
 }
 
 export async function updateFile(

--- a/packages/reactor-browser/src/actions/document.ts
+++ b/packages/reactor-browser/src/actions/document.ts
@@ -34,7 +34,10 @@ import {
   replayDocument,
 } from "@powerhousedao/shared/document-model";
 import { logger } from "document-model";
-import { UnsupportedDocumentTypeError } from "../errors.js";
+import {
+  DocumentModelNotFoundError,
+  UnsupportedDocumentTypeError,
+} from "../errors.js";
 import { isDocumentTypeSupported } from "../utils/documents.js";
 import { getUserPermissions } from "../utils/user.js";
 import { queueActions, queueOperations, uploadOperations } from "./queue.js";
@@ -216,9 +219,7 @@ export async function loadFile(path: string | File) {
       module.documentModel.global.id === baseDocument.header.documentType,
   );
   if (!documentModelModule) {
-    throw new Error(
-      `Document "${baseDocument.header.documentType}" is not supported`,
-    );
+    throw new DocumentModelNotFoundError(baseDocument.header.documentType);
   }
   return documentModelModule.utils.loadFromInput(path);
 }
@@ -369,23 +370,18 @@ export async function addFileWithProgress(
   // Loading stage (0-10%)
   try {
     onProgress?.({ stage: "loading", progress: 0 });
-
-    // Pre-read the document type before full load so we can attempt
-    // package discovery if the module is not installed.
-    const docType = await getDocumentTypeFromFile(file);
-
     let document: PHDocument;
     try {
       document = await loadFile(file);
     } catch (loadError) {
-      // Only attempt discovery if the failure is due to a missing document
-      // model module, not for other errors like corrupt files or hash failures.
+      // Only attempt discovery if the failure is specifically a missing
+      // document model module, not for other errors like corrupt files.
       const discoveryService = window.ph?.packageDiscoveryService;
-      if (discoveryService && docType && !(await hasDocumentModel(docType))) {
+      if (discoveryService && DocumentModelNotFoundError.isError(loadError)) {
         // Trigger discovery and retry without blocking the drop handler
         void retryAfterDiscovery(
           discoveryService,
-          docType,
+          loadError.documentType,
           file,
           driveId,
           name,
@@ -532,32 +528,6 @@ export async function addFileWithProgress(
       });
     }
     throw error;
-  }
-}
-
-async function hasDocumentModel(documentType: string): Promise<boolean> {
-  const reactorClient = window.ph?.reactorClient;
-  if (!reactorClient) return false;
-  try {
-    await reactorClient.getDocumentModelModule(documentType);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function getDocumentTypeFromFile(
-  file: string | File,
-): Promise<string | undefined> {
-  try {
-    const baseDocument = await baseLoadFromInput(
-      file,
-      (state: PHDocument) => state,
-      { checkHashes: false },
-    );
-    return baseDocument.header.documentType;
-  } catch {
-    return undefined;
   }
 }
 

--- a/packages/reactor-browser/src/errors.ts
+++ b/packages/reactor-browser/src/errors.ts
@@ -18,8 +18,16 @@ export class DocumentNotFoundError extends Error {
 }
 
 export class DocumentModelNotFoundError extends Error {
+  readonly documentType: string;
+  readonly name = "DocumentModelNotFoundError";
+
   constructor(documentType: string) {
     super(`Document model module for type ${documentType} not found`);
+    this.documentType = documentType;
+  }
+
+  static isError(error: unknown): error is DocumentModelNotFoundError {
+    return Error.isError(error) && error.name === "DocumentModelNotFoundError";
   }
 }
 

--- a/packages/reactor-browser/src/hooks/add-ph-event-handlers.ts
+++ b/packages/reactor-browser/src/hooks/add-ph-event-handlers.ts
@@ -55,6 +55,7 @@ import {
   addIsExternalControlsEnabledEventHandler,
 } from "./config/editor.js";
 import { addDocumentCacheEventHandler } from "./document-cache.js";
+import { addPackageDiscoveryServiceEventHandler } from "./package-discovery.js";
 import { addDrivesEventHandler } from "./drives.js";
 import { addLoadingEventHandler } from "./loading.js";
 import { addModalEventHandler } from "./modals.js";
@@ -97,6 +98,7 @@ const phGlobalEventHandlerRegisterFunctions: PHGlobalEventHandlerAdders = {
     addSetSelectedNodeOnPopStateEventHandler();
   },
   vetraPackageManager: addVetraPackageManagerEventHandler,
+  packageDiscoveryService: addPackageDiscoveryServiceEventHandler,
   selectedTimelineRevision: addSelectedTimelineRevisionEventHandler,
   revisionHistoryVisible: addRevisionHistoryVisibleEventHandler,
   selectedTimelineItem: addSelectedTimelineItemEventHandler,

--- a/packages/reactor-browser/src/hooks/index.ts
+++ b/packages/reactor-browser/src/hooks/index.ts
@@ -27,6 +27,7 @@ export * from "./loading.js";
 export * from "./make-ph-event-functions.js";
 export * from "./modals.js";
 export * from "./node-actions.js";
+export * from "./package-discovery.js";
 export * from "./node-by-id.js";
 export * from "./node-path.js";
 export * from "./parent-folder.js";

--- a/packages/reactor-browser/src/hooks/package-discovery.ts
+++ b/packages/reactor-browser/src/hooks/package-discovery.ts
@@ -1,0 +1,10 @@
+import { makePHEventFunctions } from "./make-ph-event-functions.js";
+
+const packageDiscoveryFunctions = makePHEventFunctions(
+  "packageDiscoveryService",
+);
+
+export const usePackageDiscoveryService = packageDiscoveryFunctions.useValue;
+export const setPackageDiscoveryService = packageDiscoveryFunctions.setValue;
+export const addPackageDiscoveryServiceEventHandler =
+  packageDiscoveryFunctions.addEventHandler;

--- a/packages/reactor-browser/src/types/global.ts
+++ b/packages/reactor-browser/src/types/global.ts
@@ -10,6 +10,7 @@ import type { IDocumentCache } from "./documents.js";
 import type { PHModal } from "./modals.js";
 import type { TimelineItem } from "./timeline.js";
 import type { PHToastFn } from "./toast.js";
+import type { IPackageDiscoveryService } from "./package-discovery.js";
 import type { IPackageManager } from "./vetra.js";
 
 export type BrowserReactorClientModule = ReactorClientModule & {
@@ -32,6 +33,7 @@ export type PHGlobal = PHGlobalConfig & {
   selectedTimelineRevision?: string | number | null;
   revisionHistoryVisible?: boolean;
   selectedTimelineItem?: TimelineItem | null;
+  packageDiscoveryService?: IPackageDiscoveryService;
   features?: Map<string, boolean>;
   toast?: PHToastFn;
 };

--- a/packages/reactor-browser/src/types/index.ts
+++ b/packages/reactor-browser/src/types/index.ts
@@ -7,3 +7,4 @@ export type * from "./timeline.js";
 export type * from "./toast.js";
 export type * from "./upload.js";
 export type * from "./vetra.js";
+export type * from "./package-discovery.js";

--- a/packages/reactor-browser/src/types/package-discovery.ts
+++ b/packages/reactor-browser/src/types/package-discovery.ts
@@ -1,0 +1,38 @@
+import type { DocumentModelModule } from "@powerhousedao/shared/document-model";
+
+export type PendingInstallation = {
+  documentType: string;
+  packageNames: string[];
+};
+
+export type DiscoveryEvent =
+  | { type: "type-discovered"; documentType: string; packageNames: string[] }
+  | {
+      type: "installation-prompted";
+      documentType: string;
+      packageNames: string[];
+    }
+  | {
+      type: "installation-approved";
+      packageName: string;
+      documentTypes: string[];
+    }
+  | {
+      type: "installation-dismissed";
+      packageName: string;
+      documentTypes: string[];
+    }
+  | { type: "installation-failed"; packageName: string; error: Error }
+  | { type: "registry-query-failed"; documentType: string; error: Error };
+
+export type DiscoveryEventListener = (event: DiscoveryEvent) => void;
+
+export interface IPackageDiscoveryService {
+  load(documentType: string): Promise<DocumentModelModule<any>>;
+  getPendingInstallations(): PendingInstallation[];
+  subscribePending(listener: () => void): () => void;
+  subscribeEvents(listener: DiscoveryEventListener): () => void;
+  approveInstallation(packageName: string): Promise<void>;
+  dismissInstallation(packageName: string): void;
+  promptInstallation(documentType: string): void;
+}

--- a/packages/reactor-browser/src/types/upload.ts
+++ b/packages/reactor-browser/src/types/upload.ts
@@ -1,4 +1,4 @@
-import type { FileNode } from "@powerhousedao/shared/document-drive";
+import type { FileNode, Node } from "@powerhousedao/shared/document-drive";
 
 export type DocumentTypeIcon =
   | "analytics-processor"
@@ -28,6 +28,7 @@ export interface FileUploadProgress {
   error?: string;
   documentType?: DocumentTypeIcon;
   duplicateType?: "id" | "name";
+  fileNode?: Node;
 }
 
 export type FileUploadProgressCallback = (progress: FileUploadProgress) => void;

--- a/packages/reactor-browser/src/types/upload.ts
+++ b/packages/reactor-browser/src/types/upload.ts
@@ -1,4 +1,4 @@
-import type { FileNode, Node } from "@powerhousedao/shared/document-drive";
+import type { FileNode } from "@powerhousedao/shared/document-drive";
 
 export type DocumentTypeIcon =
   | "analytics-processor"
@@ -28,7 +28,7 @@ export interface FileUploadProgress {
   error?: string;
   documentType?: DocumentTypeIcon;
   duplicateType?: "id" | "name";
-  fileNode?: Node;
+  fileNode?: FileNode;
 }
 
 export type FileUploadProgressCallback = (progress: FileUploadProgress) => void;


### PR DESCRIPTION
## Summary

Restores and improves the package discovery feature from PR #2401 that was removed during the build system refactor in #2415.

- Adds `PackageDiscoveryService` implementing `IDocumentModelLoader` — queries the registry for unknown document types, prompts the user to install, and retries automatically
- Supports configurable prompt mode (`"immediate"` for sync-triggered, `"manual"` for on-demand)
- Emits typed events (`type-discovered`, `installation-prompted`, `installation-approved`, `installation-dismissed`, `installation-failed`, `registry-query-failed`) for observability
- Integrates with drag-and-drop: dismisses the drop overlay before showing the install prompt, and supports "Open Document" after deferred install
- Redesigns `PackageInstallModal` to group by package, show all pending installs at once, and match the design system's modal conventions
- Wires into `window.ph` via `makePHEventFunctions` pattern, keeping state off React

## Changes

**`packages/reactor-browser/`** — `IPackageDiscoveryService` interface, `PendingInstallation`/`DiscoveryEvent` types, `window.ph` integration hook, `FileUploadProgress.fileNode` field, discovery-aware `addFileWithProgress`

**`apps/connect/`** — `PackageDiscoveryService` class, reactor wiring, `usePendingInstallations` hook, `PackageInstallPrompt` component

**`packages/design-system/`** — Redesigned `PackageInstallModal` (groups by package, disabled buttons during install, consistent styling), upload tracker captures `fileNode` from progress events

## Test plan

- [ ] Drag a `.phd` file of an unknown type into a drive → install prompt appears, install succeeds, "Open Document" works
- [ ] Dismiss a type, reload, drag again → no prompt (persisted in localStorage)
- [ ] Add a remote drive with unknown document types → prompt appears during sync, install makes documents viewable
- [ ] Run without `PH_PACKAGE_REGISTRY_URL` → no prompt, no errors