### PR TITLE
feat(ph-cli): run migrate with target codegen version

### DIFF
--- a/clis/ph-cli/src/services/migrate.ts
+++ b/clis/ph-cli/src/services/migrate.ts
@@ -24,24 +24,45 @@ function getBundledPhCliVersion(): string | undefined {
 export async function startMigrate({
   versionPositional,
   version,
+  force,
   debug,
 }: MigrateArgs) {
   const requested = versionPositional ?? version;
   if (debug) console.log(`[migrate] requested version: ${requested}`);
 
-  const targetVersion = await fetchPackageVersionFromNpmRegistry(
-    `@powerhousedao/ph-cli@${requested}`,
-  );
-  const bundledVersion = getBundledPhCliVersion();
-  if (debug) {
-    console.log(`[migrate] resolved target version: ${targetVersion}`);
-    console.log(`[migrate] current ph-cli version: ${bundledVersion}`);
+  let targetVersion: string | undefined;
+  try {
+    targetVersion = await fetchPackageVersionFromNpmRegistry(
+      `@powerhousedao/ph-cli@${requested}`,
+    );
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    if (!force) {
+      throw new Error(
+        `Failed to resolve "${requested}" from the npm registry: ${reason}\nRe-run with --force to migrate using the installed version.`,
+      );
+    }
+    if (debug) {
+      console.log(
+        `[migrate] failed to resolve target version, --force is set, falling back to bundled codegen: ${reason}`,
+      );
+    }
   }
 
-  if (targetVersion === bundledVersion) {
+  const bundledVersion = getBundledPhCliVersion();
+  if (debug) {
+    console.log(
+      `[migrate] resolved target version: ${targetVersion ?? "(unknown)"}`,
+    );
+    console.log(
+      `[migrate] current ph-cli version: ${bundledVersion ?? "(unknown)"}`,
+    );
+  }
+
+  if (!targetVersion || force || targetVersion === bundledVersion) {
     if (debug) console.log(`[migrate] running migrate from bundled codegen`);
     const { migrate } = await import("@powerhousedao/codegen");
-    await migrate(targetVersion);
+    await migrate(targetVersion ?? requested);
     return;
   }
 

--- a/clis/ph-cli/src/services/migrate.ts
+++ b/clis/ph-cli/src/services/migrate.ts
@@ -1,10 +1,68 @@
-import { migrate } from "@powerhousedao/codegen";
+import { fetchPackageVersionFromNpmRegistry } from "@powerhousedao/shared/clis";
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { detect, resolveCommand } from "package-manager-detector";
 import type { MigrateArgs } from "../types.js";
 
-export async function startMigrate(args: MigrateArgs) {
-  const { version, debug } = args;
-  if (debug) {
-    console.log({ args });
+function getBundledPhCliVersion(): string | undefined {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 5; i++) {
+    try {
+      const pkg = JSON.parse(
+        readFileSync(join(dir, "package.json"), "utf8"),
+      ) as { name?: string; version?: string };
+      if (pkg.name === "@powerhousedao/ph-cli") return pkg.version;
+    } catch {
+      // keep walking
+    }
+    dir = dirname(dir);
   }
-  await migrate(version);
+}
+
+export async function startMigrate({
+  versionPositional,
+  version,
+  debug,
+}: MigrateArgs) {
+  const requested = versionPositional ?? version;
+  if (debug) console.log(`[migrate] requested version: ${requested}`);
+
+  const targetVersion = await fetchPackageVersionFromNpmRegistry(
+    `@powerhousedao/ph-cli@${requested}`,
+  );
+  const bundledVersion = getBundledPhCliVersion();
+  if (debug) {
+    console.log(`[migrate] resolved target version: ${targetVersion}`);
+    console.log(`[migrate] current ph-cli version: ${bundledVersion}`);
+  }
+
+  if (targetVersion === bundledVersion) {
+    if (debug) console.log(`[migrate] running migrate from bundled codegen`);
+    const { migrate } = await import("@powerhousedao/codegen");
+    await migrate(targetVersion);
+    return;
+  }
+
+  const agent = (await detect())?.agent ?? "npm";
+  const resolved = resolveCommand(agent, "execute", [
+    `@powerhousedao/ph-cli@${targetVersion}`,
+    "migrate",
+    "--version",
+    targetVersion,
+    ...(debug ? ["--debug"] : []),
+  ]);
+  if (!resolved) {
+    throw new Error(
+      `Failed to resolve execute command for package manager "${agent}".`,
+    );
+  }
+
+  const command = `${resolved.command} ${resolved.args.join(" ")}`;
+  if (debug) {
+    console.log(`[migrate] detected package manager: ${agent}`);
+    console.log(`[migrate] re-executing: ${command}`);
+  }
+  execSync(command, { stdio: "inherit" });
 }

--- a/packages/codegen/src/templates/boilerplate/document-models/document-models.ts
+++ b/packages/codegen/src/templates/boilerplate/document-models/document-models.ts
@@ -5,7 +5,6 @@ export const documentModelsTemplate = ts`
  * WARNING: DO NOT EDIT
  * This file is auto-generated and updated by codegen
  */
-import type { DocumentModelModule } from "document-model";
 
 export const documentModels = [] as const;
 `.raw;

--- a/packages/shared/clis/args/migrate.ts
+++ b/packages/shared/clis/args/migrate.ts
@@ -1,7 +1,13 @@
-import { option, string } from "cmd-ts";
+import { option, optional, positional, string } from "cmd-ts";
 import { debugArgs } from "./common.js";
 
 export const migrateArgs = {
+  versionPositional: positional({
+    type: optional(string),
+    displayName: "version",
+    description:
+      "The version to migrate to. Accepts a valid semver version or `staging`, `dev`, `latest`.",
+  }),
   version: option({
     long: "version",
     short: "v",

--- a/packages/shared/clis/args/migrate.ts
+++ b/packages/shared/clis/args/migrate.ts
@@ -1,4 +1,4 @@
-import { option, optional, positional, string } from "cmd-ts";
+import { boolean, flag, option, optional, positional, string } from "cmd-ts";
 import { debugArgs } from "./common.js";
 
 export const migrateArgs = {
@@ -16,6 +16,13 @@ export const migrateArgs = {
       "The version to migrate to. Accepts a valid semver version or `staging`, `dev`, `latest`.",
     defaultValue: () => "latest" as const,
     defaultValueIsSerializable: true,
+  }),
+  force: flag({
+    type: optional(boolean),
+    long: "force",
+    short: "f",
+    description:
+      "Run migrate from the bundled codegen even if the target version cannot be resolved from the npm registry or differs from the installed ph-cli version.",
   }),
   ...debugArgs,
 };


### PR DESCRIPTION
## Summary
- `ph migrate <version>` was running the migration logic bundled with the locally installed `@powerhousedao/codegen`, regardless of the requested version. Now `startMigrate` compares the target version against the bundled ph-cli version: on match it runs the local `migrate` directly; otherwise it re-execs via the user's package manager (`npx` / `pnpm dlx` / `yarn dlx` / `bunx`) against `@powerhousedao/ph-cli@<version>`, so the migration code matches the target stack.
- Accepts the version as a positional (`ph migrate <version>`) in addition to `-v` / `--version`.

## Test plan
- [ ] `ph migrate <bundled-version>` takes the fast path and runs migrate locally.
- [ ] `ph migrate <other-version>` re-execs via the detected package manager.
- [ ] `ph migrate latest` (and `staging`/`dev`) still works — always re-execs since tags don't string-equal the bundled semver.
- [ ] Both `ph migrate 6.0.0-dev.221` and `ph migrate -v 6.0.0-dev.221` resolve to the same target.