### PR TITLE
fix(ci): pick docker tag matching branch channel

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -42,10 +42,28 @@ jobs:
         run: git fetch --tags origin
       - name: Set last tag
         id: get-tag
+        env:
+          BRANCH: ${{ github.ref_name }}
         run: |
-          TAG=$(git for-each-ref --sort=creatordate --format '%(refname:short)' refs/tags | tail -n 1)
-          echo "GITHUB_TAG=$TAG" >> $GITHUB_ENV
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          # Pick the most recent tag for the channel matching this branch.
+          # Same channel logic as `determine-downstream-params` in
+          # release-branch.yml. The previous "tail of all tags" picker would
+          # grab a tag from a sibling channel whenever, say, a
+          # `release/staging/*` cut happened after the most recent `-dev` tag —
+          # the nightly main pipeline would then build with that staging tag
+          # and overwrite Harbor's `staging` floating tag with main-branch code.
+          if [[ "$BRANCH" == "main" ]]; then
+            TAG=$(git tag --sort=-creatordate --list '*-dev.*' | head -n 1)
+          elif [[ "$BRANCH" == release/staging/* ]]; then
+            TAG=$(git tag --sort=-creatordate --list '*-staging.*' | head -n 1)
+          elif [[ "$BRANCH" == release/production/* ]]; then
+            TAG=$(git tag --sort=-creatordate | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+          else
+            echo "::error::Unknown branch '$BRANCH' — refusing to guess a tag"
+            exit 1
+          fi
+          echo "GITHUB_TAG=$TAG" >> "$GITHUB_ENV"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
       - name: Validate tag
         run: |
           if [ -z "${{ env.GITHUB_TAG }}" ]; then


### PR DESCRIPTION
## Summary

The Docker publish job's tag picker (`publish-docker-images.yml:46`) was channel-blind:

```yaml
TAG=$(git for-each-ref --sort=creatordate --format '%(refname:short)' refs/tags | tail -n 1)
```

This returns the most recent tag *in the entire repo*, regardless of branch. Whenever a sibling channel cut a tag after the current channel's most recent one, the workflow built with the wrong tag.

## What broke (May 5 nightly)

- `v6.0.0-dev.214` was created at 15:34 on May 4 by the previous main run.
- `v6.0.2-staging.6` was created at 17:28 on May 4 by a staging release.
- The May 5 03:11 main nightly ran `chore(release): publish 6.0.0-dev.214` — but the docker job picked **`v6.0.2-staging.6`** as its tag.
- All four images (registry, academy, switchboard, connect) were built from `main`, then pushed to Harbor under `:v6.0.2-staging.6` and the floating `:staging` tag.
- `update-k8s-academy` then bumped `tenants/staging/powerhouse-values.yaml` to `v6.0.2-staging.6`. **Staging tenant's academy is now running main-branch code.**

## Fix

Filter tags by channel matching the branch — same logic `determine-downstream-params` already uses in `release-branch.yml`:

| Branch                    | Pattern              |
| ------------------------- | -------------------- |
| `main`                    | `*-dev.*`            |
| `release/staging/*`       | `*-staging.*`        |
| `release/production/*`    | final `vX.Y.Z` semver |
| anything else             | fail loudly          |

Verified locally against the current tag set:

| Branch                        | Picked tag         |
| ----------------------------- | ------------------ |
| `main`                        | `v6.0.0-dev.214` ✓ |
| `release/staging/6.0.2`       | `v6.0.2-staging.6` |
| `release/production/1.0.0`    | `v5.3.6`           |
| `unknown`                     | (fails)            |

Also moved `${{ github.ref_name }}` into an `env:` block to follow the GitHub Actions injection-safety guidance.

## Test plan

- [ ] Merge and let the next nightly run prove out the picker. (Manual `workflow_dispatch` with `dry_run: true` won't exercise this job since `publish-docker` is gated on `dry_run != true`.)
- [ ] Recovery follow-ups (separate, not in this PR):
  - Re-run docker publish for `v6.0.0-dev.214` so coral-deer-49 et al. can roll forward.
  - Re-run the staging release pipeline for `release/staging/6.0.2` to overwrite Harbor's contaminated `:v6.0.2-staging.6` and `:staging` tags with the right code.