### PR TITLE
feat: use generated get document with operations query in switchboard link

### DIFF
--- a/packages/reactor-browser/src/utils/switchboard.ts
+++ b/packages/reactor-browser/src/utils/switchboard.ts
@@ -1,4 +1,5 @@
 import * as lzString from "lz-string";
+import { GetDocumentWithOperationsDocument } from "../graphql/gen/schema.js";
 
 export async function getDriveIdBySlug(driveUrl: string, slug: string) {
   if (!driveUrl) {
@@ -48,27 +49,21 @@ export function getSwitchboardGatewayUrlFromDriveUrl(driveUrl: string) {
 }
 
 export function getDocumentGraphqlQuery() {
-  return `query getDocument($documentId: String!) {
-  document(id: $documentId) {
-      id
-      documentType
-      createdAtUtcIso
-      lastModifiedAtUtcIso
-      name
-      revision
-      stateJSON
-    }
-  }`;
+  const loc = GetDocumentWithOperationsDocument.loc;
+  if (!loc) {
+    throw new Error(
+      "GetDocumentWithOperationsDocument is misconfigured, loc is missing.",
+    );
+  }
+  return loc.source.body;
 }
 
 export function buildDocumentSubgraphQuery(
-  driveUrl: string,
-  documentId: string,
+  identifier: string,
   authToken?: string,
 ) {
-  const driveSlug = getSlugFromDriveUrl(driveUrl);
   const query = getDocumentGraphqlQuery();
-  const variables = { documentId, driveId: driveSlug };
+  const variables = { identifier };
   const headers = authToken
     ? {
         Authorization: `Bearer ${authToken}`,
@@ -87,13 +82,9 @@ export function buildDocumentSubgraphQuery(
 
 export function buildDocumentSubgraphUrl(
   driveUrl: string,
-  documentId: string,
+  identifier: string,
   authToken?: string,
 ) {
-  const encodedQuery = buildDocumentSubgraphQuery(
-    driveUrl,
-    documentId,
-    authToken,
-  );
+  const encodedQuery = buildDocumentSubgraphQuery(identifier, authToken);
   return `${driveUrl}?explorerURLState=${encodedQuery}`;
 }

--- a/packages/reactor-browser/test/getSwitchboardUrl.test.tsx
+++ b/packages/reactor-browser/test/getSwitchboardUrl.test.tsx
@@ -1,5 +1,6 @@
 import { decompressFromEncodedURIComponent } from "lz-string";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GetDocumentWithOperationsDocument } from "../src/graphql/gen/schema.js";
 import { buildDocumentSubgraphQuery } from "../src/utils/switchboard.js";
 
 interface CompressedQueryData {
@@ -9,13 +10,15 @@ interface CompressedQueryData {
 }
 
 interface QueryVariables {
-  documentId: string;
-  driveId: string;
+  identifier: string;
 }
 
 interface QueryHeaders {
   Authorization?: string;
 }
+
+const documentWithOperationsQuery =
+  GetDocumentWithOperationsDocument.loc!.source.body;
 
 // Mock the generateDocumentStateQueryFields function
 vi.mock("document-drive", () => ({
@@ -31,7 +34,7 @@ describe("buildDocumentSubgraphQuery", () => {
   });
 
   it("should build query without auth token", () => {
-    const result = buildDocumentSubgraphQuery(mockDriveUrl, mockDocumentId);
+    const result = buildDocumentSubgraphQuery(mockDocumentId);
 
     // The result should be a compressed string
     expect(typeof result).toBe("string");
@@ -50,19 +53,14 @@ describe("buildDocumentSubgraphQuery", () => {
     // Verify variables contain correct documentId and driveId
     const variables = JSON.parse(decompressed.variables) as QueryVariables;
     expect(variables).toEqual({
-      documentId: mockDocumentId,
-      driveId: "test-drive",
+      identifier: mockDocumentId,
     });
   });
 
   it("should build query with auth token", () => {
     const authToken = "test-auth-token-123";
 
-    const result = buildDocumentSubgraphQuery(
-      mockDriveUrl,
-      mockDocumentId,
-      authToken,
-    );
+    const result = buildDocumentSubgraphQuery(mockDocumentId, authToken);
 
     // The result should be a compressed string
     expect(typeof result).toBe("string");
@@ -84,21 +82,8 @@ describe("buildDocumentSubgraphQuery", () => {
     });
   });
 
-  it("should extract drive slug from drive URL correctly", () => {
-    const driveUrlWithSlug = "https://example.com/d/my-test-drive";
-
-    const result = buildDocumentSubgraphQuery(driveUrlWithSlug, mockDocumentId);
-
-    const decompressed = JSON.parse(
-      decompressFromEncodedURIComponent(result) || "",
-    ) as CompressedQueryData;
-    const variables = JSON.parse(decompressed.variables) as QueryVariables;
-
-    expect(variables.driveId).toBe("my-test-drive");
-  });
-
   it("should handle empty auth token as undefined", () => {
-    const result = buildDocumentSubgraphQuery(mockDriveUrl, mockDocumentId, "");
+    const result = buildDocumentSubgraphQuery(mockDocumentId, "");
 
     const decompressed = JSON.parse(
       decompressFromEncodedURIComponent(result) || "",
@@ -109,77 +94,32 @@ describe("buildDocumentSubgraphQuery", () => {
   });
 
   it("should generate correct GraphQL query structure", () => {
-    const result = buildDocumentSubgraphQuery(mockDriveUrl, mockDocumentId);
+    const result = buildDocumentSubgraphQuery(mockDocumentId);
 
     const decompressed = JSON.parse(
       decompressFromEncodedURIComponent(result) || "",
     ) as CompressedQueryData;
 
     // Verify the document contains expected GraphQL query structure
-    expect(decompressed.document)
-      .toStrictEqual(`query getDocument($documentId: String!) {
-  document(id: $documentId) {
-      id
-      documentType
-      createdAtUtcIso
-      lastModifiedAtUtcIso
-      name
-      revision
-      stateJSON
-    }
-  }`);
-  });
-
-  it("should handle different drive URL formats", () => {
-    const urls = [
-      "https://example.com/d/simple-slug",
-      "https://subdomain.example.com/d/complex-slug-123",
-      "http://localhost:3000/d/local-dev",
-    ];
-
-    urls.forEach((url) => {
-      const result = buildDocumentSubgraphQuery(url, mockDocumentId);
-
-      const decompressed = JSON.parse(
-        decompressFromEncodedURIComponent(result) || "",
-      ) as CompressedQueryData;
-      const variables = JSON.parse(decompressed.variables) as QueryVariables;
-
-      const expectedSlug = url.split("/").pop();
-      expect(variables.driveId).toBe(expectedSlug);
-    });
+    expect(decompressed.document.replaceAll(/\s/g, "")).toStrictEqual(
+      documentWithOperationsQuery.replaceAll(/\s/g, ""),
+    );
   });
 
   it("should produce consistent results for same inputs", () => {
     console.log("test-token");
-    const result1 = buildDocumentSubgraphQuery(
-      mockDriveUrl,
-      mockDocumentId,
-      "test-token",
-    );
+    const result1 = buildDocumentSubgraphQuery(mockDocumentId, "test-token");
 
-    const result2 = buildDocumentSubgraphQuery(
-      mockDriveUrl,
-      mockDocumentId,
-      "test-token",
-    );
+    const result2 = buildDocumentSubgraphQuery(mockDocumentId, "test-token");
 
     // Results should be identical for same inputs
     expect(result1).toBe(result2);
   });
 
   it("should produce different results for different auth tokens", () => {
-    const result1 = buildDocumentSubgraphQuery(
-      mockDriveUrl,
-      mockDocumentId,
-      "token1",
-    );
+    const result1 = buildDocumentSubgraphQuery(mockDocumentId, "token1");
 
-    const result2 = buildDocumentSubgraphQuery(
-      mockDriveUrl,
-      mockDocumentId,
-      "token2",
-    );
+    const result2 = buildDocumentSubgraphQuery(mockDocumentId, "token2");
 
     // Results should be different for different auth tokens
     expect(result1).not.toBe(result2);

--- a/packages/reactor-browser/test/switchboard.test.tsx
+++ b/packages/reactor-browser/test/switchboard.test.tsx
@@ -2,7 +2,6 @@
 
 import {
   buildDocumentSubgraphUrl,
-  getDocumentGraphqlQuery,
   getSwitchboardGatewayUrlFromDriveUrl,
 } from "@powerhousedao/reactor-browser";
 import { describe, it } from "vitest";
@@ -15,29 +14,13 @@ describe("Switchboard hooks", () => {
     expect(url).toBe("https://example.com/graphql");
   });
 
-  it("should generate the proper query for a document type", () => {
-    expect(getDocumentGraphqlQuery()).toBe(
-      `query getDocument($documentId: String!) {
-  document(id: $documentId) {
-      id
-      documentType
-      createdAtUtcIso
-      lastModifiedAtUtcIso
-      name
-      revision
-      stateJSON
-    }
-  }`,
-    );
-  });
-
   it("should return the proper switchboard link", () => {
     const url = buildDocumentSubgraphUrl(
       "https://example.com/d/123",
       "test-document",
     );
     expect(url).toBe(
-      "https://example.com/d/123?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAOYIoAi08yKAFACSSyKoCSY6RAyingJZISAQgCURYAB0kRIsxqo6-TkSbVWKDuKkzZe5dL175GgCoEADgkNGiUPAgCGKBGACCKAKooobAM4QNkYANo5+KACyEGD8AGb8rh7evgFBekiOiGmyDgBu-H78EEjZROHOCABS3ADyAHJpAL42jSAANCC5jgKOAEbBCH4YIDqykuDqtBzjXOMu4QC0JrTjbTbjYAK5CNMYROMAjABMAMzj0q2NQA",
+      "https://example.com/d/123?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAOIIoAi08yKA6gJYoAWA8gA74CGKDESAZwAUAHSREJRACQMwtBgDMG+dEQDKKPAyQBzAIRjJ0gG7KA7qoBq5gGIMANinwBJJOxgpDkqRE54efIJ2jipEVLCIqBzcvPwCwU54ru6e4t6+MYECAApcOto6qrn5uskeXgCURMBeEpARtEKy8kqhMnKoisp4ADREpggWJuZVNWlG9TSo1bVGRAB0i9kAEuFTKHYI9mACs0YZ-rGCQkoheKo+fgFxCfh97HkFFwfXgsUFo3tzTAhwAjPjOZGbRyAAeXyBvEQAhQXDg7AAqigoABZXaAoESZhcATMCFzAQAawY7HxRnweAgeDJklkNIkXCgRwBmMxdIxrKIKAInHpkihCBhcMRyLRfIk2hS4qIAigGWlPFhUGYkRQ-zGnMxYB4XGlEjgDEQABUeQg9URsbjzQhQU5BIFzacEAA5OFmjmsgC+0rlqBtKBZmoJDB0SHwgaDcxgAnDGsjmK4YDAeEF6PjmLDKDMVMJzjA5qMyq42jzBaI3o9Qa47HYEfTkiQbrLEkJCAIZYr9ckAhDjZQMBTafrnfjI81Y8xE8hEFh9gAwhAYKgaZbnf7iu7NZbsinTIucnlN5zYHgBFT8VPy19lQ4wHmhxIRyOvAp-DpVUQVmtVZttv9+J+qzUB+cYSvmgICPYMA6LMjaILMkyqiavIQbCTizLuDA9nEAAyWEBqB3ZyihQKYdhSCzBOUApjwCBgAAgigSJQM4Z6zPYOIoCiEBgF0dGMcxrEQF4nogD0IDGFwWhcAARvYgoYCAcYiCAzSdK01IYEQKlODCAC0iG0CpPReCpyYMMYCCllpKkAIwAEwAMwqWIomekAA",
     );
   });
 });


### PR DESCRIPTION
fixes #2516 

Currently we have been using a hardcoded string when generating the query we use to populate the explorer when the user clicks the switchboard button in connect.

This string is long out of date and does not work anymore.

Since we already generate the `GetDocumentWithOperationsDocument` in reactor browser, which we then use elsewhere, we can simply use the string value of the body of this query in this function instead. This will prevent future drift also.

The variables created were for `documentId`, which is no longer the correct name, should now be `identifier`, and `driveId`, which the explorer says is not a valid variable. I have updated the former and removed the latter.