### PR TITLE
fix(shared): keep react in browser neverBundle to avoid duplicate instances

### DIFF
--- a/packages/shared/clis/build-config.ts
+++ b/packages/shared/clis/build-config.ts
@@ -17,8 +17,11 @@ const entry = [
 
 const alwaysBundle = ["**"];
 
-// esmExternalRequirePlugin converts CJS require() calls for these to ESM imports.
-// They must NOT be in rolldown's external list — the plugin owns them entirely.
+// React must be external in rolldown (via neverBundle) so ESM `import ... from "react"`
+// stays as a bare import and resolves to the host's React at runtime — otherwise
+// rolldown bundles react.production.js into a chunk and we get two React instances.
+// esmExternalRequirePlugin additionally rewrites any CJS `require("react")` in bundled
+// deps to an ESM import so they hit the same external.
 const reactExternals = [
   "react",
   "react-dom",
@@ -52,10 +55,7 @@ const nodeNeverBundle = [
   "@types/react-dom",
 ];
 
-const browserNeverBundle = [
-  ...nodeNeverBundle.filter((m) => !reactExternals.includes(m)),
-  "@powerhousedao/reactor-api",
-];
+const browserNeverBundle = [...nodeNeverBundle, "@powerhousedao/reactor-api"];
 
 const copy = [{ from: "powerhouse.manifest.json", to: "dist" }];
 


### PR DESCRIPTION
This commit [78941ed7c](https://github.com/powerhouse-inc/powerhouse/commit/78941ed7cd14850e9e3951c462996217de29ecf7) removed React from `browserNeverBundle` and relied on `esmExternalRequirePlugin` alone. That plugin only rewrites CJS `require("react")` calls, it does not intercept ESM `import ... from "react"`, and it does not mark anything external.

**Result:** any bundled dependency with a plain ESM import of React gets React's source inlined into the output.

Concretely, `@powerhousedao/reactor-browser` has:

```js
// reactor-browser/dist/index.js:8
import { useSyncExternalStore, ... } from "react";
```

`alwaysBundle: ["**"]` inlines `reactor-browser` → rolldown follows that ESM import → since `react` isn't external anymore, it emits `dist/browser/react-BbTFp2_J.js` (full React production bundle).

When Connect loads the package, it runs alongside Connect's own React → two instances → `useSyncExternalStore` dispatcher is `null`:

```text
TypeError: Cannot read properties of null (reading 'useSyncExternalStore')
```
