### PR TITLE
chore: bump @powerhousedao/document-engineering to 1.40.5

### DIFF
--- a/packages/shared/clis/constants.ts
+++ b/packages/shared/clis/constants.ts
@@ -173,7 +173,7 @@ export const externalDevDependencies = {
   "@electric-sql/pglite": "0.3.15",
   "@electric-sql/pglite-tools": "0.2.20",
   "@eslint/js": "^9.38.0",
-  "@powerhousedao/document-engineering": "1.40.3",
+  "@powerhousedao/document-engineering": "1.40.5",
   "@tailwindcss/cli": "^4.1.18",
   "@tailwindcss/vite": "^4.1.18",
   "@types/node": "^24.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: 1.19.0
       version: 1.19.0
     '@powerhousedao/document-engineering':
-      specifier: 1.40.3
-      version: 1.40.3
+      specifier: 1.40.5
+      version: 1.40.5
     '@preact/preset-vite':
       specifier: 2.10.5
       version: 2.10.5
@@ -301,22 +301,22 @@ importers:
         version: 9.39.4
       '@nx/devkit':
         specifier: 22.7.1
-        version: 22.7.1(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))
+        version: 22.7.1(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))
       '@nx/js':
         specifier: 22.7.1
-        version: 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))(verdaccio@6.5.0(typanion@3.14.0))
+        version: 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))(verdaccio@6.5.0(typanion@3.14.0))
       '@nx/plugin':
         specifier: ^22.7.1
-        version: 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@types/node@25.2.3)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))(eslint@9.39.4(jiti@2.6.1))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.5.0(typanion@3.14.0))
+        version: 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)(@types/node@25.2.3)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))(eslint@9.39.4(jiti@2.6.1))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))(typescript@5.9.3)(verdaccio@6.5.0(typanion@3.14.0))
       '@powerhousedao/ph-cli':
         specifier: workspace:*
         version: link:clis/ph-cli
       '@swc-node/register':
         specifier: ~1.10.9
-        version: 1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3)
+        version: 1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3)
       '@swc/core':
         specifier: ~1.11.1
-        version: 1.11.31(@swc/helpers@0.5.19)
+        version: 1.11.31
       '@types/node':
         specifier: 'catalog:'
         version: 25.2.3
@@ -358,7 +358,7 @@ importers:
         version: 5.84.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.2.3)(typescript@5.9.3)
       nx:
         specifier: 22.7.1
-        version: 22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))
+        version: 22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)
       prettier:
         specifier: 'catalog:'
         version: 3.8.1
@@ -400,19 +400,19 @@ importers:
         version: 2.20.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@docusaurus/core':
         specifier: ^3.10.0
-        version: 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+        version: 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       '@docusaurus/faster':
         specifier: ^3.10.0
-        version: 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3)
+        version: 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3)
       '@docusaurus/plugin-content-docs':
         specifier: ^3.10.0
-        version: 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+        version: 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       '@docusaurus/preset-classic':
         specifier: ^3.10.0
-        version: 3.10.0(@algolia/client-search@5.49.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)(typescript@6.0.3)
+        version: 3.10.0(@algolia/client-search@5.49.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)(typescript@6.0.3)
       '@docusaurus/theme-search-algolia':
         specifier: ^3.10.0
-        version: 3.10.0(@algolia/client-search@5.49.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)(typescript@6.0.3)
+        version: 3.10.0(@algolia/client-search@5.49.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)(typescript@6.0.3)
       '@mdx-js/react':
         specifier: ^3.0.0
         version: 3.1.1(@types/react@19.2.14)(react@19.2.6)
@@ -431,13 +431,13 @@ importers:
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: ^3.10.0
-        version: 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@docusaurus/tsconfig':
         specifier: ^3.10.0
         version: 3.10.0
       '@docusaurus/types':
         specifier: ^3.10.0
-        version: 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@marp-team/marp-cli':
         specifier: ^4.2.3
         version: 4.2.3(typescript@6.0.3)
@@ -473,7 +473,7 @@ importers:
         version: link:../../packages/design-system
       '@powerhousedao/document-engineering':
         specifier: 'catalog:'
-        version: 1.40.3(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+        version: 1.40.5(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql@16.12.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.3.6)
       '@powerhousedao/powerhouse-vetra-packages':
         specifier: workspace:*
         version: link:../../packages/powerhouse-vetra-packages
@@ -1133,7 +1133,7 @@ importers:
         version: 5.0.7(graphql@16.12.0)
       '@powerhousedao/document-engineering':
         specifier: 'catalog:'
-        version: 1.40.3(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+        version: 1.40.5(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql@16.12.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.3.6)
       '@powerhousedao/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1565,7 +1565,7 @@ importers:
         version: link:../design-system
       '@powerhousedao/document-engineering':
         specifier: 'catalog:'
-        version: 1.40.3(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+        version: 1.40.5(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql@16.12.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.3.6)
       '@powerhousedao/reactor-browser':
         specifier: workspace:*
         version: link:../reactor-browser
@@ -1737,7 +1737,7 @@ importers:
         version: link:../config
       '@powerhousedao/document-engineering':
         specifier: 'catalog:'
-        version: 1.40.3(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+        version: 1.40.5(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql@16.12.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.3.6)
       '@powerhousedao/pglite-fs':
         specifier: workspace:*
         version: link:../pglite-fs
@@ -2493,7 +2493,7 @@ importers:
         version: link:../../packages/design-system
       '@powerhousedao/document-engineering':
         specifier: 'catalog:'
-        version: 1.40.3(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+        version: 1.40.5(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql@16.12.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.3.6)
       '@powerhousedao/ph-cli':
         specifier: workspace:*
         version: link:../../clis/ph-cli
@@ -2841,7 +2841,7 @@ importers:
         version: link:../../packages/design-system
       '@powerhousedao/document-engineering':
         specifier: 'catalog:'
-        version: 1.40.3(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+        version: 1.40.5(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql@16.12.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.3.6)
       '@powerhousedao/ph-cli':
         specifier: workspace:*
         version: link:../../clis/ph-cli
@@ -2949,7 +2949,7 @@ importers:
         version: link:../../packages/design-system
       '@powerhousedao/document-engineering':
         specifier: 'catalog:'
-        version: 1.40.3(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+        version: 1.40.5(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql@16.12.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.3.6)
       '@powerhousedao/reactor-browser':
         specifier: workspace:*
         version: link:../../packages/reactor-browser
@@ -3019,9 +3019,6 @@ packages:
 
   '@adraffy/ens-normalize@1.10.1':
     resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
-
-  '@adraffy/ens-normalize@1.11.1':
-    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
   '@algolia/abtesting@1.15.1':
     resolution: {integrity: sha512-2yuIC48rUuHGhU1U5qJ9kJHaxYpJ0jpDHJVI5ekOxSMYXlH4+HP+pA31G820lsAznfmu2nzDV7n5RO44zIY1zw==}
@@ -5721,9 +5718,6 @@ packages:
       '@types/node':
         optional: true
 
-  '@internationalized/date@3.11.0':
-    resolution: {integrity: sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q==}
-
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -6124,10 +6118,6 @@ packages:
 
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
-
-  '@noble/curves@1.9.1':
-    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
-    engines: {node: ^14.21.3 || >=16}
 
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
@@ -7145,11 +7135,13 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@powerhousedao/document-engineering@1.40.3':
-    resolution: {integrity: sha512-4TdmDCdM21ILgfgEoKcrh7wp+i2qjqeDDW90Drsp+cGt0oE1PdKqEtqmnxp6YpuYSyGQbK26vdQvLVnWH3tJDg==}
+  '@powerhousedao/document-engineering@1.40.5':
+    resolution: {integrity: sha512-8gPp4cVFll64EcJ8MBUqM1zaeVAxAy8IiSHb5rwHCQH89XEB0E75AI/ScKauUudTkrTjUv1vhSG2BEN+PhavzQ==}
     peerDependencies:
+      graphql: ^16.9.0
       react: ^19.2.0
       react-dom: ^19.2.0
+      zod: ^4.0.0
 
   '@preact/preset-vite@2.10.5':
     resolution: {integrity: sha512-p0vJpxiVO7KWWazWny3LUZ+saXyZKWv6Ju0bYMWNJRp2YveufRPgSUB1C4MTqGJfz07EehMgfN+AJNwQy+w6Iw==}
@@ -7527,19 +7519,6 @@ packages:
 
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-separator@1.1.8':
-    resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8215,17 +8194,8 @@ packages:
   '@rspack/lite-tapable@1.1.0':
     resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
 
-  '@scure/base@1.2.6':
-    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
-
   '@scure/base@2.0.0':
     resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
-
-  '@scure/bip32@1.7.0':
-    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
-
-  '@scure/bip39@1.6.0':
-    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@sentry-internal/browser-utils@10.40.0':
     resolution: {integrity: sha512-3CDeVNBXYOIvBVdT0SOdMZx5LzYDLuhGK/z7A14sYZz4Cd2+f4mSeFDaEOoH/g2SaY2CKR5KGkAADy8IyjZ21w==}
@@ -8788,9 +8758,6 @@ packages:
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
-  '@swc/helpers@0.5.19':
-    resolution: {integrity: sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==}
 
   '@swc/html-darwin-arm64@1.15.24':
     resolution: {integrity: sha512-2yH5kkeBM6mcSajWdIvh482HZDthvWM+SkH17CAzmgDgP2WGZ3IpdeIQxdV8Jj9kRdJaI0VqdXGT0qRRt6zw4A==}
@@ -9880,23 +9847,9 @@ packages:
   '@zxcvbn-ts/language-en@3.0.2':
     resolution: {integrity: sha512-Zp+zL+I6Un2Bj0tRXNs6VUBq3Djt+hwTwUz4dkt2qgsQz47U0/XthZ4ULrT/RxjwJRl5LwiaKOOZeOtmixHnjg==}
 
-  '@zxcvbn-ts/matcher-pwned@3.0.4':
-    resolution: {integrity: sha512-7BY6/IfY0Eb9HjTQGbDPIMceiBR6jZtQTOQfA3X3XREAZZ29GQ2XAm9dwZ76wF35XOajszGoXQ+L/fYh8DpkMg==}
-
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
-
-  abitype@1.2.3:
-    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3.22.0 || ^4.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -11171,6 +11124,9 @@ packages:
       typescript:
         optional: true
 
+  countries-list@3.3.0:
+    resolution: {integrity: sha512-XRUjS+dcZuNh/fg3+mka3bXgcg4TbQZ1gaK5IJqO6qulerBANl1bmrd20P2dgmPkBpP+5FnejiSF1gd7bgAg+g==}
+
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
@@ -11387,11 +11343,6 @@ packages:
 
   dataloader@2.2.3:
     resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
-
-  date-fns-tz@3.2.0:
-    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
-    peerDependencies:
-      date-fns: ^3.0.0 || ^4.0.0
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
@@ -12251,9 +12202,6 @@ packages:
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
-
-  eventemitter3@5.0.1:
-    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
@@ -15212,14 +15160,6 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
-  ox@0.14.7:
-    resolution: {integrity: sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   oxc-resolver@11.19.0:
     resolution: {integrity: sha512-oEe42WEoZc2T5sCQqgaRBx8huzP4cJvrnm+BfNTJESdtM633Tqs6iowkpsMTXgnb7SLwU6N6D9bqwW/PULjo6A==}
 
@@ -16367,10 +16307,6 @@ packages:
   react-docgen@7.1.1:
     resolution: {integrity: sha512-hlSJDQ2synMPKFZOsKo9Hi8WWZTC7POR8EmWvTSjow+VDgKzkmjQvFm2fk0tmRw+f0vTOIYKlarR0iL4996pdg==}
     engines: {node: '>=16.14.0'}
-
-  react-docgen@8.0.2:
-    resolution: {integrity: sha512-+NRMYs2DyTP4/tqWz371Oo50JqmWltR1h2gcdgUMAWZJIAvrd0/SqlCfx7tpzpl/s36rzw6qH2MjoNrxtRNYhA==}
-    engines: {node: ^20.9.0 || >=22}
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -18396,14 +18332,6 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  viem@2.47.6:
-    resolution: {integrity: sha512-zExmbI99NGvMdYa7fmqSTLgkwh48dmhgEqFrUgkpL4kfG4XkVefZ8dZqIKVUhZo6Uhf0FrrEXOsHm9LUyIvI2Q==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   vite-bundle-analyzer@1.3.6:
     resolution: {integrity: sha512-elFXkF9oGy4CJEeOdP1DSEHRDKWfmaEDfT9/GuF4jmyfmUF6nC//iN+ythqMEVvrtchOEHGKLumZwnu1NjoI0w==}
     hasBin: true
@@ -18755,9 +18683,6 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
-  world-countries@5.1.0:
-    resolution: {integrity: sha512-CXR6EBvTbArDlDDIWU3gfKb7Qk0ck2WNZ234b/A0vuecPzIfzzxH+O6Ejnvg1sT8XuiZjVlzOH0h08ZtaO7g0w==}
-
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -18818,18 +18743,6 @@ packages:
 
   ws@8.17.1:
     resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -19041,8 +18954,6 @@ snapshots:
   '@adobe/css-tools@4.4.4': {}
 
   '@adraffy/ens-normalize@1.10.1': {}
-
-  '@adraffy/ens-normalize@1.11.1': {}
 
   '@algolia/abtesting@1.15.1':
     dependencies:
@@ -20936,7 +20847,7 @@ snapshots:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@docusaurus/babel@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@docusaurus/babel@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -20948,7 +20859,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.3
       tslib: 2.8.1
@@ -20961,34 +20872,34 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@docusaurus/bundler@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.29.0
-      '@docusaurus/babel': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/babel': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@docusaurus/cssnano-preset': 3.10.0
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
-      css-loader: 6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.27.3)(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      copy-webpack-plugin: 11.0.0(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
+      css-loader: 6.11.0(@rspack/core@1.7.11)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.27.3)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       cssnano: 6.1.2(postcss@8.5.12)
-      file-loader: 6.2.0(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      file-loader: 6.2.0(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.10.0(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
-      null-loader: 4.0.1(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      mini-css-extract-plugin: 2.10.0(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
+      null-loader: 4.0.1(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       postcss: 8.5.12
-      postcss-loader: 7.3.4(postcss@8.5.12)(typescript@6.0.3)(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      postcss-loader: 7.3.4(postcss@8.5.12)(typescript@6.0.3)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       postcss-preset-env: 10.6.1(postcss@8.5.12)
-      terser-webpack-plugin: 5.3.16(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      terser-webpack-plugin: 5.3.16(@swc/core@1.11.31)(esbuild@0.27.3)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)))(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
-      webpackbar: 6.0.1(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)))(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
+      webpackbar: 6.0.1(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
     optionalDependencies:
-      '@docusaurus/faster': 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3)
+      '@docusaurus/faster': 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -21004,15 +20915,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@docusaurus/core@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/babel': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/bundler': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/babel': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/bundler': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -21028,7 +20939,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.3
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.6(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      html-webpack-plugin: 5.6.6(@rspack/core@1.7.11)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       leven: 3.1.0
       lodash: 4.18.1
       open: 8.4.2
@@ -21038,7 +20949,7 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.6)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.6))(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.6))(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       react-router: 5.3.4(react@19.2.6)
       react-router-config: 5.1.1(react-router@5.3.4(react@19.2.6))(react@19.2.6)
       react-router-dom: 5.3.4(react@19.2.6)
@@ -21047,12 +20958,12 @@ snapshots:
       tinypool: 1.1.1
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       webpack-merge: 6.0.1
     optionalDependencies:
-      '@docusaurus/faster': 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3)
+      '@docusaurus/faster': 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -21076,18 +20987,18 @@ snapshots:
       postcss-sort-media-queries: 5.2.0(postcss@8.5.12)
       tslib: 2.8.1
 
-  '@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3)':
+  '@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3)':
     dependencies:
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@rspack/core': 1.7.11(@swc/helpers@0.5.19)
-      '@swc/core': 1.11.31(@swc/helpers@0.5.19)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@rspack/core': 1.7.11
+      '@swc/core': 1.11.31
       '@swc/html': 1.15.24
       browserslist: 4.28.1
       lightningcss: 1.32.0
       semver: 7.7.4
-      swc-loader: 0.2.7(@swc/core@1.11.31(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      swc-loader: 0.2.7(@swc/core@1.11.31)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       tslib: 2.8.1
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
     transitivePeerDependencies:
       - '@swc/helpers'
       - esbuild
@@ -21099,16 +21010,16 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@docusaurus/mdx-loader@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@mdx-js/mdx': 3.1.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.5.0
-      file-loader: 6.2.0(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      file-loader: 6.2.0(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       fs-extra: 11.3.3
       image-size: 2.0.2
       mdast-util-mdx: 3.0.0
@@ -21124,9 +21035,9 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)))(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)))(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       vfile: 6.0.3
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -21134,9 +21045,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@docusaurus/module-type-aliases@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -21152,17 +21063,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@docusaurus/plugin-content-blog@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       cheerio: 1.0.0-rc.12
       combine-promises: 1.2.0
       feed: 4.2.2
@@ -21175,7 +21086,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.1.0
       utility-types: 3.11.0
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -21194,17 +21105,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.3
@@ -21215,7 +21126,7 @@ snapshots:
       schema-dts: 1.1.5
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -21234,18 +21145,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@docusaurus/plugin-content-pages@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       fs-extra: 11.3.3
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       tslib: 2.8.1
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -21264,12 +21175,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@docusaurus/plugin-css-cascade-layers@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -21291,11 +21202,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@docusaurus/plugin-debug@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       fs-extra: 11.3.3
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -21319,11 +21230,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-analytics@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       tslib: 2.8.1
@@ -21345,11 +21256,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-gtag@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/gtag.js': 0.0.20
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -21372,11 +21283,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-tag-manager@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       tslib: 2.8.1
@@ -21398,14 +21309,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@docusaurus/plugin-sitemap@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       fs-extra: 11.3.3
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -21429,18 +21340,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@docusaurus/plugin-svgr@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/webpack': 8.1.0(typescript@6.0.3)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       tslib: 2.8.1
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -21459,23 +21370,23 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.10.0(@algolia/client-search@5.49.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)(typescript@6.0.3)':
+  '@docusaurus/preset-classic@3.10.0(@algolia/client-search@5.49.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/plugin-content-pages': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/plugin-css-cascade-layers': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/plugin-debug': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/plugin-google-analytics': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/plugin-google-gtag': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/plugin-google-tag-manager': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/plugin-sitemap': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/plugin-svgr': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/theme-classic': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/theme-search-algolia': 3.10.0(@algolia/client-search@5.49.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/plugin-content-pages': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/plugin-css-cascade-layers': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/plugin-debug': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/plugin-google-analytics': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/plugin-google-gtag': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/plugin-google-tag-manager': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/plugin-sitemap': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/plugin-svgr': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/theme-classic': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@rspack/core@1.7.11)(@swc/core@1.11.31)(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/theme-search-algolia': 3.10.0(@algolia/client-search@5.49.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
@@ -21504,21 +21415,21 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.6
 
-  '@docusaurus/theme-classic@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@docusaurus/theme-classic@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@rspack/core@1.7.11)(@swc/core@1.11.31)(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/plugin-content-pages': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/plugin-content-pages': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
@@ -21552,13 +21463,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/module-type-aliases': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -21576,17 +21487,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.10.0(@algolia/client-search@5.49.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)(typescript@6.0.3)':
+  '@docusaurus/theme-search-algolia@3.10.0(@algolia/client-search@5.49.1)(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(@types/react@19.2.14)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)(typescript@6.0.3)':
     dependencies:
       '@algolia/autocomplete-core': 1.19.2(@algolia/client-search@5.49.1)(algoliasearch@5.49.1)(search-insights@2.17.3)
       '@docsearch/react': 4.6.0(@algolia/client-search@5.49.1)(@types/react@19.2.14)(algoliasearch@5.49.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)
-      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@swc/helpers@0.5.19)(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11(@swc/helpers@0.5.19))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/plugin-content-docs': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(esbuild@0.27.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-validation': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       algoliasearch: 5.49.1
       algoliasearch-helper: 3.28.0(algoliasearch@5.49.1)
       clsx: 2.1.1
@@ -21625,7 +21536,7 @@ snapshots:
 
   '@docusaurus/tsconfig@3.10.0': {}
 
-  '@docusaurus/types@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@docusaurus/types@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@types/history': 4.7.11
@@ -21637,7 +21548,7 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)'
       utility-types: 3.11.0
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -21646,9 +21557,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@docusaurus/utils-common@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -21659,11 +21570,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@docusaurus/utils-validation@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       fs-extra: 11.3.3
       joi: 17.13.3
       js-yaml: 4.1.1
@@ -21678,14 +21589,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@docusaurus/utils@3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/types': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/utils-common': 3.10.0(@swc/core@1.11.31)(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      file-loader: 6.2.0(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       fs-extra: 11.3.3
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -21698,9 +21609,9 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)))(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)))(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       utility-types: 3.11.0
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -23230,10 +23141,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
 
-  '@internationalized/date@3.11.0':
-    dependencies:
-      '@swc/helpers': 0.5.19
-
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -23881,10 +23788,6 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.3.2
 
-  '@noble/curves@1.9.1':
-    dependencies:
-      '@noble/hashes': 1.8.0
-
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -23923,27 +23826,27 @@ snapshots:
 
   '@npmcli/redact@4.0.0': {}
 
-  '@nx/devkit@22.7.1(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))':
+  '@nx/devkit@22.7.1(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))':
     dependencies:
       '@zkochan/js-yaml': 0.0.7
       ejs: 5.0.1
       enquirer: 2.3.6
       minimatch: 10.2.4
-      nx: 22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))
+      nx: 22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)
       semver: 7.7.4
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
-  '@nx/eslint@22.7.1(@babel/traverse@7.29.0)(@nx/jest@22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@types/node@25.2.3)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.5.0(typanion@3.14.0)))(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))(verdaccio@6.5.0(typanion@3.14.0))':
+  '@nx/eslint@22.7.1(@babel/traverse@7.29.0)(@nx/jest@22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)(@types/node@25.2.3)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))(typescript@5.9.3)(verdaccio@6.5.0(typanion@3.14.0)))(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))(verdaccio@6.5.0(typanion@3.14.0))':
     dependencies:
-      '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))
-      '@nx/js': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))(verdaccio@6.5.0(typanion@3.14.0))
+      '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))
+      '@nx/js': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))(verdaccio@6.5.0(typanion@3.14.0))
       eslint: 9.39.4(jiti@2.6.1)
       semver: 7.7.4
       tslib: 2.8.1
       typescript: 5.9.3
     optionalDependencies:
-      '@nx/jest': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@types/node@25.2.3)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.5.0(typanion@3.14.0))
+      '@nx/jest': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)(@types/node@25.2.3)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))(typescript@5.9.3)(verdaccio@6.5.0(typanion@3.14.0))
       '@zkochan/js-yaml': 0.0.7
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -23954,12 +23857,12 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/jest@22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@types/node@25.2.3)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.5.0(typanion@3.14.0))':
+  '@nx/jest@22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)(@types/node@25.2.3)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))(typescript@5.9.3)(verdaccio@6.5.0(typanion@3.14.0))':
     dependencies:
       '@jest/reporters': 30.2.0
       '@jest/test-result': 30.2.0
-      '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))
-      '@nx/js': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))(verdaccio@6.5.0(typanion@3.14.0))
+      '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))
+      '@nx/js': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))(verdaccio@6.5.0(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
       identity-obj-proxy: 3.0.0
       jest-config: 30.2.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))
@@ -23986,7 +23889,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/js@22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))(verdaccio@6.5.0(typanion@3.14.0))':
+  '@nx/js@22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))(verdaccio@6.5.0(typanion@3.14.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -23995,8 +23898,8 @@ snapshots:
       '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
-      '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))
-      '@nx/workspace': 22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))
+      '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))
+      '@nx/workspace': 22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)
       '@zkochan/js-yaml': 0.0.7
       babel-plugin-const-enum: 1.2.0(@babel/core@7.29.0)
       babel-plugin-macros: 3.1.0
@@ -24054,12 +23957,12 @@ snapshots:
   '@nx/nx-win32-x64-msvc@22.7.1':
     optional: true
 
-  '@nx/plugin@22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@types/node@25.2.3)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))(eslint@9.39.4(jiti@2.6.1))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.5.0(typanion@3.14.0))':
+  '@nx/plugin@22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)(@types/node@25.2.3)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))(eslint@9.39.4(jiti@2.6.1))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))(typescript@5.9.3)(verdaccio@6.5.0(typanion@3.14.0))':
     dependencies:
-      '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))
-      '@nx/eslint': 22.7.1(@babel/traverse@7.29.0)(@nx/jest@22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@types/node@25.2.3)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.5.0(typanion@3.14.0)))(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))(verdaccio@6.5.0(typanion@3.14.0))
-      '@nx/jest': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(@types/node@25.2.3)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))(typescript@5.9.3)(verdaccio@6.5.0(typanion@3.14.0))
-      '@nx/js': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))(verdaccio@6.5.0(typanion@3.14.0))
+      '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))
+      '@nx/eslint': 22.7.1(@babel/traverse@7.29.0)(@nx/jest@22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)(@types/node@25.2.3)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))(typescript@5.9.3)(verdaccio@6.5.0(typanion@3.14.0)))(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))(verdaccio@6.5.0(typanion@3.14.0))
+      '@nx/jest': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)(@types/node@25.2.3)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.3))(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))(typescript@5.9.3)(verdaccio@6.5.0(typanion@3.14.0))
+      '@nx/js': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))(verdaccio@6.5.0(typanion@3.14.0))
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -24078,13 +23981,13 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/workspace@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))':
+  '@nx/workspace@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)':
     dependencies:
-      '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)))
+      '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31))
       '@zkochan/js-yaml': 0.0.7
       chalk: 4.1.2
       enquirer: 2.3.6
-      nx: 22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19))
+      nx: 22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31)
       picomatch: 4.0.4
       semver: 7.7.4
       tslib: 2.8.1
@@ -25166,16 +25069,15 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@powerhousedao/document-engineering@1.40.3(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)':
+  '@powerhousedao/document-engineering@1.40.5(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(graphql@16.12.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.3.6)':
     dependencies:
-      '@internationalized/date': 3.11.0
+      '@noble/hashes': 1.8.0
       '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-progress': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-separator': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -25184,12 +25086,11 @@ snapshots:
       '@zxcvbn-ts/core': 3.0.4
       '@zxcvbn-ts/language-common': 3.0.4
       '@zxcvbn-ts/language-en': 3.0.2
-      '@zxcvbn-ts/matcher-pwned': 3.0.4
       class-variance-authority: 0.7.0
       clsx: 2.1.1
       cmdk: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      countries-list: 3.3.0
       date-fns: 4.1.0
-      date-fns-tz: 3.2.0(date-fns@4.1.0)
       diff: 7.0.0
       focus-trap: 7.8.0
       graphql: 16.12.0
@@ -25201,7 +25102,6 @@ snapshots:
       react: 19.2.6
       react-circle-flags: 0.0.22(react@19.2.6)
       react-day-picker: 9.4.3(react@19.2.6)
-      react-docgen: 8.0.2
       react-dom: 19.2.6(react@19.2.6)
       react-dropzone: 14.4.1(react@19.2.6)
       react-hook-form: 7.71.2(react@19.2.6)
@@ -25210,75 +25110,13 @@ snapshots:
       remark-gfm: 4.0.1
       tailwind-merge: 3.4.0
       usehooks-ts: 3.1.1(react@19.2.6)
-      viem: 2.47.6(typescript@5.9.3)(zod@4.3.6)
-      world-countries: 5.1.0
       zod: 4.3.6
     transitivePeerDependencies:
       - '@types/express'
       - '@types/koa'
       - '@types/react'
       - '@types/react-dom'
-      - bufferutil
       - supports-color
-      - typescript
-      - utf-8-validate
-
-  '@powerhousedao/document-engineering@1.40.3(@types/express@4.17.25)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
-    dependencies:
-      '@internationalized/date': 3.11.0
-      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-progress': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-separator': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-visually-hidden': 1.2.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@zxcvbn-ts/core': 3.0.4
-      '@zxcvbn-ts/language-common': 3.0.4
-      '@zxcvbn-ts/language-en': 3.0.2
-      '@zxcvbn-ts/matcher-pwned': 3.0.4
-      class-variance-authority: 0.7.0
-      clsx: 2.1.1
-      cmdk: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      date-fns: 4.1.0
-      date-fns-tz: 3.2.0(date-fns@4.1.0)
-      diff: 7.0.0
-      focus-trap: 7.8.0
-      graphql: 16.12.0
-      graphql-upload: 17.0.0(@types/express@4.17.25)(graphql@16.12.0)
-      libphonenumber-js: 1.12.37
-      mime: 4.1.0
-      nanoid: 5.1.6
-      natural-compare-lite: 1.4.0
-      react: 19.2.6
-      react-circle-flags: 0.0.22(react@19.2.6)
-      react-day-picker: 9.4.3(react@19.2.6)
-      react-docgen: 8.0.2
-      react-dom: 19.2.6(react@19.2.6)
-      react-dropzone: 14.4.1(react@19.2.6)
-      react-hook-form: 7.71.2(react@19.2.6)
-      react-portal: 4.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react-virtualized: 9.22.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      remark-gfm: 4.0.1
-      tailwind-merge: 3.4.0
-      usehooks-ts: 3.1.1(react@19.2.6)
-      viem: 2.47.6(typescript@6.0.3)(zod@4.3.6)
-      world-countries: 5.1.0
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - '@types/express'
-      - '@types/koa'
-      - '@types/react'
-      - '@types/react-dom'
-      - bufferutil
-      - supports-color
-      - typescript
-      - utf-8-validate
 
   '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.28.4)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -25703,15 +25541,6 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
@@ -26152,30 +25981,15 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.7.11
       '@rspack/binding-win32-x64-msvc': 1.7.11
 
-  '@rspack/core@1.7.11(@swc/helpers@0.5.19)':
+  '@rspack/core@1.7.11':
     dependencies:
       '@module-federation/runtime-tools': 0.22.0
       '@rspack/binding': 1.7.11
       '@rspack/lite-tapable': 1.1.0
-    optionalDependencies:
-      '@swc/helpers': 0.5.19
 
   '@rspack/lite-tapable@1.1.0': {}
 
-  '@scure/base@1.2.6': {}
-
   '@scure/base@2.0.0': {}
-
-  '@scure/bip32@1.7.0':
-    dependencies:
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.6
-
-  '@scure/bip39@1.6.0':
-    dependencies:
-      '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.6
 
   '@sentry-internal/browser-utils@10.40.0':
     dependencies:
@@ -26746,16 +26560,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@swc-node/core@1.14.1(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)':
+  '@swc-node/core@1.14.1(@swc/core@1.11.31)(@swc/types@0.1.25)':
     dependencies:
-      '@swc/core': 1.11.31(@swc/helpers@0.5.19)
+      '@swc/core': 1.11.31
       '@swc/types': 0.1.25
 
-  '@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3)':
+  '@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3)':
     dependencies:
-      '@swc-node/core': 1.14.1(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)
+      '@swc-node/core': 1.14.1(@swc/core@1.11.31)(@swc/types@0.1.25)
       '@swc-node/sourcemap-support': 0.5.1
-      '@swc/core': 1.11.31(@swc/helpers@0.5.19)
+      '@swc/core': 1.11.31
       colorette: 2.0.20
       debug: 4.4.3(supports-color@5.5.0)
       oxc-resolver: 5.3.0
@@ -26801,7 +26615,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.11.31':
     optional: true
 
-  '@swc/core@1.11.31(@swc/helpers@0.5.19)':
+  '@swc/core@1.11.31':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.25
@@ -26816,13 +26630,8 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.11.31
       '@swc/core-win32-ia32-msvc': 1.11.31
       '@swc/core-win32-x64-msvc': 1.11.31
-      '@swc/helpers': 0.5.19
 
   '@swc/counter@0.1.3': {}
-
-  '@swc/helpers@0.5.19':
-    dependencies:
-      tslib: 2.8.1
 
   '@swc/html-darwin-arm64@1.15.24':
     optional: true
@@ -28327,24 +28136,10 @@ snapshots:
 
   '@zxcvbn-ts/language-en@3.0.2': {}
 
-  '@zxcvbn-ts/matcher-pwned@3.0.4':
-    dependencies:
-      '@zxcvbn-ts/core': 3.0.4
-
   JSONStream@1.3.5:
     dependencies:
       jsonparse: 1.3.1
       through: 2.3.8
-
-  abitype@1.2.3(typescript@5.9.3)(zod@4.3.6):
-    optionalDependencies:
-      typescript: 5.9.3
-      zod: 4.3.6
-
-  abitype@1.2.3(typescript@6.0.3)(zod@4.3.6):
-    optionalDependencies:
-      typescript: 6.0.3
-      zod: 4.3.6
 
   abort-controller@3.0.0:
     dependencies:
@@ -28720,12 +28515,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
 
   babel-plugin-const-enum@1.2.0(@babel/core@7.29.0):
     dependencies:
@@ -29707,7 +29502,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.2: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  copy-webpack-plugin@11.0.0(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -29715,7 +29510,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
 
   copyfiles@2.4.1:
     dependencies:
@@ -29812,6 +29607,8 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  countries-list@3.3.0: {}
+
   crc-32@1.2.2: {}
 
   crc-native@1.1.8(bare-url@2.3.2):
@@ -29871,7 +29668,7 @@ snapshots:
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  css-loader@6.11.0(@rspack/core@1.7.11)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.12)
       postcss: 8.5.12
@@ -29882,10 +29679,10 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
-      '@rspack/core': 1.7.11(@swc/helpers@0.5.19)
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      '@rspack/core': 1.7.11
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.27.3)(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.27.3)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 6.1.2(postcss@8.5.12)
@@ -29893,7 +29690,7 @@ snapshots:
       postcss: 8.5.12
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
     optionalDependencies:
       clean-css: 5.3.3
       esbuild: 0.27.3
@@ -30092,10 +29889,6 @@ snapshots:
       is-data-view: 1.0.2
 
   dataloader@2.2.3: {}
-
-  date-fns-tz@3.2.0(date-fns@4.1.0):
-    dependencies:
-      date-fns: 4.1.0
 
   date-fns@4.1.0: {}
 
@@ -31082,8 +30875,6 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
-  eventemitter3@5.0.1: {}
-
   eventemitter3@5.0.4: {}
 
   events-universal@1.0.1:
@@ -31432,11 +31223,11 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  file-loader@6.2.0(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
 
   file-selector@2.1.2:
     dependencies:
@@ -32231,7 +32022,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.6(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  html-webpack-plugin@5.6.6(@rspack/core@1.7.11)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -32239,8 +32030,8 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
-      '@rspack/core': 1.7.11(@swc/helpers@0.5.19)
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      '@rspack/core': 1.7.11
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -32813,10 +32604,6 @@ snapshots:
   isomorphic-ws@5.0.0(ws@8.20.0):
     dependencies:
       ws: 8.20.0
-
-  isows@1.0.7(ws@8.18.3):
-    dependencies:
-      ws: 8.18.3
 
   isows@1.0.7(ws@8.20.0):
     dependencies:
@@ -34456,11 +34243,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.10.0(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  mini-css-extract-plugin@2.10.0(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
 
   minimalistic-assert@1.0.1: {}
 
@@ -34886,17 +34673,17 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  null-loader@4.0.1(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
 
   nullthrows@1.1.1: {}
 
   nwsapi@2.2.23: {}
 
-  nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31(@swc/helpers@0.5.19)):
+  nx@22.7.1(@swc-node/register@1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.11.31):
     dependencies:
       '@emnapi/core': 1.4.5
       '@emnapi/runtime': 1.4.5
@@ -35019,8 +34806,8 @@ snapshots:
       '@nx/nx-linux-x64-musl': 22.7.1
       '@nx/nx-win32-arm64-msvc': 22.7.1
       '@nx/nx-win32-x64-msvc': 22.7.1
-      '@swc-node/register': 1.10.10(@swc/core@1.11.31(@swc/helpers@0.5.19))(@swc/types@0.1.25)(typescript@5.9.3)
-      '@swc/core': 1.11.31(@swc/helpers@0.5.19)
+      '@swc-node/register': 1.10.10(@swc/core@1.11.31)(@swc/types@0.1.25)(typescript@5.9.3)
+      '@swc/core': 1.11.31
     transitivePeerDependencies:
       - debug
 
@@ -35158,36 +34945,6 @@ snapshots:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
-
-  ox@0.14.7(typescript@5.9.3)(zod@4.3.6):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - zod
-
-  ox@0.14.7(typescript@6.0.3)(zod@4.3.6):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@6.0.3)(zod@4.3.6)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - zod
 
   oxc-resolver@11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     optionalDependencies:
@@ -35762,13 +35519,13 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  postcss-loader@7.3.4(postcss@8.5.12)(typescript@6.0.3)(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  postcss-loader@7.3.4(postcss@8.5.12)(typescript@6.0.3)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@6.0.3)
       jiti: 1.21.7
       postcss: 8.5.12
       semver: 7.7.4
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
     transitivePeerDependencies:
       - typescript
 
@@ -36439,21 +36196,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-docgen@8.0.2:
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@types/babel__core': 7.20.5
-      '@types/babel__traverse': 7.28.0
-      '@types/doctrine': 0.0.9
-      '@types/resolve': 1.20.6
-      doctrine: 3.0.0
-      resolve: 1.22.11
-      strip-indent: 4.1.1
-    transitivePeerDependencies:
-      - supports-color
-
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -36510,11 +36252,11 @@ snapshots:
 
   react-lifecycles-compat@3.0.4: {}
 
-  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.6))(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.6))(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       '@babel/runtime': 7.29.2
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.6)'
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
 
   react-portal@4.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -38065,11 +37807,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  swc-loader@0.2.7(@swc/core@1.11.31(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  swc-loader@0.2.7(@swc/core@1.11.31)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
-      '@swc/core': 1.11.31(@swc/helpers@0.5.19)
+      '@swc/core': 1.11.31
       '@swc/counter': 0.1.3
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
 
   symbol-observable@4.0.0: {}
 
@@ -38154,16 +37896,16 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  terser-webpack-plugin@5.3.16(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  terser-webpack-plugin@5.3.16(@swc/core@1.11.31)(esbuild@0.27.3)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.46.1
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
     optionalDependencies:
-      '@swc/core': 1.11.31(@swc/helpers@0.5.19)
+      '@swc/core': 1.11.31
       esbuild: 0.27.3
 
   terser@5.46.1:
@@ -38783,14 +38525,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)))(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)))(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      file-loader: 6.2.0(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
 
   url-parse@1.5.10:
     dependencies:
@@ -38972,40 +38714,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
-
-  viem@2.47.6(typescript@5.9.3)(zod@4.3.6):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
-      isows: 1.0.7(ws@8.18.3)
-      ox: 0.14.7(typescript@5.9.3)(zod@4.3.6)
-      ws: 8.18.3
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
-  viem@2.47.6(typescript@6.0.3)(zod@4.3.6):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@6.0.3)(zod@4.3.6)
-      isows: 1.0.7(ws@8.18.3)
-      ox: 0.14.7(typescript@6.0.3)(zod@4.3.6)
-      ws: 8.18.3
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
 
   vite-bundle-analyzer@1.3.6: {}
 
@@ -39394,7 +39102,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.56.10(tslib@2.8.1)
@@ -39403,11 +39111,11 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -39435,10 +39143,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       ws: 8.20.0
     optionalDependencies:
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -39464,7 +39172,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3):
+  webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -39488,7 +39196,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3))
+      terser-webpack-plugin: 5.3.16(@swc/core@1.11.31)(esbuild@0.27.3)(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:
@@ -39496,7 +39204,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpackbar@6.0.1(webpack@5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)):
+  webpackbar@6.0.1(webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -39505,7 +39213,7 @@ snapshots:
       markdown-table: 2.0.0
       pretty-time: 1.1.0
       std-env: 3.10.0
-      webpack: 5.105.2(@swc/core@1.11.31(@swc/helpers@0.5.19))(esbuild@0.27.3)
+      webpack: 5.105.2(@swc/core@1.11.31)(esbuild@0.27.3)
       wrap-ansi: 7.0.0
 
   websocket-driver@0.7.4:
@@ -39608,8 +39316,6 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  world-countries@5.1.0: {}
-
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -39683,8 +39389,6 @@ snapshots:
   ws@7.5.10: {}
 
   ws@8.17.1: {}
-
-  ws@8.18.3: {}
 
   ws@8.19.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ packages:
 catalog:
   "vite-tsconfig-paths": 6.1.1
   "@modelcontextprotocol/sdk": 1.29.0
-  "@powerhousedao/document-engineering": 1.40.3
+  "@powerhousedao/document-engineering": 1.40.5
   "kysely": 0.28.16
   "kysely-pglite-dialect": 1.2.0
   "kysely-pglite": 0.6.1


### PR DESCRIPTION
## Summary
- Bump `@powerhousedao/document-engineering` from 1.40.3 to 1.40.5 in `pnpm-workspace.yaml` catalog and `packages/shared/clis/constants.ts`
- Refresh `pnpm-lock.yaml`

## Test plan
- [ ] CI green