### PR TITLE
fix(reactor-api): resolve linked packages via dist/node/<sub>/index.mjs

### DIFF
--- a/packages/reactor-api/src/packages/import-resolver.ts
+++ b/packages/reactor-api/src/packages/import-resolver.ts
@@ -8,6 +8,8 @@ async function tryNodeSuggestedPaths<T>(
   subPath: string,
 ): Promise<T | null> {
   const suggestedPaths = [
+    `${packageName}/dist/node/${subPath}/index.mjs`,
+    `${packageName}/dist/node/${subPath}.mjs`,
     `${packageName}/dist/${subPath}/index.js`,
     `${packageName}/dist/${subPath}.js`,
   ];
@@ -36,6 +38,8 @@ async function tryImportMetaResolve<T>(
 
     const packageRoot = path.dirname(new URL(resolvedUrl).pathname);
     const pathsToTry = [
+      path.join(packageRoot, "dist", "node", subPath, "index.mjs"),
+      path.join(packageRoot, "dist", "node", `${subPath}.mjs`),
       path.join(packageRoot, "dist", subPath, "index.js"),
       path.join(packageRoot, "dist", `${subPath}.js`),
       path.join(packageRoot, subPath, "index.js"),
@@ -80,6 +84,8 @@ async function resolveSymlinkedPaths(
         const realPath = fs.realpathSync(nodeModulesPath);
 
         workspacePatterns.push(
+          path.join(realPath, "dist", "node", subPath, "index.mjs"),
+          path.join(realPath, "dist", "node", `${subPath}.mjs`),
           path.join(realPath, "dist", subPath, "index.js"),
           path.join(realPath, "dist", `${subPath}.js`),
           path.join(realPath, subPath, "index.js"),
@@ -109,6 +115,23 @@ function getCommonWorkspacePaths(
   const workspacePatterns: string[] = [];
   for (const root of commonRoots) {
     workspacePatterns.push(
+      path.join(
+        root,
+        "packages",
+        packageBaseName || packageName,
+        "dist",
+        "node",
+        subPath,
+        "index.mjs",
+      ),
+      path.join(
+        root,
+        "packages",
+        packageBaseName || packageName,
+        "dist",
+        "node",
+        `${subPath}.mjs`,
+      ),
       path.join(
         root,
         "packages",


### PR DESCRIPTION
## Summary
- The `resolveLinkedPackage` fallback in `packages/reactor-api/src/packages/import-resolver.ts` only tried `dist/<sub>/index.js`, but tsdown-built Powerhouse packages emit Node entrypoints at `dist/node/<sub>/index.mjs`.
- As a result, `ph switchboard` (non-dev mode) silently failed to load `document-models`, `subgraphs`, and `processors` from packages declared in `powerhouse.config.json` whenever the package wasn't resolvable from inside reactor-api's own `dist/` (e.g. workspace symlinks under a downstream project's `node_modules`). `ph vetra` was unaffected because its Vite loader resolves from project cwd.
- Try `dist/node/<sub>/index.mjs` (and `dist/node/<sub>.mjs`) first across all four resolution strategies (`tryNodeSuggestedPaths`, `tryImportMetaResolve`, `resolveSymlinkedPaths`, `getCommonWorkspacePaths`). The existing `dist/<sub>/index.js` patterns remain as a fallback. No browser-conditional path added.

## Test plan
- [x] `pnpm tsc --noEmit` passes in `packages/reactor-api`.
- [x] `eslint src/packages/import-resolver.ts` — 0 errors (1 pre-existing warning unrelated to this change).
- [x] Repro in `test/vetra-e2e`: `ph switchboard` now logs `Registered /graphql/todo subgraph` and `Registered /graphql/test-custom subgraph`, and `[ImportPackageLoader] Loaded document models from package @powerhousedao/versioned-documents`. Previously these were silently dropped.