### PR TITLE
fix(reactor): avoid stack overflow in processor backfill on large op pages

### DIFF
--- a/packages/reactor/src/executor/simple-job-executor.ts
+++ b/packages/reactor/src/executor/simple-job-executor.ts
@@ -676,8 +676,11 @@ export class SimpleJobExecutor implements IJobExecutor {
 
     let allOpsFromMinConflictingIndex: Operation[] = conflictingOps;
     if (conflictingOps.length > 0) {
-      const minConflictingIndex = Math.min(
-        ...conflictingOps.map((op) => op.index),
+      // Using reduce instead of Math.min(...arr) to keep this stack-safe even
+      // if a conflicting-ops query returns a very large result.
+      const minConflictingIndex = conflictingOps.reduce(
+        (m, op) => (op.index < m ? op.index : m),
+        Number.POSITIVE_INFINITY,
       );
       try {
         const allOpsResult = await stores.operationStore.getSince(

--- a/packages/reactor/src/processors/processor-manager.ts
+++ b/packages/reactor/src/processors/processor-manager.ts
@@ -333,10 +333,14 @@ export class ProcessorManager
         }
       }
 
-      const maxOrdinal = Math.max(
-        ...page.results.map((op) => op.context.ordinal),
+      // Using reduce instead of Math.max(...arr) to avoid a stack overflow:
+      // backfill pages can hold the entire op log on first run (tens of
+      // thousands of entries), and the variadic spread pushes every element
+      // onto the JS argument stack.
+      tracked.lastOrdinal = page.results.reduce(
+        (m, op) => (op.context.ordinal > m ? op.context.ordinal : m),
+        tracked.lastOrdinal,
       );
-      tracked.lastOrdinal = maxOrdinal;
       await this.safeSaveProcessorCursor(tracked);
 
       if (!page.next) break;
@@ -381,7 +385,12 @@ export class ProcessorManager
   private async routeOperationsToProcessors(
     operations: OperationWithContext[],
   ): Promise<void> {
-    const maxOrdinal = Math.max(...operations.map((op) => op.context.ordinal));
+    // See backfillProcessor for rationale: avoid Math.max(...arr) on
+    // potentially-large arrays.
+    const maxOrdinal = operations.reduce(
+      (m, op) => (op.context.ordinal > m ? op.context.ordinal : m),
+      Number.NEGATIVE_INFINITY,
+    );
     const allTracked = Array.from(this.allTrackedProcessors());
 
     await Promise.all(

--- a/packages/reactor/src/read-models/base-read-model.ts
+++ b/packages/reactor/src/read-models/base-read-model.ts
@@ -169,7 +169,13 @@ export class BaseReadModel implements IReadModel {
     trx: Transaction<DocumentViewDatabase>,
     items: OperationWithContext[],
   ): Promise<void> {
-    const maxOrdinal = Math.max(...items.map((item) => item.context.ordinal));
+    // Using reduce instead of Math.max(...arr) to avoid a stack overflow when
+    // items has tens of thousands of entries (variadic spread pushes every
+    // element onto the JS argument stack).
+    const maxOrdinal = items.reduce(
+      (m, item) => (item.context.ordinal > m ? item.context.ordinal : m),
+      Number.NEGATIVE_INFINITY,
+    );
     this.lastOrdinal = maxOrdinal;
 
     await trx


### PR DESCRIPTION
## Summary

- Replace four `Math.max(...arr.map(...))` / `Math.min(...arr.map(...))` spread expressions with an iterative `reduce` in the reactor's processor + read-model + executor paths.
- The actual blocker is `ProcessorManager.backfillProcessor`: on startup against a real-world postgres reactor schema, the spread overflows V8's argument stack with `RangeError: Maximum call stack size exceeded`, before switchboard can serve any traffic.
- The other three sites are the same antipattern in adjacent code paths and would fail the same way under load. Fixed together to keep things consistent.

## Why this matters

`backfillProcessor` calls `this.operationIndex.getSinceOrdinal(tracked.lastOrdinal)` with no paging argument, so the underlying query returns the full operation log in one page. On a real dataset (~27 k ops on a single drive, ~130 k ops in the schema) we hit:

```
RangeError: Maximum call stack size exceeded
    at ProcessorManager.backfillProcessor
      (@powerhousedao/reactor/dist/index.js:3936:31)
    at async ProcessorManager.createProcessorsForDrive
    at async ProcessorManager.registerFactory
    at async _setupAPI
    at async initializeAndStartAPI
```

Bumping `--stack-size` / `--max-old-space-size` does not help — the limit is V8's argument-frame stack on a variadic call, not heap or the configured stack. `reduce` is O(n) like the old code but stack-safe at any size. No behaviour change on small arrays.

## Changes

- `packages/reactor/src/processors/processor-manager.ts`
  - `backfillProcessor` — the blocker.
  - `routeOperationsToProcessors` — same antipattern on the incoming-batch path.
- `packages/reactor/src/read-models/base-read-model.ts`
  - `ReadModelView.saveState` — same antipattern on the read-model commit path.
- `packages/reactor/src/executor/simple-job-executor.ts`
  - `Math.min(...conflictingOps.map(...))` — defensive; conflicting-ops queries are bounded in practice today but the same shape, so worth fixing while we're here.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [x] `pnpm exec vitest run test/processors/processor-manager.test.ts test/read-models/base-read-model` — 36 tests pass
- [x] Manual repro against a postgres reactor schema with ~130 k operations: switchboard crashed with `RangeError` before, boots cleanly after this patch and serves drives over GraphQL with all data intact.

## Follow-ups (not in this PR)

- `getSinceOrdinal(lastOrdinal)` returns the entire op log in one page when called without paging, which spikes RSS to >1 GB on a large schema. Worth bounding the default page in `backfillProcessor` so the existing cursor walker (`page.next()`) gets used. Happy to do as a separate PR.
- Switchboard's top-level `catch (e) { logger.error("App crashed: @error", e) }` serializes the error as `{}` and ate the stack here — debugging cost a couple of hours. Worth logging `e.stack` directly. Also a separate PR.