### PR TITLE
fix(registry): make /packages non-blocking, warm cdn-cache in background

### DIFF
--- a/packages/registry/src/middleware.ts
+++ b/packages/registry/src/middleware.ts
@@ -91,46 +91,34 @@ export function createPowerhouseRouter(
     },
   );
 
-  // Package listing API
-  router.get("/packages", async (req: Request, res: Response) => {
-    // Verdaccio's S3-backed metadata is the source of truth for "what
-    // packages exist on this registry". The local cdn-cache is per-pod
-    // ephemeral on emptyDir-mode tenants, so enumerating from disk would
-    // silently drop packages on every pod restart.
-    //
-    // We hit verdaccio's own listing first to get the authoritative names +
-    // latest versions, then warm the cdn-cache concurrently for any package
-    // whose tarball hasn't been extracted yet on this pod. That gives us a
-    // complete /packages response including manifests on the very first
-    // call after a cold start, with subsequent calls hitting warm cache.
-    let knownPackages: Array<{ name: string; version?: string }> = [];
+  // Module-scoped flag: at most one warm-up runs at a time per pod.
+  // Re-entry is cheap (extractTarball already dedups in-flight extractions),
+  // but skipping kicks off the worker pool when one is already grinding lets
+  // hot paths (readiness probes, /packages requests) stay non-blocking.
+  let warmInFlight = false;
+  async function warmCdnCacheFromVerdaccio(): Promise<void> {
+    if (warmInFlight) return;
+    warmInFlight = true;
     try {
       const r = await fetch(
         `http://localhost:${config.port}/-/verdaccio/data/packages`,
       );
-      if (r.ok) {
-        knownPackages = (await r.json()) as Array<{
-          name: string;
-          version?: string;
-        }>;
-      } else {
+      if (!r.ok) {
         console.error(
           `[registry] verdaccio package listing returned ${r.status}`,
         );
+        return;
       }
-    } catch (err) {
-      console.error("[registry] failed to enumerate packages:", err);
-    }
-
-    if (knownPackages.length > 0) {
-      // Bound concurrency so the burst of fetch+extract work doesn't drown
-      // the pod on first request after a cold start.
+      const known = (await r.json()) as Array<{
+        name: string;
+        version?: string;
+      }>;
       const concurrency = 8;
       let cursor = 0;
       const workers = Array.from({ length: concurrency }).map(async () => {
-        while (cursor < knownPackages.length) {
+        while (cursor < known.length) {
           const idx = cursor++;
-          const pkg = knownPackages[idx];
+          const pkg = known[idx];
           if (!pkg.version) continue;
           try {
             await cdn.extractTarball(pkg.name, pkg.version);
@@ -143,8 +131,26 @@ export function createPowerhouseRouter(
         }
       });
       await Promise.all(workers);
+      console.log(`[registry] /packages warm-up done (${known.length} pkgs)`);
+    } catch (err) {
+      console.error("[registry] /packages warm-up failed:", err);
+    } finally {
+      warmInFlight = false;
     }
+  }
 
+  // Kick off an initial warm so /packages is useful soon after pod start
+  // even if no clients hit it. Fire-and-forget — must not block the listener.
+  void warmCdnCacheFromVerdaccio();
+
+  // Package listing API.
+  // Returns whatever's currently in the local cdn-cache (instant response —
+  // important: this endpoint is wired to the deployment's readiness probe,
+  // so it must not synchronously fetch or extract). Each call also nudges
+  // a background warm-up so newly-published packages appear in the listing
+  // without operator intervention.
+  router.get("/packages", (req: Request, res: Response) => {
+    void warmCdnCacheFromVerdaccio();
     const packages = scanPackages(config.cdnCachePath, config.storagePath);
     const documentType = req.query.documentType as string | undefined;
     if (documentType) {


### PR DESCRIPTION
## Summary
Fixes a regression introduced by #2567: that PR's synchronous warm-up inside the \`/packages\` handler caused the deployment's readiness probe (which httpGet's \`/packages\` with \`timeoutSeconds: 3\`) to time out on cold-start pods. ArgoCD rollout to v6.0.0-dev.219 got stuck because new pods never became ready.

This PR moves the warm-up to a background fire-and-forget task. \`/packages\` returns instantly from the local cdn-cache (same as before #2567), and a single warm worker keeps the cache converging on the verdaccio source-of-truth in the background.

## Behavior
- Initial warm fires on registry startup → caches converge even with no traffic
- Every \`/packages\` request triggers another warm (debounced — at most one in flight at a time)
- Probe-friendly: handler is one synchronous scan, no awaiting

## Test plan
- [ ] All 29 existing registry tests pass (\`pnpm test\` in \`packages/registry\`)
- [ ] On cold-start, pod becomes ready within probe window
- [ ] First few \`/packages\` calls may return sparse data, but after ~10s warm-up window returns full set
- [ ] \`https://staging.vetra.io/packages\` populates within one revalidate cycle (30s)