### PR TITLE
fix(ph-cmd): suppress pnpm 11 approve-builds prompt during ph init

### DIFF
--- a/clis/ph-cli/src/services/migrate.ts
+++ b/clis/ph-cli/src/services/migrate.ts
@@ -1,4 +1,7 @@
-import { fetchPackageVersionFromNpmRegistry } from "@powerhousedao/shared/clis";
+import {
+  fetchPackageVersionFromNpmRegistry,
+  injectPnpmAllowBuilds,
+} from "@powerhousedao/shared/clis";
 import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -122,6 +125,8 @@ export async function startMigrate({
       `Failed to resolve execute command for package manager "${agent}".`,
     );
   }
+
+  injectPnpmAllowBuilds(agent, resolved);
 
   const command = `${resolved.command} ${resolved.args.join(" ")}`;
   if (debug) {

--- a/clis/ph-cmd/src/utils/delegate-init.ts
+++ b/clis/ph-cmd/src/utils/delegate-init.ts
@@ -119,23 +119,8 @@ export async function delegateInit(
     );
   }
 
-  // pnpm 11 enforces `strict-dep-builds=true`, so the outer `pnpm dlx`
-  // download of ph-cli would otherwise prompt for build approval on the
-  // generated project's allowlisted transitive deps. Inject one
-  // `--allow-build` per package after `dlx` so dlx auto-approves the same
-  // set the boilerplate already trusts via pnpm-workspace.yaml.
-  if (pm === "pnpm" && resolved.args[0] === "dlx") {
-    const { BOILERPLATE_ALLOWED_BUILDS } =
-      await import("@powerhousedao/shared/clis");
-    const allowBuildFlags = BOILERPLATE_ALLOWED_BUILDS.map(
-      (pkg) => `--allow-build=${pkg}`,
-    );
-    resolved.args = [
-      resolved.args[0],
-      ...allowBuildFlags,
-      ...resolved.args.slice(1),
-    ];
-  }
+  const { injectPnpmAllowBuilds } = await import("@powerhousedao/shared/clis");
+  injectPnpmAllowBuilds(pm, resolved);
 
   const { command: cmd, args: cmdArgs } = resolved;
   const fullCmd = `${cmd} ${cmdArgs.join(" ")}`;

--- a/clis/ph-cmd/src/utils/delegate-init.ts
+++ b/clis/ph-cmd/src/utils/delegate-init.ts
@@ -119,6 +119,24 @@ export async function delegateInit(
     );
   }
 
+  // pnpm 11 enforces `strict-dep-builds=true`, so the outer `pnpm dlx`
+  // download of ph-cli would otherwise prompt for build approval on the
+  // generated project's allowlisted transitive deps. Inject one
+  // `--allow-build` per package after `dlx` so dlx auto-approves the same
+  // set the boilerplate already trusts via pnpm-workspace.yaml.
+  if (pm === "pnpm" && resolved.args[0] === "dlx") {
+    const { BOILERPLATE_ALLOWED_BUILDS } =
+      await import("@powerhousedao/shared/clis");
+    const allowBuildFlags = BOILERPLATE_ALLOWED_BUILDS.map(
+      (pkg) => `--allow-build=${pkg}`,
+    );
+    resolved.args = [
+      resolved.args[0],
+      ...allowBuildFlags,
+      ...resolved.args.slice(1),
+    ];
+  }
+
   const { command: cmd, args: cmdArgs } = resolved;
   const fullCmd = `${cmd} ${cmdArgs.join(" ")}`;
 

--- a/packages/codegen/src/templates/boilerplate/pnpm-workspace.ts
+++ b/packages/codegen/src/templates/boilerplate/pnpm-workspace.ts
@@ -1,10 +1,10 @@
+import { BOILERPLATE_ALLOWED_BUILDS } from "@powerhousedao/shared/clis";
+
 // Allowlists transitive postinstall scripts so `pnpm install` does not fail
 // under pnpm 11's `strict-dep-builds=true` (which promotes the
 // ERR_PNPM_IGNORED_BUILDS warning to an error). pnpm 10 also reads this map.
-export const pnpmWorkspaceTemplate = `allowBuilds:
-  "@apollo/protobufjs": true
-  "@parcel/watcher": true
-  esbuild: true
-  protobufjs: true
-  "@datadog/pprof": true
-`;
+const allowBuildsBody = BOILERPLATE_ALLOWED_BUILDS.map(
+  (pkg) => `  ${/[@/]/.test(pkg) ? `"${pkg}"` : pkg}: true`,
+).join("\n");
+
+export const pnpmWorkspaceTemplate = `allowBuilds:\n${allowBuildsBody}\n`;

--- a/packages/shared/clis/constants.ts
+++ b/packages/shared/clis/constants.ts
@@ -101,6 +101,19 @@ export const VERSIONED_DEPENDENCIES = [
   ...FEATURE_DEPENDENCIES.analyticsProcessor.peerVersioned,
 ];
 
+// Transitive dependencies whose postinstall scripts the generated project
+// trusts. Mirrors the `allowBuilds` map in the boilerplate's
+// pnpm-workspace.yaml and is also passed as `--allow-build` flags to
+// `pnpm dlx @powerhousedao/ph-cli init` so pnpm 11's strict-dep-builds
+// default doesn't prompt during the outer dlx download.
+export const BOILERPLATE_ALLOWED_BUILDS = [
+  "@apollo/protobufjs",
+  "@datadog/pprof",
+  "@parcel/watcher",
+  "esbuild",
+  "protobufjs",
+] as const;
+
 export const VERSIONED_DEV_DEPENDENCIES = [
   "@powerhousedao/ph-cli",
   "@powerhousedao/reactor",

--- a/packages/shared/clis/utils.ts
+++ b/packages/shared/clis/utils.ts
@@ -1,6 +1,24 @@
 // Sub-path: this module loads on the cold path of every CLI invocation.
 import lt from "semver/functions/lt.js";
-import { MINIMUM_NODE_VERSION } from "./constants.js";
+import {
+  BOILERPLATE_ALLOWED_BUILDS,
+  MINIMUM_NODE_VERSION,
+} from "./constants.js";
+
+/**
+ * Mutates a resolved `pnpm dlx ...` command to add one `--allow-build=<pkg>`
+ * flag per package in {@link BOILERPLATE_ALLOWED_BUILDS}, so pnpm 11's
+ * `strict-dep-builds=true` default doesn't prompt for approval during the
+ * outer dlx download. No-op for other package managers or non-dlx commands.
+ */
+export function injectPnpmAllowBuilds(
+  pm: string,
+  resolved: { command: string; args: string[] },
+): void {
+  if (pm !== "pnpm" || resolved.args[0] !== "dlx") return;
+  const flags = BOILERPLATE_ALLOWED_BUILDS.map((pkg) => `--allow-build=${pkg}`);
+  resolved.args = [resolved.args[0], ...flags, ...resolved.args.slice(1)];
+}
 
 export class NodeVersionError extends Error {
   constructor(currentVersion: string, minimumVersion: string) {


### PR DESCRIPTION
## Summary

- `ph init --pnpm` triggered an interactive approve-builds prompt under pnpm 11 for `@apollo/protobufjs`, `@datadog/pprof`, `@parcel/watcher`, `esbuild`, `protobufjs`. pnpm 11 made `strict-dep-builds=true` the default, so the outer `pnpm dlx @powerhousedao/ph-cli@<v> init ...` in `clis/ph-cmd/src/utils/delegate-init.ts` prompts on transitive postinstall scripts. The inner `pnpm install` inside the generated project never prompted because the boilerplate's `pnpm-workspace.yaml` already lists those packages under `allowBuilds`.
- Inject `--allow-build=<pkg>` for each of those packages after `dlx` so the outer install auto-approves the same set the generated project already trusts.
- Extract the allowlist into `BOILERPLATE_ALLOWED_BUILDS` in `@powerhousedao/shared/clis` so the boilerplate `pnpm-workspace.yaml` template and `delegate-init.ts` share a single source of truth.

## Test plan

- [x] `pnpm --filter ph-cmd build` succeeds.
- [x] `bun -e 'import("./src/templates/boilerplate/pnpm-workspace.ts")...'` prints the same 5 packages (alphabetical now, key order is irrelevant for pnpm).
- [x] `ph init test-project --version=6.0.0-dev.248 --pnpm --debug` against a fresh dlx cache: debug log shows `pnpm dlx --allow-build=@apollo/protobufjs --allow-build=@datadog/pprof --allow-build=@parcel/watcher --allow-build=esbuild --allow-build=protobufjs @powerhousedao/ph-cli@... init ...` and completes without an approve-builds prompt.
- [x] End-to-end verified with a `pnpm pack`'d local ph-cli tarball: `pnpm dlx --allow-build=... /tmp/powerhousedao-ph-cli-6.0.0-dev.248.tgz init ...` finishes cleanly and produces a valid `test-project/`.