### PR TITLE
fix(sentry): inject debug-ids before sourcemap upload + drop dead dirs

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -104,10 +104,12 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
           echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
 
-      # release.ts appends `tag=v<workspaceVersion>` to $GITHUB_OUTPUT when it
-      # actually creates a tag (i.e. not a dry-run, not --skip-git-tag, and a
-      # real version bump occurred). That output flows through this step into
-      # the job's `outputs.tag` for downstream consumers.
+      # sentry-cli is installed before Run release: release.ts shells out
+      # to `sentry-cli sourcemaps inject` between build and publish.
+      - name: Install sentry-cli
+        if: ${{ inputs.dry_run != true && inputs.skip_publish != true }}
+        run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.58.5 bash
+
       - name: Run release
         id: run-release
         env:
@@ -126,16 +128,6 @@ jobs:
           --skip-push="${{ inputs.skip_push == true }}" \
           --skip-git-tag="${{ inputs.skip_git_tag == true }}"
 
-      # Install sentry-cli globally so the subsequent steps can invoke it
-      # reliably (npx-based invocation had resolution issues).
-      - name: Install sentry-cli
-        if: ${{ inputs.dry_run != true && inputs.skip_publish != true }}
-        run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.58.5 bash
-
-      # Upload source maps to self-hosted Sentry so production stack traces
-      # map back to original TypeScript source in this repo. Uses the tag
-      # captured by release.ts rather than `git tag --points-at HEAD`, because
-      # nx-release's lightweight tag points at the pre-bump commit, not HEAD.
       - name: Upload source maps to Sentry
         if: ${{ inputs.dry_run != true && inputs.skip_publish != true && steps.run-release.outputs.tag != '' }}
         env:
@@ -152,8 +144,7 @@ jobs:
           done
           sentry-cli releases set-commits "$VERSION" --auto -p powerhouse || true
 
-          for dir in apps/connect/dist apps/switchboard/dist apps/academy/dist \
-                     packages/reactor-api/dist packages/switchboard/dist; do
+          for dir in apps/connect/dist apps/switchboard/dist packages/reactor-api/dist; do
             [ -d "$dir" ] || continue
             sentry-cli sourcemaps upload \
               --release "$VERSION" \

--- a/apps/switchboard/package.json
+++ b/apps/switchboard/package.json
@@ -70,6 +70,7 @@
     "@powerhousedao/vetra": "workspace:*",
     "@powerhousedao/reactor-api": "workspace:*",
     "@powerhousedao/reactor-attachments": "workspace:*",
+    "@pyroscope/nodejs": "^0.4.5",
     "@renown/sdk": "workspace:*",
     "@sentry/node": "^9.6.1",
     "@sentry/opentelemetry": "^9.6.1",
@@ -82,7 +83,6 @@
     "vite": "catalog:"
   },
   "devDependencies": {
-    "@pyroscope/nodejs": "^0.4.5",
     "@types/express": "^4.17.25",
     "@types/node": "catalog:",
     "@types/pg": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,6 +652,9 @@ importers:
       '@powerhousedao/vetra':
         specifier: workspace:*
         version: link:../../packages/vetra
+      '@pyroscope/nodejs':
+        specifier: ^0.4.5
+        version: 0.4.10(express@4.22.1)(fastify@5.8.5)
       '@renown/sdk':
         specifier: workspace:*
         version: link:../../packages/renown
@@ -689,9 +692,6 @@ importers:
         specifier: 'catalog:'
         version: 8.0.8(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     devDependencies:
-      '@pyroscope/nodejs':
-        specifier: ^0.4.5
-        version: 0.4.10(express@4.22.1)(fastify@5.8.5)
       '@types/express':
         specifier: ^4.17.25
         version: 4.17.25

--- a/releases/release.ts
+++ b/releases/release.ts
@@ -1,7 +1,15 @@
 import { boolean, command, flag, oneOf, option, run } from "cmd-ts";
-import { appendFileSync } from "node:fs";
+import { appendFileSync, existsSync } from "node:fs";
 import { ReleaseClient } from "nx/release";
 import type { ReleaseType } from "semver";
+
+const SENTRY_INJECT_DIRS = [
+  "apps/connect/dist",
+  "apps/switchboard/dist",
+  "packages/reactor-api/dist",
+  "clis/ph-cli/dist",
+  "clis/ph-cmd/dist",
+];
 
 type Channel = "dev" | "staging" | "production";
 const modes = ["prerelease", "patch", "minor", "major"] as const;
@@ -297,6 +305,10 @@ const app = command({
       }
     }
 
+    if (!dryRun && !skipPublish) {
+      injectSentryDebugIds();
+    }
+
     if (!skipPublish) {
       try {
         const publishResult = await releasePublish({
@@ -424,6 +436,21 @@ function runCommandWithBun(
       ...env,
     },
   });
+}
+
+function injectSentryDebugIds(): void {
+  for (const dir of SENTRY_INJECT_DIRS) {
+    if (!existsSync(dir)) continue;
+    const result = Bun.spawnSync({
+      cmd: ["sentry-cli", "sourcemaps", "inject", dir],
+      stdio: ["inherit", "inherit", "inherit"],
+    });
+    if (result.exitCode !== 0) {
+      console.warn(
+        `sentry-cli sourcemaps inject failed for ${dir} (exit ${result.exitCode})`,
+      );
+    }
+  }
 }
 
 // Resolve a sha to bake into build artifacts as provenance. Prefer


### PR DESCRIPTION
## Summary
Sentry has been uploading sourcemap artifact bundles on every release, but production stack frames don't resolve to TypeScript — they show the bundled JS instead. Confirmed by pulling event \`6c149cdb0db34d099103c3afebbbc8b4\` (the recent \`ReferenceError: __dirname\` in \`switchboard@6.0.0-dev.240\`): the stack frame is inside \`/app/node_modules/.pnpm/@powerhousedao+switchboard@.../dist/esm-CigE675X.mjs\`, and Sentry shows JS context like \`var import_src\$1 = require_src\$1();\` instead of the original \`.ts\` source — even though that exact filename appears in the uploaded \`switchboard\` artifact bundle (\`Bundle ID: e9644b68-b8ad-567f-bb95-cbbd02cedf41\`).

**Root cause:** \`sentry-cli sourcemaps upload\` ships artifacts as an \"artifact bundle\" indexed by **debug-id**. The runtime stack frame's JS file needs a \`//# debugId=<uuid>\` directive whose UUID matches the bundle's. tsdown/rolldown don't emit that directive by default, so our artifact bundles sit in Sentry without anything to link them to runtime errors.

**Fix:** run \`sentry-cli sourcemaps inject <dir>\` immediately before each upload. \`inject\` walks the dist, mints a UUID per output file, writes it as \`//# debugId=<uuid>\` into each \`.mjs\` and into the matching \`.map\`. The upload then packs the same id into the artifact bundle, so Sentry's resolver can match runtime frames to sourcemaps regardless of file-path mismatches, release-tag tricks, or \`~/\` prefix glob behavior.

**Also dropping two dead entries from the upload loop:**
| dir | why dropped |
|---|---|
| \`apps/academy/dist\` | academy doesn't call \`Sentry.init\` and isn't in the root \`pnpm build\` filter — it builds inside the Docker workflow. The \`[ -d ... ] || continue\` was always skipping past it. |
| \`packages/switchboard/dist\` | path doesn't exist. The published package is \`packages/switchboard-gui\` (\`@powerhousedao/switchboard-gui\`), and it doesn't init Sentry either. Pure stale config. |

## Test plan
- [ ] Merge and let the next \`main\` release fire (cron or manual dispatch).
- [ ] After the release, pull a fresh event from either the \`powerhouse\` or \`ph-cli\` project: \`sentry-cli events list -p powerhouse --pages 1\` then \`gh api repos/powerhouse-inc/powerhouse/...\` or the Sentry web UI. Confirm the stack frame's \`filename\` field shows a TypeScript path (e.g. \`apps/switchboard/src/server.mts\`) instead of a bundled \`.mjs\` chunk.
- [ ] Confirm \`apps/academy/dist\` and \`packages/switchboard/dist\` are no longer attempted (you'd previously see the loop iterate past them silently; now they're not in the list).

## Open question — runtime deps
The current upload list covers the dirs whose packages actually call \`Sentry.init\`:
- \`apps/connect/dist\` — browser SDK
- \`apps/switchboard/dist\` — node SDK
- \`packages/reactor-api/dist\` — in switchboard's stack
- \`clis/ph-cli/dist\` + \`clis/ph-cmd/dist\` — via \`@powerhousedao/shared\`'s telemetry

For workspace deps (\`@powerhousedao/reactor-browser\`, \`document-drive\`, \`reactor\`, etc.), \`build-config.ts\` has \`alwaysBundle: [\"**\"]\` with a narrow \`nodeNeverBundle\` allow-list — so switchboard's tsdown output should already inline them, and switchboard's single sourcemap should cover their frames. The event I pulled corroborates this: switchboard's bundled \`esm-CigE675X.mjs\` contains pyroscope code inline.

Whether \`apps/connect\` (a Vite app) bundles its workspace deps the same way is harder to verify without reading \`apps/connect/vite.config.*\`. If a future event shows a frame in \`node_modules/@powerhousedao/reactor-browser/...\`, that's the signal to add it to the loop. I'd suggest landing this fix first and revisiting after we can see one mapped event from each project.