### PR TITLE
fix(release): unblock nightly under nx 22

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -30,11 +30,10 @@
     "projectsRelationship": "managed",
     "version": {
       "conventionalCommits": true,
-      "generatorOptions": {
-        "skipLockFileUpdate": true,
-        "updateDependents": "auto",
-        "fallbackCurrentVersionResolver": "disk",
-        "preserveLocalDependencyProtocols": true
+      "updateDependents": "auto",
+      "fallbackCurrentVersionResolver": "disk",
+      "versionActionsOptions": {
+        "skipLockFileUpdate": true
       }
     },
     "changelog": {

--- a/releases/release.ts
+++ b/releases/release.ts
@@ -263,6 +263,10 @@ const app = command({
 
     runBuild(workspaceVersion);
 
+    const changelogFromRef = !skipChangelog
+      ? resolvePreviousReleaseTag()
+      : undefined;
+
     if (!skipChangelog) {
       try {
         const changeLogDryRunResult = await releaseChangelog({
@@ -271,6 +275,7 @@ const app = command({
           releaseGraph,
           verbose,
           dryRun: true,
+          from: changelogFromRef,
           stageChanges: false,
           gitCommit: false,
           gitTag: false,
@@ -291,6 +296,7 @@ const app = command({
           dryRun,
           releaseGraph,
           verbose,
+          from: changelogFromRef,
           gitCommit: false,
           stageChanges: false,
           gitPush: false,
@@ -451,6 +457,23 @@ function injectSentryDebugIds(): void {
       );
     }
   }
+}
+
+function resolvePreviousReleaseTag(): string {
+  const result = Bun.spawnSync({
+    cmd: ["git", "describe", "--tags", "--abbrev=0", "--match", "v*", "HEAD^"],
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Failed to resolve previous release tag: ${result.stderr.toString().trim()}`,
+    );
+  }
+  const tag = result.stdout.toString().trim();
+  if (!tag) {
+    throw new Error("git describe returned no previous release tag");
+  }
+  return tag;
 }
 
 // Resolve a sha to bake into build artifacts as provenance. Prefer


### PR DESCRIPTION
## Summary

Last three nightlies failed/hung. Root cause: the `3ef97160e` nx 20 → 22 bump landed without running `nx migrate --run-migrations`, and nx 22 also changed the default for `releaseTag.strictPreid` and `releaseTag.requireSemver` from `false` → `true`. Combined with `automaticFromRef: true`, nx's tag resolver could fall through to `getFirstGitCommit()` and produce a GitHub release body spanning the entire repo history — past the 125k char limit. The 422 then hits `promptForContinueInGitHub` in `nx@22.7.1`'s github release client, which has no TTY check and waits on stdin until the 30-min job timeout.

Two commits:

1. **`chore(nx)`** — applies the schema changes from the four release-config migrations the version bump skipped (`release-version-config-changes` × 2 and `release-changelog-config-changes` × 2 from `node_modules/nx/migrations.json`). Hoists `updateDependents` and `fallbackCurrentVersionResolver` out of `generatorOptions`, moves `skipLockFileUpdate` into `versionActionsOptions`, drops `preserveLocalDependencyProtocols: true` (the new default). No behavior change on its own.

2. **`fix(release)`** — resolves the previous release tag with `git describe --tags --abbrev=0 --match "v*" HEAD^` and hands it to `releaseChangelog` as the explicit `from` ref, bypassing nx's auto-resolver entirely. `HEAD^` skips any tag at HEAD itself (a prior failed release can leave a workspace tag pointing at HEAD).

Does not address the 30-min hang itself — that's `nx@22.7.1` calling `enquirer.prompt` without a TTY check in `handleError`. Worth a separate patch (à la `releases/patches/@nx%2Fjs@22.7.1.patch`) so future GH API failures fail fast instead of timing out.

## Test plan

- [ ] Manually trigger Release Branch workflow on `main` with `dry_run=true` and watch the changelog step succeed without producing a body > 125k chars
- [ ] Confirm the next scheduled nightly publishes successfully and the GitHub Release is created with a sane body length