### PR TITLE
fix: add document drive header fallback for name field

### DIFF
--- a/packages/reactor-api/src/graphql/graphql-manager.ts
+++ b/packages/reactor-api/src/graphql/graphql-manager.ts
@@ -197,7 +197,7 @@ export class GraphQLManager {
           id: driveDoc.header.id,
           slug: driveDoc.header.slug,
           meta: driveDoc.header.meta,
-          name: driveDoc.state.global.name,
+          name: driveDoc.state.global.name || driveDoc.header.name,
           icon: driveDoc.state.global.icon ?? undefined,
           ...(graphqlEndpoint && { graphqlEndpoint }),
         });


### PR DESCRIPTION
Fixes #2529 

Add a fallback to the drive's name in the header if the name in the global state is empty.

@acaldas what does this even mean though? Like what is the drive's name actually supposed to be? Why do we still have both?