### PR TITLE
feat(connect): embed mode + drive URL flow + local-link build fix

### DIFF
--- a/apps/connect/src/components/app-container.tsx
+++ b/apps/connect/src/components/app-container.tsx
@@ -4,7 +4,7 @@ import {
   useAppModuleById,
   useDefaultAppModule,
   useSelectedDocumentId,
-  useSelectedDrive,
+  useSelectedDriveSafe,
 } from "@powerhousedao/reactor-browser";
 import { Suspense } from "react";
 import { DocumentEditorContainer } from "./document-editor-container.js";
@@ -12,11 +12,15 @@ import { EditorLoader } from "./editor-loader.js";
 import { ErrorBoundary } from "./error-boundary.js";
 
 export function AppContainer() {
-  const [selectedDrive] = useSelectedDrive();
+  const [selectedDrive] = useSelectedDriveSafe();
   const selectedDocumentId = useSelectedDocumentId();
 
-  const app = useAppModuleById(selectedDrive.header.meta?.preferredEditor);
+  const app = useAppModuleById(selectedDrive?.header.meta?.preferredEditor);
   const defaultApp = useDefaultAppModule();
+
+  if (!selectedDrive) {
+    return <EditorLoader />;
+  }
 
   const AppComponent =
     app?.Component ?? defaultApp?.Component ?? GenericDriveExplorer.Component;

--- a/apps/connect/src/components/app-skeleton.tsx
+++ b/apps/connect/src/components/app-skeleton.tsx
@@ -1,4 +1,5 @@
 import { getBasePath } from "@powerhousedao/connect/utils";
+import { getIsEmbedded } from "@powerhousedao/connect/hooks";
 import {
   AnimatedLoader,
   ConnectSidebar,
@@ -80,15 +81,21 @@ const Loader = ({ delay = LOADER_DELAY }: { delay?: number }) => {
 export const AppSkeleton: React.FC<PropsWithChildren> = (props) => {
   const isSSR = typeof window === "undefined";
   const isHomeScreen = !isSSR && window.location.pathname === getBasePath();
+  /* Match Root's behavior: when Connect is rendered inside an embed (e.g. the
+   * vetra-studio BUILD iframe), suppress the sidebar during the Suspense
+   * fallback so the loading state matches the loaded state. */
+  const isEmbedded = !isSSR && getIsEmbedded();
   return (
     <div className="flex h-screen overflow-hidden">
-      <ConnectSidebar
-        className="animate-pulse"
-        onLogin={undefined}
-        onDisconnect={undefined}
-        onClickSettings={undefined}
-        address={undefined}
-      />
+      {!isEmbedded && (
+        <ConnectSidebar
+          className="animate-pulse"
+          onLogin={undefined}
+          onDisconnect={undefined}
+          onClickSettings={undefined}
+          address={undefined}
+        />
+      )}
       <HomeScreen
         containerClassName={
           isSSR || !isHomeScreen ? "hidden home-screen" : undefined

--- a/apps/connect/src/components/root.tsx
+++ b/apps/connect/src/components/root.tsx
@@ -1,8 +1,10 @@
 import { Sidebar } from "@powerhousedao/connect/components";
+import { useIsEmbedded } from "@powerhousedao/connect/hooks";
 import { Suspense } from "react";
 import { Outlet } from "react-router-dom";
 
 export function Root() {
+  const isEmbedded = useIsEmbedded();
   return (
     <div className="h-screen">
       <div
@@ -11,7 +13,7 @@ export function Root() {
         tabIndex={0}
       >
         <Suspense name="Root">
-          <Sidebar />
+          {!isEmbedded && <Sidebar />}
           <div className="relative flex-1 overflow-auto">
             <Outlet />
           </div>

--- a/apps/connect/src/hooks/index.ts
+++ b/apps/connect/src/hooks/index.ts
@@ -4,6 +4,7 @@ export * from "./useClientErrorHandler.js";
 export * from "./useCookieBanner.js";
 export * from "./useFailedInstallations.js";
 export * from "./useInitSentry.js";
+export * from "./useIsEmbedded.js";
 export * from "./usePendingInstallations.js";
 export * from "./useRegistryPackages.js";
 export * from "./useUndoRedoShortcuts.js";

--- a/apps/connect/src/hooks/useCookieBanner.ts
+++ b/apps/connect/src/hooks/useCookieBanner.ts
@@ -1,5 +1,6 @@
 import { connectConfig } from "@powerhousedao/connect/config";
 import { useSyncExternalStore } from "react";
+import { getIsEmbedded } from "./useIsEmbedded.js";
 
 const namespace = connectConfig.routerBasename;
 
@@ -10,6 +11,7 @@ const listeners = new Set<() => void>();
 let bannerShown = getInitial();
 
 function getInitial(): boolean {
+  if (getIsEmbedded()) return false;
   try {
     const value = localStorage.getItem(COOKIE_BANNER_KEY_STORAGE);
     return value !== "false";

--- a/apps/connect/src/hooks/useIsEmbedded.ts
+++ b/apps/connect/src/hooks/useIsEmbedded.ts
@@ -1,0 +1,20 @@
+/**
+ * Detects whether Connect is being rendered inside another app (e.g. inside
+ * an iframe in the vetra-cli drive editor). When `?embed=1` is present in the
+ * URL, chrome that doesn't make sense in the embedded context — the cookie
+ * banner, the outer sidebar — is suppressed.
+ */
+export function getIsEmbedded(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const value = params.get("embed");
+    return value !== null && value !== "0" && value !== "false";
+  } catch {
+    return false;
+  }
+}
+
+export function useIsEmbedded(): boolean {
+  return getIsEmbedded();
+}

--- a/apps/connect/src/store/reactor.ts
+++ b/apps/connect/src/store/reactor.ts
@@ -340,24 +340,32 @@ export async function createReactor(localPackage?: DocumentModelLib) {
   setDocumentCache(documentCache);
   setRenown(renown);
   setDrives(drives);
+  setFeatures(features);
+
+  // If the URL pins a remote drive, register it and wait for its initial
+  // sync to materialize the drive document before selecting it. Without
+  // this, setSelectedDrive(driveSlug) below resolves to undefined and
+  // rewrites the URL to "/".
+  const remoteUrl = getDriveUrl();
+  if (remoteUrl) {
+    try {
+      await addRemoteDrive(remoteUrl, undefined, {
+        awaitInitialSync: true,
+        initialSyncTimeoutMs: 15_000,
+      });
+      await refreshReactorDataClient(reactorClientModule.client);
+    } catch (error) {
+      console.error(`Failed to add remote drive from ${remoteUrl}:`, error);
+    }
+  }
+
   setSelectedDrive(driveSlug);
   setSelectedNode(nodeSlug);
-  setFeatures(features);
 
   // Add default drives for new reactor (after window.ph is set up)
   const defaultDrivesConfig = getDefaultDrivesFromEnv();
   if (defaultDrivesConfig.length > 0) {
     await addDefaultDrivesForNewReactor(defaultDrivesConfig);
-  }
-
-  // if remoteUrl is set and drive not already existing add remote drive and open it
-  const remoteUrl = getDriveUrl();
-  if (remoteUrl) {
-    try {
-      await addRemoteDrive(remoteUrl);
-    } catch (error) {
-      console.error(`Failed to add remote drive from ${remoteUrl}:`, error);
-    }
   }
 
   // Subscribe via ReactorClient interface

--- a/apps/connect/src/store/reactor.ts
+++ b/apps/connect/src/store/reactor.ts
@@ -342,31 +342,39 @@ export async function createReactor(localPackage?: DocumentModelLib) {
   setDrives(drives);
   setFeatures(features);
 
-  // If the URL pins a remote drive, register it and wait for its initial
-  // sync to materialize the drive document before selecting it. Without
-  // this, setSelectedDrive(driveSlug) below resolves to undefined and
-  // rewrites the URL to "/".
+  // When the URL pins a drive slug, default drives and any URL-supplied
+  // remote drive must be materialized before setSelectedDrive runs —
+  // otherwise the slug is unknown and the URL gets rewritten to "/".
+  const driveResolutionRequired = Boolean(driveSlug);
+
+  const defaultDrivesConfig = getDefaultDrivesFromEnv();
+  if (defaultDrivesConfig.length > 0) {
+    await addDefaultDrivesForNewReactor(
+      defaultDrivesConfig,
+      driveResolutionRequired
+        ? { awaitInitialSync: true, initialSyncTimeoutMs: 15_000 }
+        : undefined,
+    );
+  }
+
   const remoteUrl = getDriveUrl();
   if (remoteUrl) {
     try {
       await addRemoteDrive(remoteUrl, undefined, {
-        awaitInitialSync: true,
+        awaitInitialSync: driveResolutionRequired,
         initialSyncTimeoutMs: 15_000,
       });
-      await refreshReactorDataClient(reactorClientModule.client);
     } catch (error) {
       console.error(`Failed to add remote drive from ${remoteUrl}:`, error);
     }
   }
 
+  if (driveResolutionRequired) {
+    await refreshReactorDataClient(reactorClientModule.client);
+  }
+
   setSelectedDrive(driveSlug);
   setSelectedNode(nodeSlug);
-
-  // Add default drives for new reactor (after window.ph is set up)
-  const defaultDrivesConfig = getDefaultDrivesFromEnv();
-  if (defaultDrivesConfig.length > 0) {
-    await addDefaultDrivesForNewReactor(defaultDrivesConfig);
-  }
 
   // Subscribe via ReactorClient interface
   const reactorClient = reactorClientModule.client;

--- a/apps/connect/src/utils/reactor.ts
+++ b/apps/connect/src/utils/reactor.ts
@@ -103,9 +103,12 @@ export function getDefaultDrivesFromEnv(): string[] {
  * dev server is ready before the switchboard has finished binding its port.
  *
  * @param defaultDriveUrls - Array of drive REST endpoint URLs (e.g., "https://example.com/d/powerhouse")
+ * @param options - Forwarded to addRemoteDrive. Pass `awaitInitialSync: true`
+ *   when the URL pins a drive slug that must resolve before selection.
  */
 export async function addDefaultDrivesForNewReactor(
   defaultDriveUrls: string[],
+  options?: { awaitInitialSync?: boolean; initialSyncTimeoutMs?: number },
 ): Promise<void> {
   const MAX_ATTEMPTS = 3;
   const BACKOFF_MS = 2000;
@@ -113,7 +116,7 @@ export async function addDefaultDrivesForNewReactor(
   for (const url of defaultDriveUrls) {
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       try {
-        await addRemoteDrive(url);
+        await addRemoteDrive(url, undefined, options);
         break;
       } catch (error) {
         if (attempt === MAX_ATTEMPTS) {

--- a/packages/builder-tools/connect-utils/vite-config.ts
+++ b/packages/builder-tools/connect-utils/vite-config.ts
@@ -295,7 +295,11 @@ export function getConnectBaseViteConfig(options: IConnectOptions) {
   // binary should be — which breaks PGlite at startup with "Invalid FS
   // bundle size: 760 !== 4939170". Resolve key linked packages back to
   // their real workspace roots and allow Vite to serve from there.
-  const linkedRoots = ["@powerhousedao/reactor-browser", "@electric-sql/pglite"]
+  const linkedRoots = [
+    "@powerhousedao/reactor-browser",
+    "@powerhousedao/connect",
+    "@electric-sql/pglite",
+  ]
     .map((pkg) => {
       try {
         return searchForWorkspaceRoot(

--- a/packages/powerhouse-vetra-packages/document-models/document-model/test/validation.test.ts
+++ b/packages/powerhouse-vetra-packages/document-models/document-model/test/validation.test.ts
@@ -4,6 +4,7 @@ import {
   documentModelReducer,
   getAllOperationNames,
   isReservedOperationName,
+  isValidOperationNameFormat,
   RESERVED_OPERATION_NAMES,
   setOperationName,
   setStateSchema,
@@ -493,7 +494,7 @@ describe("DocumentModel Validation Error", () => {
         );
         testDoc = documentModelReducer(
           testDoc,
-          addOperation({ id: "op-2", moduleId: "mod-1", name: "update_user" }),
+          addOperation({ id: "op-2", moduleId: "mod-1", name: "UPDATE_USER" }),
         );
 
         const names = getAllOperationNames(testDoc.state.global);
@@ -529,10 +530,10 @@ describe("DocumentModel Validation Error", () => {
           /reserved/,
         );
         expect(() =>
-          validateOperationName("set_name", doc.state.global),
+          validateOperationName("SET_NAME", doc.state.global),
         ).toThrow(/reserved/);
         expect(() =>
-          validateOperationName("Load_State", doc.state.global),
+          validateOperationName("LOAD_STATE", doc.state.global),
         ).toThrow(/reserved/);
       });
 
@@ -551,7 +552,7 @@ describe("DocumentModel Validation Error", () => {
         ).toThrow(/already used/);
       });
 
-      it("should throw error for duplicate names (different case)", () => {
+      it("rejects non-canonical case before reaching duplicate check", () => {
         let testDoc = documentModelReducer(
           doc,
           addModule({ id: "mod-1", name: "TestModule" }),
@@ -563,10 +564,10 @@ describe("DocumentModel Validation Error", () => {
 
         expect(() =>
           validateOperationName("create_user", testDoc.state.global),
-        ).toThrow(/already used/);
+        ).toThrow(/invalid/i);
         expect(() =>
           validateOperationName("Create_User", testDoc.state.global),
-        ).toThrow(/already used/);
+        ).toThrow(/invalid/i);
       });
 
       it("should not throw for valid unique names", () => {
@@ -605,6 +606,47 @@ describe("DocumentModel Validation Error", () => {
       it("should not throw for empty names", () => {
         expect(() => validateOperationName("", doc.state.global)).not.toThrow();
       });
+
+      it("should throw error for names that aren't SCREAMING_SNAKE_CASE", () => {
+        expect(() =>
+          validateOperationName("Add Workout", doc.state.global),
+        ).toThrow(/invalid/i);
+        expect(() =>
+          validateOperationName("addWorkout", doc.state.global),
+        ).toThrow(/invalid/i);
+        expect(() =>
+          validateOperationName("add-workout", doc.state.global),
+        ).toThrow(/invalid/i);
+        expect(() =>
+          validateOperationName("_LEADING_UNDERSCORE", doc.state.global),
+        ).toThrow(/invalid/i);
+      });
+
+      it("should suggest a SCREAMING_SNAKE_CASE replacement when possible", () => {
+        expect(() =>
+          validateOperationName("Add Workout", doc.state.global),
+        ).toThrow(/Did you mean "ADD_WORKOUT"\?/);
+        expect(() =>
+          validateOperationName("addWorkout", doc.state.global),
+        ).toThrow(/Did you mean "ADD_WORKOUT"\?/);
+      });
+    });
+
+    describe("isValidOperationNameFormat", () => {
+      it("accepts SCREAMING_SNAKE_CASE", () => {
+        expect(isValidOperationNameFormat("ADD")).toBe(true);
+        expect(isValidOperationNameFormat("ADD_WORKOUT")).toBe(true);
+        expect(isValidOperationNameFormat("ADD_WORKOUT_V2")).toBe(true);
+      });
+
+      it("rejects anything else", () => {
+        expect(isValidOperationNameFormat("Add Workout")).toBe(false);
+        expect(isValidOperationNameFormat("addWorkout")).toBe(false);
+        expect(isValidOperationNameFormat("add_workout")).toBe(false);
+        expect(isValidOperationNameFormat("_ADD")).toBe(false);
+        expect(isValidOperationNameFormat("1ADD")).toBe(false);
+        expect(isValidOperationNameFormat("ADD-WORKOUT")).toBe(false);
+      });
     });
 
     describe("addOperation reducer validation", () => {
@@ -630,9 +672,27 @@ describe("DocumentModel Validation Error", () => {
 
         const result2 = documentModelReducer(
           testDoc,
-          addOperation({ id: "op-2", moduleId: "mod-1", name: "set_name" }),
+          addOperation({ id: "op-2", moduleId: "mod-1", name: "SET_NAME" }),
         );
         expect(getLastOperationError(result2)).toMatch(/reserved/);
+      });
+
+      it("should record error when adding operation with invalid name format", () => {
+        const testDoc = documentModelReducer(
+          doc,
+          addModule({ id: "mod-1", name: "TestModule" }),
+        );
+
+        const result = documentModelReducer(
+          testDoc,
+          addOperation({
+            id: "op-1",
+            moduleId: "mod-1",
+            name: "Add Workout",
+          }),
+        );
+        expect(getLastOperationError(result)).toMatch(/invalid/i);
+        expect(getLastOperationError(result)).toMatch(/ADD_WORKOUT/);
       });
 
       it("should record error when adding operation with duplicate name", () => {

--- a/packages/reactor-browser/src/actions/drive.ts
+++ b/packages/reactor-browser/src/actions/drive.ts
@@ -1,6 +1,8 @@
 import {
+  DocumentChangeType,
   driveCollectionId,
   PropagationMode,
+  type IReactorClient,
   type PollBehavior,
 } from "@powerhousedao/reactor";
 import {
@@ -14,9 +16,95 @@ import {
 import type { PHDocument } from "@powerhousedao/shared/document-model";
 import { getUserPermissions } from "../utils/user.js";
 
+const DEFAULT_INITIAL_SYNC_TIMEOUT_MS = 30_000;
+
 export type AddRemoteDriveOptions = {
   pollBehavior?: PollBehavior;
+  /**
+   * When true, wait for the drive document to be materialized locally
+   * (i.e. queryable via the reactor) before resolving. Without this,
+   * `addRemoteDrive` returns as soon as the remote is registered with
+   * the sync manager, before initial backfill delivers the drive.
+   */
+  awaitInitialSync?: boolean;
+  /** Timeout for the initial-sync wait. Defaults to 30s. */
+  initialSyncTimeoutMs?: number;
+  signal?: AbortSignal;
 };
+
+/**
+ * Resolves once a document with the given id is queryable through the
+ * reactor client. Subscribes to Created events filtered by id and
+ * short-circuits if the document already exists.
+ */
+export async function waitForDocumentReady(
+  reactorClient: IReactorClient,
+  documentId: string,
+  options?: { timeoutMs?: number; signal?: AbortSignal },
+): Promise<void> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_INITIAL_SYNC_TIMEOUT_MS;
+  const signal = options?.signal;
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let unsubscribe: (() => void) | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let abortHandler: (() => void) | undefined;
+
+    const settle = (action: () => void) => {
+      if (settled) return;
+      settled = true;
+      unsubscribe?.();
+      if (timer) clearTimeout(timer);
+      if (abortHandler && signal) {
+        signal.removeEventListener("abort", abortHandler);
+      }
+      action();
+    };
+
+    unsubscribe = reactorClient.subscribe({ ids: [documentId] }, (event) => {
+      if (event.type === DocumentChangeType.Created) {
+        settle(() => resolve());
+      }
+    });
+
+    reactorClient
+      .find({ ids: [documentId] })
+      .then((existing) => {
+        if (existing.results.length > 0) {
+          settle(() => resolve());
+        }
+      })
+      .catch(() => {
+        // Ignore: the subscription will still resolve if the document arrives.
+      });
+
+    if (signal) {
+      if (signal.aborted) {
+        settle(() =>
+          reject(new DOMException("Aborted", "AbortError")),
+        );
+        return;
+      }
+      abortHandler = () => {
+        settle(() =>
+          reject(new DOMException("Aborted", "AbortError")),
+        );
+      };
+      signal.addEventListener("abort", abortHandler);
+    }
+
+    timer = setTimeout(() => {
+      settle(() =>
+        reject(
+          new Error(
+            `Timed out after ${timeoutMs}ms waiting for document ${documentId}`,
+          ),
+        ),
+      );
+    }, timeoutMs);
+  });
+}
 
 export async function addDrive(input: DriveInput, preferredEditor?: string) {
   const { isAllowedToCreateDocuments } = getUserPermissions();
@@ -76,24 +164,31 @@ export async function addRemoteDrive(
   const existingRemote = sync
     .list()
     .find((remote) => remote.collectionId === collectionId);
-  if (existingRemote) {
-    return resolvedDriveId;
+
+  if (!existingRemote) {
+    const remoteName = crypto.randomUUID();
+    await sync.add(
+      remoteName,
+      collectionId,
+      {
+        type: "gql",
+        parameters: {
+          url: driveInfo.graphqlEndpoint,
+        },
+      },
+      undefined,
+      options?.pollBehavior
+        ? { pollBehavior: options.pollBehavior }
+        : undefined,
+    );
   }
 
-  const remoteName = crypto.randomUUID();
-
-  await sync.add(
-    remoteName,
-    collectionId,
-    {
-      type: "gql",
-      parameters: {
-        url: driveInfo.graphqlEndpoint,
-      },
-    },
-    undefined,
-    options?.pollBehavior ? { pollBehavior: options.pollBehavior } : undefined,
-  );
+  if (options?.awaitInitialSync) {
+    await waitForDocumentReady(reactorClient, resolvedDriveId, {
+      timeoutMs: options.initialSyncTimeoutMs,
+      signal: options.signal,
+    });
+  }
 
   return resolvedDriveId;
 }

--- a/packages/reactor-browser/src/actions/drive.ts
+++ b/packages/reactor-browser/src/actions/drive.ts
@@ -47,7 +47,9 @@ export async function waitForDocumentReady(
 
   return new Promise<void>((resolve, reject) => {
     let settled = false;
+    // eslint-disable-next-line prefer-const
     let unsubscribe: (() => void) | undefined;
+    // eslint-disable-next-line prefer-const
     let timer: ReturnType<typeof setTimeout> | undefined;
     let abortHandler: (() => void) | undefined;
 
@@ -81,15 +83,11 @@ export async function waitForDocumentReady(
 
     if (signal) {
       if (signal.aborted) {
-        settle(() =>
-          reject(new DOMException("Aborted", "AbortError")),
-        );
+        settle(() => reject(new DOMException("Aborted", "AbortError")));
         return;
       }
       abortHandler = () => {
-        settle(() =>
-          reject(new DOMException("Aborted", "AbortError")),
-        );
+        settle(() => reject(new DOMException("Aborted", "AbortError")));
       };
       signal.addEventListener("abort", abortHandler);
     }

--- a/packages/shared/document-model/validation.ts
+++ b/packages/shared/document-model/validation.ts
@@ -1,4 +1,4 @@
-import { pascalCase } from "change-case";
+import { constantCase, pascalCase } from "change-case";
 import type { DocumentOperations } from "./operations.js";
 import type {
   DocumentModelGlobalState,
@@ -22,6 +22,17 @@ export const RESERVED_OPERATION_NAMES = [
 ] as const;
 
 export type ReservedOperationName = (typeof RESERVED_OPERATION_NAMES)[number];
+
+/**
+ * Operation names become the literal action `type` string at runtime and the
+ * key for codegen's action union. They must be SCREAMING_SNAKE_CASE so the
+ * generated TypeScript is valid.
+ */
+export const OPERATION_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+
+export function isValidOperationNameFormat(name: string): boolean {
+  return OPERATION_NAME_PATTERN.test(name);
+}
 
 /**
  * Check if name conflicts with base reducer actions (case-insensitive).
@@ -67,6 +78,19 @@ export function validateOperationName(
   excludeOperationId?: string,
 ): void {
   if (!name) return; // Empty names handled by existing validation
+
+  if (!isValidOperationNameFormat(name)) {
+    const suggestion = constantCase(name);
+    const hint =
+      suggestion &&
+      suggestion !== name &&
+      isValidOperationNameFormat(suggestion)
+        ? ` Did you mean "${suggestion}"?`
+        : "";
+    throw new Error(
+      `Operation name "${name}" is invalid. Names must be SCREAMING_SNAKE_CASE (matching ${OPERATION_NAME_PATTERN.source}).${hint}`,
+    );
+  }
 
   const upperName = name.toUpperCase();
 


### PR DESCRIPTION
## Summary

Enables vetra-cli to host Connect inside an iframe (the vetra-studio BUILD pane) while keeping standalone Connect untouched. The branch bundles five commits:

- **Embed mode chrome suppression** — `?embed=1` strips the sidebar (`Root`, `AppSkeleton`) and skips the cookie banner. Detection lives in a new `useIsEmbedded` hook + sync getter; `AppSkeleton` had to participate too so the Suspense fallback doesn't flash sidebar-then-no-sidebar.
- **Drive URL flow hardening** — three commits that materialize default drives before URL-slug resolution and let drive selection await initial sync. These close the timing window where vetra-cli's `?session=<id>` URL would resolve against an unmaterialized drive on cold start.
- **`builder-tools` linkedRoots fix** — `@powerhousedao/connect` is now resolved to its real workspace root, matching the existing reactor-browser/pglite entries. Without this, sibling repos that workspace-link Connect (e.g. vetra-cli) break PGlite worker resolution the same way reactor-browser used to.

## Test plan

- [ ] Standalone Connect renders the sidebar + cookie banner as today.
- [ ] Connect launched with `?embed=1` renders without sidebar or cookie banner (verify both during the Suspense fallback and after the App chunk resolves).
- [ ] Open vetra-cli's vetra-studio drive editor; the BUILD pane iframe loads Connect cleanly with no sidebar flash.
- [ ] `?session=<id>` cold-start URL resolves the session after sync completes (no missing-drive error during first paint).
- [ ] Vetra-cli build (`pnpm --filter vetra-app build` + `pnpm exec ph-cli connect build --outDir dist/connect`) succeeds with Connect workspace-linked — PGlite worker resolves.