### PR TITLE
chore(release): publish 6.0.0-dev.241

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- attach invocation context and tags to sentry events ([815c458bd](https://github.com/powerhouse-inc/powerhouse/commit/815c458bd))
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+- do not realExit when there are duplicate signals ([94f2750e7](https://github.com/powerhouse-inc/powerhouse/commit/94f2750e7))
+- **reactor:** fixed issue with cascading reshuffles ([36087940d](https://github.com/powerhouse-inc/powerhouse/commit/36087940d))
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+- Guillermo Puente @gpuente
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🚀 Features

--- a/apps/academy/CHANGELOG.md
+++ b/apps/academy/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/apps/academy/package.json
+++ b/apps/academy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/academy",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "homepage": "https://powerhouse.academy",
   "packageManager": "pnpm@10.9.0",
   "repository": {

--- a/apps/connect/CHANGELOG.md
+++ b/apps/connect/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/apps/connect/package.json
+++ b/apps/connect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@powerhousedao/connect",
   "productName": "Powerhouse-Connect",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "description": "Powerhouse Connect",
   "main": "dist/index.html",
   "type": "module",

--- a/apps/switchboard/CHANGELOG.md
+++ b/apps/switchboard/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/apps/switchboard/package.json
+++ b/apps/switchboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@powerhousedao/switchboard",
   "type": "module",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "main": "dist/index.mjs",
   "exports": {
     ".": {

--- a/clis/ph-cli/CHANGELOG.md
+++ b/clis/ph-cli/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+- attach invocation context and tags to sentry events ([815c458bd](https://github.com/powerhouse-inc/powerhouse/commit/815c458bd))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+- Guillermo Puente @gpuente
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/clis/ph-cli/package.json
+++ b/clis/ph-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/ph-cli",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "description": "",
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/clis/ph-cmd/CHANGELOG.md
+++ b/clis/ph-cmd/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+- attach invocation context and tags to sentry events ([815c458bd](https://github.com/powerhouse-inc/powerhouse/commit/815c458bd))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+- Guillermo Puente @gpuente
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/clis/ph-cmd/package.json
+++ b/clis/ph-cmd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ph-cmd",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "description": "",
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/packages/analytics-engine/CHANGELOG.md
+++ b/packages/analytics-engine/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/analytics-engine/benchmarks/CHANGELOG.md
+++ b/packages/analytics-engine/benchmarks/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/analytics-engine/benchmarks/package.json
+++ b/packages/analytics-engine/benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "benchmarks",
   "private": true,
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "publishConfig": {
     "access": "restricted"
   },

--- a/packages/analytics-engine/browser/CHANGELOG.md
+++ b/packages/analytics-engine/browser/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/analytics-engine/browser/package.json
+++ b/packages/analytics-engine/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/analytics-engine-browser",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/packages/analytics-engine/compat/CHANGELOG.md
+++ b/packages/analytics-engine/compat/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/analytics-engine/compat/package.json
+++ b/packages/analytics-engine/compat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "compat",
   "private": true,
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "publishConfig": {
     "access": "restricted"
   },

--- a/packages/analytics-engine/core/CHANGELOG.md
+++ b/packages/analytics-engine/core/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/analytics-engine/core/package.json
+++ b/packages/analytics-engine/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/analytics-engine-core",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/packages/analytics-engine/graphql/CHANGELOG.md
+++ b/packages/analytics-engine/graphql/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/analytics-engine/graphql/package.json
+++ b/packages/analytics-engine/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/analytics-engine-graphql",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/packages/analytics-engine/knex/CHANGELOG.md
+++ b/packages/analytics-engine/knex/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/analytics-engine/knex/package.json
+++ b/packages/analytics-engine/knex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/analytics-engine-knex",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/packages/analytics-engine/package.json
+++ b/packages/analytics-engine/package.json
@@ -18,5 +18,5 @@
     "jiti": "2.6.1",
     "@powerhousedao/shared": "workspace:*"
   },
-  "version": "6.0.0-dev.240"
+  "version": "6.0.0-dev.241"
 }

--- a/packages/analytics-engine/pg/CHANGELOG.md
+++ b/packages/analytics-engine/pg/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/analytics-engine/pg/package.json
+++ b/packages/analytics-engine/pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/analytics-engine-pg",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/packages/builder-tools/CHANGELOG.md
+++ b/packages/builder-tools/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/builder-tools/package.json
+++ b/packages/builder-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/builder-tools",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "type": "module",
   "license": "AGPL-3.0-only",
   "publishConfig": {

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/codegen",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "license": "AGPL-3.0-only",
   "private": false,
   "type": "module",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/common",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "license": "AGPL-3.0-only",
   "type": "module",
   "files": [

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/config",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "description": "",
   "license": "AGPL-3.0-only",
   "private": false,

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/design-system",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "description": "",
   "files": [
     "dist",

--- a/packages/document-model/CHANGELOG.md
+++ b/packages/document-model/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/document-model/package.json
+++ b/packages/document-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "document-model",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "license": "AGPL-3.0-only",
   "private": false,
   "files": [

--- a/packages/opentelemetry-instrumentation-reactor/CHANGELOG.md
+++ b/packages/opentelemetry-instrumentation-reactor/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/opentelemetry-instrumentation-reactor/package.json
+++ b/packages/opentelemetry-instrumentation-reactor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/opentelemetry-instrumentation-reactor",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "description": "OpenTelemetry instrumentation for @powerhousedao/reactor",
   "type": "module",
   "sideEffects": false,

--- a/packages/powerhouse-vetra-packages/CHANGELOG.md
+++ b/packages/powerhouse-vetra-packages/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/powerhouse-vetra-packages/package.json
+++ b/packages/powerhouse-vetra-packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/powerhouse-vetra-packages",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "description": "",
   "keywords": [],
   "author": "",

--- a/packages/reactor-api/CHANGELOG.md
+++ b/packages/reactor-api/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🚀 Features

--- a/packages/reactor-api/package.json
+++ b/packages/reactor-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/reactor-api",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "description": "",
   "type": "module",
   "repository": {

--- a/packages/reactor-attachments/CHANGELOG.md
+++ b/packages/reactor-attachments/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/reactor-attachments/package.json
+++ b/packages/reactor-attachments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/reactor-attachments",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "license": "AGPL-3.0-only",
   "type": "module",
   "repository": {

--- a/packages/reactor-browser/CHANGELOG.md
+++ b/packages/reactor-browser/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/reactor-browser/package.json
+++ b/packages/reactor-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/reactor-browser",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "license": "AGPL-3.0-only",
   "type": "module",
   "repository": {

--- a/packages/reactor-hypercore/CHANGELOG.md
+++ b/packages/reactor-hypercore/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/reactor-hypercore/package.json
+++ b/packages/reactor-hypercore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/reactor-hypercore",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "description": "Hypercore-backed IOperationStore for the Powerhouse Reactor",
   "repository": {
     "url": "https://github.com/powerhouse-inc/powerhouse",

--- a/packages/reactor-mcp/CHANGELOG.md
+++ b/packages/reactor-mcp/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/reactor-mcp/package.json
+++ b/packages/reactor-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/reactor-mcp",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "description": "MCP server for document model operations in the Powerhouse ecosystem. For document model creation tasks, consider using the document-model-creator agent which provides a more guided experience.",
   "type": "module",
   "repository": {

--- a/packages/reactor/CHANGELOG.md
+++ b/packages/reactor/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- do not realExit when there are duplicate signals ([94f2750e7](https://github.com/powerhouse-inc/powerhouse/commit/94f2750e7))
+- **reactor:** fixed issue with cascading reshuffles ([36087940d](https://github.com/powerhouse-inc/powerhouse/commit/36087940d))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🚀 Features

--- a/packages/reactor/package.json
+++ b/packages/reactor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/reactor",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "description": "",
   "repository": {
     "url": "https://github.com/powerhouse-inc/powerhouse",

--- a/packages/registry/CHANGELOG.md
+++ b/packages/registry/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/registry",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "description": "",
   "type": "module",
   "repository": {

--- a/packages/renown/CHANGELOG.md
+++ b/packages/renown/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/renown/package.json
+++ b/packages/renown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renown/sdk",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "description": "",
   "license": "AGPL-3.0-only",
   "private": false,

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+- attach invocation context and tags to sentry events ([815c458bd](https://github.com/powerhouse-inc/powerhouse/commit/815c458bd))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+- Guillermo Puente @gpuente
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/shared",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "type": "module",
   "sideEffects": false,
   "publishConfig": {

--- a/packages/switchboard-gui/CHANGELOG.md
+++ b/packages/switchboard-gui/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/switchboard-gui/package.json
+++ b/packages/switchboard-gui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@powerhousedao/switchboard-gui",
   "private": true,
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/vetra/CHANGELOG.md
+++ b/packages/vetra/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 6.0.0-dev.241 (2026-05-12)
+
+### 🚀 Features
+
+- **connect:** surface missing-model failures and move registry URL to ph-packages.json ([bcb8bbdb0](https://github.com/powerhouse-inc/powerhouse/commit/bcb8bbdb0))
+
+### 🩹 Fixes
+
+- **release:** pass explicit from-ref to releaseChangelog ([5af1ce209](https://github.com/powerhouse-inc/powerhouse/commit/5af1ce209))
+- **switchboard:** move @pyroscope/nodejs to dependencies ([c71e0b3de](https://github.com/powerhouse-inc/powerhouse/commit/c71e0b3de))
+- **sentry:** inject debug-ids before publish + drop dead dirs ([444c677a2](https://github.com/powerhouse-inc/powerhouse/commit/444c677a2))
+- switching postgres versions ([353951582](https://github.com/powerhouse-inc/powerhouse/commit/353951582))
+
+### ❤️ Thank You
+
+- acaldas
+- Benjamin Jordan
+
 ## 6.0.0-dev.240 (2026-05-11)
 
 ### 🩹 Fixes

--- a/packages/vetra/package.json
+++ b/packages/vetra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerhousedao/vetra",
-  "version": "6.0.0-dev.240",
+  "version": "6.0.0-dev.241",
   "license": "AGPL-3.0-only",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

Regenerates the `chore(release): publish 6.0.0-dev.241` commit that the failed nightly (run 25739203939) created on the runner but never pushed. The publish step itself succeeded for all 28 packages — `6.0.0-dev.241` is fully on npm. What got stranded was the bookkeeping commit; the tag step then failed because `v6.0.0-dev.241` was already tagged at `bcb8bbdb0` from yesterday's earlier failed run.

Without this commit on main, the next nightly bumps `package.json` from `dev.240 → dev.241` again and 403s on every publish.

Note: this PR sits on top of #2598 (the `from-ref` fix that already merged), so the regenerated CHANGELOG entries include those two commits — they're real, published as part of `6.0.0-dev.241`, so that's correct.

## Test plan

- [ ] Confirm `npm view document-model@6.0.0-dev.241` resolves (it does)
- [ ] Merge and let the next scheduled run bump `dev.241 → dev.242`
- [ ] Optional: force-move the orphaned `v6.0.0-dev.241` tag to the merged chore commit so `git describe` lines up. Leaving it at `bcb8bbdb0` is harmless for downstream tooling that just reads the version.