### PR TITLE
fix: add missing bg and text styles

### DIFF
--- a/apps/connect/src/components/missing-model-banner.tsx
+++ b/apps/connect/src/components/missing-model-banner.tsx
@@ -84,7 +84,7 @@ function MissingModelDetailsModal(props: DetailsProps) {
       }}
       contentProps={{ className: "rounded-3xl" }}
     >
-      <div className="w-[520px] max-w-[90vw] p-6">
+      <div className="w-[520px] max-w-[90vw] bg-white p-6">
         <div className="border-b border-slate-100 pb-2 text-2xl font-bold text-gray-800">
           Missing document models
         </div>

--- a/apps/connect/src/components/modal/modals/DebugSettingsModal.tsx
+++ b/apps/connect/src/components/modal/modals/DebugSettingsModal.tsx
@@ -34,7 +34,7 @@ export const DebugSettingsModal: React.FC = () => {
         className: "rounded-2xl",
       }}
     >
-      <div className="w-[700px] rounded-2xl p-6">
+      <div className="w-[700px] rounded-2xl bg-white p-6">
         <div className="mb-6 flex justify-between">
           <div className="text-xl font-bold">Debug Tools</div>
           <button id="close-modal" onClick={() => closePHModal()}>

--- a/packages/design-system/src/connect/components/editor-undo-redo-buttons/editor-undo-redo-buttons.tsx
+++ b/packages/design-system/src/connect/components/editor-undo-redo-buttons/editor-undo-redo-buttons.tsx
@@ -10,7 +10,7 @@ export type EditorUndoRedoButtonsProps = {
 export function EditorUndoRedoButtons(props: EditorUndoRedoButtonsProps) {
   const { canUndo, canRedo, undo, redo } = props;
   const buttonStyles =
-    "w-8 h-8 rounded-lg flex justify-center items-center rounded border border-gray-200";
+    "w-8 h-8 rounded-lg flex justify-center items-center rounded border border-gray-200 bg-white";
   return (
     <div className="flex gap-x-2 text-gray-500">
       <button className={buttonStyles} disabled={!canUndo} onClick={undo}>

--- a/packages/design-system/src/connect/components/form/inputs/location-info.tsx
+++ b/packages/design-system/src/connect/components/form/inputs/location-info.tsx
@@ -13,7 +13,7 @@ export function LocationInfo(props: LocationInfoProps) {
     <div
       {...divProps}
       className={twMerge(
-        "my-3 flex items-center gap-2 rounded-xl border border-gray-100 p-3 text-gray-800 shadow-sm",
+        "my-3 flex items-center gap-2 rounded-xl border border-gray-100 bg-white p-3 text-gray-800 shadow-sm",
         className,
       )}
     >

--- a/packages/design-system/src/connect/components/home-screen/home-screen-item.tsx
+++ b/packages/design-system/src/connect/components/home-screen/home-screen-item.tsx
@@ -33,7 +33,7 @@ export const HomeScreenItem = function HomeScreenItem(
         )}
       </div>
       <div className="w-full max-w-full">
-        <h3 className="w-full max-w-full truncate px-2 text-slate-50">
+        <h3 className="w-full max-w-full truncate px-2 text-gray-900">
           {title}
         </h3>
         {description && <p className="text-gray-500">{description}</p>}

--- a/packages/design-system/src/connect/components/home-screen/home-screen.tsx
+++ b/packages/design-system/src/connect/components/home-screen/home-screen.tsx
@@ -15,7 +15,7 @@ export const HomeScreen = function HomeScreen(props: HomeScreenProps) {
         containerClassName,
       )}
     >
-      <div className="m-8 flex flex-wrap justify-center gap-4 pt-12 dark:bg-slate-900">
+      <div className="m-8 flex flex-wrap justify-center gap-4 bg-white pt-12">
         <HomeBackgroundImage />
         {children}
       </div>

--- a/packages/design-system/src/connect/components/modal/__snapshots__/delete-item-modal.test.tsx.snap
+++ b/packages/design-system/src/connect/components/modal/__snapshots__/delete-item-modal.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Modal Component > should match snapshot 1`] = `
     </p>
   </span>
   <div
-    class="p-6 text-slate-300 w-[450px]"
+    class="bg-white p-6 text-slate-300 w-[450px]"
   >
     <div
       class="border-b border-slate-50 pb-2 text-2xl font-bold text-gray-800"

--- a/packages/design-system/src/connect/components/modal/__snapshots__/upgrade-drive-modal.test.tsx.snap
+++ b/packages/design-system/src/connect/components/modal/__snapshots__/upgrade-drive-modal.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`UpgradeDriveModal Component > should match snapshot 1`] = `
     </p>
   </span>
   <div
-    class="w-[400px] p-6 text-slate-300"
+    class="w-[400px] bg-white p-6 text-slate-300"
   >
     <div
       class="border-b border-slate-50 pb-2 text-2xl font-bold text-gray-800"

--- a/packages/design-system/src/connect/components/modal/add-drive-modal/add-drive-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/add-drive-modal/add-drive-modal.tsx
@@ -51,7 +51,7 @@ export function AddDriveModal(props: AddDriveModalProps) {
       <div
         {...containerProps}
         className={twMerge(
-          "w-[408px] rounded-2xl p-6",
+          "w-[408px] rounded-2xl bg-white p-6",
           containerProps?.className,
         )}
       >

--- a/packages/design-system/src/connect/components/modal/add-local-drive-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/add-local-drive-modal.tsx
@@ -38,7 +38,7 @@ export function AddLocalDriveModal(props: AddLocalDriveModal) {
       <div
         {...containerProps}
         className={twMerge(
-          "max-w-[408px] rounded-2xl p-6",
+          "max-w-[408px] rounded-2xl bg-white p-6",
           containerProps?.className,
         )}
       >

--- a/packages/design-system/src/connect/components/modal/add-remote-drive-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/add-remote-drive-modal.tsx
@@ -44,7 +44,7 @@ export function AddRemoteDriveModal(props: AddRemoteDriveModal) {
       <div
         {...containerProps}
         className={twMerge(
-          "max-w-[408px] min-w-[408px] rounded-2xl p-6",
+          "max-w-[408px] min-w-[408px] rounded-2xl bg-white p-6",
           containerProps?.className,
         )}
       >

--- a/packages/design-system/src/connect/components/modal/confirmation-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/confirmation-modal.tsx
@@ -59,7 +59,10 @@ export function ConnectConfirmationModal(props: ConfirmationModalProps) {
       {...restProps}
     >
       <div
-        {...mergeClassNameProps(containerProps, "w-[400px] p-6 text-slate-300")}
+        {...mergeClassNameProps(
+          containerProps,
+          "w-[400px] bg-white p-6 text-slate-300",
+        )}
       >
         <div
           {...mergeClassNameProps(

--- a/packages/design-system/src/connect/components/modal/create-document-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/create-document-modal.tsx
@@ -60,7 +60,7 @@ export function CreateDocumentModal(props: CreateDocumentModalProps) {
     >
       <form
         name="create-document"
-        className="w-[400px] p-6 text-slate-300"
+        className="w-[400px] bg-white p-6 text-slate-300"
         onSubmit={handleSubmit}
       >
         <div className="border-b border-slate-50 pb-2 text-2xl font-bold text-gray-800">

--- a/packages/design-system/src/connect/components/modal/drive-settings-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/drive-settings-modal.tsx
@@ -83,7 +83,7 @@ export function DriveSettingsModal(props: DriveSettingsModalProps) {
       <div
         {...containerProps}
         className={twMerge(
-          "max-w-[408px] rounded-2xl p-6",
+          "max-w-[408px] rounded-2xl bg-white p-6",
           containerProps?.className,
         )}
       >

--- a/packages/design-system/src/connect/components/modal/inspector-modal/inspector-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/inspector-modal/inspector-modal.tsx
@@ -67,7 +67,7 @@ export function InspectorModal({
       <div
         {...containerProps}
         className={twMerge(
-          "flex size-full flex-col",
+          "flex size-full flex-col bg-white",
           containerProps?.className,
         )}
       >

--- a/packages/design-system/src/connect/components/modal/missing-package-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/missing-package-modal.tsx
@@ -94,7 +94,7 @@ export function PackageInstallModal(props: PackageInstallModalProps) {
       }}
       {...restProps}
     >
-      <div className="w-[460px] p-6 text-slate-300">
+      <div className="w-[460px] bg-white p-6 text-slate-300">
         <div className="border-b border-slate-50 pb-2 text-2xl font-bold text-gray-800">
           {grouped.length === 1 ? "Package Required" : "Packages Required"}
         </div>

--- a/packages/design-system/src/connect/components/modal/read-required-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/read-required-modal.tsx
@@ -92,7 +92,10 @@ export function ReadRequiredModal(props: ReadRequiredModalProps) {
       {...restProps}
     >
       <div
-        {...mergeClassNameProps(containerProps, "w-[500px] p-6 text-slate-300")}
+        {...mergeClassNameProps(
+          containerProps,
+          "w-[500px] bg-white p-6 text-slate-300",
+        )}
       >
         <div
           {...mergeClassNameProps(

--- a/packages/design-system/src/connect/components/modal/replace-duplicate-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/replace-duplicate-modal.tsx
@@ -64,7 +64,10 @@ export function ConnectReplaceDuplicateModal(
       {...restProps}
     >
       <div
-        {...mergeClassNameProps(containerProps, "w-[450px] p-6 text-slate-300")}
+        {...mergeClassNameProps(
+          containerProps,
+          "w-[450px] bg-white p-6 text-slate-300",
+        )}
       >
         <div className="flex items-center justify-between border-b border-slate-50 pb-2">
           <div

--- a/packages/design-system/src/connect/components/modal/settings-modal-v2/default-editor.tsx
+++ b/packages/design-system/src/connect/components/modal/settings-modal-v2/default-editor.tsx
@@ -12,7 +12,7 @@ type Props = {
 export function DefaultEditor(props: Props) {
   const { className, ...rest } = props;
   return (
-    <div className={twMerge("rounded-lg p-3", className)}>
+    <div className={twMerge("rounded-lg bg-white p-3", className)}>
       <DefaultEditorSelect {...rest} />
     </div>
   );

--- a/packages/design-system/src/connect/components/modal/settings-modal-v2/package-manager/package-manager-list.tsx
+++ b/packages/design-system/src/connect/components/modal/settings-modal-v2/package-manager/package-manager-list.tsx
@@ -78,7 +78,7 @@ export const PackageManagerListItem = (props: {
   return (
     <li
       className={twMerge(
-        "relative flex flex-col items-start rounded-md border border-gray-200 p-3 text-sm/5 shadow-sm",
+        "relative flex flex-col items-start rounded-md border border-gray-200 bg-white p-3 text-sm/5 shadow-sm",
         className,
       )}
     >

--- a/packages/design-system/src/connect/components/modal/settings-modal-v2/package-manager/package-manager.tsx
+++ b/packages/design-system/src/connect/components/modal/settings-modal-v2/package-manager/package-manager.tsx
@@ -30,7 +30,7 @@ export const PackageManager: React.FC<Props> = (props) => {
   return (
     <div
       className={twMerge(
-        "flex h-full flex-1 flex-col rounded-lg p-3",
+        "flex h-full flex-1 flex-col rounded-lg bg-white p-3",
         className,
       )}
     >

--- a/packages/design-system/src/connect/components/modal/settings-modal-v2/settings-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/settings-modal-v2/settings-modal.tsx
@@ -83,7 +83,7 @@ export function SettingsModal(props: Props) {
       </div>
       <div className="flex flex-1">
         <div className="flex flex-col gap-y-1 p-3 pt-6">{tabsContent}</div>
-        <div className="m-6 flex h-full flex-1 flex-col overflow-hidden rounded-lg border border-slate-50">
+        <div className="m-6 flex h-full flex-1 flex-col overflow-hidden rounded-lg border border-slate-50 bg-white">
           {typeof SelectedTabComponent === "function" ? (
             <SelectedTabComponent />
           ) : (

--- a/packages/design-system/src/connect/components/modal/settings-modal/settings-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/settings-modal/settings-modal.tsx
@@ -38,7 +38,7 @@ export const SettingsModalOld: React.FC<SettingsModalOldProps> = (props) => {
       }}
       {...restProps}
     >
-      <div className="w-[432px] p-4 text-gray-900">
+      <div className="w-[432px] bg-white p-4 text-gray-900">
         <div className="flex justify-between">
           <h1 className="text-center text-xl font-bold">{title}</h1>
           <button

--- a/packages/design-system/src/connect/components/modal/upgrade-drive-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/upgrade-drive-modal.tsx
@@ -42,7 +42,7 @@ export function ConnectUpgradeDriveModal(props: ConnectUpgradeDriveModalProps) {
       }}
       {...restProps}
     >
-      <div className="w-[400px] p-6 text-slate-300">
+      <div className="w-[400px] bg-white p-6 text-slate-300">
         <div className="border-b border-slate-50 pb-2 text-2xl font-bold text-gray-800">
           {header}
         </div>

--- a/packages/design-system/src/connect/components/object-inspector-modal/object-inspector-modal.tsx
+++ b/packages/design-system/src/connect/components/object-inspector-modal/object-inspector-modal.tsx
@@ -42,7 +42,7 @@ export function ObjectInspectorModal({
       open={open}
       title={title}
     >
-      <div className="flex size-full flex-col">
+      <div className="flex size-full flex-col bg-white">
         <div className="flex shrink-0 items-center justify-between border-b border-gray-200 px-4 py-3">
           <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
           <button

--- a/packages/design-system/src/connect/components/revision-history/revision/errors.tsx
+++ b/packages/design-system/src/connect/components/revision-history/revision/errors.tsx
@@ -25,7 +25,7 @@ export function Errors(props: ErrorsProps) {
   const content = (
     <span
       className={twMerge(
-        "flex w-fit items-center rounded-lg border border-gray-200 px-2 py-1 text-xs",
+        "flex w-fit items-center rounded-lg border border-gray-200 bg-white px-2 py-1 text-xs",
         color,
         hasErrors && "cursor-pointer",
       )}

--- a/packages/design-system/src/connect/components/revision-history/revision/signature.tsx
+++ b/packages/design-system/src/connect/components/revision-history/revision/signature.tsx
@@ -14,7 +14,7 @@ export function Signature(props: SignatureProps) {
   return (
     <CodePopover
       trigger={
-        <span className="flex w-fit cursor-pointer items-center gap-1 rounded-lg border border-gray-200 px-2 py-1">
+        <span className="flex w-fit cursor-pointer items-center gap-1 rounded-lg border border-gray-200 bg-white px-2 py-1">
           <VerificationStatus signatures={signatures} />{" "}
           <Icon className="text-gray-300" name="InfoSquare" size={16} />
         </span>

--- a/packages/design-system/src/ui/components/command/command.tsx
+++ b/packages/design-system/src/ui/components/command/command.tsx
@@ -118,7 +118,7 @@ const CommandItem = React.forwardRef<
     className={cn(
       "relative flex items-center justify-between select-none",
       "h-8 gap-2 rounded-md py-1.5 pr-2.5 pl-1.5",
-      "text-sm/4 outline-none",
+      "text-sm/4 text-gray-900 outline-none",
       "border-y-2 border-white dark:border-slate-600",
       "data-[disabled=true]:pointer-events-none",
       "[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",


### PR DESCRIPTION
We have a lot of components which were relying on fallbacks / html defaults for their bg color and text color. 

Since we know that these fallbacks are white for bg and text-gray-900 for text, I have added these styles explicitly to components which don't have them. From what I can see, it looks exactly the same as before, which is what we want.

With this in place, we can proceed with automatically adding the dark mode variants.