### PR TITLE
feat(docker): run connect nginx as non-root (H3)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,16 +36,24 @@ WORKDIR /app/project
 RUN ph connect build --base ${PH_CONNECT_BASE_PATH}
 
 # ============================================================
-# Connect target: nginx serving static files
+# Connect target: nginx serving static files (runs as non-root)
 # ============================================================
 FROM nginx:alpine AS connect
 
-RUN apk add --no-cache gettext
+# Install envsubst for config templating, and chown the nginx runtime
+# directories so the built-in `nginx` user (UID 101) can write the
+# rendered config, the pid file, and runtime caches. Pod can then run
+# with runAsNonRoot: true, runAsUser: 101.
+RUN apk add --no-cache gettext && \
+    chown -R nginx:nginx /etc/nginx /var/cache/nginx /var/log/nginx && \
+    touch /var/run/nginx.pid && chown nginx:nginx /var/run/nginx.pid
 
-COPY docker/nginx.conf.template /etc/nginx/nginx.conf.template
-COPY --from=connect-build /app/project/.ph/connect-build/dist /var/www/html/project
-COPY docker/connect-entrypoint.sh /docker-entrypoint.sh
+COPY --chown=nginx:nginx docker/nginx.conf.template /etc/nginx/nginx.conf.template
+COPY --chown=nginx:nginx --from=connect-build /app/project/.ph/connect-build/dist /var/www/html/project
+COPY --chown=nginx:nginx docker/connect-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
+
+USER nginx
 
 ENV PORT=3001
 ENV PH_CONNECT_BASE_PATH="/"

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -1,4 +1,6 @@
-user nginx;
+# `user` directive intentionally omitted: the master process already runs as
+# the `nginx` user (set via USER in the Dockerfile's connect stage). Leaving
+# `user nginx;` in place would be a no-op when non-root and emits a warning.
 worker_processes auto;
 error_log /var/log/nginx/error.log warn;
 pid /var/run/nginx.pid;


### PR DESCRIPTION
## Summary

Runs the `connect` nginx image as the built-in `nginx` user (UID 101) instead of root. This is half of security-audit finding H3 "tenant pods run as UID 0"; `switchboard` already works non-root (built-in `node` user, read-only image tree), so this PR unblocks flipping the powerhouse-chart `securityContext` default to `runAsNonRoot: true`.

## Changes

- `docker/Dockerfile` (connect stage only):
  - `chown -R nginx:nginx /etc/nginx /var/cache/nginx /var/log/nginx` + `touch /var/run/nginx.pid && chown nginx:nginx /var/run/nginx.pid` so the nginx user can write the rendered conf, pidfile, and runtime caches.
  - `--chown=nginx:nginx` on every `COPY` (template, built dist, entrypoint).
  - `USER nginx` so the master starts as non-root.
- `docker/nginx.conf.template`: drop the `user nginx;` directive. It's a no-op when the master already runs as nginx, and emits a runtime warning otherwise.

## Test plan

- [x] Build an overlay image on top of `cr.vetra.io/powerhouse-inc-powerhouse/connect:v6.0.0-dev.164` applying the same chown / USER changes → push to Harbor → deploy with `runAsNonRoot: true, runAsUser: 101`. Pod came up 1/1, `nginx -t` clean, HTTP 200 on the root path from a separate curl pod.
- [ ] CI builds the full connect stage from this branch cleanly.
- [ ] New image tag from this PR is pulled into dev (in powerhouse-k8s-hosting) with the same securityContext override and verified.

## Follow-up (outside this repo)

- `powerhouse-k8s-hosting/powerhouse-chart/values.yaml`: flip chart default `securityContext` for connect to `{runAsNonRoot: true, runAsUser: 101}` once the first release containing this commit is tagged and published.
- Switchboard + registry deployments can move to UID 1000 in the same chart change.