### PR TITLE
fix: update import paths in generated tests

### DIFF
--- a/packages/codegen/src/file-builders/document-model/tests-dir.ts
+++ b/packages/codegen/src/file-builders/document-model/tests-dir.ts
@@ -16,6 +16,7 @@ import {
   formatSourceFileWithPrettier,
   getOrCreateSourceFile,
   getPreviousVersionSourceFile,
+  updateVersionedImports,
 } from "utils";
 
 export async function makeDocumentModelModulesOperationTestFiles(
@@ -56,6 +57,7 @@ export async function makeOperationModuleTestFile(
 
     if (previousVersionSourceFile) {
       sourceFile.replaceWithText(previousVersionSourceFile.getText());
+      updateVersionedImports({ sourceFile, version });
     } else {
       sourceFile.replaceWithText(
         ts`
@@ -182,7 +184,7 @@ export async function makeOperationModuleTestFile(
 export async function makeDocumentModelTestFile(
   args: DocumentModelFileMakerArgs,
 ) {
-  const { project, testsDirPath } = args;
+  const { project, version, testsDirPath } = args;
   const template = documentModelTestFileTemplate(args);
 
   const filePath = path.join(testsDirPath, "document-model.test.ts");
@@ -192,7 +194,10 @@ export async function makeDocumentModelTestFile(
     filePath,
   );
 
-  if (alreadyExists) return;
+  if (alreadyExists) {
+    updateVersionedImports({ sourceFile, version });
+    return;
+  }
 
   sourceFile.replaceWithText(template);
   await formatSourceFileWithPrettier(sourceFile);

--- a/packages/codegen/src/utils/index.mts
+++ b/packages/codegen/src/utils/index.mts
@@ -10,4 +10,5 @@ export * from "./syntax-builders.js";
 export * from "./syntax-getters.js";
 export * from "./ts-morph-project.js";
 export * from "./unsafe-utils.js";
+export * from "./update-versioned-imports.js";
 export * from "./validation.js";

--- a/packages/codegen/src/utils/update-versioned-imports.ts
+++ b/packages/codegen/src/utils/update-versioned-imports.ts
@@ -1,0 +1,29 @@
+import { endsWith, filter, forEach, pipe, subtract } from "remeda";
+import type { SourceFile } from "ts-morph";
+
+export function updateVersionedImports(args: {
+  sourceFile: SourceFile;
+  version: number;
+}) {
+  const { sourceFile, version } = args;
+  const previousVersion = subtract(version, 1);
+  if (previousVersion < 1) return;
+
+  const versionDir = `/v${version}`;
+  const previousVersionDir = `/v${previousVersion}`;
+
+  pipe(
+    sourceFile.getImportDeclarations(),
+    filter((i) =>
+      endsWith(i.getModuleSpecifier().getLiteralValue(), previousVersionDir),
+    ),
+    forEach((i) =>
+      i.setModuleSpecifier(
+        i
+          .getModuleSpecifier()
+          .getLiteralValue()
+          .replace(previousVersionDir, versionDir),
+      ),
+    ),
+  );
+}

--- a/test/codegen/tests/generate-doc-model.test.ts
+++ b/test/codegen/tests/generate-doc-model.test.ts
@@ -32,12 +32,6 @@ async function runDocumentModelTests(args: {
     testOutputParentDir,
     `${basename(inDirName)}-${basename(specDirName)}`,
   );
-  console.log({
-    outDir,
-    inDirName,
-    specDirName,
-    testOutputParentDir,
-  });
   await rmForce(outDir);
   await cpForce(inDirName, outDir);
   await loadDocumentModelsInDir(specDirName, outDir);

--- a/test/codegen/tests/generate-doc-model.test.ts
+++ b/test/codegen/tests/generate-doc-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import {
   DATA,
   NEW_PROJECT,
@@ -28,7 +28,16 @@ async function runDocumentModelTests(args: {
   specDirName: string;
 }) {
   const { inDirName, specDirName, testOutputParentDir } = args;
-  const outDir = join(testOutputParentDir, `${inDirName}-${specDirName}`);
+  const outDir = join(
+    testOutputParentDir,
+    `${basename(inDirName)}-${basename(specDirName)}`,
+  );
+  console.log({
+    outDir,
+    inDirName,
+    specDirName,
+    testOutputParentDir,
+  });
   await rmForce(outDir);
   await cpForce(inDirName, outDir);
   await loadDocumentModelsInDir(specDirName, outDir);
@@ -37,20 +46,19 @@ async function runDocumentModelTests(args: {
 }
 
 describe("versioned document models", () => {
-  const testOutputParentDir = join(parentOutDir, "versioned-document-models");
   describe("v1", () => {
     test("should generate new document models as v1", async () => {
       await runDocumentModelTests({
         inDirName: NEW_PROJECT,
         specDirName: SPEC_VERSION_1,
-        testOutputParentDir,
+        testOutputParentDir: parentOutDir,
       });
     });
     test("should persist existing reducers, tests, utils, and custom files when generating for the same spec version", async () => {
       await runDocumentModelTests({
         inDirName: WITH_DOCUMENT_MODELS_SPEC_1,
         specDirName: join(DATA, "spec-version-1-with-more-operations"),
-        testOutputParentDir,
+        testOutputParentDir: parentOutDir,
       });
     });
   });
@@ -59,7 +67,7 @@ describe("versioned document models", () => {
       const testOutDir = await runDocumentModelTests({
         inDirName: NEW_PROJECT,
         specDirName: SPEC_VERSION_2,
-        testOutputParentDir,
+        testOutputParentDir: parentOutDir,
       });
 
       const v1ModulePath = join(
@@ -87,7 +95,7 @@ describe("versioned document models", () => {
       await runDocumentModelTests({
         inDirName: WITH_DOCUMENT_MODELS_SPEC_1,
         specDirName: SPEC_VERSION_2,
-        testOutputParentDir,
+        testOutputParentDir: parentOutDir,
       });
     });
 
@@ -97,7 +105,7 @@ describe("versioned document models", () => {
           await runDocumentModelTests({
             inDirName: WITH_DOCUMENT_MODELS_SPEC_1,
             specDirName: join(DATA, "spec-version-2-with-state-changes"),
-            testOutputParentDir,
+            testOutputParentDir: parentOutDir,
           }),
       ).toThrow();
     });
@@ -108,7 +116,7 @@ describe("versioned document models", () => {
       await runDocumentModelTests({
         inDirName: NEW_PROJECT,
         specDirName: SPEC_VERSION_3,
-        testOutputParentDir,
+        testOutputParentDir: parentOutDir,
       });
     });
 
@@ -116,7 +124,7 @@ describe("versioned document models", () => {
       await runDocumentModelTests({
         inDirName: WITH_DOCUMENT_MODELS_SPEC_2,
         specDirName: SPEC_VERSION_3,
-        testOutputParentDir,
+        testOutputParentDir: parentOutDir,
       });
     });
 
@@ -126,7 +134,7 @@ describe("versioned document models", () => {
           await runDocumentModelTests({
             inDirName: WITH_DOCUMENT_MODELS_SPEC_2,
             specDirName: join(DATA, "spec-version-3-with-state-changes"),
-            testOutputParentDir,
+            testOutputParentDir: parentOutDir,
           }),
       ).toThrow();
     });


### PR DESCRIPTION
I noticed that when we copy an existing test file from a previous version dir, we don't update the import paths in it to be the new version. This means that for example a generated test in v2 which was previously in v1 would still import from v1 instead of v2.

I added a simple util that replaces module specifiers which end with the previous version specifier with the new one.

I also saw that we were accidentally using full file system paths instead of dir names when copying stuff in the tests, so i fixed that too.