### PR TITLE
fix(codegen): use .raw on vitestConfigTemplate

### DIFF
--- a/packages/codegen/src/templates/boilerplate/vitest.config.ts.ts
+++ b/packages/codegen/src/templates/boilerplate/vitest.config.ts.ts
@@ -12,4 +12,4 @@ export default defineConfig({
   plugins: [tsconfigPaths(), react()],
 });
 
-`;
+`.raw;


### PR DESCRIPTION
## Summary

- `vitestConfigTemplate` is the only boilerplate template exported without `.raw`. As a result its inferred type is `Template<\"ts\", unknown>` from `@tmpl/core`.
- `tsdown`'s `.d.ts` emitter cannot resolve `Template` and writes the literal `undefined<\"ts\", unknown>` into `dist/src/templates/index.d.mts`, which is invalid TypeScript syntax.
- Any consumer that imports from `@powerhousedao/codegen/templates` then fails to build with `TS1005`/`TS1109` parse errors (skipLibCheck does not suppress parse errors in `.d.ts` files).
- This change adds `.raw` to align with every other template in the package. The vitest template has no \`\${...}\` interpolations, so `.raw` is behaviorally identical to the previous output.

## Test plan

- [ ] `pnpm -F @powerhousedao/codegen build` succeeds and `dist/src/templates/index.d.mts` declares `vitestConfigTemplate: string;`
- [ ] Downstream package importing from `@powerhousedao/codegen/templates` (e.g. `ph-porter-cli`) builds with `tsc` cleanly
- [ ] Generated `vitest.config.ts` in scaffolded projects is unchanged