### PR TITLE
chore(release): bump manifest to 6.0.0-dev.221

### DIFF
--- a/apps/academy/package.json
+++ b/apps/academy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/academy",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "homepage": "https://powerhouse.academy",
   "packageManager": "pnpm@10.9.0",
   "repository": {

--- a/apps/connect/package.json
+++ b/apps/connect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@powerhousedao/connect",
   "productName": "Powerhouse-Connect",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "description": "Powerhouse Connect",
   "main": "dist/index.html",
   "type": "module",

--- a/apps/switchboard/package.json
+++ b/apps/switchboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@powerhousedao/switchboard",
   "type": "module",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "main": "dist/index.mjs",
   "exports": {
     ".": {

--- a/packages/analytics-engine/benchmarks/package.json
+++ b/packages/analytics-engine/benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "benchmarks",
   "private": true,
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "publishConfig": {
     "access": "restricted"
   },

--- a/packages/analytics-engine/browser/package.json
+++ b/packages/analytics-engine/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/analytics-engine-browser",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/packages/analytics-engine/compat/package.json
+++ b/packages/analytics-engine/compat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "compat",
   "private": true,
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "publishConfig": {
     "access": "restricted"
   },

--- a/packages/analytics-engine/core/package.json
+++ b/packages/analytics-engine/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/analytics-engine-core",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/packages/analytics-engine/graphql/package.json
+++ b/packages/analytics-engine/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/analytics-engine-graphql",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/packages/analytics-engine/knex/package.json
+++ b/packages/analytics-engine/knex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/analytics-engine-knex",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/packages/analytics-engine/package.json
+++ b/packages/analytics-engine/package.json
@@ -18,5 +18,5 @@
     "jiti": "2.6.1",
     "@powerhousedao/shared": "workspace:*"
   },
-  "version": "6.0.0-dev.220"
+  "version": "6.0.0-dev.221"
 }

--- a/packages/analytics-engine/pg/package.json
+++ b/packages/analytics-engine/pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/analytics-engine-pg",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/packages/builder-tools/package.json
+++ b/packages/builder-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/builder-tools",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "type": "module",
   "license": "AGPL-3.0-only",
   "publishConfig": {

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/codegen",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "license": "AGPL-3.0-only",
   "private": false,
   "type": "module",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/common",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "license": "AGPL-3.0-only",
   "type": "module",
   "files": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/config",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "description": "",
   "license": "AGPL-3.0-only",
   "private": false,

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/design-system",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "description": "",
   "files": [
     "dist",

--- a/packages/document-model/package.json
+++ b/packages/document-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "document-model",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "license": "AGPL-3.0-only",
   "private": false,
   "files": [

--- a/packages/opentelemetry-instrumentation-reactor/package.json
+++ b/packages/opentelemetry-instrumentation-reactor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/opentelemetry-instrumentation-reactor",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "description": "OpenTelemetry instrumentation for @powerhousedao/reactor",
   "type": "module",
   "sideEffects": false,

--- a/packages/powerhouse-vetra-packages/package.json
+++ b/packages/powerhouse-vetra-packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/powerhouse-vetra-packages",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "description": "",
   "keywords": [],
   "author": "",

--- a/packages/reactor-api/package.json
+++ b/packages/reactor-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/reactor-api",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "description": "",
   "type": "module",
   "repository": {

--- a/packages/reactor-attachments/package.json
+++ b/packages/reactor-attachments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/reactor-attachments",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "license": "AGPL-3.0-only",
   "type": "module",
   "repository": {

--- a/packages/reactor-browser/package.json
+++ b/packages/reactor-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/reactor-browser",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "license": "AGPL-3.0-only",
   "type": "module",
   "repository": {

--- a/packages/reactor-hypercore/package.json
+++ b/packages/reactor-hypercore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/reactor-hypercore",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "description": "Hypercore-backed IOperationStore for the Powerhouse Reactor",
   "repository": {
     "url": "https://github.com/powerhouse-inc/powerhouse",

--- a/packages/reactor-mcp/package.json
+++ b/packages/reactor-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/reactor-mcp",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "description": "MCP server for document model operations in the Powerhouse ecosystem. For document model creation tasks, consider using the document-model-creator agent which provides a more guided experience.",
   "type": "module",
   "repository": {

--- a/packages/reactor/package.json
+++ b/packages/reactor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/reactor",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "description": "",
   "repository": {
     "url": "https://github.com/powerhouse-inc/powerhouse",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/registry",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "description": "",
   "type": "module",
   "repository": {

--- a/packages/renown/package.json
+++ b/packages/renown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renown/sdk",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "description": "",
   "license": "AGPL-3.0-only",
   "private": false,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/shared",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "type": "module",
   "sideEffects": false,
   "publishConfig": {

--- a/packages/switchboard-gui/package.json
+++ b/packages/switchboard-gui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@powerhousedao/switchboard-gui",
   "private": true,
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/vetra/package.json
+++ b/packages/vetra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/vetra",
-  "version": "6.0.0-dev.220",
+  "version": "6.0.0-dev.221",
   "license": "AGPL-3.0-only",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- Realign package manifests with the `v6.0.0-dev.221` tag and npm publish that already landed from a previous release run.
- The companion bump commit from that run was never pushed to `main` (likely a race with concurrent pushes), leaving `package.json` at `6.0.0-dev.220` while npm `dev` and the git tag both point at `221`.
- Without this bump, the release workflow keeps trying to recreate the existing `v6.0.0-dev.221` tag and fails with `fatal: tag 'v6.0.0-dev.221' already exists` (see [run 25438961276](https://github.com/powerhouse-inc/powerhouse/actions/runs/25438961276/job/74624577835)).

## Test plan
- [ ] Merge, then re-run the release workflow on `main` and confirm it bumps cleanly to `6.0.0-dev.222`.