### PR TITLE
refactor(ph-cli): rename `ph init --template` to `--clone`

### DIFF
--- a/apps/academy/docs/academy/04-APIReferences/00-PowerhouseCLI.md
+++ b/apps/academy/docs/academy/04-APIReferences/00-PowerhouseCLI.md
@@ -65,7 +65,7 @@ Initialize a new project
 
 **Remote Drive** - Remote drive identifier. - Usage: `--remote-drive, -r <str>`
 
-**Template** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the template's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--template <str>`
+**Clone** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--clone <str>`
 
 
 
@@ -158,7 +158,7 @@ Initialize a new global project
 
 **Remote Drive** - Remote drive identifier. - Usage: `--remote-drive, -r <str>`
 
-**Template** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the template's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--template <str>`
+**Clone** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--clone <str>`
 
 
 

--- a/apps/academy/llms-full.txt
+++ b/apps/academy/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-05-28T06:17:12.090Z
+> Generated: 2026-05-28T07:03:10.551Z
 > Total Documents: 86
 > Source: https://powerhouse.academy/llms-full.txt
 
@@ -17749,7 +17749,7 @@ Initialize a new project
 
 **Remote Drive** - Remote drive identifier. - Usage: `--remote-drive, -r <str>`
 
-**Template** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the template's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--template <str>`
+**Clone** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--clone <str>`
 
 
 ### Flags
@@ -17831,7 +17831,7 @@ Initialize a new global project
 
 **Remote Drive** - Remote drive identifier. - Usage: `--remote-drive, -r <str>`
 
-**Template** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the template's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--template <str>`
+**Clone** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--clone <str>`
 
 
 ### Flags

--- a/apps/academy/static/llms-full.txt
+++ b/apps/academy/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-05-28T06:17:12.090Z
+> Generated: 2026-05-28T07:03:10.551Z
 > Total Documents: 86
 > Source: https://powerhouse.academy/llms-full.txt
 
@@ -17749,7 +17749,7 @@ Initialize a new project
 
 **Remote Drive** - Remote drive identifier. - Usage: `--remote-drive, -r <str>`
 
-**Template** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the template's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--template <str>`
+**Clone** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--clone <str>`
 
 
 ### Flags
@@ -17831,7 +17831,7 @@ Initialize a new global project
 
 **Remote Drive** - Remote drive identifier. - Usage: `--remote-drive, -r <str>`
 
-**Template** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the template's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--template <str>`
+**Clone** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--clone <str>`
 
 
 ### Flags

--- a/clis/ph-cli/src/services/init.ts
+++ b/clis/ph-cli/src/services/init.ts
@@ -25,7 +25,7 @@ export async function startInit(args: InitArgs) {
     dev,
     staging,
     remoteDrive,
-    template,
+    clone,
   } = args;
 
   let name = namePositional ?? nameOption;
@@ -87,10 +87,10 @@ export async function startInit(args: InitArgs) {
     staging,
   });
 
-  if (template && (tag || version || dev || staging)) {
+  if (clone && (tag || version || dev || staging)) {
     console.log(
       chalk.yellow(
-        "⚠️  --template is set; --version/--tag/--dev/--staging are ignored (the template's dependency set is authoritative).",
+        "⚠️  --clone is set; --version/--tag/--dev/--staging are ignored (the cloned project's dependency set is authoritative).",
       ),
     );
   }

--- a/clis/ph-cmd/COMMANDS.md
+++ b/clis/ph-cmd/COMMANDS.md
@@ -38,9 +38,9 @@ Specify the exact semver release version to use for your project.<br><br>
 Remote drive identifier.<br><br>
 **usage:** `--remote-drive, -r <str>`<br>
 
-#### Template <br>
-Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the template's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored).<br><br>
-**usage:** `--template <str>`<br>
+#### Clone <br>
+Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored).<br><br>
+**usage:** `--clone <str>`<br>
 
 
 ### flags
@@ -154,9 +154,9 @@ Specify the exact semver release version to use for your project.<br><br>
 Remote drive identifier.<br><br>
 **usage:** `--remote-drive, -r <str>`<br>
 
-#### Template <br>
-Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the template's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored).<br><br>
-**usage:** `--template <str>`<br>
+#### Clone <br>
+Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored).<br><br>
+**usage:** `--clone <str>`<br>
 
 
 ### flags

--- a/packages/codegen/src/create-lib/create-project.ts
+++ b/packages/codegen/src/create-lib/create-project.ts
@@ -19,12 +19,12 @@ type CreateProjectArgs = {
   skipInstall?: boolean;
   /**
    * Path to an existing scaffolded project to clone instead of generating +
-   * resolving deps from scratch. The template's source + pnpm-lock.yaml are
+   * resolving deps from scratch. The clone's source + pnpm-lock.yaml are
    * copied (node_modules is not — it's rebuilt from the lockfile via the warm
    * pnpm store with `pnpm install --frozen-lockfile --offline`). Requires
    * packageManager === "pnpm".
    */
-  template?: string;
+  clone?: string;
 };
 export async function createProject({
   name,
@@ -34,7 +34,7 @@ export async function createProject({
   remoteDrive,
   skipGitInit,
   skipInstall,
-  template,
+  clone,
 }: CreateProjectArgs) {
   const appPath = path.join(process.cwd(), name);
 
@@ -46,11 +46,11 @@ export async function createProject({
   }
 
   try {
-    if (template) {
-      await createProjectFromTemplate({
+    if (clone) {
+      await createProjectFromClone({
         name,
         appPath,
-        template,
+        clone,
         packageManager,
         skipGitInit,
         skipInstall,
@@ -112,19 +112,20 @@ export async function createProject({
 }
 
 /**
- * Fast path for `ph init --template <path>`: copy an already-scaffolded
- * project's source + lockfile (NOT node_modules), re-apply the per-project
+ * Fast path for `ph init --clone <path>`: copy an already-scaffolded project's
+ * source + lockfile (NOT node_modules), re-apply the per-project
  * customizations, then rebuild node_modules with
  * `pnpm install --frozen-lockfile --offline`. pnpm materializes the tree from
  * the warm store via clone/hardlink — far faster and ~0 extra disk vs a fresh
  * resolve+install, and the lockfile guarantees an identical dependency set.
- * Requires the template's packages to be present in the local pnpm store
- * (which is the case in an image where the template was scaffolded at build).
+ * Requires the cloned project's packages to be present in the local pnpm
+ * store (which is the case in an image where the source was scaffolded at
+ * build).
  */
-async function createProjectFromTemplate(args: {
+async function createProjectFromClone(args: {
   name: string;
   appPath: string;
-  template: string;
+  clone: string;
   packageManager: string;
   skipGitInit?: boolean;
   skipInstall?: boolean;
@@ -133,45 +134,40 @@ async function createProjectFromTemplate(args: {
   const {
     name,
     appPath,
-    template,
+    clone,
     packageManager,
     skipGitInit,
     skipInstall,
     remoteDrive,
   } = args;
-  // The template path materializes deps from the template's pnpm-lock.yaml via
-  // `pnpm install --frozen-lockfile --offline`. Other package managers have no
-  // equivalent offline-from-pnpm-lockfile mode, so require pnpm explicitly
-  // instead of silently switching.
+  // The clone path materializes deps from the source project's pnpm-lock.yaml
+  // via `pnpm install --frozen-lockfile --offline`. Other package managers
+  // have no equivalent offline-from-pnpm-lockfile mode, so require pnpm
+  // explicitly instead of silently switching.
   if (packageManager !== "pnpm") {
     console.error(
-      `⛔ --template requires --pnpm (got "${packageManager}"). The fast path materializes deps from the template's pnpm-lock.yaml.`,
+      `⛔ --clone requires --pnpm (got "${packageManager}"). The fast path materializes deps from the cloned project's pnpm-lock.yaml.`,
     );
     process.exit(1);
   }
-  const templatePath = path.resolve(process.cwd(), template);
-  if (
-    !fs.existsSync(templatePath) ||
-    !fs.statSync(templatePath).isDirectory()
-  ) {
+  const clonePath = path.resolve(process.cwd(), clone);
+  if (!fs.existsSync(clonePath) || !fs.statSync(clonePath).isDirectory()) {
     console.error(
-      `⛔ Template "${template}" not found (resolved to "${templatePath}"). Pass a path to an existing scaffolded project.`,
+      `⛔ Clone source "${clone}" not found (resolved to "${clonePath}"). Pass a path to an existing scaffolded project.`,
     );
     process.exit(1);
   }
-  if (!fs.existsSync(path.join(templatePath, "pnpm-lock.yaml"))) {
+  if (!fs.existsSync(path.join(clonePath, "pnpm-lock.yaml"))) {
     console.error(
-      `⛔ Template "${template}" has no pnpm-lock.yaml. --template requires a pnpm project scaffolded with a committed lockfile.`,
+      `⛔ Clone source "${clone}" has no pnpm-lock.yaml. --clone requires a pnpm project scaffolded with a committed lockfile.`,
     );
     process.exit(1);
   }
 
   // Copy source + lockfile only; node_modules is rebuilt from the store below,
-  // and the template's .git is irrelevant (we re-init fresh).
-  console.log(
-    chalk.blue(`▶️ Creating project from template "${template}"...\n`),
-  );
-  fs.cpSync(templatePath, appPath, {
+  // and the source's .git is irrelevant (we re-init fresh).
+  console.log(chalk.blue(`▶️ Cloning project from "${clone}"...\n`));
+  fs.cpSync(clonePath, appPath, {
     recursive: true,
     filter: (src) => {
       const base = path.basename(src);
@@ -185,7 +181,7 @@ async function createProjectFromTemplate(args: {
       );
     },
   });
-  console.log(chalk.green(`✅ Template files copied\n`));
+  console.log(chalk.green(`✅ Project files cloned\n`));
 
   if (!skipGitInit) {
     console.log(chalk.blue(`▶️ Initializing git repository...\n`));
@@ -207,6 +203,6 @@ async function createProjectFromTemplate(args: {
   }
 
   console.log(
-    chalk.bold(`🎉 Successfully created project "${name}" from template 🎉\n`),
+    chalk.bold(`🎉 Successfully cloned project "${name}" from "${clone}" 🎉\n`),
   );
 }

--- a/packages/codegen/src/create-lib/create-project.ts
+++ b/packages/codegen/src/create-lib/create-project.ts
@@ -9,6 +9,22 @@ import {
   writeAllGeneratedProjectFiles,
   writeProjectRootFiles,
 } from "file-builders";
+
+// Install recipes for `--clone`. Only managers with a cache-miss-fails
+// offline mode are listed; yarn needs an opt-in offline mirror and bun has
+// no real offline mode (https://github.com/oven-sh/bun/issues/7956).
+type CloneRecipe = { lockfile: string; install: string };
+const CLONE_RECIPES: Record<string, CloneRecipe | undefined> = {
+  pnpm: {
+    lockfile: "pnpm-lock.yaml",
+    install: "pnpm install --frozen-lockfile --offline",
+  },
+  npm: {
+    lockfile: "package-lock.json",
+    install: "npm ci --offline",
+  },
+};
+
 type CreateProjectArgs = {
   name: string;
   packageManager: string;
@@ -39,76 +55,70 @@ export async function createProject({
   const appPath = path.join(process.cwd(), name);
 
   if (fs.existsSync(appPath)) {
-    console.error(
+    throw new Error(
       `⛔ The folder "${name}" already exists in the current directory, please give it another name.`,
     );
-    process.exit(1);
   }
 
-  try {
-    if (clone) {
-      await createProjectFromClone({
-        name,
-        appPath,
-        clone,
-        packageManager,
-        skipGitInit,
-        skipInstall,
-        remoteDrive,
-      });
-      return;
-    }
-
-    // Create a new directory for the project
-    console.log(chalk.blue(`▶️ Creating directory for project "${name}"...\n`));
-    fs.mkdirSync(appPath);
-    process.chdir(appPath);
-    console.log(chalk.green(`✅ Project directory created\n`));
-
-    await writeFileEnsuringDir(".gitignore", gitIgnoreTemplate);
-    if (!skipGitInit) {
-      // Create a .gitignore file, then initialize the git repository
-      console.log(chalk.blue(`▶️ Initializing git repository...\n`));
-      runCmd(`git init`);
-      console.log(chalk.green(`\n✅ Git repository initialized\n`));
-    }
-
-    // Write the boilerplate files for the project
-    console.log(chalk.blue(`▶️ Creating project boilerplate files...\n`));
-    await writeProjectRootFiles({
+  if (clone) {
+    await createProjectFromClone({
       name,
-      tag,
-      version,
-      remoteDrive,
+      appPath,
+      clone,
       packageManager,
+      skipGitInit,
+      skipInstall,
+      remoteDrive,
     });
-    await writeAllGeneratedProjectFiles();
-    console.log(chalk.green(`✅ Project boilerplate files created\n`));
-
-    if (!skipInstall) {
-      // Install the project dependencies with the specified package manager
-      console.log(
-        chalk.blue(
-          `▶️ Installing project dependencies with ${packageManager}...\n`,
-        ),
-      );
-      const extra =
-        packageManager === "pnpm" ? " --config.minimum-release-age=0" : "";
-      runCmd(`${packageManager} install${extra}`);
-      console.log(chalk.green(`\n✅ Project dependencies installed\n`));
-    }
-
-    // Use the installed version of `prettier` to format the generated code
-    console.log(chalk.blue(`▶️ Formatting boilerplate project files...\n`));
-    await runPrettier();
-    console.log(chalk.green(`✅ Boilerplate files formatted\n`));
-
-    // Project creation complete
-    console.log(chalk.bold(`🎉 Successfully created project "${name}" 🎉\n`));
-  } catch (error) {
-    console.error(error);
-    process.exit(1);
+    return;
   }
+
+  // Create a new directory for the project
+  console.log(chalk.blue(`▶️ Creating directory for project "${name}"...\n`));
+  fs.mkdirSync(appPath);
+  process.chdir(appPath);
+  console.log(chalk.green(`✅ Project directory created\n`));
+
+  await writeFileEnsuringDir(".gitignore", gitIgnoreTemplate);
+  if (!skipGitInit) {
+    // Create a .gitignore file, then initialize the git repository
+    console.log(chalk.blue(`▶️ Initializing git repository...\n`));
+    runCmd(`git init`);
+    console.log(chalk.green(`\n✅ Git repository initialized\n`));
+  }
+
+  // Write the boilerplate files for the project
+  console.log(chalk.blue(`▶️ Creating project boilerplate files...\n`));
+  await writeProjectRootFiles({
+    name,
+    tag,
+    version,
+    remoteDrive,
+    packageManager,
+  });
+  await writeAllGeneratedProjectFiles();
+  console.log(chalk.green(`✅ Project boilerplate files created\n`));
+
+  if (!skipInstall) {
+    // Install the project dependencies with the specified package manager
+    console.log(
+      chalk.blue(
+        `▶️ Installing project dependencies with ${packageManager}...\n`,
+      ),
+    );
+    const extra =
+      packageManager === "pnpm" ? " --config.minimum-release-age=0" : "";
+    runCmd(`${packageManager} install${extra}`);
+    console.log(chalk.green(`\n✅ Project dependencies installed\n`));
+  }
+
+  // Use the installed version of `prettier` to format the generated code
+  console.log(chalk.blue(`▶️ Formatting boilerplate project files...\n`));
+  await runPrettier();
+  console.log(chalk.green(`✅ Boilerplate files formatted\n`));
+
+  // Project creation complete
+  console.log(chalk.bold(`🎉 Successfully created project "${name}" 🎉\n`));
 }
 
 /**
@@ -140,28 +150,26 @@ async function createProjectFromClone(args: {
     skipInstall,
     remoteDrive,
   } = args;
-  // The clone path materializes deps from the source project's pnpm-lock.yaml
-  // via `pnpm install --frozen-lockfile --offline`. Other package managers
-  // have no equivalent offline-from-pnpm-lockfile mode, so require pnpm
-  // explicitly instead of silently switching.
-  if (packageManager !== "pnpm") {
-    console.error(
-      `⛔ --clone requires --pnpm (got "${packageManager}"). The fast path materializes deps from the cloned project's pnpm-lock.yaml.`,
+  // --clone needs a package manager with a hard-offline install mode that
+  // refuses to hit the network on a cache miss. pnpm and npm qualify; yarn
+  // and bun do not (bun has no offline flag at all — cache misses silently
+  // re-fetch).
+  const recipe = CLONE_RECIPES[packageManager];
+  if (!recipe) {
+    throw new Error(
+      `⛔ --clone is only compatible with --pnpm or --npm (got "${packageManager}").`,
     );
-    process.exit(1);
   }
   const clonePath = path.resolve(process.cwd(), clone);
   if (!fs.existsSync(clonePath) || !fs.statSync(clonePath).isDirectory()) {
-    console.error(
+    throw new Error(
       `⛔ Clone source "${clone}" not found (resolved to "${clonePath}"). Pass a path to an existing scaffolded project.`,
     );
-    process.exit(1);
   }
-  if (!fs.existsSync(path.join(clonePath, "pnpm-lock.yaml"))) {
-    console.error(
-      `⛔ Clone source "${clone}" has no pnpm-lock.yaml. --clone requires a pnpm project scaffolded with a committed lockfile.`,
+  if (!fs.existsSync(path.join(clonePath, recipe.lockfile))) {
+    throw new Error(
+      `⛔ Clone source "${clone}" has no ${recipe.lockfile}. --clone with --${packageManager} requires a committed lockfile.`,
     );
-    process.exit(1);
   }
 
   // Copy source + lockfile only; node_modules is rebuilt from the store below,
@@ -194,11 +202,11 @@ async function createProjectFromClone(args: {
   console.log(chalk.green(`✅ Project customizations applied\n`));
 
   if (!skipInstall) {
-    // Rebuild node_modules from the lockfile, offline, via the warm store.
+    // Rebuild node_modules from the lockfile, offline, via the warm cache.
     console.log(
       chalk.blue(`▶️ Installing dependencies from lockfile (offline)...\n`),
     );
-    runCmd(`pnpm install --frozen-lockfile --offline`, { cwd: appPath });
+    runCmd(recipe.install, { cwd: appPath });
     console.log(chalk.green(`\n✅ Dependencies installed from lockfile\n`));
   }
 

--- a/packages/shared/clis/args/init.ts
+++ b/packages/shared/clis/args/init.ts
@@ -55,11 +55,11 @@ export const initArgs = {
     short: "r",
     description: "Remote drive identifier.",
   }),
-  template: option({
+  clone: option({
     type: optional(string),
-    long: "template",
+    long: "clone",
     description:
-      "Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the template's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored).",
+      "Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored).",
   }),
   ...debugArgs,
 };


### PR DESCRIPTION
## Summary

Rename `ph init --template <path>` → `ph init --clone <path>`.

The fast-path flag clones an existing scaffolded project; it does not pick a project type. Reserving `--template` for a future Vite/CRA-style project-type-preset semantic (`--template react-app`, `--template minimal`, etc.) avoids a name collision before any user depends on the current spelling.

## What changed

- **Flag rename** (`packages/shared/clis/args/init.ts`): `--template` → `--clone`, help text reworded.
- **API rename** (`packages/codegen/src/create-lib/create-project.ts`): `CreateProjectArgs.template?` → `clone?`; internal helper `createProjectFromTemplate` → `createProjectFromClone`; error and progress strings updated.
- **CLI wiring** (`clis/ph-cli/src/services/init.ts`): destructures `clone` instead of `template`; the "ignored flags" warning text refers to `--clone`.
- **Generated docs** regenerated: `clis/ph-cmd/COMMANDS.md`, `apps/academy/docs/academy/04-APIReferences/00-PowerhouseCLI.md`, `apps/academy/llms-full.txt`.

No behavior change.

## Test plan
- [x] `pnpm exec tsc -b packages/codegen packages/shared clis/ph-cli` — green
- [x] No `--template` / `createProjectFromTemplate` residue in the renamed files
- [x] Regenerated CLI docs reflect `--clone`
