### PR TITLE
feat: dispatch set name operation on document when renaming node in drive

### DIFF
--- a/packages/reactor-browser/src/actions/document.ts
+++ b/packages/reactor-browser/src/actions/document.ts
@@ -34,6 +34,7 @@ import {
   documentModelDocumentType,
   generateId,
   replayDocument,
+  setName,
 } from "@powerhousedao/shared/document-model";
 import { logger } from "document-model";
 import {
@@ -772,6 +773,14 @@ export async function renameNode(
     throw new Error("ReactorClient not initialized");
   }
 
+  const renameNodeResult = await reactorClient.execute(nodeId, "main", [
+    setName({ name }),
+  ]);
+
+  if (renameNodeResult.header.name !== name) {
+    throw new Error("There was an error renaming the node");
+  }
+
   // Rename the node in the drive document using updateNode action
   const drive = await reactorClient.execute<DocumentDriveDocument>(
     driveId,
@@ -781,7 +790,7 @@ export async function renameNode(
 
   const node = drive.state.global.nodes.find((n) => n.id === nodeId);
   if (!node) {
-    throw new Error("There was an error renaming node");
+    throw new Error("There was an error renaming node in the drive");
   }
   return node;
 }
@@ -799,6 +808,14 @@ export async function renameDriveNode(
   const reactorClient = window.ph?.reactorClient;
   if (!reactorClient) {
     throw new Error("ReactorClient not initialized");
+  }
+
+  const renameNodeResult = await reactorClient.execute(nodeId, "main", [
+    setName({ name }),
+  ]);
+
+  if (renameNodeResult.header.name !== name) {
+    throw new Error("There was an error renaming the node");
   }
 
   await reactorClient.execute(driveId, "main", [


### PR DESCRIPTION
The name of a node in a given drive is a separate value from its name as defined in it's document header. This has lead to some confusion, since people expect a rename action to update both values.

Update the `renameNode` and `renameDriveNode` actions used by connect to also dispatch the `setName` action when renaming a node. I am not sure why there are separate functions for `renameNode` and `renameDriveNode`, so I have just added it in both.