### PR TITLE
fix(release): resolve release tag by channel, not by HEAD

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -57,6 +57,12 @@ jobs:
     name: Release packages in monorepo
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      # Tag the release step just created (release.ts writes this directly to
+      # $GITHUB_OUTPUT). Empty when no version bump happened, when --skip-git-tag
+      # is set, or when release.ts exits early — downstream jobs (notably
+      # publish-ph-binaries) gate on this so they only run for real releases.
+      tag: ${{ steps.run-release.outputs.tag }}
     steps:
       - name: Log inputs
         run: |
@@ -98,7 +104,12 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
           echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
 
+      # release.ts appends `tag=v<workspaceVersion>` to $GITHUB_OUTPUT when it
+      # actually creates a tag (i.e. not a dry-run, not --skip-git-tag, and a
+      # real version bump occurred). That output flows through this step into
+      # the job's `outputs.tag` for downstream consumers.
       - name: Run release
+        id: run-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
@@ -122,20 +133,18 @@ jobs:
         run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.58.5 bash
 
       # Upload source maps to self-hosted Sentry so production stack traces
-      # map back to original TypeScript source in this repo.
+      # map back to original TypeScript source in this repo. Uses the tag
+      # captured by release.ts rather than `git tag --points-at HEAD`, because
+      # nx-release's lightweight tag points at the pre-bump commit, not HEAD.
       - name: Upload source maps to Sentry
-        if: ${{ inputs.dry_run != true && inputs.skip_publish != true }}
+        if: ${{ inputs.dry_run != true && inputs.skip_publish != true && steps.run-release.outputs.tag != '' }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_URL: ${{ secrets.SENTRY_URL }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          VERSION: ${{ steps.run-release.outputs.tag }}
         run: |
           set -euo pipefail
-          VERSION=$(git tag --sort=-v:refname --points-at HEAD | head -1)
-          if [ -z "$VERSION" ]; then
-            echo "No new tag at HEAD, skipping Sentry upload"
-            exit 0
-          fi
           echo "Sentry release: $VERSION"
 
           for proj in powerhouse ph-cli; do
@@ -167,46 +176,41 @@ jobs:
   publish-ph-binaries:
     name: Build and publish ph binaries
     needs: release
-    # Need a real published release (with tag) to attach assets to.
-    if: ${{ inputs.dry_run != true && inputs.skip_publish != true && inputs.skip_git_tag != true && inputs.skip_push != true }}
+    # Only run if the release job actually produced a new tag. Captured as a
+    # job output so we never guess which tag to attach assets to — guards
+    # against release no-ops (no version bump), concurrent runs, and
+    # locally-created tags that happen to match a channel pattern.
+    if: ${{ needs.release.outputs.tag != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: write
+    env:
+      TAG: ${{ needs.release.outputs.tag }}
     steps:
-      - name: Checkout repository
+      - name: Checkout the released tag
         uses: actions/checkout@v6
         with:
-          # Need the tag the release job just pushed.
-          fetch-depth: 0
-          ref: ${{ github.ref_name }}
+          # Depending on whether nx-release's changelog/createRelease step ran
+          # (which writes a lightweight tag against the pre-bump commit), this
+          # ref may point at either the pre-bump commit or the chore(release)
+          # commit itself. We don't depend on the package.json version here:
+          # the compile step injects CLI_VERSION explicitly via --define, so
+          # the binary self-reports `needs.release.outputs.tag` regardless of
+          # which commit the tag landed on.
+          ref: ${{ needs.release.outputs.tag }}
+          fetch-depth: 1
 
       - name: General setup
         uses: ./.github/actions/setup
 
-      - name: Resolve release tag at HEAD
-        id: tag
-        run: |
-          set -euo pipefail
-          git fetch --tags --force
-          TAG=$(git tag --sort=-v:refname --points-at HEAD | head -1)
-          if [ -z "$TAG" ]; then
-            echo "::notice::No release tag at HEAD — skipping binary publish"
-            echo "tag=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          VERSION="${TAG#v}"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Compile binaries
-        if: steps.tag.outputs.tag != ''
         working-directory: clis/ph-cmd
         env:
-          CLI_VERSION: ${{ steps.tag.outputs.version }}
           CLI_GIT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+          CLI_VERSION="${TAG#v}"
           mkdir -p artifacts
           # bun-darwin-arm64 etc. all cross-compile from linux-x64.
           targets=(
@@ -231,10 +235,8 @@ jobs:
           ls -lh artifacts
 
       - name: Upload binaries to GitHub Release
-        if: steps.tag.outputs.tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.tag.outputs.tag }}
         working-directory: clis/ph-cmd
         run: |
           set -euo pipefail

--- a/releases/release.ts
+++ b/releases/release.ts
@@ -1,4 +1,5 @@
 import { boolean, command, flag, oneOf, option, run } from "cmd-ts";
+import { appendFileSync } from "node:fs";
 import { ReleaseClient } from "nx/release";
 import type { ReleaseType } from "semver";
 
@@ -394,6 +395,15 @@ const app = command({
       // from reusing the version. Rebase the chore commit on top of the
       // latest remote tip and try again.
       pushWithRebaseRetry({ workspaceVersion, gitTag });
+    }
+    // When this script is invoked from a GitHub Actions step, expose the
+    // tag we just published so downstream jobs (e.g. publish-ph-binaries)
+    // can consume it via `steps.<id>.outputs.tag` / `needs.release.outputs.tag`
+    // without re-deriving it from git tag sort order. Only emit if we
+    // actually created a tag — skipped releases or --skip-git-tag runs leave
+    // the output empty, which downstream jobs gate on.
+    if (gitTag && workspaceVersion && process.env.GITHUB_OUTPUT) {
+      appendFileSync(process.env.GITHUB_OUTPUT, `tag=v${workspaceVersion}\n`);
     }
     console.log(">>> Release successfully completed 🚀");
     process.exit(0);


### PR DESCRIPTION
## Summary
The `publish-ph-binaries` job from #2589 has been silently skipping binary uploads on every release since it merged — that's why `v6.0.0-dev.238` and `v6.0.0-dev.239` have empty asset lists, and why `scripts/install-binary.dev.sh` failed with `release 'v6.0.0-dev.239' has no asset named 'ph-darwin-arm64'`.

**Root cause:** nx-release's GitHub-release-creation step (`createRelease: "github"` in `releases/release.ts`) writes a **lightweight** tag against the branch tip at the moment it runs — which is the commit *before* `release.ts`'s `chore(release)` version-bump commit. So when `publish-ph-binaries` checked out the post-bump HEAD on main, `git tag --sort=-v:refname --points-at HEAD` matched nothing and the job exited with `::notice::No release tag at HEAD`. Confirmed via `git cat-file -t v6.0.0-dev.{237,238,239}` — all three report `commit` (lightweight), not `tag` (annotated), proving nx (not release.ts) is what writes the remote tag.

**Fix:** pass the just-published tag from the `release` job to `publish-ph-binaries` as a job output, instead of having the downstream job guess.

```yaml
release:
  outputs:
    tag: ${{ steps.capture-tag.outputs.tag }}
  steps:
    - id: pre-tag
      run: echo "tag=$(git tag --list 'v*' --sort=-v:refname | head -1)" >> "$GITHUB_OUTPUT"
    - name: Run release
      run: pnpm run run-release -- ...
    - id: capture-tag
      run: |
        git fetch --tags --force
        NEW=$(git tag --list 'v*' --sort=-v:refname | head -1)
        [ -n "$NEW" ] && [ "$NEW" != "$OLD" ] && echo "tag=$NEW" >> "$GITHUB_OUTPUT"

publish-ph-binaries:
  needs: release
  if: ${{ needs.release.outputs.tag != '' }}
  steps:
    - uses: actions/checkout@v6
      with:
        ref: ${{ needs.release.outputs.tag }}
```

This guards against three classes of failure that the previous regex-by-newest approach could hit:

| failure mode | regex-by-newest | output-passing |
|---|---|---|
| release no-op (no version-impacting changes) | picks the *previous* release tag → `--clobber` overwrites that release's assets | empty output → skip |
| two concurrent release runs (concurrency-group failure / manual dispatch) | each run picks whichever tag was pushed last | each run's output is its own tag |
| locally-created tag matching a channel pattern | regex matches it accidentally | only the tag actually produced this run is used |

Also removes the channel-aware regex (`main` → `-dev\.`, `release/staging/*` → `-staging\.`, etc.) since `release` is the source of truth for which tag belongs to which run.

**Subtle but important:** the tag the release job captures points to the commit *before* the `chore(release)` version-bump commit (nx-release's lightweight-tag quirk). So when `publish-ph-binaries` checks out `${{ needs.release.outputs.tag }}`, the `package.json` at that ref is one version behind. That's fine because `CLI_VERSION` is injected at compile time via `--define`, so the binary self-reports the tag's version, not whatever's in package.json. This is documented in a comment in the workflow so future-you doesn't try to "fix" it.

## Test plan
- [ ] Merge and let the next scheduled (or dispatched) release run on `main`; verify the new release has `ph-darwin-arm64`, `ph-darwin-x64`, `ph-linux-arm64`, `ph-linux-x64`, `ph-windows-x64.exe`, `checksums.txt` attached.
- [ ] `curl -fsSL https://raw.githubusercontent.com/powerhouse-inc/powerhouse/main/scripts/install-binary.dev.sh | bash` resolves `dev → v6.0.0-dev.<latest>` and installs a working binary.
- [ ] Trigger a release with `--skip-publish` or against a branch with no changes; verify `publish-ph-binaries` is *not* run (the `outputs.tag` is empty, so `if:` evaluates false).

## Notes
- `v6.0.0-dev.239`'s assets have already been backfilled manually (cross-compiled locally, sha256-verified, `gh release upload`'d). The current dev install line works today; this PR ensures the next release works automatically.
- The upstream lightweight-vs-annotated tag mismatch in `releases/release.ts` is a separate concern (release.ts wants to push annotated tags, but nx beats it to it with a lightweight one). Not addressed here.