### PR TITLE
ci(publish-docker): auto-bump dev tenant switchboard + connect tags

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -210,6 +210,53 @@ jobs:
             -d "{\"query\":\"mutation { notifyNewImageRelease(input: { tag: \\\"${TAG}\\\", channel: \\\"${CHANNEL}\\\", images: [\\\"switchboard\\\", \\\"connect\\\"], secret: \\\"${WEBHOOK_SECRET}\\\" }) { updatedEnvironments } }\"}" \
             || echo "Auto-update notification failed (non-fatal)"
 
+  update-k8s-switchboard-connect:
+    name: Update Switchboard + Connect Images in K8s Hosting
+    needs: build
+    if: ${{ needs.build.outputs.tag != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine target environments
+        id: env
+        env:
+          TAG: ${{ needs.build.outputs.tag }}
+        run: |
+          if [[ "$TAG" == *"-dev."* ]]; then
+            echo "targets=dev" >> $GITHUB_OUTPUT
+          else
+            echo "Skipping k8s update — switchboard+connect auto-bump is scoped to the -dev. channel only"
+          fi
+
+      - name: Update switchboard + connect image tags in k8s-hosting
+        if: ${{ steps.env.outputs.targets != '' }}
+        env:
+          TAG: ${{ needs.build.outputs.tag }}
+          TARGETS: ${{ steps.env.outputs.targets }}
+          K8S_REPO_PAT: ${{ secrets.K8S_REPO_PAT }}
+        run: |
+          git clone "https://x-access-token:${K8S_REPO_PAT}@github.com/powerhouse-inc/powerhouse-k8s-hosting.git"
+          cd powerhouse-k8s-hosting
+
+          git config user.name "Github Actions Bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          for TARGET_ENV in $TARGETS; do
+            VALUES_FILE="tenants/${TARGET_ENV}/powerhouse-values.yaml"
+            # Update switchboard image tag (line after switchboard's repository line)
+            sed -i '/repository: cr.vetra.io\/powerhouse-inc-powerhouse\/switchboard/{n;s/\(.*tag: \).*/\1'"${TAG}"'/}' "$VALUES_FILE"
+            # Update connect image tag (line after connect's repository line)
+            sed -i '/repository: cr.vetra.io\/powerhouse-inc-powerhouse\/connect/{n;s/\(.*tag: \).*/\1'"${TAG}"'/}' "$VALUES_FILE"
+            git add "$VALUES_FILE"
+          done
+
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore(${TARGETS// /,}): update switchboard + connect image tags to ${TAG}"
+          for i in 1 2 3; do
+            git pull --rebase origin main && git push && break
+            echo "Push attempt $i failed, retrying..."
+            sleep 5
+          done
+
   update-k8s-registry:
     name: Update Registry Image in K8s Hosting
     needs: build


### PR DESCRIPTION
## Summary

Extends `.github/workflows/publish-docker-images.yml` with one new job — `update-k8s-switchboard-connect` — that, after the switchboard + connect images are built and pushed for a `-dev.N` tag from `main`, clones the `powerhouse-k8s-hosting` repo and bumps the dev tenant's two image tags.

Mirrors the existing `update-k8s-academy` / `update-k8s-registry` jobs in the same file: same git identity (`Github Actions Bot`), same `K8S_REPO_PAT`, same retry-on-push pattern, same `chore(...)` commit message shape.

## What gets committed downstream

```
diff --git a/tenants/dev/powerhouse-values.yaml b/tenants/dev/powerhouse-values.yaml
@@ switchboard:
   image:
     repository: cr.vetra.io/powerhouse-inc-powerhouse/switchboard
-    tag: v6.0.0-dev.164
+    tag: v6.0.0-dev.239
@@ connect:
   image:
     repository: cr.vetra.io/powerhouse-inc-powerhouse/connect
-    tag: v6.0.0-dev.164
+    tag: v6.0.0-dev.239
```

Single commit per build, signed by `github-actions[bot]`.

## Scope

- `-dev.N` tags → `dev` tenant only (this PR).
- `-staging.N` and production tags are deliberately not bumped here. The staging tenant for switchboard/connect is currently pinned by hand; extending to staging is a one-line `targets` change when desired.

## Why

Today the dev tenant pin lives in `tenants/dev/powerhouse-values.yaml` and only updates via hand-written PRs. After powerhouse#2590 (OTel + Sentry bootstrap consolidation) landed at 09:03Z and produced `v6.0.0-dev.239` at 09:40Z, dev was still on `v6.0.0-dev.164` with no automation to catch up. This closes that gap.

## Test plan

- [ ] Run the workflow manually via `workflow_dispatch` on this branch (uses the latest tag — no actual k8s-hosting write because the job only runs for `-dev.N` tags from a main-style branch).
- [ ] After merge, the next nightly main build that produces a new `-dev.N` tag should emit a `chore(dev): update switchboard + connect image tags to ...` commit on `powerhouse-k8s-hosting` main.
- [ ] ArgoCD picks up the change and rolls the dev switchboard + connect deployments.