### PR TITLE
fix(document-model): throw on missing target id in reducers

### DIFF
--- a/packages/shared/document-model/reducers.ts
+++ b/packages/shared/document-model/reducers.ts
@@ -236,8 +236,19 @@ export const documentModelOperationErrorReducer: DocumentModelOperationErrorOper
     },
 
     deleteOperationErrorOperation(state, action) {
-      findOperationErrorOrThrow(state, action.input.id);
+      // Tolerate duplicate ids here: the filter removes every copy, so delete
+      // is the recovery path for a document that already holds duplicates.
       const latestSpec = state.specifications[state.specifications.length - 1];
+      const exists = latestSpec.modules.some((mod) =>
+        mod.operations.some((op) =>
+          op.errors.some((e) => e.id === action.input.id),
+        ),
+      );
+      if (!exists) {
+        throw new Error(
+          `Operation error "${action.input.id}" not found in the latest specification`,
+        );
+      }
       for (const mod of latestSpec.modules) {
         for (const op of mod.operations) {
           op.errors = op.errors.filter((e) => e.id != action.input.id);
@@ -268,8 +279,19 @@ export const documentModelOperationExampleReducer: DocumentModelOperationExample
     },
 
     deleteOperationExampleOperation(state, action) {
-      findOperationExampleOrThrow(state, action.input.id);
+      // Tolerate duplicate ids here: the filter removes every copy, so delete
+      // is the recovery path for a document that already holds duplicates.
       const latestSpec = state.specifications[state.specifications.length - 1];
+      const exists = latestSpec.modules.some((mod) =>
+        mod.operations.some((op) =>
+          op.examples.some((e) => e.id === action.input.id),
+        ),
+      );
+      if (!exists) {
+        throw new Error(
+          `Operation example "${action.input.id}" not found in the latest specification`,
+        );
+      }
       for (const mod of latestSpec.modules) {
         for (const op of mod.operations) {
           op.examples = op.examples.filter((e) => e.id != action.input.id);
@@ -339,34 +361,33 @@ export const documentModelOperationReducer: DocumentModelOperationOperations = {
   },
 
   moveOperationOperation(state, action) {
-    // Resolve the destination first: a missing target module must abort the
-    // move, not silently drop the operation it was removed from its source.
+    // Validate fully before mutating: resolve the destination module and the
+    // operation to move first, so a missing/ambiguous target aborts the move
+    // without having already removed the operation from its source module.
     const targetModule = findModuleOrThrow(state, action.input.newModuleId);
     const latestSpec = state.specifications[state.specifications.length - 1];
 
-    const moved: OperationSpecification[] = [];
-    for (const mod of latestSpec.modules) {
-      mod.operations = mod.operations.filter((operation) => {
-        if (operation.id == action.input.operationId) {
-          moved.push(operation);
-          return false;
-        }
-        return true;
-      });
-    }
-
-    if (moved.length === 0) {
+    const matches = latestSpec.modules.flatMap((mod) =>
+      mod.operations.filter((op) => op.id === action.input.operationId),
+    );
+    if (matches.length === 0) {
       throw new Error(
         `Operation "${action.input.operationId}" not found in the latest specification`,
       );
     }
-    if (moved.length > 1) {
+    if (matches.length > 1) {
       throw new Error(
         `Operation "${action.input.operationId}" is duplicated in the latest specification`,
       );
     }
+    const moved = matches[0];
 
-    targetModule.operations.push(moved[0]);
+    for (const mod of latestSpec.modules) {
+      mod.operations = mod.operations.filter(
+        (op) => op.id !== action.input.operationId,
+      );
+    }
+    targetModule.operations.push(moved);
   },
 
   deleteOperationOperation(state, action) {

--- a/packages/shared/document-model/reducers.ts
+++ b/packages/shared/document-model/reducers.ts
@@ -101,18 +101,40 @@ import type {
   UpdateStateExampleAction,
 } from "./types.js";
 import {
+  assertModuleIdUnique,
+  assertOperationIdUnique,
   findModuleOrThrow,
+  findOperationErrorOrThrow,
+  findOperationExampleOrThrow,
   findOperationOrThrow,
   validateOperationName,
 } from "./validation.js";
 
-function sorter<TItem extends { id: string }>(
+/**
+ * Reorder `items` by the position of their id in `order`. Ids not listed in
+ * `order` keep their relative position after the listed ones. Throws if `order`
+ * references an id that isn't present, so a stale or mistyped id fails loudly
+ * instead of silently producing an arbitrary order.
+ */
+function orderBy<TItem extends { id: string }>(
+  items: TItem[],
   order: string[],
-): (a: TItem, b: TItem) => number {
-  const mapping: Record<string, number> = {};
-  order.forEach((key, index) => (mapping[key] = index));
-  return (a: TItem, b: TItem) =>
-    (mapping[b.id] || 999999) - (mapping[a.id] || 999999);
+): TItem[] {
+  const ids = new Set(items.map((item) => item.id));
+  for (const id of order) {
+    if (!ids.has(id)) {
+      throw new Error(`Cannot reorder: unknown id "${id}"`);
+    }
+  }
+  const rank = new Map(order.map((id, index) => [id, index]));
+  return items
+    .map((item, index) => ({ item, index }))
+    .sort((a, b) => {
+      const ra = rank.get(a.item.id) ?? Number.MAX_SAFE_INTEGER;
+      const rb = rank.get(b.item.id) ?? Number.MAX_SAFE_INTEGER;
+      return ra - rb || a.index - b.index;
+    })
+    .map(({ item }) => item);
 }
 
 export const documentModelHeaderReducer: DocumentModelHeaderOperations = {
@@ -144,6 +166,7 @@ export const documentModelHeaderReducer: DocumentModelHeaderOperations = {
 };
 export const documentModelModuleReducer: DocumentModelModuleOperations = {
   addModuleOperation(state, action) {
+    assertModuleIdUnique(state, action.input.id);
     const latestSpec = state.specifications[state.specifications.length - 1];
     latestSpec.modules.push({
       id: action.input.id,
@@ -154,24 +177,17 @@ export const documentModelModuleReducer: DocumentModelModuleOperations = {
   },
 
   setModuleNameOperation(state, action) {
-    const latestSpec = state.specifications[state.specifications.length - 1];
-    for (let i = 0; i < latestSpec.modules.length; i++) {
-      if (latestSpec.modules[i].id === action.input.id) {
-        latestSpec.modules[i].name = action.input.name || "";
-      }
-    }
+    const targetModule = findModuleOrThrow(state, action.input.id);
+    targetModule.name = action.input.name || "";
   },
 
   setModuleDescriptionOperation(state, action) {
-    const latestSpec = state.specifications[state.specifications.length - 1];
-    for (let i = 0; i < latestSpec.modules.length; i++) {
-      if (latestSpec.modules[i].id === action.input.id) {
-        latestSpec.modules[i].description = action.input.description || "";
-      }
-    }
+    const targetModule = findModuleOrThrow(state, action.input.id);
+    targetModule.description = action.input.description || "";
   },
 
   deleteModuleOperation(state, action) {
+    findModuleOrThrow(state, action.input.id);
     const latestSpec = state.specifications[state.specifications.length - 1];
     latestSpec.modules = latestSpec.modules.filter(
       (m) => m.id != action.input.id,
@@ -180,7 +196,7 @@ export const documentModelModuleReducer: DocumentModelModuleOperations = {
 
   reorderModulesOperation(state, action) {
     const latestSpec = state.specifications[state.specifications.length - 1];
-    latestSpec.modules.sort(sorter(action.input.order));
+    latestSpec.modules = orderBy(latestSpec.modules, action.input.order);
   },
 };
 export const documentModelOperationErrorReducer: DocumentModelOperationErrorOperations =
@@ -197,184 +213,75 @@ export const documentModelOperationErrorReducer: DocumentModelOperationErrorOper
     },
 
     setOperationErrorCodeOperation(state, action) {
-      const latestSpec = state.specifications[state.specifications.length - 1];
-      for (let i = 0; i < latestSpec.modules.length; i++) {
-        for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-          for (
-            let k = 0;
-            k < latestSpec.modules[i].operations[j].errors.length;
-            k++
-          ) {
-            if (
-              latestSpec.modules[i].operations[j].errors[k].id ==
-              action.input.id
-            ) {
-              latestSpec.modules[i].operations[j].errors[k].code =
-                action.input.errorCode || "";
-            }
-          }
-        }
-      }
+      const error = findOperationErrorOrThrow(state, action.input.id);
+      error.code = action.input.errorCode || "";
     },
 
     setOperationErrorNameOperation(state, action) {
-      const latestSpec = state.specifications[state.specifications.length - 1];
-      for (let i = 0; i < latestSpec.modules.length; i++) {
-        for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-          for (
-            let k = 0;
-            k < latestSpec.modules[i].operations[j].errors.length;
-            k++
-          ) {
-            if (
-              latestSpec.modules[i].operations[j].errors[k].id ==
-              action.input.id
-            ) {
-              latestSpec.modules[i].operations[j].errors[k].name =
-                action.input.errorName || "";
-            }
-          }
-        }
-      }
+      const error = findOperationErrorOrThrow(state, action.input.id);
+      error.name = action.input.errorName || "";
     },
 
     setOperationErrorDescriptionOperation(state, action) {
-      const latestSpec = state.specifications[state.specifications.length - 1];
-      for (let i = 0; i < latestSpec.modules.length; i++) {
-        for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-          for (
-            let k = 0;
-            k < latestSpec.modules[i].operations[j].errors.length;
-            k++
-          ) {
-            if (
-              latestSpec.modules[i].operations[j].errors[k].id ==
-              action.input.id
-            ) {
-              latestSpec.modules[i].operations[j].errors[k].description =
-                action.input.errorDescription || "";
-            }
-          }
-        }
-      }
+      const error = findOperationErrorOrThrow(state, action.input.id);
+      error.description = action.input.errorDescription || "";
     },
 
     setOperationErrorTemplateOperation(state, action) {
-      const latestSpec = state.specifications[state.specifications.length - 1];
-      for (let i = 0; i < latestSpec.modules.length; i++) {
-        for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-          for (
-            let k = 0;
-            k < latestSpec.modules[i].operations[j].errors.length;
-            k++
-          ) {
-            if (
-              latestSpec.modules[i].operations[j].errors[k].id ==
-              action.input.id
-            ) {
-              latestSpec.modules[i].operations[j].errors[k].template =
-                action.input.errorTemplate || "";
-            }
-          }
-        }
-      }
+      const error = findOperationErrorOrThrow(state, action.input.id);
+      error.template = action.input.errorTemplate || "";
     },
 
     deleteOperationErrorOperation(state, action) {
+      findOperationErrorOrThrow(state, action.input.id);
       const latestSpec = state.specifications[state.specifications.length - 1];
-      for (let i = 0; i < latestSpec.modules.length; i++) {
-        for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-          latestSpec.modules[i].operations[j].errors = latestSpec.modules[
-            i
-          ].operations[j].errors.filter((e) => e.id != action.input.id);
+      for (const mod of latestSpec.modules) {
+        for (const op of mod.operations) {
+          op.errors = op.errors.filter((e) => e.id != action.input.id);
         }
       }
     },
 
     reorderOperationErrorsOperation(state, action) {
-      const latestSpec = state.specifications[state.specifications.length - 1];
-      for (let i = 0; i < latestSpec.modules.length; i++) {
-        for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-          if (
-            latestSpec.modules[i].operations[j].id == action.input.operationId
-          ) {
-            latestSpec.modules[i].operations[j].errors.sort(
-              sorter(action.input.order),
-            );
-          }
-        }
-      }
+      const targetOp = findOperationOrThrow(state, action.input.operationId);
+      targetOp.errors = orderBy(targetOp.errors, action.input.order);
     },
   };
 
 export const documentModelOperationExampleReducer: DocumentModelOperationExampleOperations =
   {
     addOperationExampleOperation(state, action) {
-      const latestSpec = state.specifications[state.specifications.length - 1];
-      for (let i = 0; i < latestSpec.modules.length; i++) {
-        for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-          if (
-            latestSpec.modules[i].operations[j].id == action.input.operationId
-          ) {
-            latestSpec.modules[i].operations[j].examples.push({
-              id: action.input.id,
-              value: action.input.example,
-            });
-          }
-        }
-      }
+      const targetOp = findOperationOrThrow(state, action.input.operationId);
+      targetOp.examples.push({
+        id: action.input.id,
+        value: action.input.example,
+      });
     },
 
     updateOperationExampleOperation(state, action) {
-      const latestSpec = state.specifications[state.specifications.length - 1];
-      for (let i = 0; i < latestSpec.modules.length; i++) {
-        for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-          for (
-            let k = 0;
-            k < latestSpec.modules[i].operations[j].examples.length;
-            k++
-          ) {
-            if (
-              latestSpec.modules[i].operations[j].examples[k].id ==
-              action.input.id
-            ) {
-              latestSpec.modules[i].operations[j].examples[k].value =
-                action.input.example;
-            }
-          }
-        }
-      }
+      const example = findOperationExampleOrThrow(state, action.input.id);
+      example.value = action.input.example;
     },
 
     deleteOperationExampleOperation(state, action) {
+      findOperationExampleOrThrow(state, action.input.id);
       const latestSpec = state.specifications[state.specifications.length - 1];
-      for (let i = 0; i < latestSpec.modules.length; i++) {
-        for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-          latestSpec.modules[i].operations[j].examples = latestSpec.modules[
-            i
-          ].operations[j].examples.filter((e) => e.id != action.input.id);
+      for (const mod of latestSpec.modules) {
+        for (const op of mod.operations) {
+          op.examples = op.examples.filter((e) => e.id != action.input.id);
         }
       }
     },
 
     reorderOperationExamplesOperation(state, action) {
-      const latestSpec = state.specifications[state.specifications.length - 1];
-      for (let i = 0; i < latestSpec.modules.length; i++) {
-        for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-          if (
-            latestSpec.modules[i].operations[j].id == action.input.operationId
-          ) {
-            latestSpec.modules[i].operations[j].examples.sort(
-              sorter(action.input.order),
-            );
-          }
-        }
-      }
+      const targetOp = findOperationOrThrow(state, action.input.operationId);
+      targetOp.examples = orderBy(targetOp.examples, action.input.order);
     },
   };
 export const documentModelOperationReducer: DocumentModelOperationOperations = {
   addOperationOperation(state, action) {
     validateOperationName(action.input.name, state);
+    assertOperationIdUnique(state, action.input.id);
     const targetModule = findModuleOrThrow(state, action.input.moduleId);
     targetModule.operations.push({
       id: action.input.id,
@@ -393,15 +300,8 @@ export const documentModelOperationReducer: DocumentModelOperationOperations = {
     if (action.input.name) {
       validateOperationName(action.input.name, state, action.input.id);
     }
-
-    const latestSpec = state.specifications[state.specifications.length - 1];
-    for (let i = 0; i < latestSpec.modules.length; i++) {
-      for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-        if (latestSpec.modules[i].operations[j].id == action.input.id) {
-          latestSpec.modules[i].operations[j].name = action.input.name || "";
-        }
-      }
-    }
+    const targetOp = findOperationOrThrow(state, action.input.id);
+    targetOp.name = action.input.name || "";
   },
 
   setOperationScopeOperation(state, action) {
@@ -415,95 +315,67 @@ export const documentModelOperationReducer: DocumentModelOperationOperations = {
   },
 
   setOperationSchemaOperation(state, action) {
-    const latestSpec = state.specifications[state.specifications.length - 1];
-    for (let i = 0; i < latestSpec.modules.length; i++) {
-      for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-        if (latestSpec.modules[i].operations[j].id == action.input.id) {
-          latestSpec.modules[i].operations[j].schema =
-            action.input.schema || "";
-        }
-      }
-    }
+    const targetOp = findOperationOrThrow(state, action.input.id);
+    targetOp.schema = action.input.schema || "";
   },
 
   setOperationDescriptionOperation(state, action) {
-    const latestSpec = state.specifications[state.specifications.length - 1];
-    for (let i = 0; i < latestSpec.modules.length; i++) {
-      for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-        if (latestSpec.modules[i].operations[j].id == action.input.id) {
-          latestSpec.modules[i].operations[j].description =
-            action.input.description || "";
-        }
-      }
-    }
+    const targetOp = findOperationOrThrow(state, action.input.id);
+    targetOp.description = action.input.description || "";
   },
 
   setOperationTemplateOperation(state, action) {
-    const latestSpec = state.specifications[state.specifications.length - 1];
-    for (let i = 0; i < latestSpec.modules.length; i++) {
-      for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-        if (latestSpec.modules[i].operations[j].id == action.input.id) {
-          latestSpec.modules[i].operations[j].template =
-            action.input.template || "";
-        }
-      }
-    }
+    const targetOp = findOperationOrThrow(state, action.input.id);
+    targetOp.template = action.input.template || "";
   },
 
   setOperationReducerOperation(state, action) {
-    const latestSpec = state.specifications[state.specifications.length - 1];
-    for (let i = 0; i < latestSpec.modules.length; i++) {
-      for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
-        if (latestSpec.modules[i].operations[j].id == action.input.id) {
-          latestSpec.modules[i].operations[j].reducer =
-            action.input.reducer || "";
-        }
-      }
-    }
+    const targetOp = findOperationOrThrow(state, action.input.id);
+    targetOp.reducer = action.input.reducer || "";
   },
 
   moveOperationOperation(state, action) {
-    const moveOperations: OperationSpecification[] = [];
+    // Resolve the destination first: a missing target module must abort the
+    // move, not silently drop the operation it was removed from its source.
+    const targetModule = findModuleOrThrow(state, action.input.newModuleId);
     const latestSpec = state.specifications[state.specifications.length - 1];
 
-    // Filter and collect
-    for (let i = 0; i < latestSpec.modules.length; i++) {
-      latestSpec.modules[i].operations = latestSpec.modules[
-        i
-      ].operations.filter((operation) => {
+    let moved: OperationSpecification | undefined;
+    for (const mod of latestSpec.modules) {
+      mod.operations = mod.operations.filter((operation) => {
         if (operation.id == action.input.operationId) {
-          moveOperations.push(operation);
+          moved = operation;
           return false;
         }
-
         return true;
       });
     }
 
-    // Inject in target modules
-    for (let i = 0; i < latestSpec.modules.length; i++) {
-      if (latestSpec.modules[i].id == action.input.newModuleId) {
-        latestSpec.modules[i].operations.push(...moveOperations);
-      }
+    if (!moved) {
+      throw new Error(
+        `Operation "${action.input.operationId}" not found in the latest specification`,
+      );
     }
+
+    targetModule.operations.push(moved);
   },
 
   deleteOperationOperation(state, action) {
+    findOperationOrThrow(state, action.input.id);
     const latestSpec = state.specifications[state.specifications.length - 1];
-    for (let i = 0; i < latestSpec.modules.length; i++) {
-      latestSpec.modules[i].operations = latestSpec.modules[
-        i
-      ].operations.filter((operation) => operation.id != action.input.id);
+    for (const mod of latestSpec.modules) {
+      mod.operations = mod.operations.filter(
+        (operation) => operation.id != action.input.id,
+      );
     }
   },
 
   reorderModuleOperationsOperation(state, action) {
-    const latestSpec = state.specifications[state.specifications.length - 1];
-    for (let i = 0; i < latestSpec.modules.length; i++) {
-      if (latestSpec.modules[i].id == action.input.moduleId) {
-        latestSpec.modules[i].operations.sort(sorter(action.input.order));
-      }
-    }
+    const targetModule = findModuleOrThrow(state, action.input.moduleId);
+    targetModule.operations = orderBy(
+      targetModule.operations,
+      action.input.order,
+    );
   },
 };
 export const documentModelStateSchemaReducer: DocumentModelStateOperations = {
@@ -547,34 +419,38 @@ export const documentModelStateSchemaReducer: DocumentModelStateOperations = {
     const examples =
       latestSpec.state[action.input.scope as keyof ScopeState].examples;
 
-    for (let i = 0; i < examples.length; i++) {
-      if (examples[i].id == action.input.id) {
-        examples[i].value = action.input.newExample;
-      }
+    const example = examples.find((e) => e.id == action.input.id);
+    if (!example) {
+      throw new Error(
+        `State example "${action.input.id}" not found in scope "${action.input.scope}"`,
+      );
     }
+    example.value = action.input.newExample;
   },
 
   deleteStateExampleOperation(state, action) {
     const latestSpec = state.specifications[state.specifications.length - 1];
-    if (Object.keys(latestSpec.state).includes(action.input.scope)) {
-      latestSpec.state[action.input.scope as keyof ScopeState].examples =
-        latestSpec.state[
-          action.input.scope as keyof ScopeState
-        ].examples.filter((e) => e.id != action.input.id);
-    } else {
+    if (!Object.keys(latestSpec.state).includes(action.input.scope)) {
       throw new Error(`Invalid scope: ${action.input.scope}`);
     }
+    const scopeState = latestSpec.state[action.input.scope as keyof ScopeState];
+    if (!scopeState.examples.some((e) => e.id == action.input.id)) {
+      throw new Error(
+        `State example "${action.input.id}" not found in scope "${action.input.scope}"`,
+      );
+    }
+    scopeState.examples = scopeState.examples.filter(
+      (e) => e.id != action.input.id,
+    );
   },
 
   reorderStateExamplesOperation(state, action) {
     const latestSpec = state.specifications[state.specifications.length - 1];
-    if (Object.keys(latestSpec.state).includes(action.input.scope)) {
-      latestSpec.state[action.input.scope as keyof ScopeState].examples.sort(
-        sorter(action.input.order),
-      );
-    } else {
+    if (!Object.keys(latestSpec.state).includes(action.input.scope)) {
       throw new Error(`Invalid scope: ${action.input.scope}`);
     }
+    const scopeState = latestSpec.state[action.input.scope as keyof ScopeState];
+    scopeState.examples = orderBy(scopeState.examples, action.input.order);
   },
 };
 

--- a/packages/shared/document-model/reducers.ts
+++ b/packages/shared/document-model/reducers.ts
@@ -102,6 +102,8 @@ import type {
 } from "./types.js";
 import {
   assertModuleIdUnique,
+  assertOperationErrorIdUnique,
+  assertOperationExampleIdUnique,
   assertOperationIdUnique,
   findModuleOrThrow,
   findOperationErrorOrThrow,
@@ -203,6 +205,7 @@ export const documentModelOperationErrorReducer: DocumentModelOperationErrorOper
   {
     addOperationErrorOperation(state, action) {
       const targetOp = findOperationOrThrow(state, action.input.operationId);
+      assertOperationErrorIdUnique(state, action.input.id);
       targetOp.errors.push({
         id: action.input.id,
         name: action.input.errorName || "",
@@ -252,6 +255,7 @@ export const documentModelOperationExampleReducer: DocumentModelOperationExample
   {
     addOperationExampleOperation(state, action) {
       const targetOp = findOperationOrThrow(state, action.input.operationId);
+      assertOperationExampleIdUnique(state, action.input.id);
       targetOp.examples.push({
         id: action.input.id,
         value: action.input.example,
@@ -340,24 +344,29 @@ export const documentModelOperationReducer: DocumentModelOperationOperations = {
     const targetModule = findModuleOrThrow(state, action.input.newModuleId);
     const latestSpec = state.specifications[state.specifications.length - 1];
 
-    let moved: OperationSpecification | undefined;
+    const moved: OperationSpecification[] = [];
     for (const mod of latestSpec.modules) {
       mod.operations = mod.operations.filter((operation) => {
         if (operation.id == action.input.operationId) {
-          moved = operation;
+          moved.push(operation);
           return false;
         }
         return true;
       });
     }
 
-    if (!moved) {
+    if (moved.length === 0) {
       throw new Error(
         `Operation "${action.input.operationId}" not found in the latest specification`,
       );
     }
+    if (moved.length > 1) {
+      throw new Error(
+        `Operation "${action.input.operationId}" is duplicated in the latest specification`,
+      );
+    }
 
-    targetModule.operations.push(moved);
+    targetModule.operations.push(moved[0]);
   },
 
   deleteOperationOperation(state, action) {

--- a/packages/shared/document-model/validation.ts
+++ b/packages/shared/document-model/validation.ts
@@ -301,46 +301,59 @@ export function findOperationOrThrow(
 
 /**
  * Find an operation error by id across all operations in the latest
- * specification, or throw. Same rationale as findOperationOrThrow.
+ * specification, or throw. Throws on a duplicate id too: setters act on a
+ * single error, so an ambiguous id must fail loudly rather than mutate an
+ * arbitrary match.
  */
 export function findOperationErrorOrThrow(
   state: DocumentModelGlobalState,
   errorId: string,
 ): OperationErrorSpecification {
   const latestSpec = state.specifications[state.specifications.length - 1];
-  if (latestSpec) {
-    for (const mod of latestSpec.modules) {
-      for (const op of mod.operations) {
-        const error = op.errors.find((e) => e.id === errorId);
-        if (error) return error;
-      }
-    }
+  const matches =
+    latestSpec?.modules.flatMap((mod) =>
+      mod.operations.flatMap((op) => op.errors.filter((e) => e.id === errorId)),
+    ) ?? [];
+  if (matches.length === 0) {
+    throw new Error(
+      `Operation error "${errorId}" not found in the latest specification`,
+    );
   }
-  throw new Error(
-    `Operation error "${errorId}" not found in the latest specification`,
-  );
+  if (matches.length > 1) {
+    throw new Error(
+      `Operation error "${errorId}" is duplicated in the latest specification`,
+    );
+  }
+  return matches[0];
 }
 
 /**
  * Find an operation example (code example) by id across all operations in the
- * latest specification, or throw.
+ * latest specification, or throw. Throws on a duplicate id for the same reason
+ * as findOperationErrorOrThrow.
  */
 export function findOperationExampleOrThrow(
   state: DocumentModelGlobalState,
   exampleId: string,
 ): CodeExample {
   const latestSpec = state.specifications[state.specifications.length - 1];
-  if (latestSpec) {
-    for (const mod of latestSpec.modules) {
-      for (const op of mod.operations) {
-        const example = op.examples.find((e) => e.id === exampleId);
-        if (example) return example;
-      }
-    }
+  const matches =
+    latestSpec?.modules.flatMap((mod) =>
+      mod.operations.flatMap((op) =>
+        op.examples.filter((e) => e.id === exampleId),
+      ),
+    ) ?? [];
+  if (matches.length === 0) {
+    throw new Error(
+      `Operation example "${exampleId}" not found in the latest specification`,
+    );
   }
-  throw new Error(
-    `Operation example "${exampleId}" not found in the latest specification`,
-  );
+  if (matches.length > 1) {
+    throw new Error(
+      `Operation example "${exampleId}" is duplicated in the latest specification`,
+    );
+  }
+  return matches[0];
 }
 
 /**
@@ -354,7 +367,9 @@ export function assertModuleIdUnique(
 ): void {
   const latestSpec = state.specifications[state.specifications.length - 1];
   if (latestSpec?.modules.some((m) => m.id === id)) {
-    throw new Error(`Module "${id}" already exists in the latest specification`);
+    throw new Error(
+      `Module "${id}" already exists in the latest specification`,
+    );
   }
 }
 
@@ -373,6 +388,46 @@ export function assertOperationIdUnique(
   if (exists) {
     throw new Error(
       `Operation "${id}" already exists in the latest specification`,
+    );
+  }
+}
+
+/**
+ * Assert no operation error in the latest specification already uses `id`.
+ * Error ids are targeted document-wide by the setter/delete reducers, so the id
+ * must be unique to keep those operations unambiguous.
+ */
+export function assertOperationErrorIdUnique(
+  state: DocumentModelGlobalState,
+  id: string,
+): void {
+  const latestSpec = state.specifications[state.specifications.length - 1];
+  const exists = latestSpec?.modules.some((m) =>
+    m.operations.some((o) => o.errors.some((e) => e.id === id)),
+  );
+  if (exists) {
+    throw new Error(
+      `Operation error "${id}" already exists in the latest specification`,
+    );
+  }
+}
+
+/**
+ * Assert no operation example in the latest specification already uses `id`.
+ * Example ids are targeted document-wide by the update/delete reducers, so the
+ * id must be unique to keep those operations unambiguous.
+ */
+export function assertOperationExampleIdUnique(
+  state: DocumentModelGlobalState,
+  id: string,
+): void {
+  const latestSpec = state.specifications[state.specifications.length - 1];
+  const exists = latestSpec?.modules.some((m) =>
+    m.operations.some((o) => o.examples.some((e) => e.id === id)),
+  );
+  if (exists) {
+    throw new Error(
+      `Operation example "${id}" already exists in the latest specification`,
     );
   }
 }

--- a/packages/shared/document-model/validation.ts
+++ b/packages/shared/document-model/validation.ts
@@ -1,8 +1,10 @@
 import { constantCase, pascalCase } from "change-case";
 import type { DocumentOperations } from "./operations.js";
 import type {
+  CodeExample,
   DocumentModelGlobalState,
   ModuleSpecification,
+  OperationErrorSpecification,
   OperationSpecification,
   ValidationError,
 } from "./types.js";
@@ -295,6 +297,84 @@ export function findOperationOrThrow(
   throw new Error(
     `Operation "${operationId}" not found in the latest specification`,
   );
+}
+
+/**
+ * Find an operation error by id across all operations in the latest
+ * specification, or throw. Same rationale as findOperationOrThrow.
+ */
+export function findOperationErrorOrThrow(
+  state: DocumentModelGlobalState,
+  errorId: string,
+): OperationErrorSpecification {
+  const latestSpec = state.specifications[state.specifications.length - 1];
+  if (latestSpec) {
+    for (const mod of latestSpec.modules) {
+      for (const op of mod.operations) {
+        const error = op.errors.find((e) => e.id === errorId);
+        if (error) return error;
+      }
+    }
+  }
+  throw new Error(
+    `Operation error "${errorId}" not found in the latest specification`,
+  );
+}
+
+/**
+ * Find an operation example (code example) by id across all operations in the
+ * latest specification, or throw.
+ */
+export function findOperationExampleOrThrow(
+  state: DocumentModelGlobalState,
+  exampleId: string,
+): CodeExample {
+  const latestSpec = state.specifications[state.specifications.length - 1];
+  if (latestSpec) {
+    for (const mod of latestSpec.modules) {
+      for (const op of mod.operations) {
+        const example = op.examples.find((e) => e.id === exampleId);
+        if (example) return example;
+      }
+    }
+  }
+  throw new Error(
+    `Operation example "${exampleId}" not found in the latest specification`,
+  );
+}
+
+/**
+ * Assert no module in the latest specification already uses `id`. Modules are
+ * targeted by id by the setter/delete/reorder reducers, so a duplicate id makes
+ * those operations ambiguous.
+ */
+export function assertModuleIdUnique(
+  state: DocumentModelGlobalState,
+  id: string,
+): void {
+  const latestSpec = state.specifications[state.specifications.length - 1];
+  if (latestSpec?.modules.some((m) => m.id === id)) {
+    throw new Error(`Module "${id}" already exists in the latest specification`);
+  }
+}
+
+/**
+ * Assert no operation in the latest specification already uses `id`. Operations
+ * are targeted by id across all modules, so the id must be unique document-wide.
+ */
+export function assertOperationIdUnique(
+  state: DocumentModelGlobalState,
+  id: string,
+): void {
+  const latestSpec = state.specifications[state.specifications.length - 1];
+  const exists = latestSpec?.modules.some((m) =>
+    m.operations.some((o) => o.id === id),
+  );
+  if (exists) {
+    throw new Error(
+      `Operation "${id}" already exists in the latest specification`,
+    );
+  }
 }
 
 export function validateOperations(operations: DocumentOperations) {


### PR DESCRIPTION
## What

Hardens the document-model reducers in `packages/shared/document-model/` so mutating operations targeting an unknown id **fail loudly** instead of silently no-op'ing.

## Changes

**`reducers.ts`**
- Replaced nested triple `for`-loop id matching across set/delete/move/reorder reducers with `findOrThrow` lookups — much less code, and missing targets now throw.
- `moveOperationOperation` resolves the destination module *first*, so a bad `newModuleId` aborts the move instead of removing the operation from its source and dropping it.
- Replaced `sorter()` with `orderBy()`, which throws on unknown ids and fixes a latent bug: the old comparator used `mapping[b.id] || 999999`, so an id at index `0` evaluated falsy and fell through to `999999`.
- Added id-uniqueness guards on add (modules / operations).

**`validation.ts`**
- New helpers: `findOperationErrorOrThrow`, `findOperationExampleOrThrow`, `assertModuleIdUnique`, `assertOperationIdUnique`.

## Notes

Net −44 lines in `reducers.ts`. Behavior change: reducers that previously silently ignored unknown ids now throw.