### PR TITLE
fix(connect): prevent HMR page reloads and support hot module re-injection

### DIFF
--- a/apps/connect/src/package-manager.ts
+++ b/apps/connect/src/package-manager.ts
@@ -64,17 +64,22 @@ export class BrowserPackageManager implements IPackageManager {
     const vetraPackageWithMeta = this.#loadVetraPackage();
     this.#registerPackage(vetraPackageWithMeta);
     if (localPackage) {
-      this.#localPackage = localPackage;
-      this.#registerPackage({
-        name: LOCAL_PACKAGE_NAME,
-        stylesheetUrl: null,
-        importUrl: null,
-        loadedPackage: localPackage,
-      });
+      this.updateLocalPackage(localPackage);
     }
     for (const packageName of this.#storage.keys()) {
       await this.addPackage(packageName);
     }
+  }
+
+  updateLocalPackage(pkg: DocumentModelLib) {
+    console.debug("Updating local package:", pkg);
+    this.#localPackage = pkg;
+    this.#registerPackage({
+      name: LOCAL_PACKAGE_NAME,
+      stylesheetUrl: null,
+      importUrl: null,
+      loadedPackage: pkg,
+    });
   }
 
   get packages() {

--- a/apps/connect/start-connect.tsx
+++ b/apps/connect/start-connect.tsx
@@ -8,8 +8,26 @@ import { AppLoader } from "./src/components/index.js";
  *
  * // main.tsx
  * import * as localPackage from "./index.js";
- * startConnect(localPackage);
+ * const { updateLocalPackage } = startConnect(localPackage);
+ *
+ * if (import.meta.hot) {
+ *   import.meta.hot.accept(["./index.js"], ([newModule]) => {
+ *     if (newModule) {
+ *       updateLocalPackage(newModule);
+ *     }
+ *   });
+ * }
  */
+
+// Type for Vite HMR modules
+export type ModuleNamespace = Record<string, any> & {
+  [Symbol.toStringTag]: "Module";
+};
+
+function updateLocalPackage(pkg: DocumentModelLib | ModuleNamespace) {
+  window.ph?.vetraPackageManager?.updateLocalPackage(pkg as DocumentModelLib);
+}
+
 export function startConnect(localPackage: Partial<DocumentModelLib>) {
   if (!window.ph) {
     window.ph = {};
@@ -18,4 +36,8 @@ export function startConnect(localPackage: Partial<DocumentModelLib>) {
   createRoot(document.getElementById("root")!).render(
     <AppLoader localPackage={localPackage as DocumentModelLib} />,
   );
+
+  return {
+    updateLocalPackage,
+  };
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -231,7 +231,6 @@ const typescriptLanguageOptions = {
         "mcr.config.js",
         "tools/scripts/merge-coverage.js",
         "test/scripts/analyze-ops.ts",
-        "packages/vetra/main.tsx",
       ],
     },
     tsconfigRootDir: import.meta.dirname,

--- a/packages/builder-tools/connect-utils/vite-config.ts
+++ b/packages/builder-tools/connect-utils/vite-config.ts
@@ -259,6 +259,11 @@ export function getConnectBaseViteConfig(options: IConnectOptions) {
   const config: InlineConfig = {
     configFile: false,
     mode,
+    server: {
+      watch: {
+        ignored: ["**/backup-documents/**", "**/.ph/**"],
+      },
+    },
     resolve: {
       tsconfigPaths: true,
     },
@@ -271,6 +276,12 @@ export function getConnectBaseViteConfig(options: IConnectOptions) {
       exclude: ["@electric-sql/pglite", "@electric-sql/pglite-tools"],
     },
     plugins: [
+      // phPackagesPlugin must be registered before tailwind so its hotUpdate
+      // hook runs first and can suppress HMR updates for codegen-generated
+      // files, preventing tailwind from triggering full page reloads.
+      phPackagesPlugin({
+        packages: phPackages,
+      }),
       ...plugins,
       // Externalize React so both Connect and dynamically loaded registry
       // packages share the same React instance via the import map in index.html.
@@ -284,9 +295,6 @@ export function getConnectBaseViteConfig(options: IConnectOptions) {
       // NOTE: Do NOT also list these in build.rolldownOptions.external — overlapping
       // entries prevent the plugin from transforming require() calls.
       esmExternalRequirePlugin({ external: reactExternal }),
-      phPackagesPlugin({
-        packages: phPackages,
-      }),
     ],
     worker: {
       format: "es",

--- a/packages/builder-tools/connect-utils/vite-config.ts
+++ b/packages/builder-tools/connect-utils/vite-config.ts
@@ -15,10 +15,8 @@ import {
 } from "vite";
 import { createHtmlPlugin } from "vite-plugin-html";
 import type { IConnectOptions } from "./types.js";
+import { connectFaviconPlugin } from "./vite-plugins/favicon.js";
 import { phPackagesPlugin } from "./vite-plugins/ph-packages.js";
-
-const isLocalDev = true;
-const esmShUrl = isLocalDev ? "http://localhost:8080" : "https://esm.sh";
 
 export function getConnectHtmlTags(
   options: {
@@ -295,6 +293,7 @@ export function getConnectBaseViteConfig(options: IConnectOptions) {
       // NOTE: Do NOT also list these in build.rolldownOptions.external — overlapping
       // entries prevent the plugin from transforming require() calls.
       esmExternalRequirePlugin({ external: reactExternal }),
+      connectFaviconPlugin(),
     ],
     worker: {
       format: "es",

--- a/packages/builder-tools/connect-utils/vite-plugins/favicon.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/favicon.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import type { Plugin } from "vite";
+
+/**
+ * Vite plugin to serve the Connect favicon (icon.ico) from the connect package.
+ * This ensures the favicon is available in development and included in the production build.
+ */
+export function connectFaviconPlugin(): Plugin {
+  return {
+    name: "copy-connect-favicon",
+    configureServer(server) {
+      // Serve icon.ico before Vite's static middleware so it acts as a fallback
+      server.middlewares.use("/icon.ico", (_req, res, next) => {
+        server.pluginContainer
+          .resolveId("@powerhousedao/connect/assets/icon.ico")
+          .then((resolved) => {
+            if (!resolved) return next();
+            res.setHeader("Content-Type", "image/x-icon");
+            res.end(readFileSync(resolved.id));
+          })
+          .catch(() => next());
+      });
+    },
+    async generateBundle(_options, bundle) {
+      try {
+        if ("icon.ico" in bundle) return;
+        const resolved = await this.resolve(
+          "@powerhousedao/connect/assets/icon.ico",
+        );
+        if (!resolved) return;
+        this.emitFile({
+          type: "asset",
+          fileName: "icon.ico",
+          source: readFileSync(resolved.id),
+        });
+      } catch {
+        // connect package not found, skip favicon
+      }
+    },
+  };
+}

--- a/packages/builder-tools/connect-utils/vite-plugins/ph-packages.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/ph-packages.ts
@@ -35,7 +35,7 @@ export function phPackagesPlugin(options: PhPackagesPluginOptions): Plugin {
             return true;
           }
           const importer = mod.importers.values().next();
-          return !importer.value?.file?.endsWith("style.css");
+          return !importer.value?.file?.endsWith(".css");
         });
       },
     },

--- a/packages/builder-tools/connect-utils/vite-plugins/ph-packages.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/ph-packages.ts
@@ -25,6 +25,20 @@ export function phPackagesPlugin(options: PhPackagesPluginOptions): Plugin {
         next();
       });
     },
+    hotUpdate: {
+      order: "pre",
+      handler(ctx) {
+        // filter out modules only imported by "style.css"
+        // to avoid page reloads triggered by tailwind
+        return ctx.modules.filter((mod) => {
+          if (mod.importers.size > 1) {
+            return true;
+          }
+          const importer = mod.importers.values().next();
+          return !importer.value?.file?.endsWith("style.css");
+        });
+      },
+    },
     generateBundle() {
       this.emitFile({
         type: "asset",

--- a/packages/codegen/src/templates/boilerplate/main.tsx.ts
+++ b/packages/codegen/src/templates/boilerplate/main.tsx.ts
@@ -4,5 +4,13 @@ export const mainTsxTemplate = tsx`
 import { startConnect } from "@powerhousedao/connect";
 import * as localPackage from "./index.js";
 
-startConnect(localPackage);
+const { updateLocalPackage } = startConnect(localPackage);
+
+if (import.meta.hot) {
+  import.meta.hot.accept(["./index.js"], ([newModule]) => {
+    if (newModule) {
+      updateLocalPackage(newModule);
+    }
+  });
+}
 `.raw;

--- a/packages/codegen/src/templates/boilerplate/package.json.ts
+++ b/packages/codegen/src/templates/boilerplate/package.json.ts
@@ -87,6 +87,7 @@ const devDependenciesTemplate = (versionedDevDependencies: string[]) =>
   "tailwindcss": "^4.1.16",
   "typescript": "^5.9.3",
   "typescript-eslint": "^8.46.2",
+  "vite": "8.0.2",
   "vitest": "4.1.1",
   "@vitejs/plugin-react": "6.0.1",
   "vite-tsconfig-paths": "6.1.1"

--- a/packages/codegen/src/templates/boilerplate/tsconfig.json.ts
+++ b/packages/codegen/src/templates/boilerplate/tsconfig.json.ts
@@ -36,7 +36,7 @@ export const tsConfigTemplate = json`
     "moduleDetection": "force",
     "target": "esnext",
     "jsx": "react-jsx",
-    "types": ["node", "vitest/globals"],
+    "types": ["node", "vite/client", "vitest/globals"],
     "lib": ["ESNext", "dom", "dom.iterable"],
     "declaration": true,
     "declarationMap": true,

--- a/packages/reactor-browser/src/hooks/vetra-packages.ts
+++ b/packages/reactor-browser/src/hooks/vetra-packages.ts
@@ -45,6 +45,9 @@ function updateReactorClientDocumentModels(packages: DocumentModelLib[]) {
       registry.registerModules(module);
     } catch (error) {
       if (DuplicateModuleError.isError(error)) {
+        const documentType = module.documentModel.global.id;
+        registry.unregisterModules(documentType);
+        registry.registerModules(module);
         continue;
       }
       throw error;

--- a/packages/reactor-browser/src/types/vetra.ts
+++ b/packages/reactor-browser/src/types/vetra.ts
@@ -25,6 +25,7 @@ export interface IPackageManager extends IDocumentModelLoader {
     packageNames: string[],
   ): Promise<PackageManagerInstallResult[]> | PackageManagerInstallResult[];
   removePackage(name: string): void;
+  updateLocalPackage(pkg: DocumentModelLib): void;
   subscribe(handler: IPackagesListener): IPackageListerUnsubscribe;
   getPackageSource: (packageName: string) => RegistryPackageSource | null;
 }

--- a/packages/vetra/main.tsx
+++ b/packages/vetra/main.tsx
@@ -1,6 +1,13 @@
 import { startConnect } from "@powerhousedao/connect";
-
 import "@powerhousedao/connect/style.css";
 import * as localPackage from "./index.js";
 
-startConnect(localPackage);
+const { updateLocalPackage } = startConnect(localPackage);
+
+if (import.meta.hot) {
+  import.meta.hot.accept(["./index.js"], ([newModule]) => {
+    if (newModule) {
+      updateLocalPackage(newModule);
+    }
+  });
+}

--- a/packages/vetra/package.json
+++ b/packages/vetra/package.json
@@ -89,6 +89,7 @@
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "tailwindcss": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:",
     "tsdown": "catalog:"
   },

--- a/packages/vetra/processors/codegen/document-handlers/document-codegen-manager.ts
+++ b/packages/vetra/processors/codegen/document-handlers/document-codegen-manager.ts
@@ -4,7 +4,7 @@ import { logger } from "../logger.js";
 import type { BaseDocumentGen } from "./base-document-gen.js";
 import type { CodegenInput, Config } from "./types.js";
 
-const DEFAULT_DEBOUNCE_TIME = 3000; // 3 seconds
+const DEFAULT_DEBOUNCE_TIME = 1000; // wait 1 second between codegen calls
 
 /**
  * Manager class responsible for routing documents to the correct generator

--- a/packages/vetra/tsconfig.json
+++ b/packages/vetra/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.options.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "types": ["node", "vitest/globals"],
+    "types": ["node", "vite/client", "vitest/globals"],
     "lib": ["ESNext", "dom", "dom.iterable"],
     "paths": {
       "@powerhousedao/vetra/document-models": ["./document-models/index.ts"],
@@ -16,7 +16,7 @@
     }
   },
   "include": ["**/*", "./powerhouse.manifest.json"],
-  "exclude": ["dist", "node_modules", ".ph", "main.tsx", "index.html"],
+  "exclude": ["dist", "node_modules", ".ph", "index.html"],
   "references": [
     {
       "path": "../builder-tools"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2454,6 +2454,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.21.0(oxc-resolver@11.19.0)(synckit@0.11.12)(typescript@5.9.3)
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.2(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/browser-playwright@4.1.1)(happy-dom@20.8.8(bufferutil@4.1.0)(utf-8-validate@6.0.6))(jsdom@24.1.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@8.0.2(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -2608,6 +2611,9 @@ importers:
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.2(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-tsconfig-paths:
         specifier: 'catalog:'
         version: 6.1.1(typescript@5.9.3)(vite@8.0.2(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -2874,6 +2880,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.21.0(oxc-resolver@11.19.0)(synckit@0.11.12)(typescript@5.9.3)
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.2(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-tsconfig-paths:
         specifier: 'catalog:'
         version: 6.1.1(typescript@5.9.3)(vite@8.0.2(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -2938,6 +2947,9 @@ importers:
       tailwindcss:
         specifier: 'catalog:'
         version: 4.2.2
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.2(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/browser-playwright@4.1.1)(happy-dom@20.8.8(bufferutil@4.1.0)(utf-8-validate@6.0.6))(jsdom@24.1.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@8.0.2(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -23804,9 +23816,9 @@ snapshots:
 
   '@docusaurus/cssnano-preset@3.9.2':
     dependencies:
-      cssnano-preset-advanced: 6.1.2(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-sort-media-queries: 5.2.0(postcss@8.5.6)
+      cssnano-preset-advanced: 6.1.2(postcss@8.5.8)
+      postcss: 8.5.8
+      postcss-sort-media-queries: 5.2.0(postcss@8.5.8)
       tslib: 2.8.1
 
   '@docusaurus/logger@3.9.2':
@@ -33538,6 +33550,15 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  autoprefixer@10.4.27(postcss@8.5.8):
+    dependencies:
+      browserslist: 4.28.1
+      caniuse-lite: 1.0.30001774
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.8
+      postcss-value-parser: 4.2.0
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -35036,6 +35057,10 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
+  css-declaration-sorter@7.3.1(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+
   css-has-pseudo@7.0.3(postcss@8.5.6):
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
@@ -35045,12 +35070,12 @@ snapshots:
 
   css-loader@6.11.0(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
+      icss-utils: 5.1.0(postcss@8.5.8)
+      postcss: 8.5.8
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.8)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.8)
+      postcss-modules-scope: 3.2.1(postcss@8.5.8)
+      postcss-modules-values: 4.0.0(postcss@8.5.8)
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
@@ -35059,9 +35084,9 @@ snapshots:
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.27.3)(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      cssnano: 6.1.2(postcss@8.5.6)
+      cssnano: 6.1.2(postcss@8.5.8)
       jest-worker: 29.7.0
-      postcss: 8.5.6
+      postcss: 8.5.8
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
@@ -35109,16 +35134,16 @@ snapshots:
 
   cssfilter@0.0.10: {}
 
-  cssnano-preset-advanced@6.1.2(postcss@8.5.6):
+  cssnano-preset-advanced@6.1.2(postcss@8.5.8):
     dependencies:
-      autoprefixer: 10.4.27(postcss@8.5.6)
+      autoprefixer: 10.4.27(postcss@8.5.8)
       browserslist: 4.28.1
-      cssnano-preset-default: 6.1.2(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-discard-unused: 6.0.5(postcss@8.5.6)
-      postcss-merge-idents: 6.0.3(postcss@8.5.6)
-      postcss-reduce-idents: 6.0.3(postcss@8.5.6)
-      postcss-zindex: 6.0.2(postcss@8.5.6)
+      cssnano-preset-default: 6.1.2(postcss@8.5.8)
+      postcss: 8.5.8
+      postcss-discard-unused: 6.0.5(postcss@8.5.8)
+      postcss-merge-idents: 6.0.3(postcss@8.5.8)
+      postcss-reduce-idents: 6.0.3(postcss@8.5.8)
+      postcss-zindex: 6.0.2(postcss@8.5.8)
 
   cssnano-preset-default@6.1.2(postcss@8.5.6):
     dependencies:
@@ -35154,15 +35179,59 @@ snapshots:
       postcss-svgo: 6.0.3(postcss@8.5.6)
       postcss-unique-selectors: 6.0.4(postcss@8.5.6)
 
+  cssnano-preset-default@6.1.2(postcss@8.5.8):
+    dependencies:
+      browserslist: 4.28.1
+      css-declaration-sorter: 7.3.1(postcss@8.5.8)
+      cssnano-utils: 4.0.2(postcss@8.5.8)
+      postcss: 8.5.8
+      postcss-calc: 9.0.1(postcss@8.5.8)
+      postcss-colormin: 6.1.0(postcss@8.5.8)
+      postcss-convert-values: 6.1.0(postcss@8.5.8)
+      postcss-discard-comments: 6.0.2(postcss@8.5.8)
+      postcss-discard-duplicates: 6.0.3(postcss@8.5.8)
+      postcss-discard-empty: 6.0.3(postcss@8.5.8)
+      postcss-discard-overridden: 6.0.2(postcss@8.5.8)
+      postcss-merge-longhand: 6.0.5(postcss@8.5.8)
+      postcss-merge-rules: 6.1.1(postcss@8.5.8)
+      postcss-minify-font-values: 6.1.0(postcss@8.5.8)
+      postcss-minify-gradients: 6.0.3(postcss@8.5.8)
+      postcss-minify-params: 6.1.0(postcss@8.5.8)
+      postcss-minify-selectors: 6.0.4(postcss@8.5.8)
+      postcss-normalize-charset: 6.0.2(postcss@8.5.8)
+      postcss-normalize-display-values: 6.0.2(postcss@8.5.8)
+      postcss-normalize-positions: 6.0.2(postcss@8.5.8)
+      postcss-normalize-repeat-style: 6.0.2(postcss@8.5.8)
+      postcss-normalize-string: 6.0.2(postcss@8.5.8)
+      postcss-normalize-timing-functions: 6.0.2(postcss@8.5.8)
+      postcss-normalize-unicode: 6.1.0(postcss@8.5.8)
+      postcss-normalize-url: 6.0.2(postcss@8.5.8)
+      postcss-normalize-whitespace: 6.0.2(postcss@8.5.8)
+      postcss-ordered-values: 6.0.2(postcss@8.5.8)
+      postcss-reduce-initial: 6.1.0(postcss@8.5.8)
+      postcss-reduce-transforms: 6.0.2(postcss@8.5.8)
+      postcss-svgo: 6.0.3(postcss@8.5.8)
+      postcss-unique-selectors: 6.0.4(postcss@8.5.8)
+
   cssnano-utils@4.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+
+  cssnano-utils@4.0.2(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
 
   cssnano@6.1.2(postcss@8.5.6):
     dependencies:
       cssnano-preset-default: 6.1.2(postcss@8.5.6)
       lilconfig: 3.1.3
       postcss: 8.5.6
+
+  cssnano@6.1.2(postcss@8.5.8):
+    dependencies:
+      cssnano-preset-default: 6.1.2(postcss@8.5.8)
+      lilconfig: 3.1.3
+      postcss: 8.5.8
 
   csso@5.0.5:
     dependencies:
@@ -38050,9 +38119,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.5.6):
+  icss-utils@5.1.0(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
   idb-keyval@6.2.1:
     optional: true
@@ -42315,6 +42384,12 @@ snapshots:
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
+  postcss-calc@9.0.1(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+      postcss-selector-parser: 6.1.2
+      postcss-value-parser: 4.2.0
+
   postcss-clamp@4.1.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -42349,10 +42424,24 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-colormin@6.1.0(postcss@8.5.8):
+    dependencies:
+      browserslist: 4.28.1
+      caniuse-api: 3.0.0
+      colord: 2.9.3
+      postcss: 8.5.8
+      postcss-value-parser: 4.2.0
+
   postcss-convert-values@6.1.0(postcss@8.5.6):
     dependencies:
       browserslist: 4.28.1
       postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
+  postcss-convert-values@6.1.0(postcss@8.5.8):
+    dependencies:
+      browserslist: 4.28.1
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-custom-media@11.0.6(postcss@8.5.6):
@@ -42389,21 +42478,37 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
+  postcss-discard-comments@6.0.2(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+
   postcss-discard-duplicates@6.0.3(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+
+  postcss-discard-duplicates@6.0.3(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
 
   postcss-discard-empty@6.0.3(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
+  postcss-discard-empty@6.0.3(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+
   postcss-discard-overridden@6.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  postcss-discard-unused@6.0.5(postcss@8.5.6):
+  postcss-discard-overridden@6.0.2(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
+
+  postcss-discard-unused@6.0.5(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
       postcss-selector-parser: 6.1.2
 
   postcss-double-position-gradients@6.0.4(postcss@8.5.6):
@@ -42461,10 +42566,10 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-merge-idents@6.0.3(postcss@8.5.6):
+  postcss-merge-idents@6.0.3(postcss@8.5.8):
     dependencies:
-      cssnano-utils: 4.0.2(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 4.0.2(postcss@8.5.8)
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-merge-longhand@6.0.5(postcss@8.5.6):
@@ -42472,6 +42577,12 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
       stylehacks: 6.1.1(postcss@8.5.6)
+
+  postcss-merge-longhand@6.0.5(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+      postcss-value-parser: 4.2.0
+      stylehacks: 6.1.1(postcss@8.5.8)
 
   postcss-merge-rules@6.1.1(postcss@8.5.6):
     dependencies:
@@ -42481,9 +42592,22 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
+  postcss-merge-rules@6.1.1(postcss@8.5.8):
+    dependencies:
+      browserslist: 4.28.1
+      caniuse-api: 3.0.0
+      cssnano-utils: 4.0.2(postcss@8.5.8)
+      postcss: 8.5.8
+      postcss-selector-parser: 6.1.2
+
   postcss-minify-font-values@6.1.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
+  postcss-minify-font-values@6.1.0(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-minify-gradients@6.0.3(postcss@8.5.6):
@@ -42493,6 +42617,13 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-minify-gradients@6.0.3(postcss@8.5.8):
+    dependencies:
+      colord: 2.9.3
+      cssnano-utils: 4.0.2(postcss@8.5.8)
+      postcss: 8.5.8
+      postcss-value-parser: 4.2.0
+
   postcss-minify-params@6.1.0(postcss@8.5.6):
     dependencies:
       browserslist: 4.28.1
@@ -42500,31 +42631,43 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-minify-params@6.1.0(postcss@8.5.8):
+    dependencies:
+      browserslist: 4.28.1
+      cssnano-utils: 4.0.2(postcss@8.5.8)
+      postcss: 8.5.8
+      postcss-value-parser: 4.2.0
+
   postcss-minify-selectors@6.0.4(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
+  postcss-minify-selectors@6.0.4(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
+      postcss-selector-parser: 6.1.2
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.6):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.8):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
+      postcss: 8.5.8
+
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.8):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.8)
+      postcss: 8.5.8
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.6):
+  postcss-modules-scope@3.2.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-selector-parser: 7.1.1
 
-  postcss-modules-values@4.0.0(postcss@8.5.6):
+  postcss-modules-values@4.0.0(postcss@8.5.8):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
+      icss-utils: 5.1.0(postcss@8.5.8)
+      postcss: 8.5.8
 
   postcss-nesting@13.0.2(postcss@8.5.6):
     dependencies:
@@ -42537,9 +42680,18 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
+  postcss-normalize-charset@6.0.2(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+
   postcss-normalize-display-values@6.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-display-values@6.0.2(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-normalize-positions@6.0.2(postcss@8.5.6):
@@ -42547,9 +42699,19 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-positions@6.0.2(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-repeat-style@6.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-repeat-style@6.0.2(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-normalize-string@6.0.2(postcss@8.5.6):
@@ -42557,9 +42719,19 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-string@6.0.2(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-timing-functions@6.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-timing-functions@6.0.2(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-normalize-unicode@6.1.0(postcss@8.5.6):
@@ -42568,14 +42740,30 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-unicode@6.1.0(postcss@8.5.8):
+    dependencies:
+      browserslist: 4.28.1
+      postcss: 8.5.8
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-url@6.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-url@6.0.2(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-whitespace@6.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-whitespace@6.0.2(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-opacity-percentage@3.0.0(postcss@8.5.6):
@@ -42586,6 +42774,12 @@ snapshots:
     dependencies:
       cssnano-utils: 4.0.2(postcss@8.5.6)
       postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
+  postcss-ordered-values@6.0.2(postcss@8.5.8):
+    dependencies:
+      cssnano-utils: 4.0.2(postcss@8.5.8)
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-overflow-shorthand@6.0.0(postcss@8.5.6):
@@ -42682,9 +42876,9 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 7.1.1
 
-  postcss-reduce-idents@6.0.3(postcss@8.5.6):
+  postcss-reduce-idents@6.0.3(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-reduce-initial@6.1.0(postcss@8.5.6):
@@ -42693,9 +42887,20 @@ snapshots:
       caniuse-api: 3.0.0
       postcss: 8.5.6
 
+  postcss-reduce-initial@6.1.0(postcss@8.5.8):
+    dependencies:
+      browserslist: 4.28.1
+      caniuse-api: 3.0.0
+      postcss: 8.5.8
+
   postcss-reduce-transforms@6.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
+  postcss-reduce-transforms@6.0.2(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-replace-overflow-wrap@4.0.0(postcss@8.5.6):
@@ -42717,9 +42922,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-sort-media-queries@5.2.0(postcss@8.5.6):
+  postcss-sort-media-queries@5.2.0(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       sort-css-media-queries: 2.2.0
 
   postcss-svgo@6.0.3(postcss@8.5.6):
@@ -42728,16 +42933,27 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 3.3.2
 
+  postcss-svgo@6.0.3(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+      postcss-value-parser: 4.2.0
+      svgo: 3.3.2
+
   postcss-unique-selectors@6.0.4(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
+  postcss-unique-selectors@6.0.4(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+      postcss-selector-parser: 6.1.2
+
   postcss-value-parser@4.2.0: {}
 
-  postcss-zindex@6.0.2(postcss@8.5.6):
+  postcss-zindex@6.0.2(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
   postcss@8.4.49:
     dependencies:
@@ -44074,7 +44290,7 @@ snapshots:
     dependencies:
       escalade: 3.2.0
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.8
       strip-json-comments: 3.1.1
 
   run-applescript@7.1.0: {}
@@ -44959,6 +45175,12 @@ snapshots:
     dependencies:
       browserslist: 4.28.1
       postcss: 8.5.6
+      postcss-selector-parser: 6.1.2
+
+  stylehacks@6.1.1(postcss@8.5.8):
+    dependencies:
+      browserslist: 4.28.1
+      postcss: 8.5.8
       postcss-selector-parser: 6.1.2
 
   stylis@4.2.0: {}

--- a/test/codegen/package.json
+++ b/test/codegen/package.json
@@ -56,6 +56,7 @@
     "ts-morph": "catalog:",
     "tsx": "catalog:",
     "vite-tsconfig-paths": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:",
     "write-package": "catalog:",
     "zod": "catalog:"

--- a/test/test-consumer-project/index.html
+++ b/test/test-consumer-project/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Powerhouse Connect</title>
+    <link rel="icon" href="/icon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/test/test-consumer-project/main.tsx
+++ b/test/test-consumer-project/main.tsx
@@ -1,4 +1,12 @@
 import { startConnect } from "@powerhousedao/connect";
 import * as localPackage from "./index.js";
 
-startConnect(localPackage);
+const { updateLocalPackage } = startConnect(localPackage);
+
+if (import.meta.hot) {
+  import.meta.hot.accept(["./index.js"], ([newModule]) => {
+    if (newModule) {
+      updateLocalPackage(newModule);
+    }
+  });
+}

--- a/test/test-consumer-project/powerhouse.manifest.json
+++ b/test/test-consumer-project/powerhouse.manifest.json
@@ -1,14 +1,14 @@
 {
-  "name": "test-consumer-project",
-  "description": "",
-  "category": "",
-  "publisher": {
-    "name": "",
-    "url": ""
-  },
-  "documentModels": [],
-  "editors": [],
-  "apps": [],
-  "subgraphs": [],
-  "importScripts": []
+    "name": "test-consumer-project",
+    "description": "",
+    "category": "",
+    "publisher": {
+        "name": "",
+        "url": ""
+    },
+    "documentModels": [],
+    "editors": [],
+    "apps": [],
+    "subgraphs": [],
+    "importScripts": []
 }

--- a/test/test-consumer-project/tsconfig.json
+++ b/test/test-consumer-project/tsconfig.json
@@ -5,7 +5,8 @@
     "module": "nodenext",
     "target": "esnext",
     "types": [
-      "node"
+      "node",
+      "vite/client"
     ],
     "lib": [
       "ESNext",
@@ -19,7 +20,34 @@
     "verbatimModuleSyntax": true,
     "isolatedModules": true,
     "moduleDetection": "force",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "paths": {
+      "document-models": [
+        "./document-models/index.ts"
+      ],
+      "document-models/*": [
+        "./document-models/*/index.ts"
+      ],
+      "editors": [
+        "./editors/index.ts"
+      ],
+      "editors/*": [
+        "./editors/*/index.ts"
+      ],
+      "processors": [
+        "./processors/index.ts"
+      ],
+      "processors/*": [
+        "./processors/*/index.ts"
+      ],
+      "subgraphs": [
+        "./subgraphs/index.ts"
+      ],
+      "subgraphs/*": [
+        "./subgraphs/*/index.ts"
+      ]
+    }
   },
   "include": [
     "**/*",

--- a/test/versioned-documents/main.tsx
+++ b/test/versioned-documents/main.tsx
@@ -1,4 +1,12 @@
 import { startConnect } from "@powerhousedao/connect";
 import * as localPackage from "./index.js";
 
-startConnect(localPackage);
+const { updateLocalPackage } = startConnect(localPackage);
+
+if (import.meta.hot) {
+  import.meta.hot.accept(["./index.js"], ([newModule]) => {
+    if (newModule) {
+      updateLocalPackage(newModule);
+    }
+  });
+}

--- a/test/versioned-documents/package.json
+++ b/test/versioned-documents/package.json
@@ -92,6 +92,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:",
     "vite-tsconfig-paths": "catalog:"
   },

--- a/test/versioned-documents/tsconfig.json
+++ b/test/versioned-documents/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.options.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "types": ["node", "vitest/globals"],
+    "types": ["node", "vite/client", "vitest/globals"],
     "lib": ["ESNext", "dom", "dom.iterable"],
     "customConditions": ["source"],
     "paths": {

--- a/test/vetra-e2e/main.tsx
+++ b/test/vetra-e2e/main.tsx
@@ -1,4 +1,12 @@
 import { startConnect } from "@powerhousedao/connect";
 import * as localPackage from "./index.js";
 
-startConnect(localPackage);
+const { updateLocalPackage } = startConnect(localPackage);
+
+if (import.meta.hot) {
+  import.meta.hot.accept(["./index.js"], ([newModule]) => {
+    if (newModule) {
+      updateLocalPackage(newModule);
+    }
+  });
+}

--- a/test/vetra-e2e/package.json
+++ b/test/vetra-e2e/package.json
@@ -69,6 +69,7 @@
   "devDependencies": {
     "@powerhousedao/ph-cli": "workspace:*",
     "@powerhousedao/e2e-utils": "workspace:*",
+    "vite": "catalog:",
     "vitest": "catalog:",
     "tailwindcss": "catalog:",
     "@tailwindcss/cli": "catalog:",

--- a/test/vetra-e2e/playwright.config.ts
+++ b/test/vetra-e2e/playwright.config.ts
@@ -73,7 +73,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "pnpm vetra",
+    command: "pnpm vetra --watch",
     url: CONNECT_URL,
     stderr: "pipe",
     stdout: "pipe",

--- a/test/vetra-e2e/tests/helpers/document.ts
+++ b/test/vetra-e2e/tests/helpers/document.ts
@@ -100,7 +100,11 @@ export async function navigateToVetraDrive(
 
   // Wait for Vetra drive card to appear (default drives load asynchronously)
   // Look for the h3 heading with "Vetra" which is the drive title
-  const vetraDrive = page.getByRole("heading", { name: "Vetra", level: 3 });
+  const vetraDrive = page.getByRole("heading", {
+    name: "Vetra",
+    level: 3,
+    exact: true,
+  });
   await expect(vetraDrive).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
   await vetraDrive.click();
 

--- a/test/vetra-e2e/tests/hmr-no-reload.spec.ts
+++ b/test/vetra-e2e/tests/hmr-no-reload.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "./helpers/fixtures.js";
+
+test.describe.configure({ mode: "serial", timeout: 5 * 60 * 60 * 1000 });
+
+test.use({
+  storageState: {
+    cookies: [],
+    origins: [
+      {
+        origin: "http://localhost:3001",
+        localStorage: [
+          { name: "/:display-cookie-banner", value: "false" },
+          {
+            name: "/:acceptedCookies",
+            value: '{"analytics":true,"marketing":false,"functional":false}',
+          },
+        ],
+      },
+    ],
+  },
+});
+
+test("should not trigger a page reload when editing the manifest", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+
+  await page
+    .locator(".skeleton-loader")
+    .waitFor({ state: "hidden", timeout: 30000 });
+
+  // Click on the Vetra drive (exact match to avoid "Vetra Preview")
+  const vetraDrive = page.getByRole("heading", {
+    name: "Vetra",
+    level: 3,
+    exact: true,
+  });
+  await expect(vetraDrive).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
+  await vetraDrive.click();
+  await page.waitForLoadState("networkidle");
+
+  // Verify we're on the drive page
+  const driveHeading = page.getByRole("heading", {
+    name: "Vetra Studio Drive",
+    level: 1,
+  });
+  await expect(driveHeading).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
+
+  // Create the package manifest by clicking the prompt
+  const createManifest = page.getByText("Click to create package manifest");
+  await expect(createManifest).toBeVisible({ timeout: 30000 });
+  await createManifest.click();
+  await page.waitForLoadState("networkidle");
+
+  // Wait for the package editor to fully load
+  const categorySelect = page.locator("select#package-category");
+  await expect(categorySelect).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
+
+  // Change the category select to trigger codegen (manifest regeneration)
+  await categorySelect.selectOption("Governance");
+
+  // Wait up to 5s for a reload event; treat timeout as "no reload"
+  const reloaded = await page
+    .waitForEvent("load", { timeout: 5000 })
+    .then(() => true)
+    .catch(() => false);
+
+  expect(reloaded).toBe(false);
+});

--- a/test/vetra-e2e/tests/vetra-drive.spec.ts
+++ b/test/vetra-e2e/tests/vetra-drive.spec.ts
@@ -18,7 +18,11 @@ test("should display Vetra drive automatically on Connect main page", async ({
 
   // Wait for the Vetra drive card to appear (default drives load asynchronously)
   // Look for the h3 heading with "Vetra" which is the drive title
-  const vetraDriveCard = page.getByRole("heading", { name: "Vetra", level: 3 });
+  const vetraDriveCard = page.getByRole("heading", {
+    name: "Vetra",
+    level: 3,
+    exact: true,
+  });
   await expect(vetraDriveCard).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
 });
 
@@ -33,7 +37,11 @@ test("should allow clicking on Vetra drive", async ({ page }) => {
     .locator(".skeleton-loader")
     .waitFor({ state: "hidden", timeout: 30000 });
 
-  const vetraDrive = page.getByRole("heading", { name: "Vetra", level: 3 });
+  const vetraDrive = page.getByRole("heading", {
+    name: "Vetra",
+    level: 3,
+    exact: true,
+  });
   await expect(vetraDrive).toBeVisible({ timeout: 2 * 60 * 60 * 1000 });
 
   await vetraDrive.click();

--- a/test/vetra-e2e/tsconfig.json
+++ b/test/vetra-e2e/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "resolveJsonModule": true,
+    "types": ["node", "vite/client", "vitest/globals"],
     "paths": {
       "document-models": [
         "./document-models/index.ts"


### PR DESCRIPTION
## Summary
- Prevent full page reloads during development when codegen updates the manifest or backup documents
- Support hot module re-injection so updated document models and editors are applied without reloading
- Add e2e test to verify no page reload occurs when editing a document in the Vetra drive

## Changes

### HMR reload prevention
- **ph-packages plugin**: Add `hotUpdate` hook with `order: "pre"` that filters modules imported only by `style.css`, preventing tailwind from triggering full-reload
- **vite-config**: Register `phPackagesPlugin` before tailwind so the hook runs first. Add `server.watch.ignored` for `backup-documents` and `.ph` directories

### HMR module re-injection
- **startConnect**: Returns `{ updateLocalPackage }` for consumers to call from `import.meta.hot.accept`
- **BrowserPackageManager**: Add `updateLocalPackage` method that re-registers the local package and notifies subscribers
- **IPackageManager**: Add `updateLocalPackage` to the interface
- **vetra-packages hook**: Replace duplicate document models in the reactor registry instead of silently skipping them

### Tests
- New `hmr-no-reload.spec.ts` e2e test that creates a package manifest, changes category, and verifies no page reload via Playwright's `load` event
- Fix `vetra-drive.spec.ts` and `navigateToVetraDrive` helper to use `exact: true` for heading match (avoids ambiguity with "Vetra Preview" drive in `--watch` mode)
- Update playwright config to use `pnpm vetra --watch` for codegen support

## Test plan
- [x] `hmr-no-reload.spec.ts` passes with fix, fails without
- [x] All other vetra-e2e tests pass (9/9, excluding pre-existing registry test failure)
- [x] Manual verification: editing vetra-package category in Connect does not reload the page