### PR TITLE
fix(logger): surface Errors instead of dropping them, add lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -390,6 +390,151 @@ const cliColdPathRules = {
   ],
 };
 
+/**
+ * Logger call-shape rules. The ConsoleLogger in `document-model` substitutes
+ * `@token` placeholders in the message string with positional args (one per
+ * unique token, in first-appearance order). Extra args past the unique-token
+ * count are appended; missing args render as `"null"`.
+ *
+ * - missing-token-args (error): more `@token`s than args → `null` slot.
+ * - extra-args-without-token (warn): no `@token`s but args passed → reads
+ *   like a substitution that won't happen; encourage explicit tokens or
+ *   inline interpolation.
+ */
+const LOGGER_METHODS = new Set([
+  "verbose",
+  "debug",
+  "info",
+  "warn",
+  "error",
+]);
+
+/** Heuristic: callee object identifier ends in "logger" (case-insensitive),
+ *  or callee is `<...>.logger.<method>(...)`. */
+const isLoggerCallee = (/** @type {any} */ callee) => {
+  if (!callee || callee.type !== "MemberExpression" || callee.computed)
+    return false;
+  if (callee.property.type !== "Identifier") return false;
+  if (!LOGGER_METHODS.has(callee.property.name)) return false;
+
+  const obj = callee.object;
+  if (obj.type === "Identifier") {
+    return obj.name.toLowerCase().endsWith("logger");
+  }
+  if (obj.type === "MemberExpression" && !obj.computed) {
+    if (obj.property.type === "Identifier") {
+      return obj.property.name.toLowerCase().endsWith("logger");
+    }
+  }
+  return false;
+};
+
+/** Extract a static message string from the first arg, or null if dynamic. */
+const staticMessage = (/** @type {any} */ node) => {
+  if (!node) return null;
+  if (node.type === "Literal" && typeof node.value === "string")
+    return node.value;
+  if (node.type === "TemplateLiteral" && node.expressions.length === 0)
+    return node.quasis
+      .map((/** @type {any} */ q) => q.value.cooked ?? "")
+      .join("");
+  return null;
+};
+
+const countUniqueTokens = (/** @type {string} */ msg) => {
+  const re = /@([a-zA-Z0-9_]+)/g;
+  const seen = new Set();
+  let m;
+  while ((m = re.exec(msg)) !== null) seen.add(m[1]);
+  return seen.size;
+};
+
+/** @type {import("eslint").Rule.RuleModule} */
+const loggerMissingTokenArgsRule = {
+  meta: {
+    type: "problem",
+    schema: [],
+    messages: {
+      missing:
+        "logger.{{method}} message has {{tokens}} @token(s) but only {{args}} replacement arg(s) — missing slots render as \"null\".",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!isLoggerCallee(node.callee)) return;
+        const msg = staticMessage(node.arguments[0]);
+        if (msg === null) return;
+        const tokens = countUniqueTokens(msg);
+        const args = node.arguments.length - 1;
+        if (args < tokens) {
+          context.report({
+            node,
+            messageId: "missing",
+            data: {
+              method: /** @type {any} */ (node.callee).property.name,
+              tokens: String(tokens),
+              args: String(args),
+            },
+          });
+        }
+      },
+    };
+  },
+};
+
+/** @type {import("eslint").Rule.RuleModule} */
+const loggerExtraArgsWithoutTokenRule = {
+  meta: {
+    type: "suggestion",
+    schema: [],
+    messages: {
+      extra:
+        "logger.{{method}} passes {{args}} arg(s) but the message has no @token placeholders — extras are appended at runtime; consider adding @tokens or inlining the value.",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!isLoggerCallee(node.callee)) return;
+        const msg = staticMessage(node.arguments[0]);
+        if (msg === null) return;
+        const tokens = countUniqueTokens(msg);
+        const args = node.arguments.length - 1;
+        if (tokens === 0 && args > 0) {
+          context.report({
+            node,
+            messageId: "extra",
+            data: {
+              method: /** @type {any} */ (node.callee).property.name,
+              args: String(args),
+            },
+          });
+        }
+      },
+    };
+  },
+};
+
+/** @type {import("eslint").Linter.RulesRecord} */
+const loggerRules = {
+  "logger/missing-token-args": "error",
+  "logger/extra-args-without-token": "warn",
+};
+
+const loggerRulesConfig = {
+  files: typescriptFiles,
+  plugins: {
+    logger: {
+      rules: {
+        "missing-token-args": loggerMissingTokenArgsRule,
+        "extra-args-without-token": loggerExtraArgsWithoutTokenRule,
+      },
+    },
+  },
+  rules: loggerRules,
+};
+
 const cliColdPathConfig = {
   files: [
     "clis/ph-cli/src/cli.ts",
@@ -491,5 +636,6 @@ export default defineConfig(
   javascriptConfig,
   unsafeConfig,
   cliColdPathConfig,
+  loggerRulesConfig,
   tailwindConfig,
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,11 +2,11 @@
 import { default as eslint } from "@eslint/js";
 import betterTailwindcss from "eslint-plugin-better-tailwindcss";
 import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
+import reactHooks from "eslint-plugin-react-hooks";
 import { defineConfig, globalIgnores } from "eslint/config";
 import globals from "globals";
 import { builtinModules } from "node:module";
 import tseslint from "typescript-eslint";
-import reactHooks from "eslint-plugin-react-hooks";
 
 /** These files are typically ignored by eslint by default, so there is no need to investigate why they are ignored. */
 const normalIgnoredFiles = [
@@ -401,13 +401,7 @@ const cliColdPathRules = {
  *   like a substitution that won't happen; encourage explicit tokens or
  *   inline interpolation.
  */
-const LOGGER_METHODS = new Set([
-  "verbose",
-  "debug",
-  "info",
-  "warn",
-  "error",
-]);
+const LOGGER_METHODS = new Set(["verbose", "debug", "info", "warn", "error"]);
 
 /** Heuristic: callee object identifier ends in "logger" (case-insensitive),
  *  or callee is `<...>.logger.<method>(...)`. */
@@ -456,7 +450,7 @@ const loggerMissingTokenArgsRule = {
     schema: [],
     messages: {
       missing:
-        "logger.{{method}} message has {{tokens}} @token(s) but only {{args}} replacement arg(s) — missing slots render as \"null\".",
+        'logger.{{method}} message has {{tokens}} @token(s) but only {{args}} replacement arg(s) — missing slots render as "null".',
     },
   },
   create(context) {

--- a/packages/document-model/src/logger.ts
+++ b/packages/document-model/src/logger.ts
@@ -9,10 +9,33 @@ const dtf = new Intl.DateTimeFormat(undefined, {
   fractionalSecondDigits: 2,
 });
 
+const stringify = (value: unknown, includeStack: boolean): string => {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "string") return value;
+  if (value instanceof Error) {
+    const base = `${value.name}: ${value.message}`;
+    return includeStack && value.stack ? `${base}\n${value.stack}` : base;
+  }
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  if (typeof value === "function") {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    const name = (value as Function).name;
+    return name ? `${name}()` : "anonymous()";
+  }
+  return String(value);
+};
+
 const formatMessage = (
   tagString: string,
   message: string,
   replacements: any[],
+  includeStack: boolean,
 ): [string, Record<string, any>] => {
   const meta: Record<string, any> = {};
   const uniqueTokens: string[] = [];
@@ -33,22 +56,14 @@ const formatMessage = (
 
   // replace
   for (const [key, value] of Object.entries(meta)) {
-    let stringValue;
-    if (!value) {
-      stringValue = "null";
-    } else if (typeof value === "string") {
-      stringValue = value;
-    } else if (typeof value === "object") {
-      stringValue = JSON.stringify(value);
-    } else if (typeof value === "function") {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-      const name = (value as Function).name;
-      stringValue = name ? `${name}()` : "anonymous()";
-    } else {
-      stringValue = String(value);
-    }
+    message = message.replaceAll(`@${key}`, stringify(value, includeStack));
+  }
 
-    message = message.replaceAll(`@${key}`, stringValue);
+  // Any replacements past the unique-token count would otherwise be
+  // silently dropped — append them so positional Errors still surface.
+  const extras = replacements.slice(uniqueTokens.length);
+  if (extras.length > 0) {
+    message = `${message} ${extras.map((v) => stringify(v, includeStack)).join(" ")}`;
   }
 
   if (tagString.length > 0) {
@@ -104,12 +119,19 @@ export class ConsoleLogger implements ILogger {
     return logger;
   }
 
+  // Errors get full stacks only at debug/verbose; at info/warn/error we
+  // emit `name: message` to keep production logs readable.
+  get #includeStack(): boolean {
+    return this.#level <= LOG_LEVELS.debug;
+  }
+
   verbose(message: string, ...replacements: any[]): void {
     if (this.#level <= LOG_LEVELS.verbose) {
       const [formattedMessage, meta] = formatMessage(
         this.#tagString,
         message,
         replacements,
+        this.#includeStack,
       );
 
       console.debug(`[${meta["timestamp"]}] ${formattedMessage}`);
@@ -122,6 +144,7 @@ export class ConsoleLogger implements ILogger {
         this.#tagString,
         message,
         replacements,
+        this.#includeStack,
       );
 
       console.debug(`[${meta["timestamp"]}] ${formattedMessage}`);
@@ -134,6 +157,7 @@ export class ConsoleLogger implements ILogger {
         this.#tagString,
         message,
         replacements,
+        this.#includeStack,
       );
 
       console.info(`[${meta["timestamp"]}] ${formattedMessage}`);
@@ -146,6 +170,7 @@ export class ConsoleLogger implements ILogger {
         this.#tagString,
         message,
         replacements,
+        this.#includeStack,
       );
 
       console.warn(`[${meta["timestamp"]}] ${formattedMessage}`);
@@ -158,6 +183,7 @@ export class ConsoleLogger implements ILogger {
         this.#tagString,
         message,
         replacements,
+        this.#includeStack,
       );
 
       console.error(`[${meta["timestamp"]}] ${formattedMessage}`);

--- a/packages/document-model/test/logger.test.ts
+++ b/packages/document-model/test/logger.test.ts
@@ -19,16 +19,23 @@
  * message rather than discarded. The full stack is gated by log level so
  * production logs across apps stay readable.
  */
+import type { MockInstance } from "vitest";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { ConsoleLogger } from "../src/logger.js";
 
+type ConsoleFn = (...args: unknown[]) => void;
+
 describe("ConsoleLogger error formatting", () => {
-  let errorSpy: ReturnType<typeof vi.spyOn>;
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: MockInstance<ConsoleFn>;
+  let debugSpy: MockInstance<ConsoleFn>;
 
   beforeEach(() => {
-    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {}) as unknown as MockInstance<ConsoleFn>;
+    debugSpy = vi
+      .spyOn(console, "debug")
+      .mockImplementation(() => {}) as unknown as MockInstance<ConsoleFn>;
   });
 
   afterEach(() => {

--- a/packages/document-model/test/logger.test.ts
+++ b/packages/document-model/test/logger.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Pins the `ConsoleLogger` token-substitution + Error-handling contract.
+ *
+ * Background: the original `formatMessage` had two bugs that silently
+ * dropped errors at call sites in switchboard / reactor-api:
+ *   1. Positional replacements past the unique-`@token` count were
+ *      ignored entirely → `logger.error("...:", err)` dropped `err`.
+ *   2. `Error` values hit the generic object branch and were rendered
+ *      via `JSON.stringify`, which returns `"{}"` because Error's own
+ *      properties are non-enumerable → the cause was lost.
+ *
+ * The fix: Error gets a dedicated branch (`name: message`, plus stack at
+ * debug/verbose levels), and trailing replacements are appended to the
+ * message rather than discarded. The full stack is gated by log level so
+ * production logs across apps stay readable.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { ConsoleLogger } from "../src/logger.js";
+
+describe("ConsoleLogger error formatting", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+
+  const lastErr = (): string => {
+    const calls = errorSpy.mock.calls;
+    return calls[calls.length - 1]?.[0] as string;
+  };
+
+  const lastDebug = (): string => {
+    const calls = debugSpy.mock.calls;
+    return calls[calls.length - 1]?.[0] as string;
+  };
+
+  it("appends positional Error replacements when the message has no @token", () => {
+    // Pre-fix call site shape in reactor-api:
+    //   logger.error("API dispose: db closer failed:", error);
+    const logger = new ConsoleLogger();
+    const err = new Error("boom");
+
+    logger.error("API dispose: db closer failed:", err);
+
+    const out = lastErr();
+    expect(out).toContain("API dispose: db closer failed:");
+    expect(out).toContain("Error: boom");
+  });
+
+  it("renders Error via @token as 'name: message' (no stack at info/error level)", () => {
+    // Pre-fix call site in switchboard: logger.error("App crashed: @error", e)
+    const logger = new ConsoleLogger();
+    const err = new Error("real cause");
+
+    logger.error("App crashed: @error", err);
+
+    const out = lastErr();
+    expect(out).toContain("App crashed: Error: real cause");
+    // Stack is suppressed at default (info) level.
+    expect(out).not.toMatch(/at .*logger\.test\.ts/);
+  });
+
+  it("includes the stack when level is debug", () => {
+    const logger = new ConsoleLogger();
+    logger.level = "debug";
+    const err = new Error("with stack");
+
+    logger.error("App crashed: @error", err);
+
+    const out = lastErr();
+    expect(out).toContain("Error: with stack");
+    expect(out).toMatch(/at .*logger\.test\.ts/);
+  });
+
+  it("includes the stack when level is verbose", () => {
+    const logger = new ConsoleLogger();
+    logger.level = "verbose";
+    const err = new Error("verbose stack");
+
+    logger.error("oops:", err);
+
+    const out = lastErr();
+    expect(out).toMatch(/at .*logger\.test\.ts/);
+  });
+
+  it("suppresses stack at warn level", () => {
+    const logger = new ConsoleLogger();
+    logger.level = "warn";
+    const err = new Error("warn-level");
+
+    logger.error("oops:", err);
+    const out = lastErr();
+    expect(out).toContain("Error: warn-level");
+    expect(out).not.toMatch(/at .*logger\.test\.ts/);
+  });
+
+  it("renders null/undefined replacement as 'null'", () => {
+    const logger = new ConsoleLogger();
+    logger.error("got @value", null);
+    expect(lastErr()).toContain("got null");
+  });
+
+  it("renders a string replacement verbatim", () => {
+    const logger = new ConsoleLogger();
+    logger.error("App crashed: @msg", "boom");
+    expect(lastErr()).toContain("App crashed: boom");
+  });
+
+  it("renders a plain object replacement via JSON.stringify", () => {
+    const logger = new ConsoleLogger();
+    logger.error("ctx=@ctx", { driveId: "abc", count: 2 });
+    expect(lastErr()).toContain(`ctx={"driveId":"abc","count":2}`);
+  });
+
+  it("uses only the first replacement per unique token, appending extras", () => {
+    const logger = new ConsoleLogger();
+    logger.error("a=@a b=@b a-again=@a", "A", "B", "EXTRA");
+
+    const out = lastErr();
+    expect(out).toContain("a=A b=B a-again=A");
+    // Past the unique-token count, extras are appended rather than dropped.
+    expect(out).toContain("EXTRA");
+  });
+
+  it("renders 'null' for an unmatched @token", () => {
+    const logger = new ConsoleLogger();
+    logger.error("missing: @thing");
+    expect(lastErr()).toContain("missing: null");
+  });
+
+  it("appends multiple trailing Error replacements", () => {
+    const logger = new ConsoleLogger();
+    logger.error(
+      "two failures:",
+      new Error("first"),
+      new Error("second"),
+    );
+    const out = lastErr();
+    expect(out).toContain("Error: first");
+    expect(out).toContain("Error: second");
+  });
+
+  it("debug() honors the same stack rule", () => {
+    const logger = new ConsoleLogger();
+    logger.level = "debug";
+    const err = new Error("dbg");
+
+    logger.debug("trace:", err);
+
+    expect(lastDebug()).toMatch(/at .*logger\.test\.ts/);
+  });
+});

--- a/packages/document-model/test/logger.test.ts
+++ b/packages/document-model/test/logger.test.ts
@@ -1,3 +1,8 @@
+/* eslint-disable logger/extra-args-without-token --
+ * This file deliberately exercises the no-@token + positional-Error
+ * call shape to assert the runtime appends the extras. The lint rule
+ * would otherwise flag every test case here.
+ */
 /**
  * Pins the `ConsoleLogger` token-substitution + Error-handling contract.
  *
@@ -140,11 +145,7 @@ describe("ConsoleLogger error formatting", () => {
 
   it("appends multiple trailing Error replacements", () => {
     const logger = new ConsoleLogger();
-    logger.error(
-      "two failures:",
-      new Error("first"),
-      new Error("second"),
-    );
+    logger.error("two failures:", new Error("first"), new Error("second"));
     const out = lastErr();
     expect(out).toContain("Error: first");
     expect(out).toContain("Error: second");

--- a/packages/document-model/test/logger.test.ts
+++ b/packages/document-model/test/logger.test.ts
@@ -131,6 +131,9 @@ describe("ConsoleLogger error formatting", () => {
 
   it("renders 'null' for an unmatched @token", () => {
     const logger = new ConsoleLogger();
+    // Intentionally under-provisioned to assert the "null" fallback —
+    // the lint rule would otherwise flag this as a missing replacement.
+    // eslint-disable-next-line logger/missing-token-args
     logger.error("missing: @thing");
     expect(lastErr()).toContain("missing: null");
   });

--- a/packages/reactor-api/src/graphql/auth/subgraph.ts
+++ b/packages/reactor-api/src/graphql/auth/subgraph.ts
@@ -35,7 +35,7 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string },
       ) => {
-        this.logger.debug("documentAccess", args);
+        this.logger.debug("documentAccess(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -45,7 +45,7 @@ export class AuthSubgraph extends BaseSubgraph {
             args,
           );
         } catch (error) {
-          this.logger.error("Error in documentAccess:", error);
+          this.logger.error("Error in documentAccess: @error", error);
           throw error;
         }
       },
@@ -70,7 +70,7 @@ export class AuthSubgraph extends BaseSubgraph {
             ctx.user.address,
           );
         } catch (error) {
-          this.logger.error("Error in userDocumentPermissions:", error);
+          this.logger.error("Error in userDocumentPermissions: @error", error);
           throw error;
         }
       },
@@ -83,26 +83,26 @@ export class AuthSubgraph extends BaseSubgraph {
         try {
           return await resolvers.groups(this.documentPermissionService);
         } catch (error) {
-          this.logger.error("Error in groups:", error);
+          this.logger.error("Error in groups: @error", error);
           throw error;
         }
       },
 
       group: async (_parent: unknown, args: { id: number }) => {
-        this.logger.debug("group", args);
+        this.logger.debug("group(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
         try {
           return await resolvers.group(this.documentPermissionService, args);
         } catch (error) {
-          this.logger.error("Error in group:", error);
+          this.logger.error("Error in group: @error", error);
           throw error;
         }
       },
 
       userGroups: async (_parent: unknown, args: { userAddress: string }) => {
-        this.logger.debug("userGroups", args);
+        this.logger.debug("userGroups(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -112,7 +112,7 @@ export class AuthSubgraph extends BaseSubgraph {
             args,
           );
         } catch (error) {
-          this.logger.error("Error in userGroups:", error);
+          this.logger.error("Error in userGroups: @error", error);
           throw error;
         }
       },
@@ -121,7 +121,7 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; operationType: string },
       ) => {
-        this.logger.debug("operationPermissions", args);
+        this.logger.debug("operationPermissions(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -131,7 +131,7 @@ export class AuthSubgraph extends BaseSubgraph {
             args,
           );
         } catch (error) {
-          this.logger.error("Error in operationPermissions:", error);
+          this.logger.error("Error in operationPermissions: @error", error);
           throw error;
         }
       },
@@ -141,7 +141,7 @@ export class AuthSubgraph extends BaseSubgraph {
         args: { documentId: string; operationType: string },
         ctx: { user?: { address: string } },
       ) => {
-        this.logger.debug("canExecuteOperation", args);
+        this.logger.debug("canExecuteOperation(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -152,7 +152,7 @@ export class AuthSubgraph extends BaseSubgraph {
             ctx.user?.address,
           );
         } catch (error) {
-          this.logger.error("Error in canExecuteOperation:", error);
+          this.logger.error("Error in canExecuteOperation: @error", error);
           throw error;
         }
       },
@@ -164,7 +164,7 @@ export class AuthSubgraph extends BaseSubgraph {
           user?: { address: string };
         },
       ) => {
-        this.logger.debug("documentProtection", args);
+        this.logger.debug("documentProtection(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -179,7 +179,7 @@ export class AuthSubgraph extends BaseSubgraph {
             args,
           );
         } catch (error) {
-          this.logger.error("Error in documentProtection:", error);
+          this.logger.error("Error in documentProtection: @error", error);
           throw error;
         }
       },
@@ -194,7 +194,7 @@ export class AuthSubgraph extends BaseSubgraph {
           isAdmin?: (address: string) => boolean;
         },
       ) => {
-        this.logger.debug("setDocumentProtection", args);
+        this.logger.debug("setDocumentProtection(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -208,7 +208,7 @@ export class AuthSubgraph extends BaseSubgraph {
             isGlobalAdmin,
           );
         } catch (error) {
-          this.logger.error("Error in setDocumentProtection:", error);
+          this.logger.error("Error in setDocumentProtection: @error", error);
           throw error;
         }
       },
@@ -221,7 +221,7 @@ export class AuthSubgraph extends BaseSubgraph {
           isAdmin?: (address: string) => boolean;
         },
       ) => {
-        this.logger.debug("transferDocumentOwnership", args);
+        this.logger.debug("transferDocumentOwnership(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -235,7 +235,10 @@ export class AuthSubgraph extends BaseSubgraph {
             isGlobalAdmin,
           );
         } catch (error) {
-          this.logger.error("Error in transferDocumentOwnership:", error);
+          this.logger.error(
+            "Error in transferDocumentOwnership: @error",
+            error,
+          );
           throw error;
         }
       },
@@ -248,7 +251,7 @@ export class AuthSubgraph extends BaseSubgraph {
           isAdmin?: (address: string) => boolean;
         },
       ) => {
-        this.logger.debug("grantDocumentPermission", args);
+        this.logger.debug("grantDocumentPermission(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -265,7 +268,7 @@ export class AuthSubgraph extends BaseSubgraph {
             isGlobalAdmin,
           );
         } catch (error) {
-          this.logger.error("Error in grantDocumentPermission:", error);
+          this.logger.error("Error in grantDocumentPermission: @error", error);
           throw error;
         }
       },
@@ -278,7 +281,7 @@ export class AuthSubgraph extends BaseSubgraph {
           isAdmin?: (address: string) => boolean;
         },
       ) => {
-        this.logger.debug("revokeDocumentPermission", args);
+        this.logger.debug("revokeDocumentPermission(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -291,7 +294,7 @@ export class AuthSubgraph extends BaseSubgraph {
             isGlobalAdmin,
           );
         } catch (error) {
-          this.logger.error("Error in revokeDocumentPermission:", error);
+          this.logger.error("Error in revokeDocumentPermission: @error", error);
           throw error;
         }
       },
@@ -301,7 +304,7 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { name: string; description?: string | null },
       ) => {
-        this.logger.debug("createGroup", args);
+        this.logger.debug("createGroup(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -311,13 +314,13 @@ export class AuthSubgraph extends BaseSubgraph {
             args,
           );
         } catch (error) {
-          this.logger.error("Error in createGroup:", error);
+          this.logger.error("Error in createGroup: @error", error);
           throw error;
         }
       },
 
       deleteGroup: async (_parent: unknown, args: { id: number }) => {
-        this.logger.debug("deleteGroup", args);
+        this.logger.debug("deleteGroup(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -327,7 +330,7 @@ export class AuthSubgraph extends BaseSubgraph {
             args,
           );
         } catch (error) {
-          this.logger.error("Error in deleteGroup:", error);
+          this.logger.error("Error in deleteGroup: @error", error);
           throw error;
         }
       },
@@ -336,7 +339,7 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { userAddress: string; groupId: number },
       ) => {
-        this.logger.debug("addUserToGroup", args);
+        this.logger.debug("addUserToGroup(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -346,7 +349,7 @@ export class AuthSubgraph extends BaseSubgraph {
             args,
           );
         } catch (error) {
-          this.logger.error("Error in addUserToGroup:", error);
+          this.logger.error("Error in addUserToGroup: @error", error);
           throw error;
         }
       },
@@ -355,7 +358,7 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { userAddress: string; groupId: number },
       ) => {
-        this.logger.debug("removeUserFromGroup", args);
+        this.logger.debug("removeUserFromGroup(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -365,7 +368,7 @@ export class AuthSubgraph extends BaseSubgraph {
             args,
           );
         } catch (error) {
-          this.logger.error("Error in removeUserFromGroup:", error);
+          this.logger.error("Error in removeUserFromGroup: @error", error);
           throw error;
         }
       },
@@ -379,7 +382,7 @@ export class AuthSubgraph extends BaseSubgraph {
           isAdmin?: (address: string) => boolean;
         },
       ) => {
-        this.logger.debug("grantGroupPermission", args);
+        this.logger.debug("grantGroupPermission(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -396,7 +399,7 @@ export class AuthSubgraph extends BaseSubgraph {
             isGlobalAdmin,
           );
         } catch (error) {
-          this.logger.error("Error in grantGroupPermission:", error);
+          this.logger.error("Error in grantGroupPermission: @error", error);
           throw error;
         }
       },
@@ -409,7 +412,7 @@ export class AuthSubgraph extends BaseSubgraph {
           isAdmin?: (address: string) => boolean;
         },
       ) => {
-        this.logger.debug("revokeGroupPermission", args);
+        this.logger.debug("revokeGroupPermission(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -422,7 +425,7 @@ export class AuthSubgraph extends BaseSubgraph {
             isGlobalAdmin,
           );
         } catch (error) {
-          this.logger.error("Error in revokeGroupPermission:", error);
+          this.logger.error("Error in revokeGroupPermission: @error", error);
           throw error;
         }
       },
@@ -440,7 +443,7 @@ export class AuthSubgraph extends BaseSubgraph {
           isAdmin?: (address: string) => boolean;
         },
       ) => {
-        this.logger.debug("grantOperationPermission", args);
+        this.logger.debug("grantOperationPermission(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -453,7 +456,7 @@ export class AuthSubgraph extends BaseSubgraph {
             isGlobalAdmin,
           );
         } catch (error) {
-          this.logger.error("Error in grantOperationPermission:", error);
+          this.logger.error("Error in grantOperationPermission: @error", error);
           throw error;
         }
       },
@@ -470,7 +473,7 @@ export class AuthSubgraph extends BaseSubgraph {
           isAdmin?: (address: string) => boolean;
         },
       ) => {
-        this.logger.debug("revokeOperationPermission", args);
+        this.logger.debug("revokeOperationPermission(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -483,7 +486,10 @@ export class AuthSubgraph extends BaseSubgraph {
             isGlobalAdmin,
           );
         } catch (error) {
-          this.logger.error("Error in revokeOperationPermission:", error);
+          this.logger.error(
+            "Error in revokeOperationPermission: @error",
+            error,
+          );
           throw error;
         }
       },
@@ -496,7 +502,7 @@ export class AuthSubgraph extends BaseSubgraph {
           isAdmin?: (address: string) => boolean;
         },
       ) => {
-        this.logger.debug("grantGroupOperationPermission", args);
+        this.logger.debug("grantGroupOperationPermission(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -509,7 +515,10 @@ export class AuthSubgraph extends BaseSubgraph {
             isGlobalAdmin,
           );
         } catch (error) {
-          this.logger.error("Error in grantGroupOperationPermission:", error);
+          this.logger.error(
+            "Error in grantGroupOperationPermission: @error",
+            error,
+          );
           throw error;
         }
       },
@@ -522,7 +531,7 @@ export class AuthSubgraph extends BaseSubgraph {
           isAdmin?: (address: string) => boolean;
         },
       ) => {
-        this.logger.debug("revokeGroupOperationPermission", args);
+        this.logger.debug("revokeGroupOperationPermission(@args)", args);
         if (!this.documentPermissionService) {
           throw new GraphQLError("DocumentPermissionService not available");
         }
@@ -535,7 +544,10 @@ export class AuthSubgraph extends BaseSubgraph {
             isGlobalAdmin,
           );
         } catch (error) {
-          this.logger.error("Error in revokeGroupOperationPermission:", error);
+          this.logger.error(
+            "Error in revokeGroupOperationPermission: @error",
+            error,
+          );
           throw error;
         }
       },

--- a/packages/reactor-api/src/graphql/graphql-manager.ts
+++ b/packages/reactor-api/src/graphql/graphql-manager.ts
@@ -283,7 +283,10 @@ export class GraphQLManager {
         models.length,
       );
     } catch (error) {
-      this.logger.error("Failed to regenerate document model subgraphs", error);
+      this.logger.error(
+        "Failed to regenerate document model subgraphs: @error",
+        error,
+      );
       throw error;
     }
   }
@@ -436,7 +439,10 @@ export class GraphQLManager {
       await this.gatewayAdapter.updateSupergraph();
       this.logger.debug("Updated Apollo Gateway supergraph");
     } catch (error) {
-      this.logger.error("Failed to update Apollo Gateway supergraph", error);
+      this.logger.error(
+        "Failed to update Apollo Gateway supergraph: @error",
+        error,
+      );
     }
 
     // Refresh the supergraph-level SSE handler so it picks up

--- a/packages/reactor-api/src/graphql/packages/subgraph.ts
+++ b/packages/reactor-api/src/graphql/packages/subgraph.ts
@@ -37,20 +37,20 @@ export class PackagesSubgraph extends BaseSubgraph {
             this.packageManagementService,
           );
         } catch (error) {
-          this.logger.error("Error in installedPackages:", error);
+          this.logger.error("Error in installedPackages: @error", error);
           throw error;
         }
       },
 
       installedPackage: async (_parent: unknown, args: { name: string }) => {
-        this.logger.debug("installedPackage", args);
+        this.logger.debug("installedPackage(@args)", args);
         try {
           return await resolvers.installedPackage(
             this.packageManagementService,
             args,
           );
         } catch (error) {
-          this.logger.error("Error in installedPackage:", error);
+          this.logger.error("Error in installedPackage: @error", error);
           throw error;
         }
       },
@@ -66,7 +66,7 @@ export class PackagesSubgraph extends BaseSubgraph {
         args: { name: string; registryUrl?: string | null },
         ctx: Context,
       ) => {
-        this.logger.debug("installPackage", args);
+        this.logger.debug("installPackage(@args)", args);
         try {
           return await resolvers.installPackage(
             this.packageManagementService,
@@ -74,7 +74,7 @@ export class PackagesSubgraph extends BaseSubgraph {
             ctx,
           );
         } catch (error) {
-          this.logger.error("Error in installPackage:", error);
+          this.logger.error("Error in installPackage: @error", error);
           throw error;
         }
       },
@@ -84,7 +84,7 @@ export class PackagesSubgraph extends BaseSubgraph {
         args: { name: string },
         ctx: Context,
       ) => {
-        this.logger.debug("uninstallPackage", args);
+        this.logger.debug("uninstallPackage(@args)", args);
         try {
           return await resolvers.uninstallPackage(
             this.packageManagementService,
@@ -92,7 +92,7 @@ export class PackagesSubgraph extends BaseSubgraph {
             ctx,
           );
         } catch (error) {
-          this.logger.error("Error in uninstallPackage:", error);
+          this.logger.error("Error in uninstallPackage: @error", error);
           throw error;
         }
       },

--- a/packages/reactor-api/src/graphql/reactor/subgraph.ts
+++ b/packages/reactor-api/src/graphql/reactor/subgraph.ts
@@ -252,7 +252,11 @@ export class ReactorSubgraph extends BaseSubgraph {
             hasMore,
           };
         } catch (error) {
-          this.logger.error("Error in pollSyncEnvelopes(@args): @Error", args, error);
+          this.logger.error(
+            "Error in pollSyncEnvelopes(@args): @Error",
+            args,
+            error,
+          );
           throw error;
         }
       },
@@ -301,7 +305,11 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return result;
         } catch (error) {
-          this.logger.error("Error in createDocument(@args): @Error", args, error);
+          this.logger.error(
+            "Error in createDocument(@args): @Error",
+            args,
+            error,
+          );
           throw error;
         }
       },
@@ -348,7 +356,11 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return result;
         } catch (error) {
-          this.logger.error("Error in createEmptyDocument(@args): @Error", args, error);
+          this.logger.error(
+            "Error in createEmptyDocument(@args): @Error",
+            args,
+            error,
+          );
           throw error;
         }
       },
@@ -371,7 +383,11 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return await resolvers.mutateDocument(this.reactorClient, args);
         } catch (error) {
-          this.logger.error("Error in mutateDocument(@args): @Error", args, error);
+          this.logger.error(
+            "Error in mutateDocument(@args): @Error",
+            args,
+            error,
+          );
           throw error;
         }
       },
@@ -392,7 +408,11 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return await resolvers.mutateDocumentAsync(this.reactorClient, args);
         } catch (error) {
-          this.logger.error("Error in mutateDocumentAsync(@args): @Error", args, error);
+          this.logger.error(
+            "Error in mutateDocumentAsync(@args): @Error",
+            args,
+            error,
+          );
           throw error;
         }
       },
@@ -404,7 +424,11 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return await resolvers.renameDocument(this.reactorClient, args);
         } catch (error) {
-          this.logger.error("Error in renameDocument(@args): @Error", args, error);
+          this.logger.error(
+            "Error in renameDocument(@args): @Error",
+            args,
+            error,
+          );
           throw error;
         }
       },
@@ -416,7 +440,11 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return await resolvers.setPreferredEditor(this.reactorClient, args);
         } catch (error) {
-          this.logger.error("Error in setPreferredEditor(@args): @Error", args, error);
+          this.logger.error(
+            "Error in setPreferredEditor(@args): @Error",
+            args,
+            error,
+          );
           throw error;
         }
       },
@@ -428,7 +456,11 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return await resolvers.addRelationship(this.reactorClient, args);
         } catch (error) {
-          this.logger.error("Error in addRelationship(@args): @Error", args, error);
+          this.logger.error(
+            "Error in addRelationship(@args): @Error",
+            args,
+            error,
+          );
           throw error;
         }
       },
@@ -440,7 +472,11 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return await resolvers.removeRelationship(this.reactorClient, args);
         } catch (error) {
-          this.logger.error("Error in removeRelationship(@args): @Error", args, error);
+          this.logger.error(
+            "Error in removeRelationship(@args): @Error",
+            args,
+            error,
+          );
           throw error;
         }
       },
@@ -486,7 +522,11 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return result;
         } catch (error) {
-          this.logger.error("Error in deleteDocument(@args): @Error", args, error);
+          this.logger.error(
+            "Error in deleteDocument(@args): @Error",
+            args,
+            error,
+          );
           throw error;
         }
       },
@@ -500,7 +540,11 @@ export class ReactorSubgraph extends BaseSubgraph {
           }
           return await resolvers.deleteDocuments(this.reactorClient, args);
         } catch (error) {
-          this.logger.error("Error in deleteDocuments(@args): @Error", args, error);
+          this.logger.error(
+            "Error in deleteDocuments(@args): @Error",
+            args,
+            error,
+          );
           throw error;
         }
       },
@@ -526,7 +570,11 @@ export class ReactorSubgraph extends BaseSubgraph {
         try {
           return await resolvers.touchChannel(this.syncManager, args);
         } catch (error) {
-          this.logger.error("Error in touchChannel(@args): @Error", args, error);
+          this.logger.error(
+            "Error in touchChannel(@args): @Error",
+            args,
+            error,
+          );
           throw error;
         }
       },
@@ -571,7 +619,11 @@ export class ReactorSubgraph extends BaseSubgraph {
             mutableArgs,
           );
         } catch (error) {
-          this.logger.error("Error in pushSyncEnvelopes(@args): @Error", args, error);
+          this.logger.error(
+            "Error in pushSyncEnvelopes(@args): @Error",
+            args,
+            error,
+          );
           throw error;
         }
       },

--- a/packages/reactor-api/src/graphql/reactor/subgraph.ts
+++ b/packages/reactor-api/src/graphql/reactor/subgraph.ts
@@ -252,7 +252,7 @@ export class ReactorSubgraph extends BaseSubgraph {
             hasMore,
           };
         } catch (error) {
-          this.logger.error("Error in pollSyncEnvelopes(@args): @Error", error);
+          this.logger.error("Error in pollSyncEnvelopes(@args): @Error", args, error);
           throw error;
         }
       },
@@ -301,7 +301,7 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return result;
         } catch (error) {
-          this.logger.error("Error in createDocument(@args): @Error", error);
+          this.logger.error("Error in createDocument(@args): @Error", args, error);
           throw error;
         }
       },
@@ -348,10 +348,7 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return result;
         } catch (error) {
-          this.logger.error(
-            "Error in createEmptyDocument(@args): @Error",
-            error,
-          );
+          this.logger.error("Error in createEmptyDocument(@args): @Error", args, error);
           throw error;
         }
       },
@@ -374,7 +371,7 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return await resolvers.mutateDocument(this.reactorClient, args);
         } catch (error) {
-          this.logger.error("Error in mutateDocument(@args): @Error", error);
+          this.logger.error("Error in mutateDocument(@args): @Error", args, error);
           throw error;
         }
       },
@@ -395,10 +392,7 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return await resolvers.mutateDocumentAsync(this.reactorClient, args);
         } catch (error) {
-          this.logger.error(
-            "Error in mutateDocumentAsync(@args): @Error",
-            error,
-          );
+          this.logger.error("Error in mutateDocumentAsync(@args): @Error", args, error);
           throw error;
         }
       },
@@ -410,7 +404,7 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return await resolvers.renameDocument(this.reactorClient, args);
         } catch (error) {
-          this.logger.error("Error in renameDocument(@args): @Error", error);
+          this.logger.error("Error in renameDocument(@args): @Error", args, error);
           throw error;
         }
       },
@@ -422,10 +416,7 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return await resolvers.setPreferredEditor(this.reactorClient, args);
         } catch (error) {
-          this.logger.error(
-            "Error in setPreferredEditor(@args): @Error",
-            error,
-          );
+          this.logger.error("Error in setPreferredEditor(@args): @Error", args, error);
           throw error;
         }
       },
@@ -437,7 +428,7 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return await resolvers.addRelationship(this.reactorClient, args);
         } catch (error) {
-          this.logger.error("Error in addRelationship(@args): @Error", error);
+          this.logger.error("Error in addRelationship(@args): @Error", args, error);
           throw error;
         }
       },
@@ -449,10 +440,7 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return await resolvers.removeRelationship(this.reactorClient, args);
         } catch (error) {
-          this.logger.error(
-            "Error in removeRelationship(@args): @Error",
-            error,
-          );
+          this.logger.error("Error in removeRelationship(@args): @Error", args, error);
           throw error;
         }
       },
@@ -498,7 +486,7 @@ export class ReactorSubgraph extends BaseSubgraph {
 
           return result;
         } catch (error) {
-          this.logger.error("Error in deleteDocument(@args): @Error", error);
+          this.logger.error("Error in deleteDocument(@args): @Error", args, error);
           throw error;
         }
       },
@@ -512,7 +500,7 @@ export class ReactorSubgraph extends BaseSubgraph {
           }
           return await resolvers.deleteDocuments(this.reactorClient, args);
         } catch (error) {
-          this.logger.error("Error in deleteDocuments(@args): @Error", error);
+          this.logger.error("Error in deleteDocuments(@args): @Error", args, error);
           throw error;
         }
       },
@@ -538,7 +526,7 @@ export class ReactorSubgraph extends BaseSubgraph {
         try {
           return await resolvers.touchChannel(this.syncManager, args);
         } catch (error) {
-          this.logger.error("Error in touchChannel(@args): @Error", error);
+          this.logger.error("Error in touchChannel(@args): @Error", args, error);
           throw error;
         }
       },
@@ -583,7 +571,7 @@ export class ReactorSubgraph extends BaseSubgraph {
             mutableArgs,
           );
         } catch (error) {
-          this.logger.error("Error in pushSyncEnvelopes(@args): @Error", error);
+          this.logger.error("Error in pushSyncEnvelopes(@args): @Error", args, error);
           throw error;
         }
       },
@@ -595,7 +583,7 @@ export class ReactorSubgraph extends BaseSubgraph {
         subscribe: withFilter(
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           (() => {
-            this.logger.debug("documentChanges(@args) subscription started");
+            this.logger.debug("documentChanges subscription started");
             ensureGlobalDocumentSubscription(this.reactorClient);
 
             return getPubSub().asyncIterableIterator<DocumentChangesPayload>(

--- a/packages/reactor-api/src/packages/package-manager.ts
+++ b/packages/reactor-api/src/packages/package-manager.ts
@@ -81,7 +81,7 @@ export class PackageManager implements IPackageManager {
     try {
       this.subscribePackages(packages);
     } catch (error) {
-      this.logger.error("Failed to subscribe to packages", error);
+      this.logger.error("Failed to subscribe to packages: @error", error);
     }
 
     return {

--- a/packages/reactor-api/src/server.ts
+++ b/packages/reactor-api/src/server.ts
@@ -759,14 +759,17 @@ function buildApiDispose(args: {
     try {
       await graphqlManager.shutdown();
     } catch (error) {
-      logger.error("API dispose: graphqlManager.shutdown failed:", error);
+      logger.error(
+        "API dispose: graphqlManager.shutdown failed: @error",
+        error,
+      );
     }
 
     try {
       for (const client of wsServer.clients) client.terminate();
       await new Promise<void>((resolve) => wsServer.close(() => resolve()));
     } catch (error) {
-      logger.error("API dispose: wsServer.close failed:", error);
+      logger.error("API dispose: wsServer.close failed: @error", error);
     }
 
     if (httpServer.listening) {
@@ -778,7 +781,7 @@ function buildApiDispose(args: {
           httpServer.close((err) => (err ? reject(err) : resolve())),
         );
       } catch (error) {
-        logger.error("API dispose: httpServer.close failed:", error);
+        logger.error("API dispose: httpServer.close failed: @error", error);
       }
     }
 
@@ -786,7 +789,7 @@ function buildApiDispose(args: {
       try {
         await close();
       } catch (error) {
-        logger.error("API dispose: db closer failed:", error);
+        logger.error("API dispose: db closer failed: @error", error);
       }
     }
   };

--- a/packages/reactor-browser/src/actions/document.ts
+++ b/packages/reactor-browser/src/actions/document.ts
@@ -355,7 +355,7 @@ export async function addDocument(
       parentFolder,
     );
   } catch (e) {
-    logger.error("Error adding document", e);
+    logger.error("Error adding document: @error", e);
     throw new Error("There was an error adding document", { cause: e });
   }
 

--- a/packages/reactor-browser/src/renown/utils.ts
+++ b/packages/reactor-browser/src/renown/utils.ts
@@ -6,7 +6,7 @@ export function openRenown(documentId?: string) {
   const renown = window.ph?.renown;
   let renownUrl = renown?.baseUrl;
   if (!renownUrl) {
-    logger.warn("Renown instance not found, falling back to: ", RENOWN_URL);
+    logger.warn("Renown instance not found, falling back to: @url", RENOWN_URL);
     renownUrl = RENOWN_URL;
   }
 

--- a/packages/reactor-mcp/src/mcp-routes.ts
+++ b/packages/reactor-mcp/src/mcp-routes.ts
@@ -64,7 +64,7 @@ export async function setupMcpServer(
         await server.connect(transport);
         await transport.handleRequest(req, res, body);
       } catch (error) {
-        logger.error("Error handling MCP request:", error);
+        logger.error("Error handling MCP request: @error", error);
         if (!res.headersSent) {
           res
             .writeHead(500, { "Content-Type": "application/json" })

--- a/packages/reactor-mcp/src/stdio/loader.ts
+++ b/packages/reactor-mcp/src/stdio/loader.ts
@@ -79,7 +79,7 @@ export class VitePackageLoader implements IPackageLoader {
     const vite = await this.initVite();
 
     await access(this.fullPath);
-    this.logger.verbose("Loading document models from", this.fullPath);
+    this.logger.verbose("Loading document models from @path", this.fullPath);
 
     try {
       const localDMs = (await vite.ssrLoadModule(this.fullPath)) as Record<

--- a/packages/vetra/processors/codegen/document-handlers/document-codegen-manager.ts
+++ b/packages/vetra/processors/codegen/document-handlers/document-codegen-manager.ts
@@ -148,7 +148,10 @@ export class DocumentCodegenManager {
             },
           );
         } catch (error) {
-          logger.error("❌ Error during interactive batch processing:", error);
+          logger.error(
+            "❌ Error during interactive batch processing: @error",
+            error,
+          );
         } finally {
           // Clean up the timer reference
           this.debounceTimers.delete("interactive");

--- a/packages/vetra/processors/codegen/interactive-manager.ts
+++ b/packages/vetra/processors/codegen/interactive-manager.ts
@@ -178,7 +178,10 @@ export class InteractiveManager {
       await processor(queuedStrands);
       logger.info("✅ Code generation completed");
     } catch (error) {
-      logger.error("❌ Error during interactive queue processing:", error);
+      logger.error(
+        "❌ Error during interactive queue processing: @error",
+        error,
+      );
       throw error;
     } finally {
       this.processingConfirmation = false;

--- a/packages/vetra/processors/codegen/utils.ts
+++ b/packages/vetra/processors/codegen/utils.ts
@@ -14,7 +14,7 @@ export function debounce<T extends (...args: any[]) => any>(
       try {
         await func(...args);
       } catch (error) {
-        logger.error(`Error in debounced function:`, error);
+        logger.error(`Error in debounced function: @error`, error);
       }
     }, delay);
   };


### PR DESCRIPTION
## Summary

- **`document-model` logger**: `ConsoleLogger` previously rendered `Error` values via `JSON.stringify` (returns `"{}"` because Error's own properties are non-enumerable) and silently dropped positional replacements past the unique-`@token` count. Calls like `logger.error("App crashed: @error", err)` printed `App crashed: {}`, and `logger.error("...:", err)` printed nothing about the error. Errors now render as `name: message`, with the stack appended only at `debug`/`verbose` levels so production logs stay readable. Extras past the `@token` count are now appended instead of dropped.
- **Two new ESLint rules** under a local `logger` plugin (inline in `eslint.config.js`, mirroring the existing `cli-cold-path` rule):
  - `logger/missing-token-args` (error) — more `@token`s in the message than args → missing slots would render as `"null"`. Caught 14 real bugs in `reactor-api/src/graphql/reactor/subgraph.ts` (e.g. `"Error in pollSyncEnvelopes(@args): @Error"` was called with only `error`).
  - `logger/extra-args-without-token` (warn) — args passed with no `@token`. Stylistic post-runtime-fix, but worth flagging at the call site.
  - Detection: callee `<id>.<level>(...)` where `<id>` ends in `"logger"` (case-insensitive), or `<x>.logger.<level>(...)`. Covers `logger`, `defaultLogger`, `childLogger`-bound names, and `this.logger` class members.
- **Sweep of all 82 hits** (14 errors + 68 warnings) across reactor-api, reactor-browser, reactor-mcp, and vetra codegen.

Counter-evidence the lint rule was needed: the original PR #2609 patched three call sites by hand with `e instanceof Error ? \`${e.name}: ${e.message}\` : String(e)`. Those manual workarounds are now redundant — passing the Error directly works.

## Test plan

- [x] `pnpm --filter document-model exec vitest run test/logger.test.ts` — 12/12 pass, including stack-on-debug, no-stack-at-info, appended-extras, and unmatched-token-renders-null
- [x] `pnpm --filter document-model exec vitest run` — full suite, 232 passed / 1 skipped
- [x] `pnpm exec eslint packages apps` — 0 `logger/missing-token-args` errors, 0 `logger/extra-args-without-token` warnings
- [x] Manual A/B output check for each pre-fix call site shape (verified Error → `name: message`, stack only at debug)

## Notes for reviewers

- The runtime fix and the lint rule are intentionally split into separate commits so the rule's blast radius is easy to inspect.
- One call in `reactor/subgraph.ts:586` previously had `documentChanges(@args) subscription started` but no `args` in scope (the subscribe callback is zero-arg) — token removed rather than synthesizing a value.
- The test file gets a file-level `logger/extra-args-without-token` disable because it intentionally exercises the no-token + positional-Error shape to assert the runtime appends.