### PR TITLE
fix(registry): source /packages from verdaccio's authoritative list

### DIFF
--- a/packages/registry/src/middleware.ts
+++ b/packages/registry/src/middleware.ts
@@ -92,7 +92,59 @@ export function createPowerhouseRouter(
   );
 
   // Package listing API
-  router.get("/packages", (req: Request, res: Response) => {
+  router.get("/packages", async (req: Request, res: Response) => {
+    // Verdaccio's S3-backed metadata is the source of truth for "what
+    // packages exist on this registry". The local cdn-cache is per-pod
+    // ephemeral on emptyDir-mode tenants, so enumerating from disk would
+    // silently drop packages on every pod restart.
+    //
+    // We hit verdaccio's own listing first to get the authoritative names +
+    // latest versions, then warm the cdn-cache concurrently for any package
+    // whose tarball hasn't been extracted yet on this pod. That gives us a
+    // complete /packages response including manifests on the very first
+    // call after a cold start, with subsequent calls hitting warm cache.
+    let knownPackages: Array<{ name: string; version?: string }> = [];
+    try {
+      const r = await fetch(
+        `http://localhost:${config.port}/-/verdaccio/data/packages`,
+      );
+      if (r.ok) {
+        knownPackages = (await r.json()) as Array<{
+          name: string;
+          version?: string;
+        }>;
+      } else {
+        console.error(
+          `[registry] verdaccio package listing returned ${r.status}`,
+        );
+      }
+    } catch (err) {
+      console.error("[registry] failed to enumerate packages:", err);
+    }
+
+    if (knownPackages.length > 0) {
+      // Bound concurrency so the burst of fetch+extract work doesn't drown
+      // the pod on first request after a cold start.
+      const concurrency = 8;
+      let cursor = 0;
+      const workers = Array.from({ length: concurrency }).map(async () => {
+        while (cursor < knownPackages.length) {
+          const idx = cursor++;
+          const pkg = knownPackages[idx];
+          if (!pkg.version) continue;
+          try {
+            await cdn.extractTarball(pkg.name, pkg.version);
+          } catch (err) {
+            console.error(
+              `[registry] failed to warm cache for ${pkg.name}@${pkg.version}:`,
+              err,
+            );
+          }
+        }
+      });
+      await Promise.all(workers);
+    }
+
     const packages = scanPackages(config.cdnCachePath, config.storagePath);
     const documentType = req.query.documentType as string | undefined;
     if (documentType) {


### PR DESCRIPTION
## Summary
- Symptom: https://staging.vetra.io/packages went empty after dev pods rolled this morning. Registry's `/packages` endpoint was returning `[]`, even though verdaccio's S3-backed storage still had all 30 packages.
- Root cause: our custom `/packages` enumerated by reading the local `cdn-cache/` directory. After tenants moved to `persistence.kind=emptyDir` for horizontal scaling, that cache wipes on every pod restart and is per-replica anyway.
- Fix: hit verdaccio's own `/-/verdaccio/data/packages` (source of truth, shared via S3), then warm the local cdn-cache concurrently for packages whose tarballs haven't been extracted on this pod yet. Bounded concurrency (8) so cold-start doesn't fan out the world. First request after pod start does the work; subsequent ones hit warm cache.

Same family of bug as the registry login issue I just fixed — local per-pod state where there should be shared truth.

## Test plan
- [ ] All 29 existing registry tests still pass (`pnpm test` in `packages/registry`)
- [ ] Deploy + curl `/packages` against `registry.dev.vetra.io` — should return ~30 entries with manifests
- [ ] Reload https://staging.vetra.io/packages — should render the package grid
- [ ] Hit `/packages` from cold-start pod (e.g. after `kubectl rollout restart`); first request slow, second snappy