### PR TITLE
fix(reactor-attachments): tolerate executed migrations no longer shipped

### DIFF
--- a/packages/reactor-api/src/migrations/index.ts
+++ b/packages/reactor-api/src/migrations/index.ts
@@ -1,31 +1,77 @@
 import {
   Migrator,
+  sql,
   type Kysely,
   type Migration,
   type MigrationProvider,
 } from "kysely";
+import type { ILogger } from "document-model";
 import * as migration001 from "./001_create_document_permissions.js";
 import * as migration002 from "./002_add_document_protection.js";
 
-/**
- * Custom migration provider that loads migrations from imported modules
- */
+const NOOP_MIGRATION: Migration = {
+  async up() {},
+  async down() {},
+};
+
+const migrations: Record<string, Migration> = {
+  "001_create_document_permissions": migration001,
+  "002_add_document_protection": migration002,
+};
+
 class StaticMigrationProvider implements MigrationProvider {
-  async getMigrations(): Promise<Record<string, Migration>> {
-    return {
-      "001_create_document_permissions": migration001,
-      "002_add_document_protection": migration002,
-    };
+  constructor(private readonly entries: Record<string, Migration>) {}
+  getMigrations() {
+    return Promise.resolve(this.entries);
   }
+}
+
+async function readExecutedMigrationNames(
+  db: Kysely<unknown>,
+): Promise<string[]> {
+  try {
+    const result = await sql<{ name: string }>`
+      SELECT name FROM kysely_migration
+    `.execute(db);
+    return result.rows.map((row) => row.name);
+  } catch {
+    return [];
+  }
+}
+
+// Stub out recorded names we no longer ship so a downgrade doesn't trip Kysely's missing-migration guard.
+async function buildMigrationSet(
+  db: Kysely<unknown>,
+  logger: Pick<ILogger, "warn">,
+): Promise<Record<string, Migration>> {
+  const executedNames = await readExecutedMigrationNames(db);
+  const entries: Record<string, Migration> = { ...migrations };
+  const stubbed: string[] = [];
+  for (const name of executedNames) {
+    if (!(name in entries)) {
+      entries[name] = NOOP_MIGRATION;
+      stubbed.push(name);
+    }
+  }
+  if (stubbed.length > 0) {
+    logger.warn(
+      `[reactor-api] Stubbing ${stubbed.length} recorded migration(s) not shipped by this version (likely a downgrade): ${stubbed.join(", ")}`,
+    );
+  }
+  return entries;
 }
 
 /**
  * Run all pending migrations
  */
-export async function runMigrations(db: Kysely<unknown>): Promise<void> {
+export async function runMigrations(
+  db: Kysely<unknown>,
+  logger?: Pick<ILogger, "warn">,
+): Promise<void> {
+  const entries = await buildMigrationSet(db, logger ?? console);
   const migrator = new Migrator({
     db,
-    provider: new StaticMigrationProvider(),
+    provider: new StaticMigrationProvider(entries),
   });
 
   const { error, results } = await migrator.migrateToLatest();
@@ -48,9 +94,10 @@ export async function runMigrations(db: Kysely<unknown>): Promise<void> {
  * Rollback the last migration
  */
 export async function rollbackMigration(db: Kysely<unknown>): Promise<void> {
+  const entries = await buildMigrationSet(db, console);
   const migrator = new Migrator({
     db,
-    provider: new StaticMigrationProvider(),
+    provider: new StaticMigrationProvider(entries),
   });
 
   const { error, results } = await migrator.migrateDown();

--- a/packages/reactor-api/src/server.ts
+++ b/packages/reactor-api/src/server.ts
@@ -477,7 +477,7 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
     );
     dbClosers.push(...makeDbClosers(knex, pglite));
     // Run document permission migrations
-    await runMigrations(db as Kysely<unknown>);
+    await runMigrations(db as Kysely<unknown>, logger);
     logger.info("Document permission migrations completed");
     documentPermissionService = new DocumentPermissionService(
       db as Kysely<DocumentPermissionDatabase>,
@@ -508,7 +508,9 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
   const attachments = await new AttachmentBuilder(
     attachmentDb,
     attachmentStoragePath,
-  ).build();
+  )
+    .withLogger(logger)
+    .build();
   logger.info("Attachment service initialized");
 
   // Initialize package manager

--- a/packages/reactor-attachments/src/attachment-builder.ts
+++ b/packages/reactor-attachments/src/attachment-builder.ts
@@ -11,6 +11,7 @@ import { DirectAttachmentUploadFactory } from "./direct/direct-attachment-upload
 import {
   runAttachmentMigrations,
   ATTACHMENT_SCHEMA,
+  type MigrationLogger,
 } from "./storage/migrations/migrator.js";
 import { NullAttachmentTransport } from "./null-attachment-transport.js";
 
@@ -25,6 +26,7 @@ export class AttachmentBuilder {
   private transport: IAttachmentTransport = new NullAttachmentTransport();
   private customUploadFactory?: IAttachmentUploadFactory;
   private maxUploadBytes?: number;
+  private logger?: MigrationLogger;
 
   constructor(
     private readonly db: Kysely<any>,
@@ -46,8 +48,17 @@ export class AttachmentBuilder {
     return this;
   }
 
+  withLogger(logger: MigrationLogger): this {
+    this.logger = logger;
+    return this;
+  }
+
   async build(): Promise<AttachmentBuildResult> {
-    const result = await runAttachmentMigrations(this.db, ATTACHMENT_SCHEMA);
+    const result = await runAttachmentMigrations(
+      this.db,
+      ATTACHMENT_SCHEMA,
+      this.logger,
+    );
     if (!result.success && result.error) {
       throw result.error;
     }

--- a/packages/reactor-attachments/src/storage/migrations/migrator.ts
+++ b/packages/reactor-attachments/src/storage/migrations/migrator.ts
@@ -1,5 +1,5 @@
 import { Migrator, sql } from "kysely";
-import type { MigrationProvider, Kysely } from "kysely";
+import type { Migration, MigrationProvider, Kysely } from "kysely";
 
 import * as migration001 from "./001_create_attachment_table.js";
 import * as migration002 from "./002_create_reservation_table.js";
@@ -15,7 +15,16 @@ export interface MigrationResult {
   error?: Error;
 }
 
-const migrations = {
+export interface MigrationLogger {
+  warn(message: string, ...replacements: unknown[]): void;
+}
+
+const NOOP_MIGRATION: Migration = {
+  async up() {},
+  async down() {},
+};
+
+const migrations: Record<string, Migration> = {
   "001_create_attachment_table": migration001,
   "002_create_reservation_table": migration002,
   "003_add_reservation_expires_at": migration003,
@@ -24,15 +33,55 @@ const migrations = {
 };
 
 class ProgrammaticMigrationProvider implements MigrationProvider {
+  constructor(private readonly entries: Record<string, Migration>) {}
   getMigrations() {
-    return Promise.resolve(migrations);
+    return Promise.resolve(this.entries);
   }
+}
+
+async function readExecutedMigrationNames(
+  db: Kysely<any>,
+  schema: string,
+): Promise<string[]> {
+  try {
+    const result = await sql<{ name: string }>`
+      SELECT name FROM ${sql.id(schema)}.kysely_migration
+    `.execute(db);
+    return result.rows.map((row) => row.name);
+  } catch {
+    return [];
+  }
+}
+
+// Stub out recorded names we no longer ship so a downgrade doesn't trip Kysely's missing-migration guard.
+async function buildMigrationSet(
+  db: Kysely<any>,
+  schema: string,
+  logger: MigrationLogger,
+): Promise<Record<string, Migration>> {
+  const executedNames = await readExecutedMigrationNames(db, schema);
+  const entries: Record<string, Migration> = { ...migrations };
+  const stubbed: string[] = [];
+  for (const name of executedNames) {
+    if (!(name in entries)) {
+      entries[name] = NOOP_MIGRATION;
+      stubbed.push(name);
+    }
+  }
+  if (stubbed.length > 0) {
+    logger.warn(
+      `[reactor-attachments] Stubbing ${stubbed.length} recorded migration(s) not shipped by this version (likely a downgrade): ${stubbed.join(", ")}`,
+    );
+  }
+  return entries;
 }
 
 export async function runAttachmentMigrations(
   db: Kysely<any>,
   schema: string = ATTACHMENT_SCHEMA,
+  logger?: MigrationLogger,
 ): Promise<MigrationResult> {
+  const log = logger ?? console;
   try {
     await sql`CREATE SCHEMA IF NOT EXISTS ${sql.id(schema)}`.execute(db);
   } catch (error) {
@@ -44,9 +93,12 @@ export async function runAttachmentMigrations(
     };
   }
 
+  const scopedDb = db.withSchema(schema);
+  const entries = await buildMigrationSet(scopedDb, schema, log);
+
   const migrator = new Migrator({
-    db: db.withSchema(schema),
-    provider: new ProgrammaticMigrationProvider(),
+    db: scopedDb,
+    provider: new ProgrammaticMigrationProvider(entries),
     migrationTableSchema: schema,
   });
 

--- a/packages/reactor-attachments/test/storage/migrator.test.ts
+++ b/packages/reactor-attachments/test/storage/migrator.test.ts
@@ -1,0 +1,55 @@
+import { PGlite } from "@electric-sql/pglite";
+import { Kysely, sql } from "kysely";
+import { PGliteDialect } from "kysely-pglite-dialect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ATTACHMENT_SCHEMA,
+  runAttachmentMigrations,
+} from "../../src/storage/migrations/migrator.js";
+
+describe("runAttachmentMigrations", () => {
+  let db: Kysely<unknown>;
+
+  beforeEach(() => {
+    db = new Kysely<unknown>({
+      dialect: new PGliteDialect(new PGlite()),
+    });
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("runs all bundled migrations on a fresh database", async () => {
+    const result = await runAttachmentMigrations(db, ATTACHMENT_SCHEMA);
+    expect(result.success).toBe(true);
+    expect(result.migrationsExecuted).toEqual([
+      "001_create_attachment_table",
+      "002_create_reservation_table",
+      "003_add_reservation_expires_at",
+      "004_add_reservation_soft_delete",
+      "005_add_reservation_active_index",
+    ]);
+  });
+
+  it("tolerates previously executed migrations that are no longer shipped and warns the logger", async () => {
+    const first = await runAttachmentMigrations(db, ATTACHMENT_SCHEMA);
+    expect(first.success).toBe(true);
+
+    // Simulate a downgrade or removed migration by inserting an orphan row.
+    await sql`
+      INSERT INTO ${sql.id(ATTACHMENT_SCHEMA)}.kysely_migration (name, timestamp)
+      VALUES ('999_phantom_migration', ${new Date().toISOString()})
+    `.execute(db.withSchema(ATTACHMENT_SCHEMA));
+
+    const warn = vi.fn();
+    const second = await runAttachmentMigrations(db, ATTACHMENT_SCHEMA, {
+      warn,
+    });
+    expect(second.success).toBe(true);
+    expect(second.error).toBeUndefined();
+    expect(second.migrationsExecuted).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("999_phantom_migration");
+  });
+});

--- a/packages/reactor/src/core/reactor-builder.ts
+++ b/packages/reactor/src/core/reactor-builder.ts
@@ -239,7 +239,11 @@ export class ReactorBuilder {
     const baseDatabase = this.kyselyInstance ?? (await createDefaultDatabase());
 
     if (this.migrationStrategy === "auto") {
-      const result = await runMigrations(baseDatabase, REACTOR_SCHEMA);
+      const result = await runMigrations(
+        baseDatabase,
+        REACTOR_SCHEMA,
+        this.logger,
+      );
       if (!result.success && result.error) {
         throw new Error(`Database migration failed: ${result.error.message}`);
       }

--- a/packages/reactor/src/storage/migrations/migrator.ts
+++ b/packages/reactor/src/storage/migrations/migrator.ts
@@ -1,5 +1,6 @@
 import { Migrator, sql } from "kysely";
-import type { MigrationProvider, Kysely } from "kysely";
+import type { Migration, MigrationProvider, Kysely } from "kysely";
+import type { ILogger } from "document-model";
 import type { MigrationResult } from "./types.js";
 
 export const REACTOR_SCHEMA = "reactor";
@@ -18,7 +19,12 @@ import * as migration012 from "./012_add_source_remote_column.js";
 import * as migration013 from "./013_create_sync_dead_letters_table.js";
 import * as migration014 from "./014_create_processor_cursor_table.js";
 
-const migrations = {
+const NOOP_MIGRATION: Migration = {
+  async up() {},
+  async down() {},
+};
+
+const migrations: Record<string, Migration> = {
   "001_create_operation_table": migration001,
   "002_create_keyframe_table": migration002,
   "003_create_document_table": migration003,
@@ -36,15 +42,55 @@ const migrations = {
 };
 
 class ProgrammaticMigrationProvider implements MigrationProvider {
+  constructor(private readonly entries: Record<string, Migration>) {}
   getMigrations() {
-    return Promise.resolve(migrations);
+    return Promise.resolve(this.entries);
   }
+}
+
+async function readExecutedMigrationNames(
+  db: Kysely<any>,
+  schema: string,
+): Promise<string[]> {
+  try {
+    const result = await sql<{ name: string }>`
+      SELECT name FROM ${sql.id(schema)}.kysely_migration
+    `.execute(db);
+    return result.rows.map((row) => row.name);
+  } catch {
+    return [];
+  }
+}
+
+// Stub out recorded names we no longer ship so a downgrade doesn't trip Kysely's missing-migration guard.
+async function buildMigrationSet(
+  db: Kysely<any>,
+  schema: string,
+  logger: Pick<ILogger, "warn">,
+): Promise<Record<string, Migration>> {
+  const executedNames = await readExecutedMigrationNames(db, schema);
+  const entries: Record<string, Migration> = { ...migrations };
+  const stubbed: string[] = [];
+  for (const name of executedNames) {
+    if (!(name in entries)) {
+      entries[name] = NOOP_MIGRATION;
+      stubbed.push(name);
+    }
+  }
+  if (stubbed.length > 0) {
+    logger.warn(
+      `[reactor] Stubbing ${stubbed.length} recorded migration(s) not shipped by this version (likely a downgrade): ${stubbed.join(", ")}`,
+    );
+  }
+  return entries;
 }
 
 export async function runMigrations(
   db: Kysely<any>,
   schema: string = REACTOR_SCHEMA,
+  logger?: Pick<ILogger, "warn">,
 ): Promise<MigrationResult> {
+  const log = logger ?? console;
   try {
     await sql`CREATE SCHEMA IF NOT EXISTS ${sql.id(schema)}`.execute(db);
   } catch (error) {
@@ -56,9 +102,12 @@ export async function runMigrations(
     };
   }
 
+  const scopedDb = db.withSchema(schema);
+  const entries = await buildMigrationSet(scopedDb, schema, log);
+
   const migrator = new Migrator({
-    db: db.withSchema(schema),
-    provider: new ProgrammaticMigrationProvider(),
+    db: scopedDb,
+    provider: new ProgrammaticMigrationProvider(entries),
     migrationTableSchema: schema,
   });
 
@@ -95,9 +144,11 @@ export async function getMigrationStatus(
   db: Kysely<any>,
   schema: string = REACTOR_SCHEMA,
 ) {
+  const scopedDb = db.withSchema(schema);
+  const entries = await buildMigrationSet(scopedDb, schema, console);
   const migrator = new Migrator({
-    db: db.withSchema(schema),
-    provider: new ProgrammaticMigrationProvider(),
+    db: scopedDb,
+    provider: new ProgrammaticMigrationProvider(entries),
     migrationTableSchema: schema,
   });
 


### PR DESCRIPTION
## Summary

- Kysely's migrator aborts with `corrupted migrations: previously executed migration <name> is missing` when the `kysely_migration` table contains a name the current code no longer provides. This happens on a **downgrade** of `reactor-attachments` (the same PGlite data dir was previously touched by a newer version that ran additional migrations), leaving consumers like `ph-clint` unable to load their PGlite-fs DB.
- Before handing migrations to Kysely, read the recorded names from `<schema>.kysely_migration` and inject a no-op `{up, down}` stub for any name not in the bundled set. Pending newer migrations still run; the schema changes from the missing entries stay in place.

## Repro

Globally installed `ph-clint-cli@0.1.0-dev.76` pins `reactor-attachments@6.0.0-dev.216` (ships migrations 001–003). A `read-model.db` populated by a newer reactor-attachments has rows for 004 and 005. Running `ph-clint` against that data dir fails with:

```
Reactor ready (drive: ...)
corrupted migrations: previously executed migration 004_add_reservation_soft_delete is missing
```

With this fix dropped over the same install, the migrator accepts the recorded rows and the attachment service initializes normally.

## Test plan

- [x] New unit test `test/storage/migrator.test.ts` covers both the fresh-DB path and the phantom-recorded-migration path (test fails without the fix, passes with it).
- [x] Full `pnpm test` in `packages/reactor-attachments` (152 tests) and `pnpm tsc` clean.
- [x] End-to-end: replaced the dist files in `ph-clint-cli`'s installed `reactor-attachments@6.0.0-dev.216` with this fix's build and re-ran `ph-clint` against the failing data dir — startup completes, `Attachment service initialized` logged.