### PR TITLE
fix(connect): cache usePendingInstallations snapshot to prevent infinite re-render

### DIFF
--- a/apps/connect/src/hooks/usePendingInstallations.ts
+++ b/apps/connect/src/hooks/usePendingInstallations.ts
@@ -2,14 +2,30 @@ import {
   usePackageDiscoveryService,
   type PendingInstallation,
 } from "@powerhousedao/reactor-browser";
-import { useSyncExternalStore } from "react";
+import { useCallback, useRef, useSyncExternalStore } from "react";
 
-const emptyArray: PendingInstallation[] = [];
+const emptyArray: readonly PendingInstallation[] = [];
 
 export function usePendingInstallations() {
   const discoveryService = usePackageDiscoveryService();
+  const cacheRef = useRef<readonly PendingInstallation[]>(emptyArray);
+
+  const getSnapshot = useCallback(() => {
+    if (!discoveryService) return emptyArray;
+    const next = discoveryService.getPendingInstallations() ?? emptyArray;
+    const prev = cacheRef.current;
+    if (
+      next === prev ||
+      (next.length === prev.length && next.every((p, i) => p === prev[i]))
+    ) {
+      return prev;
+    }
+    cacheRef.current = next;
+    return next;
+  }, [discoveryService]);
+
   return useSyncExternalStore(
     (cb) => discoveryService?.subscribePending(cb) ?? (() => {}),
-    () => discoveryService?.getPendingInstallations() ?? emptyArray,
+    getSnapshot,
   );
 }


### PR DESCRIPTION
## Summary

`usePendingInstallations` was passing an unstable `getSnapshot` to `useSyncExternalStore`. `discoveryService.getPendingInstallations()` returns a fresh array reference on every call, so `Object.is(prev, next)` was always false and React entered a max-update-depth loop on mount. `PackageInstallPrompt` mounts at the top-level App layer, so the loop fired on every initial load and was caught by the App's `ErrorBoundary`, replacing the UI with the fallback.

This patch applies Option B from the bug report: cache the snapshot in a `useRef` and return the previous reference when contents are unchanged, so `useSyncExternalStore`'s identity check passes.

- Affected versions: `@powerhousedao/connect@6.0.0-dev.241`, `6.0.0-dev.242`, `6.0.0-dev.243`
- Regression introduced with the missing-model-failures feature (`bcb8bbdb0`); worked in `dev.240` and earlier.

## Test plan

- [ ] `pnpm dev` on `apps/connect` against a project using the missing-model-failures flow — page loads to the normal UI, no "Maximum update depth exceeded" in console, no ErrorBoundary fallback.
- [ ] With pending installations present, `PackageInstallModal` still renders the list and install/dismiss callbacks still fire (the cache only short-circuits when contents are unchanged).
- [ ] `pnpm test` on `apps/connect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)