### PR TITLE
fix(codegen): stop reordering document-model keys and fix generateMock import

### DIFF
--- a/packages/codegen/src/file-builders/document-model/tests-dir.ts
+++ b/packages/codegen/src/file-builders/document-model/tests-dir.ts
@@ -160,7 +160,7 @@ export async function makeOperationModuleTestFile(
   describeCallBody.addStatements(testCasesToAdd);
 
   const GENERATE_MOCK_NAME = "generateMock";
-  const GENERATE_MOCK_MODULE_SPECIFIER = "@powerhousedao/codegen";
+  const GENERATE_MOCK_MODULE_SPECIFIER = "document-model";
 
   const generateMockImport = sourceFile.getImportDeclaration((i) =>
     i.getNamedImports().some((v) => v.getText().includes(GENERATE_MOCK_NAME)),

--- a/packages/shared/document-model/schemas.ts
+++ b/packages/shared/document-model/schemas.ts
@@ -424,11 +424,11 @@ export function DocumentModelGlobalStateSchema(): z.ZodObject<
 > {
   return z.object({
     __typename: z.literal("DocumentModelGlobalState").optional(),
-    author: AuthorSchema(),
-    description: z.string(),
-    extension: z.string(),
     id: z.string(),
     name: z.string(),
+    author: AuthorSchema(),
+    extension: z.string(),
+    description: z.string(),
     specifications: z.array(DocumentSpecificationSchema()),
   });
 }
@@ -438,19 +438,19 @@ export function DocumentSpecificationSchema(): z.ZodObject<
 > {
   return z.object({
     __typename: z.literal("DocumentSpecification").optional(),
-    changeLog: z.array(z.string()),
-    modules: z.array(ModuleSchema()),
     state: ScopeStateSchema(),
+    modules: z.array(ModuleSchema()),
     version: z.number().int(),
+    changeLog: z.array(z.string()),
   });
 }
 
 export function ModuleSchema(): z.ZodObject<Properties<ModuleSpecification>> {
   return z.object({
     __typename: z.literal("ModuleSpecification").optional(),
-    description: z.string().nullable(),
     id: z.string(),
     name: z.string(),
+    description: z.string().nullable(),
     operations: z.array(OperationSpecificationSchema()),
   });
 }
@@ -469,14 +469,14 @@ export function OperationSpecificationSchema(): z.ZodObject<
 > {
   return z.object({
     __typename: z.literal("OperationSpecification").optional(),
-    description: z.string().nullable(),
-    errors: z.array(OperationErrorSchema()),
-    examples: z.array(CodeExampleSchema()),
     id: z.string(),
     name: z.string().nullable(),
-    reducer: z.string().nullable(),
+    description: z.string().nullable(),
     schema: z.string().nullable(),
     template: z.string().nullable(),
+    reducer: z.string().nullable(),
+    errors: z.array(OperationErrorSchema()),
+    examples: z.array(CodeExampleSchema()),
     scope: OperationScopeSchema(),
   });
 }
@@ -486,10 +486,10 @@ export function OperationErrorSchema(): z.ZodObject<
 > {
   return z.object({
     __typename: z.literal("OperationErrorSpecification").optional(),
-    code: z.string().nullable(),
-    description: z.string().nullable(),
     id: z.string(),
     name: z.string().nullable(),
+    code: z.string().nullable(),
+    description: z.string().nullable(),
     template: z.string().nullable(),
   });
 }
@@ -724,16 +724,16 @@ export function SetStateSchemaInputSchema(): z.ZodObject<
 export function StateSchema(): z.ZodObject<Properties<State>> {
   return z.object({
     __typename: z.literal("State").optional(),
+    schema: z.string(),
     examples: z.array(CodeExampleSchema()),
     initialValue: z.string(),
-    schema: z.string(),
   });
 }
 
 export function ScopeStateSchema(): z.ZodObject<Properties<ScopeState>> {
   return z.object({
-    global: StateSchema(),
     local: StateSchema(),
+    global: StateSchema(),
   });
 }
 


### PR DESCRIPTION
## Summary

Two `ph migrate` fixes surfaced while running migrate against `test/team-project`:

- **Key reordering in `document-model.ts` and `<name>.json`.** `loadDocumentModelInDir` runs the parsed JSON through `DocumentModelGlobalStateSchema().safeParse(...)`. Zod returns objects with keys in **schema-declared order**, not input order — and the schemas were ordered alphabetically. That ordering then flowed into `buildObjectLiteral` (TS emit) and `JSON.stringify` (JSON emit), causing migrate to reshuffle every key on every run. Reordered the relevant schemas (`DocumentModelGlobalState`, `DocumentSpecification`, `Module`, `Operation`, `OperationError`, `State`, `ScopeState`) to match the canonical order used in existing `*.json` files. After this, re-running migrate produces zero diff on the bug/feature/kanban-board models.
- **`generateMock` imported from the wrong package.** `tests-dir.ts` set `GENERATE_MOCK_MODULE_SPECIFIER = "@powerhousedao/codegen"`, but `generateMock` is exported from `document-model` (`packages/shared/document-model/mock.ts`, re-exported via `utils.ts`). New test cases added by codegen were getting an import from a module that doesn't export the symbol. The initial template at line 64 of the same file already correctly used `"document-model"` — this aligns the constant with that.

## Test plan

- [x] Reset `test/team-project` and re-run `ph-cli migrate --force 6.0.0-dev.248` with the rebuilt `@powerhousedao/shared` and `@powerhousedao/codegen` packages overlaid.
- [x] Verified `document-models/*/bug.json`, `feature.json`, `kanban-board.json` and `document-models/*/v1/gen/document-model.ts` show **zero diff** vs. the pre-migrate state.
- [x] Verified `import { generateMock } from "document-model";` is emitted in newly populated test files (previously `@powerhousedao/codegen`).
- [ ] CI to validate no other consumers depended on the previous schema field order.