### PR TITLE
fix(codegen): install dependencies during migrate before regeneration

### DIFF
--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -41,6 +41,7 @@
     "build": "tsdown"
   },
   "dependencies": {
+    "@graphql-codegen/add": "catalog:",
     "@graphql-codegen/cli": "catalog:",
     "@graphql-codegen/typescript": "catalog:",
     "@powerhousedao/document-engineering": "catalog:",

--- a/packages/codegen/src/codegen/migrate.ts
+++ b/packages/codegen/src/codegen/migrate.ts
@@ -1,9 +1,12 @@
 import {
   externalDevDependencies,
   FEATURE_DEPENDENCIES,
+  getPackageManagerAtPowerhouseProjectDirPath,
+  getPowerhouseProjectInstallCommand,
   packageJsonExports,
   packageScripts,
   PEER_EXTERNAL_DEPENDENCIES,
+  runCmd,
   VERSIONED_DEV_DEPENDENCIES,
   VERSIONED_PEER_DEPENDENCIES,
 } from "@powerhousedao/shared/clis";
@@ -242,9 +245,23 @@ export async function migrate(version: string, projectDir = process.cwd()) {
   const project = buildTsMorphProject(projectDir);
   console.log("Fixing legacy import paths...");
   fixLegacyImportPaths(project, packageJson.name);
+  console.log("Installing dependencies...");
+  await installProjectDependencies(projectDir);
   console.log("Re-generating code...");
   await generateAll(project);
   await project.save();
+}
+
+async function installProjectDependencies(projectDir: string) {
+  const agent = await getPackageManagerAtPowerhouseProjectDirPath(projectDir);
+  if (!agent) {
+    throw new Error(
+      "Failed to detect your package manager. Run install manually.",
+    );
+  }
+  const installCommand = await getPowerhouseProjectInstallCommand(agent);
+  console.log(`Installing dependencies with \`${agent}\``);
+  runCmd(installCommand, { cwd: projectDir });
 }
 
 function moveLegacyDocumentModels(projectDir: string) {

--- a/packages/shared/clis/file-system/run-cmd.ts
+++ b/packages/shared/clis/file-system/run-cmd.ts
@@ -1,8 +1,8 @@
 import { execSync } from "child_process";
 
-export function runCmd(command: string) {
+export function runCmd(command: string, options: { cwd?: string } = {}) {
   try {
-    execSync(command, { stdio: "inherit" });
+    execSync(command, { stdio: "inherit", cwd: options.cwd });
   } catch (error) {
     console.log("\x1b[31m", error, "\x1b[0m");
     throw error;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1125,6 +1125,9 @@ importers:
 
   packages/codegen:
     dependencies:
+      '@graphql-codegen/add':
+        specifier: 'catalog:'
+        version: 6.0.0(graphql@16.12.0)
       '@graphql-codegen/cli':
         specifier: 'catalog:'
         version: 6.1.1(@fastify/websocket@11.2.0)(@parcel/watcher@2.5.6)(@types/node@25.2.3)(graphql@16.12.0)(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- Declares previously-missing `@graphql-codegen/add` and `package-manager-detector` as dependencies of `@powerhousedao/codegen`.
- Adds an install step in the `migrate` flow between the `package.json` rewrite and `generateAll`, mirroring `ph update`'s install pattern (detect agent + `runCmd`).
- Fixes `pnpm dlx @powerhousedao/ph-cli migrate` failing with `Unable to find template plugin matching 'typescript'` / `'add'` — graphql-codegen plugins now resolve because the new project deps are installed before codegen runs.

## Test plan
- [ ] Run `pnpm dlx @powerhousedao/ph-cli@<this-version> migrate` against a pre-existing project and confirm migrate completes without graphql-codegen plugin errors.
- [ ] Confirm `ph generate` continues to work post-migrate.