### PR TITLE
fix(renown,registry): pass audience to verifyAuthBearerToken

### DIFF
--- a/packages/registry/src/auth/renown-middleware.ts
+++ b/packages/registry/src/auth/renown-middleware.ts
@@ -74,7 +74,12 @@ export function createRenownAuthMiddleware(opts: RenownAuthOptions) {
 
     let verified: Awaited<ReturnType<typeof verifyAuthBearerToken>>;
     try {
-      verified = await verifyAuthBearerToken(token);
+      // Pass `audience` so did-jwt validates the `aud` claim itself. Tokens
+      // minted by ph-cli for this registry carry aud=publicUrl; if we don't
+      // tell did-jwt what audience to accept, it throws
+      // `invalid_config: JWT audience is required but your app address has
+      // not been configured` and we silently fall through.
+      verified = await verifyAuthBearerToken(token, { audience: expectedAud });
     } catch {
       return next();
     }
@@ -82,6 +87,9 @@ export function createRenownAuthMiddleware(opts: RenownAuthOptions) {
       return next();
     }
 
+    // Defence-in-depth: did-jwt's `audience` option already enforced this,
+    // but verify the claim again in case verifyAuthBearerToken's behavior
+    // ever changes (e.g. silently passing without checking).
     const payload = verified.payload as JwtPayloadShape | undefined;
     if (!audienceMatches(payload?.aud, expectedAud)) {
       return next();

--- a/packages/renown/src/utils.ts
+++ b/packages/renown/src/utils.ts
@@ -50,8 +50,17 @@ export function parsePkhDid(did: string): PKHDid {
   };
 }
 
+export interface VerifyAuthBearerTokenOptions {
+  /** Expected `aud` claim. Required when verifying tokens that include an
+   *  audience claim — did-jwt rejects them otherwise with
+   *  `invalid_config: JWT audience is required but your app address has not
+   *  been configured`. Tokens minted without `aud` are unaffected. */
+  audience?: string;
+}
+
 export async function verifyAuthBearerToken(
   jwt: string,
+  options?: VerifyAuthBearerTokenOptions,
 ): Promise<false | AuthVerifiedCredential> {
   try {
     const now = parseInt(String(Date.now() / 1000));
@@ -59,6 +68,7 @@ export async function verifyAuthBearerToken(
       jwt,
       getResolver(),
       {
+        ...(options?.audience !== undefined && { audience: options.audience }),
         policies: {
           now: parseInt(String(Date.now() / 1000)),
           expirationDate: true,


### PR DESCRIPTION
## Symptom

After dev.221 rolled (renown CLI args wired in correctly), the registry pod's startup banner correctly prints \`Renown auth: https://registry.dev.vetra.io\` and the env vars are read by cmd-ts. But hitting \`/-/whoami\` with a fresh, valid Renown bearer token still returns \`{}\` (anonymous), and \`ph publish\` still gets E401.

## Root cause

\`@renown/sdk\`'s \`verifyAuthBearerToken\` calls did-jwt-vc's \`verifyCredential\` without an \`audience\` option. When the JWT carries an \`aud\` claim — which our \`ph-cli\` does on every registry token, by design, for cross-service isolation — did-jwt throws:

\`\`\`
invalid_config: JWT audience is required but your app address has not been configured
\`\`\`

even though the token is otherwise perfectly valid. The SDK's catch returns \`false\`. Our middleware then silently falls through to verdaccio's anonymous-user path. End result: tokens with \`aud\` are *always* rejected.

Reproduced locally:

\`\`\`js
await verifyAuthBearerToken(token);
// Error: invalid_config: JWT audience is required but your app address has not been configured

await verifyAuthBearerToken(token, { audience: 'https://registry.dev.vetra.io' });
// → verified ok, address extracted

await verifyAuthBearerToken(token, { audience: 'https://wrong.example' });
// → false (did-jwt rejects on audience mismatch)
\`\`\`

## Fix

- **renown SDK** (\`packages/renown/src/utils.ts\`): \`verifyAuthBearerToken\` now accepts an optional \`{ audience }\` option, forwarded to did-jwt-vc. Backwards compatible — tokens without \`aud\` still work as before.
- **registry middleware** (\`packages/registry/src/auth/renown-middleware.ts\`): pass \`{ audience: opts.publicUrl }\`. Kept the explicit \`audienceMatches\` check as belt-and-braces.

## Test plan

- [ ] All 29 registry tests still pass.
- [ ] \`curl -H \"Authorization: Bearer …\" /-/whoami\` returns the user's address (not \`{}\`).
- [ ] Wrong-audience token → still anonymous (verdaccio sees no auth).
- [ ] \`ph publish\` succeeds end-to-end against \`registry.dev.vetra.io\`.