### PR TITLE
fix(release): retry git push with rebase + add workflow concurrency

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -8,6 +8,13 @@ permissions:
   contents: write
   packages: write
 
+# Share the release-monorepo concurrency group so a standalone
+# workflow_dispatch of this workflow cannot run alongside a release-branch
+# run that's about to invoke this same workflow as a downstream step.
+concurrency:
+  group: release-monorepo-${{ github.ref_name }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   HARBOR_REGISTRY: cr.vetra.io

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -44,6 +44,14 @@ permissions:
   packages: write
   id-token: write
 
+# Serialize releases per branch. Two simultaneous releases would both bump
+# versions, both publish to npm (one claiming the next dev.X tag, the other
+# failing on republish), and race on git push. Queue rather than cancel —
+# releases shouldn't be aborted mid-publish.
+concurrency:
+  group: release-monorepo-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Release packages in monorepo

--- a/releases/release.ts
+++ b/releases/release.ts
@@ -386,20 +386,12 @@ const app = command({
     }
 
     if (gitPush && didCommit) {
-      const gitPushCommitCmd = [
-        "git",
-        "push",
-        "origin",
-        "HEAD",
-        "--follow-tags",
-      ];
-      console.log(
-        `Pushing the current commit in git with the following command: ${gitPushCommitCmd.join(" ")}`,
-      );
-      const result = runCommandWithBun(gitPushCommitCmd);
-      if (result.exitCode !== 0) {
-        throw new Error("Failed to push commit with git");
-      }
+      // Push with rebase retry. By the time we get here npm has already been
+      // poisoned (immutable versions), so a stuck push is the worst possible
+      // outcome — it leaves an orphaned tag that prevents the next release
+      // from reusing the version. Rebase the chore commit on top of the
+      // latest remote tip and try again.
+      pushWithRebaseRetry({ workspaceVersion, gitTag });
     }
     console.log(">>> Release successfully completed 🚀");
     process.exit(0);
@@ -420,4 +412,84 @@ function runCommandWithBun(
       ...env,
     },
   });
+}
+
+/**
+ * Push the chore-release commit (and optional tag) to origin, rebasing on top
+ * of the remote branch if the push is rejected for being non-fast-forward.
+ *
+ * This protects against the standard race: another PR merges to the same
+ * branch while the release is mid-flight (the npm publish step takes minutes,
+ * leaving a wide window). Without retry the chore commit is stranded, the
+ * tag is orphaned, and the npm package is already published, so the next
+ * release attempt can't reuse the version. With retry, the chore commit
+ * rebases over the new tip and we push again.
+ */
+function pushWithRebaseRetry(opts: {
+  workspaceVersion: string;
+  gitTag: boolean;
+}): void {
+  const branch = getBranchName();
+  const tag = `v${opts.workspaceVersion}`;
+  const maxAttempts = 4;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const cmd = ["git", "push", "origin", "HEAD", "--follow-tags"];
+    console.log(
+      `Push attempt ${attempt}/${maxAttempts} on ${branch}: ${cmd.join(" ")}`,
+    );
+    const result = runCommandWithBun(cmd);
+    if (result.exitCode === 0) {
+      console.log("Push succeeded.");
+      return;
+    }
+
+    if (attempt === maxAttempts) {
+      throw new Error(
+        `Failed to push commit with git after ${maxAttempts} attempts`,
+      );
+    }
+
+    console.warn(
+      `Push rejected (likely non-fast-forward race). Rebasing onto origin/${branch} and retrying.`,
+    );
+
+    const fetch = runCommandWithBun(["git", "fetch", "origin", branch]);
+    if (fetch.exitCode !== 0) {
+      throw new Error("Failed to fetch origin during push retry");
+    }
+
+    // Annotated tag is bound to the old chore commit's SHA. After we rebase,
+    // that commit will have a new SHA, so drop the local tag and recreate it
+    // post-rebase. The tag wasn't pushed (push was rejected) so there's
+    // nothing to undo on the remote.
+    if (opts.gitTag) {
+      runCommandWithBun(["git", "tag", "-d", tag]);
+    }
+
+    const rebase = runCommandWithBun(["git", "rebase", `origin/${branch}`]);
+    if (rebase.exitCode !== 0) {
+      // Conflict between the chore commit (touches package.json + CHANGELOG.md)
+      // and an unrelated PR that touched the same files. Bail loudly — npm
+      // is already poisoned and we need an operator to fix this manually.
+      runCommandWithBun(["git", "rebase", "--abort"]);
+      throw new Error(
+        `Rebase onto origin/${branch} during push retry conflicted; manual intervention required`,
+      );
+    }
+
+    if (opts.gitTag) {
+      const retag = runCommandWithBun([
+        "git",
+        "tag",
+        "--annotate",
+        tag,
+        "--message",
+        tag,
+      ]);
+      if (retag.exitCode !== 0) {
+        throw new Error(`Failed to recreate tag ${tag} after rebase`);
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Why

Twice today the release pipeline failed at the very last step (\`git push origin HEAD --follow-tags\`) because a regular PR merged to main during the multi-minute window between \`pnpm build\` and \`git push\`. By the time we reach the push, npm already has the new package version (immutable), the chore-release commit is local-only on the runner, and the next manual rerun tries to bump to the same tag → \`fatal: tag 'vX.Y.Z' already exists\` → stuck.

## What

Two layered fixes:

### 1. Push retry with rebase (\`releases/release.ts\`)
On a rejected push, the new \`pushWithRebaseRetry\` helper:
- \`git fetch origin <branch>\`
- Drops the local annotated tag (it's bound to the old chore SHA; will recreate)
- \`git rebase origin/<branch>\` (replays the chore commit on top)
- Recreates the annotated tag at the new SHA
- Retries the push (up to 4 attempts total)

Conflicts during rebase abort and fail loudly. Concurrent edits to package.json / CHANGELOG.md from unrelated PRs are rare and shouldn't auto-resolve.

### 2. Workflow concurrency
Both \`release-branch.yml\` and \`publish-docker-images.yml\` now share the group \`release-monorepo-\${ github.ref_name }\` with \`cancel-in-progress: false\`. Prevents:
- Cron-triggered release racing a manual one.
- A standalone \`publish-docker-images\` \`workflow_dispatch\` running alongside the release-branch run that's about to invoke it as a downstream step.

## Test plan
- [ ] Workflow YAML lints OK (GitHub will run validation when the PR opens).
- [ ] Next release run completes through to the final push and exits 0.
- [ ] Force a race by triggering two releases back-to-back; second one queues, no overlap, no orphaned tags.
- [ ] (Manual / observational) If a PR merges during a release run, the push gets one retry that succeeds, log shows \`Push attempt 2/4\` then \`Push succeeded.\`