### PR TITLE
fix(reactor-api): correctly load subgraphs from HTTP-registry packages

### DIFF
--- a/packages/reactor-api/src/packages/http-loader.ts
+++ b/packages/reactor-api/src/packages/http-loader.ts
@@ -19,6 +19,24 @@ type DocumentModelsExport = Record<string, DocumentModelModule>;
 // Expected shape of the subgraphs bundle export
 type SubgraphsExport = Record<string, SubgraphClass>;
 
+/**
+ * Extract subgraph classes from the imported subgraphs/index.mjs module shape.
+ *
+ * The published bundle uses `export * as Foo from "./file"`, which Node turns
+ * into `{ Foo: <namespace>, … }`. The inner namespace's keys come from the
+ * source file's named exports — typically `Subgraph` / `default` / the class
+ * name itself — so the shape varies. Flatten one level and keep callables.
+ *
+ * Exported for direct unit testing against synthetic module shapes.
+ */
+export function extractSubgraphsFromModule(
+  module: Record<string, SubgraphsExport>,
+): SubgraphClass[] {
+  return Object.values(module)
+    .flatMap((namespace) => Object.values(namespace))
+    .filter((s): s is SubgraphClass => typeof s === "function");
+}
+
 // Expected shape of the processors bundle export
 type ProcessorsExport = {
   processorFactory?: ProcessorFactoryBuilder;
@@ -112,13 +130,7 @@ export class HttpPackageLoader implements IPackageLoader {
 
     this.logger.verbose(`Importing subgraphs from: ${url}`);
     const module = (await import(url)) as Record<string, SubgraphsExport>;
-    const subgraphs = new Array<SubgraphClass>();
-    for (const [key, value] of Object.entries(module)) {
-      const subgraph = value[key];
-      if (subgraph && typeof subgraph === "function") {
-        subgraphs.push(subgraph);
-      }
-    }
+    const subgraphs = extractSubgraphsFromModule(module);
 
     this.logger.verbose(
       `Loaded ${subgraphs.length} subgraphs from ${packageName}`,

--- a/packages/reactor-api/src/packages/https-hooks.mts
+++ b/packages/reactor-api/src/packages/https-hooks.mts
@@ -47,16 +47,43 @@ export async function resolve(
     return { url: resolved, shortCircuit: true, format: "module" };
   }
 
-  // For bare specifiers (e.g. "document-model") imported from HTTP modules,
-  // Node's default resolver fails because it can't find node_modules from an HTTP parent.
-  // Fall back to resolving from the process's working directory instead.
+  // Bare specifiers from HTTP modules need a node_modules root to resolve
+  // against. Under pnpm's strict isolation the deps a registry-built bundle
+  // needs split into two classes:
+  //   - Peer deps the *consumer* declared (react, react-dom, graphql, …) —
+  //     live at the consumer project root.
+  //   - Things reactor-api keeps external by design (the reactor-api package
+  //     itself, for class identity; internal helpers) — live in reactor-api's
+  //     own tree.
+  // Neither root sees the other under strict mode, so try the consumer first
+  // (its declared peers win on version) and fall back to reactor-api's tree.
+  //
+  // At this point: specifier is not an http(s):// URL (branch 1) and not
+  // relative (branch 2). Only redirect bare package specifiers; let absolute
+  // paths and other URL schemes (e.g. "node:fs", "file://…") fall through.
   if (
     parentURL &&
     (parentURL.startsWith("https://") || parentURL.startsWith("http://"))
   ) {
-    const { pathToFileURL } = await import("node:url");
-    const localParent = pathToFileURL(process.cwd() + "/").href;
-    return nextResolve(specifier, { ...context, parentURL: localParent });
+    const isBareSpecifier =
+      !specifier.startsWith("/") && !/^[a-z][a-z0-9+.-]*:/i.test(specifier);
+    if (isBareSpecifier) {
+      const { pathToFileURL } = await import("node:url");
+      const consumerRoot = pathToFileURL(process.cwd() + "/").href;
+      try {
+        return await nextResolve(specifier, {
+          ...context,
+          parentURL: consumerRoot,
+        });
+      } catch (e) {
+        const code = (e as NodeJS.ErrnoException | undefined)?.code;
+        if (code !== "ERR_MODULE_NOT_FOUND") throw e;
+        return nextResolve(specifier, {
+          ...context,
+          parentURL: import.meta.url,
+        });
+      }
+    }
   }
 
   // Let Node.js handle all other specifiers

--- a/packages/reactor-api/src/packages/package-manager.ts
+++ b/packages/reactor-api/src/packages/package-manager.ts
@@ -20,6 +20,37 @@ import type {
 } from "./types.js";
 import { debounce } from "./util.js";
 
+/**
+ * A loader throwing "this package isn't mine to load" is normal — loaders are
+ * fallbacks for each other. These shapes mean "not found here", not "broken".
+ *
+ * `ERR_MODULE_NOT_FOUND` is ambiguous: it can mean either (a) the loader's own
+ * entry import for `pkg` failed (expected — the package isn't installed
+ * locally), or (b) the entry loaded successfully but a *transitive* bare
+ * import inside it couldn't resolve (real error — the bundle is broken). We
+ * distinguish by checking whether the error names the package we asked for —
+ * either bare (`'pkg'`) or as a subpath (`'pkg/subgraphs'`), since loaders
+ * import sub-entries like `${pkg}/subgraphs` / `${pkg}/document-models`.
+ */
+export function isExpectedLoaderMiss(error: unknown, pkg: string): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code === "ERR_UNSUPPORTED_DIR_IMPORT") return true; // empty subgraphs/ etc.
+  // HttpPackageLoader rejects local paths and invalid npm names before any fetch
+  if (error.message.startsWith("Invalid package name:")) return true;
+  if (code === "ERR_MODULE_NOT_FOUND") {
+    // Match `'pkg'`, `"pkg"`, `'pkg/...'`, or `"pkg/..."`. Anything else is a
+    // transitive resolution failure inside a successfully-fetched bundle.
+    return (
+      error.message.includes(`'${pkg}'`) ||
+      error.message.includes(`"${pkg}"`) ||
+      error.message.includes(`'${pkg}/`) ||
+      error.message.includes(`"${pkg}/`)
+    );
+  }
+  return false;
+}
+
 export function getUniqueDocumentModels(
   ...documentModels: readonly (readonly DocumentModelModule<any>[])[]
 ): DocumentModelModule[] {
@@ -117,6 +148,8 @@ export class PackageManager implements IPackageManager {
 
     for (const pkg of packages) {
       const allDocumentModels: DocumentModelModule[] = [];
+      const failures: { loader: string; error: unknown }[] = [];
+      let succeeded = false;
 
       for (const loader of this.loaders) {
         try {
@@ -128,8 +161,10 @@ export class PackageManager implements IPackageManager {
             pkg,
             documentModels.map((dm) => dm.documentModel.global.id),
           );
+          succeeded = true;
           break;
         } catch (error) {
+          failures.push({ loader: loader.name, error });
           this.logger.debug(
             `[${loader.name}] Failed to load document models from package @pkg: @error`,
             pkg,
@@ -137,6 +172,13 @@ export class PackageManager implements IPackageManager {
           );
         }
       }
+
+      this.maybeWarnAllLoadersFailed(
+        "document models",
+        pkg,
+        succeeded,
+        failures,
+      );
 
       documentModelModuleMap.set(pkg, allDocumentModels);
     }
@@ -155,20 +197,26 @@ export class PackageManager implements IPackageManager {
 
     for (const pkg of packages) {
       const allSubgraphs: SubgraphClass[] = [];
+      const failures: { loader: string; error: unknown }[] = [];
+      let succeeded = false;
 
       for (const loader of this.loaders) {
         try {
           const subgraphs = await loader.loadSubgraphs(pkg);
 
           allSubgraphs.push(...subgraphs);
+          succeeded = true;
           break;
         } catch (error) {
+          failures.push({ loader: loader.name, error });
           this.logger.debug(
             `[${loader.name}] Failed to load subgraphs from package ${pkg}`,
             error,
           );
         }
       }
+
+      this.maybeWarnAllLoadersFailed("subgraphs", pkg, succeeded, failures);
 
       subgraphsMap.set(pkg, allSubgraphs);
     }
@@ -187,6 +235,8 @@ export class PackageManager implements IPackageManager {
 
     for (const pkg of packages) {
       const allProcessors: ProcessorFactoryBuilder[] = [];
+      const failures: { loader: string; error: unknown }[] = [];
+      let succeeded = false;
 
       for (const loader of this.loaders) {
         try {
@@ -195,8 +245,10 @@ export class PackageManager implements IPackageManager {
           if (processors) {
             allProcessors.push(processors);
           }
+          succeeded = true;
           break;
         } catch (error) {
+          failures.push({ loader: loader.name, error });
           this.logger.debug(
             `[${loader.name}] Failed to load processors from package ${pkg}`,
             error,
@@ -204,11 +256,43 @@ export class PackageManager implements IPackageManager {
         }
       }
 
+      this.maybeWarnAllLoadersFailed("processors", pkg, succeeded, failures);
+
       processorsMap.set(pkg, allProcessors);
     }
     this.updateProcessorsMap(processorsMap);
 
     return processorsMap;
+  }
+
+  private maybeWarnAllLoadersFailed(
+    kind: "document models" | "subgraphs" | "processors",
+    pkg: string,
+    succeeded: boolean,
+    failures: { loader: string; error: unknown }[],
+  ): void {
+    if (succeeded || failures.length === 0) return;
+    // Each loader's "this package isn't mine" failure is expected fallthrough,
+    // not a real error. Only surface a warning when at least one loader hit
+    // something unexpected (e.g. a bundle evaluation error or registry 5xx),
+    // and show only those non-expected failures — expected misses would just
+    // mislead the reader about which loader actually broke.
+    const realFailures = failures.filter(
+      ({ error }) => !isExpectedLoaderMiss(error, pkg),
+    );
+    if (realFailures.length === 0) return;
+
+    const details = realFailures
+      .map(({ loader, error }) => {
+        const message = error instanceof Error ? error.message : String(error);
+        return `  [${loader}] ${message}`;
+      })
+      .join("\n");
+    this.logger.warn(
+      `All package loaders failed to load ${kind} from @pkg:\n@details`,
+      pkg,
+      details,
+    );
   }
 
   private async updateDocumentModelsForPackage(pkg: string): Promise<void> {

--- a/packages/reactor-api/test/package-loader-helpers.test.ts
+++ b/packages/reactor-api/test/package-loader-helpers.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the small helpers underpinning HTTP-registry package loading:
+ *
+ *   - `extractSubgraphsFromModule` — pulls subgraph classes out of the
+ *     `subgraphs/index.mjs` namespace shape, which varies depending on how
+ *     the source file's exports are named.
+ *   - `isExpectedLoaderMiss` — classifies a loader exception as either an
+ *     "expected fallthrough" (suppress) or a real error (warn).
+ *
+ * Both are exercised against synthetic inputs that mirror real-world shapes,
+ * since wiring up an actual HTTP-loaded bundle just for two pure helpers
+ * would be disproportionate.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { SubgraphClass } from "../src/graphql/types.js";
+import { extractSubgraphsFromModule } from "../src/packages/http-loader.js";
+import { isExpectedLoaderMiss } from "../src/packages/package-manager.js";
+
+class Foo {}
+class Bar {}
+
+describe("extractSubgraphsFromModule", () => {
+  it("extracts classes when the inner key matches the outer alias", () => {
+    // Shape produced when the source file's class name equals the alias used
+    // in `export * as Foo from "./file"` — common case in current op-hub.
+    const module = {
+      FooSubgraph: { FooSubgraph: Foo },
+      BarSubgraph: { BarSubgraph: Bar },
+    } as unknown as Record<string, Record<string, SubgraphClass>>;
+
+    const subgraphs = extractSubgraphsFromModule(module);
+
+    expect(subgraphs).toHaveLength(2);
+    expect(subgraphs).toContain(Foo as unknown as SubgraphClass);
+    expect(subgraphs).toContain(Bar as unknown as SubgraphClass);
+  });
+
+  it("extracts classes when the inner key is `Subgraph` / `default`", () => {
+    // Shape produced by older bundles where the source file exports the class
+    // under a generic name like `Subgraph` or `default`. The buggy
+    // `value[outerKey]` lookup silently returned [] for this shape.
+    const module = {
+      FooSubgraph: { Subgraph: Foo, default: Foo },
+      BarSubgraph: { Subgraph: Bar, default: Bar },
+    } as unknown as Record<string, Record<string, SubgraphClass>>;
+
+    const subgraphs = extractSubgraphsFromModule(module);
+
+    // Each namespace contributes two entries (Subgraph + default), both Foo/Bar.
+    expect(subgraphs).toHaveLength(4);
+    expect(subgraphs.filter((s) => s === (Foo as unknown))).toHaveLength(2);
+    expect(subgraphs.filter((s) => s === (Bar as unknown))).toHaveLength(2);
+  });
+
+  it("filters out non-callable namespace members", () => {
+    // export * also includes type-only re-exports, constants, etc. Anything
+    // that isn't `typeof === "function"` should be dropped.
+    const module = {
+      FooSubgraph: {
+        FooSubgraph: Foo,
+        FOO_VERSION: "1.0.0" as unknown as SubgraphClass,
+        FOO_CONFIG: { x: 1 } as unknown as SubgraphClass,
+      },
+    } as unknown as Record<string, Record<string, SubgraphClass>>;
+
+    const subgraphs = extractSubgraphsFromModule(module);
+
+    expect(subgraphs).toEqual([Foo]);
+  });
+
+  it("returns [] for an empty module", () => {
+    expect(extractSubgraphsFromModule({})).toEqual([]);
+  });
+});
+
+describe("isExpectedLoaderMiss", () => {
+  const pkg = "@powerhousedao/op-hub";
+
+  function moduleNotFound(message: string): Error {
+    const err = new Error(message) as NodeJS.ErrnoException;
+    err.code = "ERR_MODULE_NOT_FOUND";
+    return err;
+  }
+
+  it("treats ERR_MODULE_NOT_FOUND matching the requested package as expected", () => {
+    const err = moduleNotFound(`Cannot find package '${pkg}' imported from /x`);
+    expect(isExpectedLoaderMiss(err, pkg)).toBe(true);
+  });
+
+  it("matches subpath imports of the requested package", () => {
+    // Loaders call `import("${pkg}/subgraphs")`; the error name retains the subpath.
+    const err = moduleNotFound(
+      `Cannot find module '${pkg}/subgraphs' imported from /x`,
+    );
+    expect(isExpectedLoaderMiss(err, pkg)).toBe(true);
+  });
+
+  it("matches double-quoted error messages", () => {
+    const err = moduleNotFound(`Cannot find package "${pkg}" imported from /x`);
+    expect(isExpectedLoaderMiss(err, pkg)).toBe(true);
+  });
+
+  it("does NOT treat transitive resolution failures as expected", () => {
+    // A bundle for `pkg` loaded successfully, but its bare `import "react"`
+    // didn't resolve. That's a real bundle-side bug, not a loader miss.
+    const err = moduleNotFound(
+      `Cannot find package 'react' imported from /path/to/bundle.mjs`,
+    );
+    expect(isExpectedLoaderMiss(err, pkg)).toBe(false);
+  });
+
+  it("treats ERR_UNSUPPORTED_DIR_IMPORT as expected (empty subgraphs/ dir)", () => {
+    const err = new Error(
+      "Directory import '/foo/subgraphs' is not supported",
+    ) as NodeJS.ErrnoException;
+    err.code = "ERR_UNSUPPORTED_DIR_IMPORT";
+    expect(isExpectedLoaderMiss(err, pkg)).toBe(true);
+  });
+
+  it("treats HttpPackageLoader's 'Invalid package name:' as expected", () => {
+    const err = new Error("Invalid package name: /Users/foo/test-hub");
+    expect(isExpectedLoaderMiss(err, pkg)).toBe(true);
+  });
+
+  it("treats unrelated errors as unexpected (real failures)", () => {
+    expect(isExpectedLoaderMiss(new TypeError("boom"), pkg)).toBe(false);
+    expect(
+      isExpectedLoaderMiss(new Error("Bundle evaluation crashed"), pkg),
+    ).toBe(false);
+  });
+
+  it("treats non-Error throws as unexpected", () => {
+    expect(isExpectedLoaderMiss("string thrown", pkg)).toBe(false);
+    expect(isExpectedLoaderMiss(null, pkg)).toBe(false);
+    expect(isExpectedLoaderMiss(undefined, pkg)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Three coordinated fixes in `reactor-api` so subgraphs from HTTP-registry packages (e.g. `@powerhousedao/op-hub`) actually register, and so failures aren't invisible.

### 1. `HttpPackageLoader.loadSubgraphs` extraction loop (`http-loader.ts`)

The loop iterated `Object.entries(module)` and read `value[key]`. For `export * as Foo from "./file"`, `value` is the namespace and its inner keys come from the source file's named exports — so `value[key]` only works when the inner class name happens to match the outer alias (a fragile coincidence). For any other shape (older op-hub bundles, anything with `Subgraph`/`default` inner names) the loop silently returned `[]`.

Match the `ImportPackageLoader` pattern: flatten each inner namespace and keep callable exports.

### 2. `https-hooks.mts` bare-import resolution

Previously redirected every bare specifier from HTTP-loaded modules to `process.cwd()`. Under pnpm's strict isolation, the consumer's project root only sees direct deps — so transitive helpers the bundle relies on (notably `@powerhousedao/reactor-api`, which `build-config.mts` keeps external on purpose for class-identity) couldn't resolve.

New behavior: try the consumer root first (handles peer deps the consumer declared — `react`, `graphql`, etc.) then fall back to this hooks file's location, which lives in reactor-api's installed tree (covers reactor-api itself and its internal helpers). Relative imports are untouched and still resolve against their HTTP parent.

### 3. `PackageManager` visibility (`package-manager.ts`)

Loader exceptions used to be `debug`-only, so a registry package that failed to load left no observable signal. Now: when every loader fails for a package, emit a single `warn` line summarizing each loader's error.

The expected-miss filter:
- `ERR_UNSUPPORTED_DIR_IMPORT` and HttpPackageLoader's "Invalid package name:" stay suppressed (always benign — empty `subgraphs/` directory, or local-path packages rejected by HTTP).
- `ERR_MODULE_NOT_FOUND` is disambiguated: only counts as a miss if the missing module is the exact package the loader was asked to load. A transitive resolution failure inside a successfully-fetched bundle (e.g. a bare dep in the bundle that doesn't resolve in the consumer's tree) now correctly surfaces.
- Only non-expected failures are shown in the warn details, so the displayed culprit isn't drowned out by routine fallthroughs.

## Why this matters

Without these, an end-user running `ph switchboard` against a project that depends on a registry-distributed package would see the package's document models load and its custom subgraphs silently disappear, with nothing in the logs explaining why.

## Test plan

- [x] Verified end-to-end against `@powerhousedao/op-hub` on a local registry: all seven custom subgraphs (`acc-txs-addon`, `budget-statements`, `builders-addon`, `invoice-addon`, `networks`, `resources-services`, `workstreams`) register and respond.
- [x] Confirmed peer-dep resolution (`react`, `react-dom`) still works via the consumer-root path.
- [x] Confirmed `@powerhousedao/reactor-api` (kept external for class identity) resolves via the fallback to this hooks file's location.
- [x] `pnpm run tsc` passes in `packages/reactor-api`.
- [x] `pnpm run build` passes in `packages/reactor-api`.
- [ ] Add unit tests for the new extraction loop and `isExpectedLoaderMiss` disambiguation (follow-up).