### PR TITLE
fix(connect): pin nginx base to 1.31.0-alpine for CVE-2026-42945

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,14 @@ RUN ph connect build --base ${PH_CONNECT_BASE_PATH}
 # ============================================================
 # Connect target: nginx serving static files (runs as non-root)
 # ============================================================
-FROM nginx:alpine AS connect
+# Pinned to 1.31.0-alpine for CVE-2026-42945 (heap buffer overflow
+# in ngx_http_rewrite_module — affects 0.6.27 through 1.30.0,
+# fixed in 1.31.0 / 1.30.1). Our SPA-fallback config doesn't hit
+# the trigger pattern (rewrite + PCRE captures + "?" replacement
+# + followed by rewrite/if/set), so we weren't exploitable in
+# practice — but `nginx:alpine` is a moving tag that could regress
+# on any rebuild. Pinning prevents that.
+FROM nginx:1.31.0-alpine AS connect
 
 # Install envsubst for config templating, and chown the nginx runtime
 # directories so the built-in `nginx` user (UID 101) can write the

--- a/packages/codegen/src/templates/boilerplate/docker/Dockerfile.ts
+++ b/packages/codegen/src/templates/boilerplate/docker/Dockerfile.ts
@@ -71,7 +71,9 @@ RUN ph connect build --base \${PH_CONNECT_BASE_PATH}
 # -----------------------------------------------------------------------------
 # Connect final stage - nginx
 # -----------------------------------------------------------------------------
-FROM nginx:alpine AS connect
+# Pinned for CVE-2026-42945 (nginx ngx_http_rewrite_module heap buffer
+# overflow — affects 0.6.27 through 1.30.0, fixed in 1.31.0 / 1.30.1).
+FROM nginx:1.31.0-alpine AS connect
 
 # Install envsubst for config templating
 RUN apk add --no-cache gettext

--- a/test/versioned-documents/Dockerfile
+++ b/test/versioned-documents/Dockerfile
@@ -71,7 +71,8 @@ RUN ph connect build --base ${PH_CONNECT_BASE_PATH}
 # -----------------------------------------------------------------------------
 # Connect final stage - nginx
 # -----------------------------------------------------------------------------
-FROM nginx:alpine AS connect
+# Pinned for CVE-2026-42945 — see docker/Dockerfile for full context.
+FROM nginx:1.31.0-alpine AS connect
 
 # Install envsubst for config templating
 RUN apk add --no-cache gettext


### PR DESCRIPTION
## Summary

Pin Connect's nginx base image to `nginx:1.31.0-alpine` to include the fix for [CVE-2026-42945](https://nvd.nist.gov/vuln/detail/CVE-2026-42945) (heap buffer overflow in `ngx_http_rewrite_module`).

**Severity:** CVSS 4.0: 9.2 CRITICAL / CVSS 3.1: 8.1 HIGH
**Affected:** nginx 0.6.27 through 1.30.0
**Fixed in:** 1.31.0 (mainline) or 1.30.1 (stable)

## Exposure (live cluster)

```
22 Connect pods → nginx 1.29.8   (in vuln range)
 1 Connect pod  → nginx 1.31.0   (already patched — got lucky on a recent rebuild)
 1 Connect pod  → nginx 1.29.7   (renown, in vuln range)
```

`nginx:alpine` is a moving tag — the dev tenant's pod happened to be rebuilt after upstream tagged 1.31.0 as alpine, so it was already safe. The rest of the fleet runs older images. Pinning prevents future regressions.

## Are we exploitable today?

**No.** The trigger condition (per [F5 advisory](https://my.f5.com/manage/s/article/K000161019)) requires:

> a `rewrite` directive with an unnamed PCRE capture (`$1`, `$2`) AND a replacement string that contains a `?`, followed by another `rewrite`, `if`, or `set` directive

Our Connect SPA-fallback config doesn't use `rewrite` directives at all. Grep across `/etc/nginx/` on multiple production Connect pods returned no matches for the trigger pattern. The vuln is unreachable with our config.

This PR is **defense-in-depth + version hygiene**, not an active-incident fix.

## Files touched

1. `docker/Dockerfile:42` — production Connect image (highest priority — 22 tenants in prod)
2. `test/versioned-documents/Dockerfile:74` — test infra
3. `packages/codegen/src/templates/boilerplate/docker/Dockerfile.ts:74` — boilerplate template used by `ph init` to scaffold new projects (future generated projects pick up the fix automatically)

## Rollout

After merge:
1. CI publishes the next `-dev.N` tag with the patched base
2. `update-k8s-switchboard-connect` workflow auto-bumps `tenants/dev/powerhouse-values.yaml` in `powerhouse-inc/powerhouse-k8s-hosting`
3. Other tenants pick up the new tag through vetra.to's version picker (which now reads from Harbor — recently fixed via vetra.to PR #44, so we're guaranteed not to suggest a non-existent tag)

## Verification

Once a new dev image lands:
```
kubectl -n dev exec deploy/powerhouse-dev-connect -- nginx -v
# expect: nginx version: nginx/1.31.0
```