### PR TITLE
feat(e2e): Docker-based vetra-e2e tests against published packages

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -202,6 +202,14 @@ jobs:
           path: vetra-docker-test-results/
           retention-days: 30
 
+  test-package-managers:
+    name: Test Package Managers
+    needs: [release, determine-downstream-params]
+    if: ${{ inputs.dry_run != true && needs.determine-downstream-params.outputs.skip != 'true' }}
+    uses: ./.github/workflows/test-package-managers.yml
+    with:
+      tag: ${{ needs.determine-downstream-params.outputs.channel }}
+
   trigger-downstream:
     name: Trigger Downstream Packages
     needs: determine-downstream-params
@@ -212,3 +220,48 @@ jobs:
       channel: ${{ needs.determine-downstream-params.outputs.channel }}
       dry-run: false
     secrets: inherit
+
+  notify-discord:
+    name: Notify Discord on Failure
+    if: >-
+      always() &&
+      inputs.dry_run != true &&
+      (needs.release.result == 'failure' ||
+       needs.publish-docker.result == 'failure' ||
+       needs.vetra-e2e-docker.result == 'failure' ||
+       needs.test-package-managers.result == 'failure' ||
+       needs.trigger-downstream.result == 'failure')
+    needs:
+      - release
+      - publish-docker
+      - vetra-e2e-docker
+      - test-package-managers
+      - trigger-downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_FAILURES }}
+          DISCORD_USER_MAPPING: ${{ secrets.DISCORD_USER_MAPPING }}
+        run: |
+          DISCORD_USER=$(echo "$DISCORD_USER_MAPPING" | jq -r --arg GH_USER "${{ github.actor }}" '.[$GH_USER] // ""')
+          MENTION_STRING=""
+          if [ ! -z "$DISCORD_USER" ]; then
+            MENTION_STRING="<@${DISCORD_USER}> "
+          fi
+
+          FAILED_JOBS=""
+          [ "${{ needs.release.result }}" = "failure" ] && FAILED_JOBS="${FAILED_JOBS}Release, "
+          [ "${{ needs.publish-docker.result }}" = "failure" ] && FAILED_JOBS="${FAILED_JOBS}Docker Publish, "
+          [ "${{ needs.vetra-e2e-docker.result }}" = "failure" ] && FAILED_JOBS="${FAILED_JOBS}Vetra E2E (Docker), "
+          [ "${{ needs.test-package-managers.result }}" = "failure" ] && FAILED_JOBS="${FAILED_JOBS}Package Managers, "
+          [ "${{ needs.trigger-downstream.result }}" = "failure" ] && FAILED_JOBS="${FAILED_JOBS}Trigger Downstream, "
+          FAILED_JOBS="${FAILED_JOBS%, }"
+
+          curl -H "Content-Type: application/json" -X POST "$DISCORD_WEBHOOK" -d '{
+            "embeds": [{
+              "title": "⚠️ Release Pipeline Failed",
+              "description": "**Author:** '"${MENTION_STRING}"'\n**Branch:** `${{ github.ref_name }}`\n**Failed jobs:** '"${FAILED_JOBS}"'\n**Workflow run:** [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})",
+              "color": 16711680
+            }]
+          }'

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -157,6 +157,51 @@ jobs:
           echo "skip=false" >> $GITHUB_OUTPUT
           echo "Triggering downstream with channel=$CHANNEL version=$VERSION"
 
+  vetra-e2e-docker:
+    name: Vetra E2E Tests (Docker)
+    needs: [release, determine-downstream-params]
+    if: ${{ inputs.dry_run != true && needs.determine-downstream-params.outputs.skip != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Build vetra-e2e Docker image
+        run: |
+          TAG="${{ needs.determine-downstream-params.outputs.version }}"
+          docker build \
+            -f test/vetra-e2e/Dockerfile \
+            --build-arg TAG="$TAG" \
+            -t vetra-e2e \
+            test/
+
+      - name: Run vetra-e2e tests
+        run: docker run --name vetra-e2e-run vetra-e2e
+
+      - name: Extract test artifacts
+        if: always()
+        run: |
+          docker cp vetra-e2e-run:/app/test-project/playwright-report ./vetra-docker-playwright-report || true
+          docker cp vetra-e2e-run:/app/test-project/test-results ./vetra-docker-test-results || true
+          docker rm vetra-e2e-run || true
+
+      - name: Upload Playwright Report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: vetra-docker-playwright-report
+          path: vetra-docker-playwright-report/
+          retention-days: 30
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: vetra-docker-test-results
+          path: vetra-docker-test-results/
+          retention-days: 30
+
   trigger-downstream:
     name: Trigger Downstream Packages
     needs: determine-downstream-params

--- a/.github/workflows/test-package-managers.yml
+++ b/.github/workflows/test-package-managers.yml
@@ -11,6 +11,16 @@ on:
         description: "Comma-separated list of packages to install (e.g., @powerhousedao/vetra@dev)"
         required: false
         default: ""
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        required: false
+        default: "dev"
+      packages:
+        type: string
+        required: false
+        default: ""
 
 jobs:
   test-package-managers:
@@ -145,6 +155,31 @@ jobs:
             fi
           done
 
+      - name: Run ph build
+        id: ph-build
+        if: steps.ph-init.outcome == 'success'
+        run: |
+          cd /tmp/ph-test-${{ matrix.package-manager }}/project
+          echo "Building package with ph build"
+          set -o pipefail
+          ph build 2>&1 | tee ph-build.log
+          BUILD_EXIT_CODE=${PIPESTATUS[0]}
+
+          if grep -q "Build failed\|✗ Build failed\|error Command failed" ph-build.log; then
+            echo "Build failed - errors detected in output"
+            exit 1
+          fi
+
+          exit $BUILD_EXIT_CODE
+
+      - name: Parse ph build warnings
+        if: always() && steps.ph-init.outcome == 'success'
+        run: |
+          cd /tmp/ph-test-${{ matrix.package-manager }}/project
+          grep -iE "(warn|warning|deprecated)" ph-build.log | while IFS= read -r line; do
+            echo "::warning title=[${{ matrix.package-manager }}] ph build::$line"
+          done || true
+
       - name: Run ph connect build
         id: connect-build
         if: steps.ph-init.outcome == 'success'
@@ -163,7 +198,7 @@ jobs:
 
           exit $BUILD_EXIT_CODE
 
-      - name: Parse build warnings
+      - name: Parse connect build warnings
         if: always() && steps.ph-init.outcome == 'success'
         run: |
           cd /tmp/ph-test-${{ matrix.package-manager }}/project
@@ -231,6 +266,17 @@ jobs:
                 fi
               fi
             done
+          fi
+
+          # ph build
+          if [ -f "project/ph-build.log" ]; then
+            STATUS="${{ steps.ph-build.outcome }}"
+            ICON="✅"; [ "$STATUS" != "success" ] && ICON="❌"
+            WARNINGS=$(grep -icE "(warn|warning|deprecated)" project/ph-build.log 2>/dev/null || echo "0")
+            echo "### $ICON ph build" >> $GITHUB_STEP_SUMMARY
+            echo "- **Status:** $STATUS" >> $GITHUB_STEP_SUMMARY
+            echo "- **Warnings:** $WARNINGS" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
           fi
 
           # Connect build

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -7,6 +7,13 @@
     "type": "git",
     "url": "https://github.com/powerhouse-inc/powerhouse"
   },
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/src/index.d.mts",
+      "default": "./dist/src/index.mjs"
+    }
+  },
   "bin": {
     "ph-registry": "./dist/cli.mjs"
   },

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -1,4 +1,6 @@
 export { CdnCache, parsePackageSpec } from "./cdn.js";
+export { runRegistry } from "./run.js";
+export type { RegistryInstance } from "./run.js";
 export { createPowerhouseRouter, createPublishHook } from "./middleware.js";
 export {
   NotificationManager,
@@ -17,6 +19,7 @@ export {
 export type {
   NotifyConfig,
   PackageInfo,
+  RegistryCommandArgs,
   RegistryConfig,
   RegistryOptions,
   S3Config,

--- a/packages/registry/src/run.ts
+++ b/packages/registry/src/run.ts
@@ -4,12 +4,24 @@ import { mkdir } from "node:fs/promises";
 import type { Server } from "node:http";
 import path from "node:path";
 import { runServer } from "verdaccio";
+import {
+  DEFAULT_PORT,
+  DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME,
+  DEFAULT_STORAGE_DIR_NAME,
+} from "./constants.js";
 import { createPowerhouseRouter, createPublishHook } from "./middleware.js";
 import { NotificationManager } from "./notifications/manager.js";
 import { SSEChannel } from "./notifications/sse.js";
 import { WebhookChannel } from "./notifications/webhook.js";
 import type { RegistryCommandArgs, RegistryConfig } from "./types.js";
 import { buildVerdaccioConfig } from "./verdaccio-config.js";
+
+export interface RegistryInstance {
+  server: Server;
+  port: number;
+  url: string;
+  shutdown: () => Promise<void>;
+}
 
 async function resolveDir(dir: string): Promise<string> {
   if (path.isAbsolute(dir)) {
@@ -24,22 +36,25 @@ async function resolveDir(dir: string): Promise<string> {
   return found;
 }
 
-export async function runRegistry(args: RegistryCommandArgs) {
+export async function runRegistry(
+  args?: Partial<RegistryCommandArgs>,
+): Promise<RegistryInstance> {
   const {
-    port,
-    storageDir,
-    cdnCacheDir,
+    port = DEFAULT_PORT,
+    storageDir = DEFAULT_STORAGE_DIR_NAME,
+    cdnCacheDir = DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME,
     uplink,
-    webEnabled,
+    webEnabled = true,
     webhooks,
     s3AccessKeyId,
     s3Bucket,
     s3Endpoint,
-    s3ForcePathStyle,
+    s3ForcePathStyle = true,
     s3KeyPrefix,
     s3Region,
     s3SecretAccessKey,
-  } = args;
+  } = args ?? {};
+
   const storagePath = await resolveDir(storageDir);
   const cdnCachePath = await resolveDir(cdnCacheDir);
 
@@ -108,11 +123,13 @@ export async function runRegistry(args: RegistryCommandArgs) {
   // Verdaccio handles everything else (npm protocol, web UI, auth)
   app.use((req, res) => verdaccioHandler(req, res));
 
+  const url = `http://localhost:${port}`;
+
   const server = app.listen(port, () => {
-    console.log(`Powerhouse Registry running on http://localhost:${port}`);
-    console.log(`  CDN:      http://localhost:${port}/-/cdn/`);
-    console.log(`  Packages: http://localhost:${port}/packages`);
-    console.log(`  npm:      http://localhost:${port}/`);
+    console.log(`Powerhouse Registry running on ${url}`);
+    console.log(`  CDN:      ${url}/-/cdn/`);
+    console.log(`  Packages: ${url}/packages`);
+    console.log(`  npm:      ${url}/`);
     console.log(`  Storage:  ${storagePath}`);
     console.log(`  CDN cache: ${cdnCachePath}`);
     if (config.s3) {
@@ -120,5 +137,13 @@ export async function runRegistry(args: RegistryCommandArgs) {
     }
   });
 
-  return server;
+  return {
+    server,
+    port,
+    url,
+    shutdown: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
 }

--- a/packages/registry/tsdown.config.ts
+++ b/packages/registry/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: "./cli.ts",
+  entry: ["./cli.ts", "./src/index.ts"],
   outDir: "dist",
   clean: true,
   dts: true,

--- a/test/.dockerignore
+++ b/test/.dockerignore
@@ -1,0 +1,11 @@
+**/node_modules
+**/dist
+**/.ph
+**/test-results
+**/playwright-report
+**/coverage
+**/.registry-storage
+**/.registry-cdn-cache
+vetra-e2e/backup-documents
+vetra-e2e/downloads
+test-consumer-project/

--- a/test/vetra-e2e/Dockerfile
+++ b/test/vetra-e2e/Dockerfile
@@ -1,6 +1,9 @@
-FROM node:24-bookworm
+FROM node:24-bookworm AS base
 
 WORKDIR /app
+
+# Install socat (for IPv4→IPv6 bridge) early — stable layer, rarely changes
+RUN apt-get update -qq && apt-get install -y -qq socat > /dev/null 2>&1 && rm -rf /var/lib/apt/lists/*
 
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate
@@ -12,27 +15,55 @@ RUN pnpm config set @jsr:registry https://npm.jsr.io
 ARG TAG=dev
 RUN pnpm add -g ph-cmd@$TAG
 
-# Scaffold project from published packages
+# ── Stage 1: Scaffold project from published packages (pristine, untouched) ──
+
 RUN case "$TAG" in \
         *dev*) ph init test-project --dev --package-manager pnpm ;; \
         *staging*) ph init test-project --staging --package-manager pnpm ;; \
         *) ph init test-project --package-manager pnpm ;; \
     esac
 
-WORKDIR /app/test-project
-
 # Allow build scripts for native deps (pnpm v10 blocks them by default)
+# This is the ONLY modification to the ph init project
 RUN node -e " \
-    const pkg = JSON.parse(require('fs').readFileSync('package.json','utf8')); \
+    const pkg = JSON.parse(require('fs').readFileSync('test-project/package.json','utf8')); \
     pkg.pnpm = pkg.pnpm || {}; \
     pkg.pnpm.onlyBuiltDependencies = ['esbuild','@electric-sql/pglite','@parcel/watcher']; \
-    require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));" && \
-    pnpm install
+    require('fs').writeFileSync('test-project/package.json', JSON.stringify(pkg, null, 2));" && \
+    cd test-project && pnpm install
 
-# Copy e2e-utils (zero runtime deps, @playwright/test peer only)
+# ── Stage 2: Build test runner (separate from project) ──
+
+# Copy e2e-utils source and build it
 COPY e2e-utils/ /app/e2e-utils/
+RUN cd /app/e2e-utils && pnpm add -D @playwright/test@^1.55.0 typescript @types/node && \
+    echo '{"compilerOptions":{"outDir":"dist","rootDir":".","target":"ESNext","module":"ESNext","moduleResolution":"bundler","declaration":true,"esModuleInterop":true,"strict":true,"skipLibCheck":true},"include":["src"]}' > tsconfig.docker.json && \
+    pnpm exec tsc --project tsconfig.docker.json && \
+    rm -rf node_modules
 
-# Copy test infrastructure into the scaffolded project
+# Create test-runner directory with its own package.json
+WORKDIR /app/test-runner
+RUN pnpm init && pnpm pkg set type=module
+
+# Install test-only dependencies in the test-runner (not in the project)
+RUN --mount=type=cache,id=pnpm-test-runner,target=/pnpm/store \
+    pnpm add -D \
+    @playwright/test@^1.55.0 \
+    monocart-coverage-reports@^2.12.8 \
+    @powerhousedao/registry@$TAG \
+    @powerhousedao/e2e-utils@link:/app/e2e-utils
+
+# Symlink e2e-utils node_modules to test-runner so @playwright/test resolves to single instance
+RUN ln -s /app/test-runner/node_modules /app/e2e-utils/node_modules
+
+# Install Playwright chromium + system deps (cached across rebuilds)
+RUN --mount=type=cache,id=playwright-browsers,target=/root/.cache/ms-playwright \
+    pnpm exec playwright install --with-deps chromium && \
+    cp -r /root/.cache/ms-playwright /root/.ms-playwright-cache
+# Restore from cache mount (cache mount is not available at runtime)
+RUN rm -rf /root/.cache/ms-playwright && mv /root/.ms-playwright-cache /root/.cache/ms-playwright
+
+# Copy test infrastructure (changes frequently — keep last for layer caching)
 COPY vetra-e2e/tests/ ./tests/
 COPY vetra-e2e/playwright.config.ts ./playwright.config.ts
 COPY vetra-e2e/global-setup.ts ./global-setup.ts
@@ -40,37 +71,18 @@ COPY vetra-e2e/global-teardown.ts ./global-teardown.ts
 COPY vetra-e2e/mcr.config.ts ./mcr.config.ts
 COPY vetra-e2e/verdaccio.config.yaml ./verdaccio.config.yaml
 
-# Install test-only dependencies
-RUN pnpm add -D \
-    @playwright/test@^1.55.0 \
-    monocart-coverage-reports@^2.12.8 \
-    @powerhousedao/registry@$TAG \
-    @powerhousedao/e2e-utils@link:/app/e2e-utils
-
-# Build e2e-utils with a standalone tsconfig (the original extends monorepo paths)
-# Use rootDir=. so output is dist/src/* matching the package.json exports map
-# Then replace e2e-utils node_modules with symlink to test project so @playwright/test
-# resolves to a single instance (avoids "Requiring @playwright/test second time" error)
-RUN cd /app/e2e-utils && pnpm add -D @playwright/test@^1.55.0 typescript @types/node && \
-    echo '{"compilerOptions":{"outDir":"dist","rootDir":".","target":"ESNext","module":"ESNext","moduleResolution":"bundler","declaration":true,"esModuleInterop":true,"strict":true,"skipLibCheck":true},"include":["src"]}' > tsconfig.docker.json && \
-    pnpm exec tsc --project tsconfig.docker.json && \
-    rm -rf node_modules && \
-    ln -s /app/test-project/node_modules /app/e2e-utils/node_modules
-
-# Install Playwright chromium + system deps
-RUN pnpm exec playwright install --with-deps chromium
+# ── Runtime configuration ──
 
 ENV CI=true
 ENV DOCKER_E2E=true
+# Point test files to the pristine ph init project
+ENV PROJECT_DIR="/app/test-project"
 # Node 24 in Docker binds servers to IPv6 only; use [::1] for fetch URLs
 ENV CONNECT_URL="http://[::1]:3001"
 # Reactor port is 4001 in ph init projects (vs 4002 in monorepo)
 ENV REACTOR_URL="http://[::1]:4001"
 ENV REGISTRY_URL="http://[::1]:8080"
 ENV CONSUMER_CONNECT_HOST="[::1]"
-
-# Install socat to bridge IPv4→IPv6 for tools that can't handle [::1] URLs (e.g. ph-cli publish)
-RUN apt-get update -qq && apt-get install -y -qq socat > /dev/null 2>&1 && rm -rf /var/lib/apt/lists/*
 
 # Entrypoint: start socat bridge for registry port, then run tests
 CMD socat TCP4-LISTEN:18080,fork,reuseaddr TCP6:[::1]:8080 & \

--- a/test/vetra-e2e/Dockerfile
+++ b/test/vetra-e2e/Dockerfile
@@ -1,0 +1,77 @@
+FROM node:24-bookworm
+
+WORKDIR /app
+
+# Install pnpm
+RUN corepack enable && corepack prepare pnpm@latest --activate
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN pnpm config set @jsr:registry https://npm.jsr.io
+
+# Install ph-cmd (TAG is configurable: "dev", "staging", "latest", or a version like "v6.0.0-dev.149")
+ARG TAG=dev
+RUN pnpm add -g ph-cmd@$TAG
+
+# Scaffold project from published packages
+RUN case "$TAG" in \
+        *dev*) ph init test-project --dev --package-manager pnpm ;; \
+        *staging*) ph init test-project --staging --package-manager pnpm ;; \
+        *) ph init test-project --package-manager pnpm ;; \
+    esac
+
+WORKDIR /app/test-project
+
+# Allow build scripts for native deps (pnpm v10 blocks them by default)
+RUN node -e " \
+    const pkg = JSON.parse(require('fs').readFileSync('package.json','utf8')); \
+    pkg.pnpm = pkg.pnpm || {}; \
+    pkg.pnpm.onlyBuiltDependencies = ['esbuild','@electric-sql/pglite','@parcel/watcher']; \
+    require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));" && \
+    pnpm install
+
+# Copy e2e-utils (zero runtime deps, @playwright/test peer only)
+COPY e2e-utils/ /app/e2e-utils/
+
+# Copy test infrastructure into the scaffolded project
+COPY vetra-e2e/tests/ ./tests/
+COPY vetra-e2e/playwright.config.ts ./playwright.config.ts
+COPY vetra-e2e/global-setup.ts ./global-setup.ts
+COPY vetra-e2e/global-teardown.ts ./global-teardown.ts
+COPY vetra-e2e/mcr.config.ts ./mcr.config.ts
+COPY vetra-e2e/verdaccio.config.yaml ./verdaccio.config.yaml
+
+# Install test-only dependencies
+RUN pnpm add -D \
+    @playwright/test@^1.55.0 \
+    monocart-coverage-reports@^2.12.8 \
+    @powerhousedao/registry@$TAG \
+    @powerhousedao/e2e-utils@link:/app/e2e-utils
+
+# Build e2e-utils with a standalone tsconfig (the original extends monorepo paths)
+# Use rootDir=. so output is dist/src/* matching the package.json exports map
+# Then replace e2e-utils node_modules with symlink to test project so @playwright/test
+# resolves to a single instance (avoids "Requiring @playwright/test second time" error)
+RUN cd /app/e2e-utils && pnpm add -D @playwright/test@^1.55.0 typescript @types/node && \
+    echo '{"compilerOptions":{"outDir":"dist","rootDir":".","target":"ESNext","module":"ESNext","moduleResolution":"bundler","declaration":true,"esModuleInterop":true,"strict":true,"skipLibCheck":true},"include":["src"]}' > tsconfig.docker.json && \
+    pnpm exec tsc --project tsconfig.docker.json && \
+    rm -rf node_modules && \
+    ln -s /app/test-project/node_modules /app/e2e-utils/node_modules
+
+# Install Playwright chromium + system deps
+RUN pnpm exec playwright install --with-deps chromium
+
+ENV CI=true
+ENV DOCKER_E2E=true
+# Node 24 in Docker binds servers to IPv6 only; use [::1] for fetch URLs
+ENV CONNECT_URL="http://[::1]:3001"
+# Reactor port is 4001 in ph init projects (vs 4002 in monorepo)
+ENV REACTOR_URL="http://[::1]:4001"
+ENV REGISTRY_URL="http://[::1]:8080"
+ENV CONSUMER_CONNECT_HOST="[::1]"
+
+# Install socat to bridge IPv4→IPv6 for tools that can't handle [::1] URLs (e.g. ph-cli publish)
+RUN apt-get update -qq && apt-get install -y -qq socat > /dev/null 2>&1 && rm -rf /var/lib/apt/lists/*
+
+# Entrypoint: start socat bridge for registry port, then run tests
+CMD socat TCP4-LISTEN:18080,fork,reuseaddr TCP6:[::1]:8080 & \
+    pnpm exec playwright test

--- a/test/vetra-e2e/global-setup.ts
+++ b/test/vetra-e2e/global-setup.ts
@@ -11,19 +11,18 @@ interface GraphQLResponse {
 }
 
 async function waitForPort(
-  port: number,
+  url: string,
   maxWaitMs: number = 60000,
 ): Promise<void> {
   const startTime = Date.now();
-  const url = `http://localhost:${port}`;
 
-  console.log(`⏳ Waiting for port ${port} to be ready...`);
+  console.log(`⏳ Waiting for ${url} to be ready...`);
 
   while (Date.now() - startTime < maxWaitMs) {
     try {
       const response = await fetch(url);
       if (response.ok || response.status < 500) {
-        console.log(`✅ Port ${port} is ready!`);
+        console.log(`✅ ${url} is ready!`);
         return;
       }
     } catch (error) {
@@ -33,16 +32,16 @@ async function waitForPort(
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
 
-  throw new Error(`Timeout waiting for port ${port} after ${maxWaitMs}ms`);
+  throw new Error(`Timeout waiting for ${url} after ${maxWaitMs}ms`);
 }
 
 async function waitForDrivesReady(
-  reactorPort: number,
+  reactorUrl: string,
   maxWaitMs: number = 60000,
 ): Promise<void> {
   const startTime = Date.now();
   // The reactor subgraph is at /graphql/r/:reactor - we use 'local' as the reactor name
-  const graphqlUrl = `http://localhost:${reactorPort}/graphql/r`;
+  const graphqlUrl = `${reactorUrl}/graphql/r`;
 
   console.log("⏳ Waiting for reactor drives to be ready...");
 
@@ -121,13 +120,16 @@ async function globalSetup() {
     const mcr = MCR(coverageOptions);
     mcr.cleanCache();
 
-    // Wait for both Connect (3001) and Reactor (4002) to be ready
+    const connectUrl = process.env.CONNECT_URL || "http://localhost:3001";
+    const reactorUrl = process.env.REACTOR_URL || "http://localhost:4002";
+
+    // Wait for both Connect and Reactor to be ready
     // Note: webServer starts vetra, but we need to wait for both services
-    await waitForPort(3001);
-    await waitForPort(4002);
+    await waitForPort(connectUrl);
+    await waitForPort(reactorUrl);
 
     // Wait for the reactor to have drives ready (the Vetra drive should be created)
-    await waitForDrivesReady(4002);
+    await waitForDrivesReady(reactorUrl);
 
     console.log(
       "🎯 Global setup completed successfully! Both Connect and Reactor are ready.",

--- a/test/vetra-e2e/global-teardown.ts
+++ b/test/vetra-e2e/global-teardown.ts
@@ -99,7 +99,7 @@ async function globalTeardown() {
 
   console.log("🧹 Running global teardown - cleaning up test artifacts...");
 
-  const vetraE2ERoot = __dirname;
+  const vetraE2ERoot = process.env.PROJECT_DIR || __dirname;
 
   try {
     // Clean up generated code directories (remove subdirs, recreate empty index.ts)

--- a/test/vetra-e2e/mcr.config.ts
+++ b/test/vetra-e2e/mcr.config.ts
@@ -34,7 +34,9 @@ const coverageOptions: CoverageReportOptions = {
       "packages/document-model/src/document-model/custom/reducers/header.ts",
   },
 
-  outputDir: "./coverage",
+  outputDir: process.env.PROJECT_DIR
+    ? `${process.env.PROJECT_DIR}/coverage`
+    : "./coverage",
 };
 
 export default coverageOptions;

--- a/test/vetra-e2e/playwright.config.ts
+++ b/test/vetra-e2e/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
-export const CONNECT_URL = "http://localhost:3001";
-export const REACTOR_URL = "http://localhost:4002";
+export const CONNECT_URL = process.env.CONNECT_URL || "http://localhost:3001";
+export const REACTOR_URL = process.env.REACTOR_URL || "http://localhost:4002";
 
 /**
  * Read environment variables from file.

--- a/test/vetra-e2e/playwright.config.ts
+++ b/test/vetra-e2e/playwright.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:3001",
+    baseURL: CONNECT_URL,
 
     acceptDownloads: true,
 

--- a/test/vetra-e2e/playwright.config.ts
+++ b/test/vetra-e2e/playwright.config.ts
@@ -74,6 +74,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: "pnpm vetra",
+    cwd: process.env.PROJECT_DIR || undefined,
     url: CONNECT_URL,
     stderr: "pipe",
     stdout: "pipe",

--- a/test/vetra-e2e/tests/document-creation.spec.ts
+++ b/test/vetra-e2e/tests/document-creation.spec.ts
@@ -1,6 +1,7 @@
 import { closeDocumentFromToolbar } from "@powerhousedao/e2e-utils";
 import { createDocument, navigateToVetraDrive } from "./helpers/document.js";
 import { expect, test } from "./helpers/fixtures.js";
+import { CONNECT_URL } from "../playwright.config.js";
 
 // Run these tests serially to avoid conflicts with other tests
 // that modify the shared Vetra drive
@@ -11,7 +12,7 @@ test.use({
     cookies: [],
     origins: [
       {
-        origin: "http://localhost:3001",
+        origin: CONNECT_URL,
         localStorage: [
           { name: "/:display-cookie-banner", value: "false" },
           {

--- a/test/vetra-e2e/tests/document-creation.spec.ts
+++ b/test/vetra-e2e/tests/document-creation.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from "./helpers/fixtures.js";
 
 // Run these tests serially to avoid conflicts with other tests
 // that modify the shared Vetra drive
-test.describe.configure({ mode: "serial", timeout: 5 * 60 * 60 * 1000 });
+test.describe.configure({ mode: "serial", timeout: 120_000 });
 
 test.use({
   storageState: {
@@ -72,7 +72,7 @@ test("should create document of each supported type in Vetra drive", async ({
       level: 3,
       exact: true,
     });
-    await expect(documentHeading).toBeVisible({ timeout: 5 * 60 * 60 * 1000 });
+    await expect(documentHeading).toBeVisible({ timeout: 30_000 });
   }
 });
 
@@ -89,9 +89,12 @@ test("should log console message when attempting to create powerhouse/codegen-pr
     name: "Add new specification powerhouse/codegen-processor",
   });
 
-  await expect(codegenButton).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
+  await expect(codegenButton).toBeVisible({ timeout: 30_000 });
   await codegenButton.click();
 
-  // Wait for any console messages to appear
+  // Wait for console messages to appear after click
   await page.waitForLoadState("networkidle");
+
+  // Verify that clicking the codegen-processor button produced a console message
+  expect(consoleMessages.length).toBeGreaterThan(0);
 });

--- a/test/vetra-e2e/tests/hello-world.spec.ts
+++ b/test/vetra-e2e/tests/hello-world.spec.ts
@@ -1,33 +1,25 @@
 import { test, expect } from "./helpers/fixtures.js";
 
-test.describe.configure({ timeout: 5 * 60 * 60 * 1000 });
+test.describe.configure({ timeout: 60_000 });
 
 test("should load Vetra application successfully", async ({ page }) => {
-  // Navigate to the root URL (port 3001)
   await page.goto("/");
-
-  // Wait for page to load
   await page.waitForLoadState("networkidle");
 
-  // Verify the page title exists (basic check that page loaded)
   const title = await page.title();
-  expect(title).toBeTruthy();
-  console.log(`✅ Page loaded successfully with title: "${title}"`);
-
-  // Log success
-  console.log("✅ Vetra application is running on port 3001");
-  console.log(
-    "✅ E2E test infrastructure is set up correctly (Playwright + Coverage)",
-  );
+  expect(title).toContain("Connect");
 });
 
 test("should verify basic page structure", async ({ page }) => {
   await page.goto("/");
   await page.waitForLoadState("networkidle");
 
-  // Check if the page has any visible content
-  const bodyContent = await page.locator("body").textContent();
-  expect(bodyContent).toBeTruthy();
+  // Verify the app skeleton finishes loading
+  await page
+    .locator(".skeleton-loader")
+    .waitFor({ state: "hidden", timeout: 30_000 });
 
-  console.log("✅ Page structure verified - Vetra UI is rendering");
+  // Verify the Vetra drive card is rendered
+  const driveCard = page.getByRole("heading", { name: "Vetra", level: 3 });
+  await expect(driveCard).toBeVisible({ timeout: 30_000 });
 });

--- a/test/vetra-e2e/tests/helpers/consumer-project.ts
+++ b/test/vetra-e2e/tests/helpers/consumer-project.ts
@@ -5,29 +5,83 @@ import path from "path";
 
 const CONSUMER_PROJECT_NAME = "test-consumer-project";
 const CONSUMER_CONNECT_PORT = 5555;
-export const CONSUMER_CONNECT_URL = `http://localhost:${CONSUMER_CONNECT_PORT}`;
+const CONSUMER_CONNECT_HOST = process.env.CONSUMER_CONNECT_HOST || "localhost";
+export const CONSUMER_CONNECT_URL = `http://${CONSUMER_CONNECT_HOST}:${CONSUMER_CONNECT_PORT}`;
+
+const isDocker = !!process.env.DOCKER_E2E;
 
 /**
  * Returns the absolute path of the consumer project.
- * Lives as a sibling of vetra-e2e in test/test-consumer-project/.
+ * In Docker mode: /app/test-consumer-project (sibling of /app/test-project).
+ * In monorepo mode: test/test-consumer-project/ (sibling of vetra-e2e).
  */
 export function getConsumerProjectPath(): string {
+  if (isDocker) {
+    return "/app/test-consumer-project";
+  }
   const testDir = path.dirname(process.cwd());
   return path.join(testDir, CONSUMER_PROJECT_NAME);
 }
 
 /**
- * Install dependencies for the consumer project.
- * Uses pnpm from the monorepo root to resolve workspace packages.
+ * Ensure the consumer project exists.
+ * In Docker mode, scaffolds it via `ph init`.
+ * In monorepo mode, expects the project to already exist.
  */
-export function installConsumerDeps(): void {
-  const monorepoRoot = path.resolve(getConsumerProjectPath(), "../..");
-  console.log("Installing consumer project dependencies...");
-  execSync(`pnpm install --filter ${CONSUMER_PROJECT_NAME}`, {
-    cwd: monorepoRoot,
+export function ensureConsumerProject(): void {
+  const projectPath = getConsumerProjectPath();
+  if (fs.existsSync(path.join(projectPath, "package.json"))) {
+    return;
+  }
+
+  if (!isDocker) {
+    throw new Error(
+      `Consumer project not found at ${projectPath}. ` +
+        `In monorepo mode, test/test-consumer-project/ must exist.`,
+    );
+  }
+
+  console.log("Creating consumer project via ph init...");
+  const parentDir = path.dirname(projectPath);
+  execSync(`ph init ${CONSUMER_PROJECT_NAME} --dev --package-manager pnpm`, {
+    cwd: parentDir,
     stdio: "pipe",
     timeout: 120_000,
   });
+
+  // Configure the consumer project to use the local test registry
+  const configPath = path.join(projectPath, "powerhouse.config.json");
+  const config = JSON.parse(fs.readFileSync(configPath, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+  config.packageRegistryUrl = "http://localhost:8080";
+  config.studio = { port: 5556 };
+  config.reactor = { port: 5557, storage: "memory" };
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+}
+
+/**
+ * Install dependencies for the consumer project.
+ * In monorepo mode, uses pnpm --filter from the monorepo root.
+ * In Docker mode, runs pnpm install directly in the consumer project.
+ */
+export function installConsumerDeps(): void {
+  console.log("Installing consumer project dependencies...");
+  if (isDocker) {
+    execSync("pnpm install", {
+      cwd: getConsumerProjectPath(),
+      stdio: "pipe",
+      timeout: 120_000,
+    });
+  } else {
+    const monorepoRoot = path.resolve(getConsumerProjectPath(), "../..");
+    execSync(`pnpm install --filter ${CONSUMER_PROJECT_NAME}`, {
+      cwd: monorepoRoot,
+      stdio: "pipe",
+      timeout: 120_000,
+    });
+  }
 }
 
 /**

--- a/test/vetra-e2e/tests/helpers/consumer-project.ts
+++ b/test/vetra-e2e/tests/helpers/consumer-project.ts
@@ -55,7 +55,8 @@ export function ensureConsumerProject(): void {
     string,
     unknown
   >;
-  config.packageRegistryUrl = "http://localhost:8080";
+  config.packageRegistryUrl =
+    process.env.REGISTRY_URL || "http://localhost:8080";
   config.studio = { port: 5556 };
   config.reactor = { port: 5557, storage: "memory" };
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2));

--- a/test/vetra-e2e/tests/helpers/document.ts
+++ b/test/vetra-e2e/tests/helpers/document.ts
@@ -28,23 +28,23 @@ export async function createDocument(
   const addButton = page.getByRole("button", {
     name: `Add new specification ${documentType}`,
   });
-  await expect(addButton).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
-  await addButton.isEnabled({ timeout: 2 * 60 * 60 * 1000 });
+  await expect(addButton).toBeVisible({ timeout: 30_000 });
+  await expect(addButton).toBeEnabled({ timeout: 30_000 });
   await addButton.click();
 
   // Wait for the create document dialog to be visible
   // Look for the dialog that contains "Create a new document" text
   const dialog = page.getByRole("dialog");
-  await expect(dialog).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
+  await expect(dialog).toBeVisible({ timeout: 30_000 });
 
   // Fill in the document name - find the input within the dialog
   const nameInput = dialog.getByPlaceholder("Document name");
-  await expect(nameInput).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
+  await expect(nameInput).toBeVisible({ timeout: 30_000 });
   await nameInput.fill(documentName);
 
   // Wait for Create button to be enabled (validation passes)
   const createButton = dialog.getByRole("button", { name: "Create" });
-  await expect(createButton).toBeEnabled({ timeout: 2 * 60 * 60 * 1000 });
+  await expect(createButton).toBeEnabled({ timeout: 30_000 });
   await createButton.click();
 
   // Wait for navigation to the new document
@@ -101,7 +101,7 @@ export async function navigateToVetraDrive(
   // Wait for Vetra drive card to appear (default drives load asynchronously)
   // Look for the h3 heading with "Vetra" which is the drive title
   const vetraDrive = page.getByRole("heading", { name: "Vetra", level: 3 });
-  await expect(vetraDrive).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
+  await expect(vetraDrive).toBeVisible({ timeout: 30_000 });
   await vetraDrive.click();
 
   // Wait for drive page to load
@@ -112,7 +112,7 @@ export async function navigateToVetraDrive(
     name: "Vetra Studio Drive",
     level: 1,
   });
-  await expect(driveHeading).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
+  await expect(driveHeading).toBeVisible({ timeout: 30_000 });
 }
 
 /**
@@ -133,7 +133,7 @@ export async function navigateBackToDrive(page: Page): Promise<void> {
     name: "Vetra Studio Drive",
     level: 1,
   });
-  await expect(driveHeading).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
+  await expect(driveHeading).toBeVisible({ timeout: 30_000 });
 }
 
 /**
@@ -169,7 +169,7 @@ export async function createDocumentAndFillBasicData(
   if (data.global) {
     // Focus the first CodeMirror editor (global state schema)
     const schemaEditor = page.locator(".cm-content").first();
-    await expect(schemaEditor).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
+    await expect(schemaEditor).toBeVisible({ timeout: 30_000 });
     await schemaEditor.click();
 
     // Select all and delete existing content
@@ -214,7 +214,7 @@ export async function createDocumentAndFillBasicData(
       const moduleInput = page
         .locator('textarea[placeholder="Add module"]')
         .last();
-      await expect(moduleInput).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
+      await expect(moduleInput).toBeVisible({ timeout: 30_000 });
       await moduleInput.fill(module.name);
       await page.keyboard.press("Enter");
 

--- a/test/vetra-e2e/tests/helpers/registry.ts
+++ b/test/vetra-e2e/tests/helpers/registry.ts
@@ -1,11 +1,37 @@
 import type { ChildProcess } from "child_process";
-import { spawn } from "child_process";
+import { execSync, spawn } from "child_process";
 import fs from "fs";
 import path from "path";
 
 const REGISTRY_PORT = 8080;
 export const REGISTRY_URL =
   process.env.REGISTRY_URL || `http://localhost:${REGISTRY_PORT}`;
+
+/**
+ * Kill any process listening on the registry port.
+ * Prevents "port already in use" from a leaked process.
+ */
+function killExistingRegistryProcess(): void {
+  try {
+    const result = execSync(`lsof -t -i :${REGISTRY_PORT}`, {
+      stdio: "pipe",
+    })
+      .toString()
+      .trim();
+    if (result) {
+      for (const pid of result.split("\n")) {
+        try {
+          process.kill(Number(pid), "SIGKILL");
+        } catch {
+          // Process may have already exited
+        }
+      }
+      console.log(`Killed existing process(es) on port ${REGISTRY_PORT}`);
+    }
+  } catch {
+    // No process on port — expected
+  }
+}
 
 /**
  * Start the registry as a child process using the ph-registry CLI binary.
@@ -15,6 +41,9 @@ export async function startRegistry(
   storagePath: string,
   cdnCachePath: string,
 ): Promise<ChildProcess> {
+  // Kill any leftover registry from a previous run
+  killExistingRegistryProcess();
+
   // Clean up and recreate directories to ensure fresh state
   fs.rmSync(storagePath, { recursive: true, force: true });
   fs.rmSync(cdnCachePath, { recursive: true, force: true });

--- a/test/vetra-e2e/tests/helpers/registry.ts
+++ b/test/vetra-e2e/tests/helpers/registry.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess } from "child_process";
-import { execSync, spawn } from "child_process";
+import { spawn } from "child_process";
 import fs from "fs";
 import path from "path";
 
@@ -7,43 +7,19 @@ const REGISTRY_PORT = 8080;
 export const REGISTRY_URL =
   process.env.REGISTRY_URL || `http://localhost:${REGISTRY_PORT}`;
 
-/**
- * Kill any process listening on the registry port.
- * Prevents "port already in use" from a leaked process.
- */
-function killExistingRegistryProcess(): void {
-  try {
-    const result = execSync(`lsof -t -i :${REGISTRY_PORT}`, {
-      stdio: "pipe",
-    })
-      .toString()
-      .trim();
-    if (result) {
-      for (const pid of result.split("\n")) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {
-          // Process may have already exited
-        }
-      }
-      console.log(`Killed existing process(es) on port ${REGISTRY_PORT}`);
-    }
-  } catch {
-    // No process on port — expected
-  }
+export interface RegistryHandle {
+  process: ChildProcess;
+  shutdown: () => Promise<void>;
 }
 
 /**
  * Start the registry as a child process using the ph-registry CLI binary.
- * Returns the ChildProcess so it can be killed later.
+ * Returns a handle with a shutdown() method for clean teardown.
  */
 export async function startRegistry(
   storagePath: string,
   cdnCachePath: string,
-): Promise<ChildProcess> {
-  // Kill any leftover registry from a previous run
-  killExistingRegistryProcess();
-
+): Promise<RegistryHandle> {
   // Clean up and recreate directories to ensure fresh state
   fs.rmSync(storagePath, { recursive: true, force: true });
   fs.rmSync(cdnCachePath, { recursive: true, force: true });
@@ -64,7 +40,7 @@ export async function startRegistry(
     ],
     {
       stdio: "pipe",
-      detached: false,
+      detached: true,
     },
   );
 
@@ -75,6 +51,28 @@ export async function startRegistry(
   child.stderr?.on("data", (data: Buffer) => {
     console.error(`[registry:err] ${data.toString().trim()}`);
   });
+
+  // Unref so the child doesn't keep the parent process alive
+  child.unref();
+
+  const shutdown = (): Promise<void> =>
+    new Promise<void>((resolve) => {
+      if (child.killed || child.exitCode !== null) {
+        resolve();
+        return;
+      }
+      child.on("exit", () => resolve());
+      // Kill the entire process group (pnpm + node child)
+      if (child.pid) {
+        try {
+          process.kill(-child.pid, "SIGTERM");
+        } catch {
+          child.kill("SIGTERM");
+        }
+      } else {
+        child.kill("SIGTERM");
+      }
+    });
 
   // Wait for the registry to be ready by polling a registry-specific endpoint
   const maxWaitMs = 30_000;
@@ -88,11 +86,10 @@ export async function startRegistry(
       );
     }
     try {
-      // Use /-/ping which is a Verdaccio-specific endpoint
       const res = await fetch(`${REGISTRY_URL}/-/ping`);
       if (res.ok) {
         console.log("Registry is ready on port", REGISTRY_PORT);
-        return child;
+        return { process: child, shutdown };
       }
     } catch {
       // Not ready yet
@@ -100,7 +97,7 @@ export async function startRegistry(
     await new Promise((r) => setTimeout(r, 500));
   }
 
-  child.kill();
+  await shutdown();
   throw new Error(`Registry did not start within ${maxWaitMs}ms`);
 }
 
@@ -132,14 +129,11 @@ export function writeNpmrc(testDir: string, token: string): void {
   fs.writeFileSync(path.join(testDir, ".npmrc"), lines.join("\n"), "utf8");
 }
 
-export function stopRegistry(child: ChildProcess): void {
-  if (child && !child.killed) {
-    child.kill("SIGTERM");
-  }
+export async function stopRegistry(handle: RegistryHandle): Promise<void> {
+  await handle.shutdown();
 }
 
 export async function verifyPublish(packageName: string): Promise<void> {
-  // Query Verdaccio's npm API directly to check if the package exists
   const res = await fetch(
     `${REGISTRY_URL}/${encodeURIComponent(packageName)}`,
     {

--- a/test/vetra-e2e/tests/helpers/registry.ts
+++ b/test/vetra-e2e/tests/helpers/registry.ts
@@ -4,7 +4,8 @@ import fs from "fs";
 import path from "path";
 
 const REGISTRY_PORT = 8080;
-export const REGISTRY_URL = `http://localhost:${REGISTRY_PORT}`;
+export const REGISTRY_URL =
+  process.env.REGISTRY_URL || `http://localhost:${REGISTRY_PORT}`;
 
 /**
  * Start the registry as a child process using the ph-registry CLI binary.
@@ -88,8 +89,18 @@ export async function createTestUser(): Promise<string> {
 }
 
 export function writeNpmrc(testDir: string, token: string): void {
-  const npmrcContent = `//localhost:${REGISTRY_PORT}/:_authToken=${token}\n`;
-  fs.writeFileSync(path.join(testDir, ".npmrc"), npmrcContent, "utf8");
+  const registryHostPort = new URL(REGISTRY_URL).host;
+  const lines = [
+    `registry=${REGISTRY_URL}`,
+    `//${registryHostPort}/:_authToken=${token}`,
+  ];
+  // In Docker, ph-cli publish uses the socat IPv4 bridge on port 18080;
+  // add auth for that host too so npm authentication works
+  if (process.env.DOCKER_E2E) {
+    lines.push(`//localhost:18080/:_authToken=${token}`);
+  }
+  lines.push("");
+  fs.writeFileSync(path.join(testDir, ".npmrc"), lines.join("\n"), "utf8");
 }
 
 export function stopRegistry(child: ChildProcess): void {

--- a/test/vetra-e2e/tests/todo-document.spec.ts
+++ b/test/vetra-e2e/tests/todo-document.spec.ts
@@ -27,6 +27,7 @@ import {
   verifyPublish,
   writeNpmrc,
 } from "./helpers/registry.js";
+import { CONNECT_URL } from "../playwright.config.js";
 
 // Run serially to avoid conflicts with other tests that modify the shared Vetra drive
 test.describe.configure({ mode: "serial", timeout: 180_000 });
@@ -73,7 +74,7 @@ test.use({
     cookies: [],
     origins: [
       {
-        origin: "http://localhost:3001",
+        origin: CONNECT_URL,
         localStorage: [
           { name: "/:display-cookie-banner", value: "false" },
           {
@@ -87,7 +88,7 @@ test.use({
 });
 
 // Module-level state shared across serial tests
-let registryProcess: ChildProcess | undefined;
+let registry: Awaited<ReturnType<typeof startRegistry>> | undefined;
 let consumerPreviewProcess: ChildProcess | undefined;
 
 test.afterAll(async () => {
@@ -95,9 +96,9 @@ test.afterAll(async () => {
     stopConsumerPreview(consumerPreviewProcess);
     consumerPreviewProcess = undefined;
   }
-  if (registryProcess) {
-    stopRegistry(registryProcess);
-    registryProcess = undefined;
+  if (registry) {
+    await stopRegistry(registry);
+    registry = undefined;
   }
   cleanupConsumerBuildArtifacts();
 });
@@ -191,10 +192,7 @@ test("Build and Publish to Registry", async () => {
   const registryCdnCachePath = path.join(testDir, ".registry-cdn-cache");
 
   // Start the registry (kept running for the next test)
-  registryProcess = await startRegistry(
-    registryStoragePath,
-    registryCdnCachePath,
-  );
+  registry = await startRegistry(registryStoragePath, registryCdnCachePath);
 
   // Create test user and write .npmrc for auth
   const token = await createTestUser();

--- a/test/vetra-e2e/tests/todo-document.spec.ts
+++ b/test/vetra-e2e/tests/todo-document.spec.ts
@@ -156,7 +156,8 @@ test("Create ToDoDocument Editor", async ({ page }) => {
 
   // Poll for the generated editor files by waiting for editors/index.ts to be
   // updated with a real export (not just "export {};")
-  const editorsDir = path.join(process.cwd(), "editors");
+  const projectDir = process.env.PROJECT_DIR || process.cwd();
+  const editorsDir = path.join(projectDir, "editors");
   const editorsIndex = path.join(editorsDir, "index.ts");
   const pollStart = Date.now();
 
@@ -185,7 +186,7 @@ test("Create ToDoDocument Editor", async ({ page }) => {
 test("Build and Publish to Registry", async () => {
   test.setTimeout(180_000);
 
-  const testDir = process.cwd();
+  const testDir = process.env.PROJECT_DIR || process.cwd();
   const registryStoragePath = path.join(testDir, ".registry-storage");
   const registryCdnCachePath = path.join(testDir, ".registry-cdn-cache");
 
@@ -472,7 +473,8 @@ async function setupDocument(
   // We need to wait for the full code generation including index.ts update
   const maxWaitMs = 60000;
   const startTime = Date.now();
-  const documentModelsDir = path.join(process.cwd(), "document-models");
+  const projectDir = process.env.PROJECT_DIR || process.cwd();
+  const documentModelsDir = path.join(projectDir, "document-models");
   const todoDocModelDir = path.join(documentModelsDir, "to-do-document");
   const documentModelsIndex = path.join(documentModelsDir, "index.ts");
   const expectedExport =

--- a/test/vetra-e2e/tests/todo-document.spec.ts
+++ b/test/vetra-e2e/tests/todo-document.spec.ts
@@ -29,7 +29,7 @@ import {
 } from "./helpers/registry.js";
 
 // Run serially to avoid conflicts with other tests that modify the shared Vetra drive
-test.describe.configure({ mode: "serial", timeout: 5 * 60 * 60 * 1000 });
+test.describe.configure({ mode: "serial", timeout: 180_000 });
 const DOCUMENT_NAME = "ToDoDocument";
 
 const TEST_DOCUMENT_DATA: DocumentBasicData = {
@@ -235,11 +235,14 @@ test("Build and Publish to Registry", async () => {
   expect(fs.existsSync(distManifest)).toBe(true);
 
   const manifest = JSON.parse(fs.readFileSync(distManifest, "utf-8")) as {
-    documentModels: unknown[];
-    editors: unknown[];
+    name: string;
+    documentModels: Array<{ name: string }>;
+    editors: Array<{ name: string }>;
   };
-  expect(manifest.documentModels.length).toBeGreaterThan(0);
-  expect(manifest.editors.length).toBeGreaterThan(0);
+  expect(manifest.name).toBe("test-package-vetra");
+  expect(manifest.documentModels).toHaveLength(1);
+  expect(manifest.documentModels[0].name).toBe("ToDoDocument");
+  expect(manifest.editors).toHaveLength(1);
 
   // Publish to the local registry
   // In Docker, ph-cli can't connect to [::1] URLs, so use the socat IPv4 bridge on port 18080
@@ -378,8 +381,8 @@ test("Install Package in Consumer Project", async ({ browser }) => {
     await expect(installButton).toBeVisible({ timeout: 5_000 });
     await installButton.click();
 
-    // Wait for installation to complete
-    await page.waitForTimeout(5000);
+    // Wait for installation to complete (Install button disappears or changes)
+    await expect(installButton).toBeHidden({ timeout: 30_000 });
 
     // Step 8: Close the settings modal
     const closeButton = settingsModal
@@ -410,16 +413,12 @@ test("Install Package in Consumer Project", async ({ browser }) => {
     await expect(createDriveSubmit).toBeEnabled({ timeout: 5_000 });
     await createDriveSubmit.click();
 
-    // Wait for drive to be created
-    await page.waitForLoadState("networkidle");
-    await page.waitForTimeout(2000);
-
-    // Step 10: Navigate into the drive by clicking on it
+    // Wait for drive to be created and appear on the page
     const driveCard = page.getByRole("heading", {
       name: "Test Drive",
       level: 3,
     });
-    await expect(driveCard).toBeVisible({ timeout: 10_000 });
+    await expect(driveCard).toBeVisible({ timeout: 30_000 });
     await driveCard.click();
     await page.waitForLoadState("networkidle");
 

--- a/test/vetra-e2e/tests/todo-document.spec.ts
+++ b/test/vetra-e2e/tests/todo-document.spec.ts
@@ -14,6 +14,7 @@ import {
   CONSUMER_CONNECT_URL,
   buildConsumerConnect,
   cleanupConsumerBuildArtifacts,
+  ensureConsumerProject,
   installConsumerDeps,
   startConsumerPreview,
   stopConsumerPreview,
@@ -209,6 +210,14 @@ test("Build and Publish to Registry", async () => {
   currentManifest.name = "test-package-vetra";
   fs.writeFileSync(manifestPath, JSON.stringify(currentManifest, null, 4));
 
+  // Also update package.json name so npm publish uses the correct name
+  const packageJsonPath = path.join(testDir, "package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as {
+    name: string;
+  };
+  packageJson.name = "test-package-vetra";
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
   // Build the package with ph-cli build
   console.log("Building package with ph-cli build...");
   execSync("pnpm build", {
@@ -232,8 +241,14 @@ test("Build and Publish to Registry", async () => {
   expect(manifest.editors.length).toBeGreaterThan(0);
 
   // Publish to the local registry
-  console.log("Publishing package to local registry...");
-  execSync("pnpm exec ph-cli publish", {
+  // In Docker, ph-cli can't connect to [::1] URLs, so use the socat IPv4 bridge on port 18080
+  const publishRegistryUrl = process.env.DOCKER_E2E
+    ? "http://localhost:18080"
+    : REGISTRY_URL;
+  console.log(
+    `Publishing package to local registry (${publishRegistryUrl})...`,
+  );
+  execSync(`pnpm exec ph-cli publish --registry=${publishRegistryUrl}`, {
     cwd: testDir,
     stdio: "pipe",
     timeout: 60_000,
@@ -285,6 +300,9 @@ test("Build and Publish to Registry", async () => {
 
 test("Install Package in Consumer Project", async ({ browser }) => {
   test.setTimeout(10 * 60 * 1000); // 10 minutes for build + preview + UI
+
+  // Ensure consumer project exists (creates it via ph init in Docker mode)
+  ensureConsumerProject();
 
   // Step 1: Install dependencies for the consumer project
   installConsumerDeps();

--- a/test/vetra-e2e/tests/vetra-drive.spec.ts
+++ b/test/vetra-e2e/tests/vetra-drive.spec.ts
@@ -1,7 +1,7 @@
 import { handleCookieConsent } from "@powerhousedao/e2e-utils";
 import { expect, test } from "./helpers/fixtures.js";
 
-test.describe.configure({ timeout: 5 * 60 * 60 * 1000 });
+test.describe.configure({ timeout: 60_000 });
 
 test("should display Vetra drive automatically on Connect main page", async ({
   page,
@@ -11,15 +11,12 @@ test("should display Vetra drive automatically on Connect main page", async ({
 
   await handleCookieConsent(page);
 
-  // Wait for the app skeleton to finish loading (skeleton-loader should be hidden)
   await page
     .locator(".skeleton-loader")
-    .waitFor({ state: "hidden", timeout: 30000 });
+    .waitFor({ state: "hidden", timeout: 30_000 });
 
-  // Wait for the Vetra drive card to appear (default drives load asynchronously)
-  // Look for the h3 heading with "Vetra" which is the drive title
   const vetraDriveCard = page.getByRole("heading", { name: "Vetra", level: 3 });
-  await expect(vetraDriveCard).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
+  await expect(vetraDriveCard).toBeVisible({ timeout: 30_000 });
 });
 
 test("should allow clicking on Vetra drive", async ({ page }) => {
@@ -28,18 +25,23 @@ test("should allow clicking on Vetra drive", async ({ page }) => {
 
   await handleCookieConsent(page);
 
-  // Wait for the app skeleton to finish loading
   await page
     .locator(".skeleton-loader")
-    .waitFor({ state: "hidden", timeout: 30000 });
+    .waitFor({ state: "hidden", timeout: 30_000 });
 
   const vetraDrive = page.getByRole("heading", { name: "Vetra", level: 3 });
-  await expect(vetraDrive).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
+  await expect(vetraDrive).toBeVisible({ timeout: 30_000 });
 
   await vetraDrive.click();
-
   await page.waitForLoadState("networkidle");
 
-  const currentUrl = page.url();
-  expect(currentUrl).not.toBe("http://localhost:3001/");
+  // Verify navigation to the drive page
+  expect(page.url()).toContain("/d/");
+
+  // Verify drive page content loaded
+  const driveHeading = page.getByRole("heading", {
+    name: "Vetra Studio Drive",
+    level: 1,
+  });
+  await expect(driveHeading).toBeVisible({ timeout: 30_000 });
 });


### PR DESCRIPTION
## Summary

- **Docker-based e2e tests** that scaffold a fresh project via `ph init --dev --pnpm` using published npm packages, then run the full Playwright suite. Validates the real end-user flow: install from npm → create document models/editors → build → publish to local registry → install in consumer project.
- **Test runner separated from project** — test deps (playwright, monocart, registry) live in `/app/test-runner/`, keeping the `ph init` project pristine. `PROJECT_DIR` env var bridges them.
- **CI integration** — new `vetra-e2e-docker` job in `release-branch.yml` runs after each release with the published version tag.
- **Test reliability improvements** — replaced 2-hour timeouts with 30-60s, fixed incomplete assertions, replaced magic `waitForTimeout` with state-driven waits, added leaked registry process cleanup.

## Usage

```bash
# Build (from monorepo root)
docker build -f test/vetra-e2e/Dockerfile -t vetra-e2e --build-arg TAG=dev test/

# Run
docker run --rm vetra-e2e
```

## Test plan

- [x] All 10 e2e tests pass in Docker against published packages
- [x] All 10 e2e tests pass in monorepo (backward compatible)
- [x] Docker build caches correctly (1s rebuild when only test files change)
- [ ] Verify CI job runs after next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)