### PR TITLE
fix(reactor-browser): hide DropZone overlay over editor opt-out regions

### DIFF
--- a/packages/design-system/src/connect/components/drop-zone/drop-zone.tsx
+++ b/packages/design-system/src/connect/components/drop-zone/drop-zone.tsx
@@ -93,7 +93,7 @@ export function DropZone(props: DropZoneProps) {
       {children}
 
       {enable && isDropTarget && (
-        <div className="fixed inset-0 z-1000 flex min-h-screen w-screen items-center justify-center bg-black/50">
+        <div className="pointer-events-none fixed inset-0 z-1000 flex min-h-screen w-screen items-center justify-center bg-black/50">
           <div className="rounded-3xl bg-white p-6 shadow-charcoal">
             <div className="relative flex h-32.5 w-100 flex-col items-center justify-start overflow-visible rounded-lg border border-dashed border-black px-4 py-6">
               <div className="text-center text-base/5 text-zinc-500">

--- a/packages/reactor-browser/src/hooks/file-drag-and-drop.ts
+++ b/packages/reactor-browser/src/hooks/file-drag-and-drop.ts
@@ -71,7 +71,13 @@ export function useDropFile(
   function handleDragEvent(event: React.DragEvent<Element>, cb?: () => void) {
     if (!isDragAndDropEnabled) return;
     if (!isFileDrop(event)) return;
-    if (isInsideEditorFileDropOptOut(event)) return;
+    if (isInsideEditorFileDropOptOut(event)) {
+      // Hide the DropZone overlay while the cursor is over an editor that
+      // opts in to its own file drops, so the overlay doesn't strand the
+      // user covering the opt-out region.
+      unsetTarget();
+      return;
+    }
     event.preventDefault();
     event.stopPropagation();
     cb?.();

--- a/packages/reactor-browser/test/file-drag-and-drop.test.ts
+++ b/packages/reactor-browser/test/file-drag-and-drop.test.ts
@@ -1,5 +1,5 @@
 import type { Node } from "@powerhousedao/shared";
-import type { DragEvent } from "react";
+import { act, type DragEvent } from "react";
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { renderHook } from "vitest-browser-react";
 import { setIsDragAndDropEnabled } from "../src/hooks/config/editor.js";
@@ -33,7 +33,11 @@ function fakeEvent(opts: {
   return { event, preventDefault, stopPropagation };
 }
 
-function mountHook(): { handlers: Handlers; container: HTMLElement } {
+function mountHook(): {
+  handlers: Handlers;
+  container: HTMLElement;
+  result: { current: Handlers };
+} {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const noop = async (): Promise<void> => {
@@ -44,7 +48,7 @@ function mountHook(): { handlers: Handlers; container: HTMLElement } {
       noop as (file: File, parent: Node | undefined) => Promise<void>,
     ),
   );
-  return { handlers: result.current, container };
+  return { handlers: result.current, container, result };
 }
 
 describe("useDropFile", () => {
@@ -100,6 +104,26 @@ describe("useDropFile", () => {
 
     expect(preventDefault).not.toHaveBeenCalled();
     expect(stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it("clears the drop target when the cursor enters an opt-out region", async () => {
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+    const editor = document.createElement("div");
+    editor.setAttribute("data-accepts-files", "");
+    document.body.appendChild(editor);
+
+    const { result } = mountHook();
+
+    await act(async () => {
+      result.current.onDragOver(fakeEvent({ target: outside }).event);
+    });
+    expect(result.current.isDropTarget).toBe(true);
+
+    await act(async () => {
+      result.current.onDragOver(fakeEvent({ target: editor }).event);
+    });
+    expect(result.current.isDropTarget).toBe(false);
   });
 
   it("still claims drops outside any opted-out editor", () => {

--- a/test/versioned-documents/editors/todo-editor/module.ts
+++ b/test/versioned-documents/editors/todo-editor/module.ts
@@ -8,7 +8,7 @@ import { lazy } from "react";
 /** Document editor module for the "["powerhouse/document-drive"]" document type */
 export const TodoEditor: EditorModule = {
   Component: lazy(() => import("./editor.js")),
-  documentTypes: ["powerhouse/document-drive"],
+  documentTypes: ["test/todo"],
   config: {
     id: "todo-editor",
     name: "TodoEditor",


### PR DESCRIPTION
## Summary

- DropZone overlay no longer strands the user when a file drag enters an `useEditorFileDrop` opt-out region.
- `useDropFile` calls `unsetTarget()` on drag events whose target is inside `[data-accepts-files]`, so the overlay disappears when the cursor moves back into the editor's drop area.
- The DropZone overlay `div` gets `pointer-events-none` so drag events pass through to the underlying editor (otherwise the overlay swallows them once shown).
- Bonus: corrects the `test/versioned-documents` todo-editor module to register `documentTypes: ["test/todo"]` (the codegen had written `"powerhouse/document-drive"`, so Connect couldn't open todo documents).

## Test plan

- [x] `pnpm --filter @powerhousedao/reactor-browser test` — new "clears the drop target when the cursor enters an opt-out region" test passes; existing file-drop / useEditorFileDrop tests still pass (4 pre-existing failures in `document-cache` / `switchboard` are unrelated).
- [x] Manual test in `test/versioned-documents` with a drive editor that has two zones — a normal drive area + an attachments panel using `useEditorFileDrop`. Dragging between zones no longer leaves the DropZone overlay stuck on top of the editor.