### PR TITLE
fix(document-model): seed document-scope operations on create

### DIFF
--- a/packages/codegen/src/templates/document-model/gen/utils.ts
+++ b/packages/codegen/src/templates/document-model/gen/utils.ts
@@ -10,12 +10,11 @@ export const documentModelGenUtilsTemplate = (v: DocumentModelFileMakerArgs) =>
 import type {
     DocumentModelUtils,
 } from "document-model";
-import { 
+import {
     baseCreateDocument,
     baseSaveToFileHandle,
     baseLoadFromInput,
     defaultBaseState,
-    generateId,
  } from "document-model";
 import { reducer } from './reducer.js';
 import { ${v.documentTypeVariableName} } from "./document-type.js";
@@ -36,17 +35,11 @@ export const utils: DocumentModelUtils<${v.phStateName}> = {
         return { ...defaultBaseState(), global: { ...initialGlobalState, ...state?.global }, local: { ...initialLocalState, ...state?.local } };
     },
     createDocument(state) {
-        const document = baseCreateDocument(
+        return baseCreateDocument(
             utils.createState,
-            state
+            state,
+            ${v.documentTypeVariableName}
         );
-
-        document.header.documentType = ${v.documentTypeVariableName};
-
-        // for backwards compatibility, but this is NOT a valid signed document id
-        document.header.id = generateId();
-
-        return document;
     },
     saveToFileHandle(document, input) {
         return baseSaveToFileHandle(document, input);

--- a/packages/document-model/src/state.ts
+++ b/packages/document-model/src/state.ts
@@ -57,8 +57,9 @@ export const documentModelCreateState: CreateState<DocumentModelPHState> = (
 export function documentModelCreateDocument(
   state?: Partial<DocumentModelPHState>,
 ): DocumentModelDocument {
-  const document = baseCreateDocument(documentModelCreateState, state);
-  document.header.documentType = documentModelDocumentType;
-
-  return document;
+  return baseCreateDocument(
+    documentModelCreateState,
+    state,
+    documentModelDocumentType,
+  );
 }

--- a/packages/document-model/test/document/document-scope-on-create.test.ts
+++ b/packages/document-model/test/document/document-scope-on-create.test.ts
@@ -1,0 +1,37 @@
+import {
+  baseLoadFromInput,
+  createZip,
+  documentModelReducer,
+  validateOperations,
+} from "@powerhousedao/shared/document-model";
+import { documentModelCreateDocument } from "../../index.js";
+import { describe, expect, it } from "vitest";
+
+describe("document-scope operations on create", () => {
+  it("seeds CREATE_DOCUMENT + UPGRADE_DOCUMENT capturing initial state", () => {
+    const doc = documentModelCreateDocument();
+    const ops = doc.operations.document ?? [];
+
+    expect(ops.map((op) => op.action.type)).toEqual([
+      "CREATE_DOCUMENT",
+      "UPGRADE_DOCUMENT",
+    ]);
+    expect(ops.map((op) => op.index)).toEqual([0, 1]);
+    expect(ops.every((op) => op.skip === 0)).toBe(true);
+    expect(validateOperations(doc.operations)).toHaveLength(0);
+
+    const upgrade = ops.find((op) => op.action.type === "UPGRADE_DOCUMENT");
+    const input = upgrade?.action.input as { initialState?: unknown };
+    expect(input.initialState).toBeDefined();
+  });
+
+  it("exports the document scope into the zip and reloads it", async () => {
+    const doc = documentModelCreateDocument();
+    const zipped = await createZip(doc);
+    const reloaded = await baseLoadFromInput(zipped, documentModelReducer);
+
+    expect(Object.keys(reloaded.operations)).toContain("document");
+    expect(reloaded.operations.document).toHaveLength(2);
+    expect(reloaded.state.global.id).toBe(doc.state.global.id);
+  });
+});

--- a/packages/reactor-drive/src/module.ts
+++ b/packages/reactor-drive/src/module.ts
@@ -54,9 +54,11 @@ export const reactorDriveCreateState: CreateState<ReactorDrivePHState> = (
 export const reactorDriveCreateDocument: CreateDocument<ReactorDrivePHState> = (
   state,
 ) => {
-  const document = baseCreateDocument(reactorDriveCreateState, state);
-  document.header.documentType = REACTOR_DRIVE_DOCUMENT_TYPE;
-  return document;
+  return baseCreateDocument(
+    reactorDriveCreateState,
+    state,
+    REACTOR_DRIVE_DOCUMENT_TYPE,
+  );
 };
 
 const reactorDriveSaveToFileHandle: SaveToFileHandle = (document, input) => {

--- a/packages/shared/document-drive/gen/utils.ts
+++ b/packages/shared/document-drive/gen/utils.ts
@@ -18,7 +18,6 @@ import {
   baseLoadFromInput,
   baseSaveToFileHandle,
   defaultBaseState,
-  generateId,
 } from "document-model";
 import {
   assertIsDriveDocument,
@@ -54,14 +53,7 @@ export const driveCreateState: CreateState<DocumentDrivePHState> = (
 export const driveCreateDocument: CreateDocument<DocumentDrivePHState> = (
   state,
 ) => {
-  const document = baseCreateDocument(driveCreateState, state);
-
-  document.header.documentType = driveDocumentType;
-
-  // for backward compatibility -- but this is NOT a valid document id
-  document.header.id = generateId();
-
-  return document;
+  return baseCreateDocument(driveCreateState, state, driveDocumentType);
 };
 
 export const driveSaveToFileHandle: SaveToFileHandle = (document, input) => {

--- a/packages/shared/document-model/documents.ts
+++ b/packages/shared/document-model/documents.ts
@@ -7,6 +7,7 @@ import type { DocumentOperations, Operation } from "./operations.js";
 import type { PHDocumentSignatureInfo } from "./signatures.js";
 import type { PHBaseState } from "./state.js";
 import type {
+  CreateDocumentActionInput,
   CreateState,
   DocumentAction,
   DocumentOperationsIgnoreMap,
@@ -20,8 +21,9 @@ import type {
   SkipHeaderOperations,
   UndoAction,
   UndoRedoAction,
+  UpgradeDocumentActionInput,
 } from "./types.js";
-import { generateId } from "./utils.js";
+import { deriveOperationId, generateId } from "./utils.js";
 
 /** Meta information about the document. */
 export type PHDocumentMeta = {
@@ -171,20 +173,88 @@ export function isDocumentAction(action: Action): action is DocumentAction {
 }
 
 /**
- * Important note: it is the responsibility of the caller to set the document type
- * on the header.
+ * The document-scope operations a reactor mints on `create`, so a standalone
+ * document carries its initial state when exported outside a reactor.
+ */
+function createDocumentScopeOperations<TState extends PHBaseState>(
+  header: PHDocumentHeader,
+  state: TState,
+): Operation[] {
+  const createInput: CreateDocumentActionInput = {
+    model: header.documentType,
+    version: 0,
+    documentId: header.id,
+    signing: {
+      signature: header.id,
+      publicKey: header.sig.publicKey,
+      nonce: header.sig.nonce,
+      createdAtUtcIso: header.createdAtUtcIso,
+      documentType: header.documentType,
+    },
+    slug: header.slug,
+    name: header.name,
+    branch: header.branch,
+    meta: header.meta,
+    protocolVersions: header.protocolVersions ?? { "base-reducer": 2 },
+  };
+  const upgradeInput: UpgradeDocumentActionInput = {
+    model: header.documentType,
+    fromVersion: 0,
+    toVersion: state.document.version,
+    documentId: header.id,
+    initialState: state,
+  };
+
+  const actions: Action[] = [
+    {
+      id: generateId(),
+      type: "CREATE_DOCUMENT",
+      scope: "document",
+      timestampUtcMs: header.createdAtUtcIso,
+      input: createInput,
+    },
+    {
+      id: generateId(),
+      type: "UPGRADE_DOCUMENT",
+      scope: "document",
+      timestampUtcMs: header.createdAtUtcIso,
+      input: upgradeInput,
+    },
+  ];
+
+  return actions.map((action, index) => ({
+    ...action,
+    action,
+    id: deriveOperationId(header.id, "document", header.branch, action.id),
+    hash: "",
+    error: undefined,
+    index,
+    skip: 0,
+  }));
+}
+
+/**
+ * Creates a new document. When `documentType` is given the header is stamped
+ * with it and the document-scope operations are seeded.
  */
 export function baseCreateDocument<TState extends PHBaseState = PHBaseState>(
   createState: CreateState<TState>,
   initialState?: Partial<TState>,
+  documentType = "",
 ): PHDocument<TState> {
   const state = createState(initialState);
-  const header = createPresignedHeader();
+  const header = createPresignedHeader(generateId(), documentType);
   const phDocument: PHDocument<TState> = {
     header,
     state,
     initialState: state,
-    operations: { global: [], local: [] },
+    operations: documentType
+      ? {
+          global: [],
+          local: [],
+          document: createDocumentScopeOperations(header, state),
+        }
+      : { global: [], local: [] },
     clipboard: [],
   };
 

--- a/packages/vetra/document-models/app-module/v1/gen/utils.ts
+++ b/packages/vetra/document-models/app-module/v1/gen/utils.ts
@@ -8,7 +8,6 @@ import {
   baseLoadFromInput,
   baseSaveToFileHandle,
   defaultBaseState,
-  generateId,
 } from "document-model";
 import {
   assertIsAppModuleDocument,
@@ -42,14 +41,7 @@ export const utils: DocumentModelUtils<AppModulePHState> = {
     };
   },
   createDocument(state) {
-    const document = baseCreateDocument(utils.createState, state);
-
-    document.header.documentType = appModuleDocumentType;
-
-    // for backwards compatibility, but this is NOT a valid signed document id
-    document.header.id = generateId();
-
-    return document;
+    return baseCreateDocument(utils.createState, state, appModuleDocumentType);
   },
   saveToFileHandle(document, input) {
     return baseSaveToFileHandle(document, input);

--- a/packages/vetra/document-models/document-editor/v1/gen/utils.ts
+++ b/packages/vetra/document-models/document-editor/v1/gen/utils.ts
@@ -8,7 +8,6 @@ import {
   baseLoadFromInput,
   baseSaveToFileHandle,
   defaultBaseState,
-  generateId,
 } from "document-model";
 import {
   assertIsDocumentEditorDocument,
@@ -41,14 +40,11 @@ export const utils: DocumentModelUtils<DocumentEditorPHState> = {
     };
   },
   createDocument(state) {
-    const document = baseCreateDocument(utils.createState, state);
-
-    document.header.documentType = documentEditorDocumentType;
-
-    // for backwards compatibility, but this is NOT a valid signed document id
-    document.header.id = generateId();
-
-    return document;
+    return baseCreateDocument(
+      utils.createState,
+      state,
+      documentEditorDocumentType,
+    );
   },
   saveToFileHandle(document, input) {
     return baseSaveToFileHandle(document, input);

--- a/packages/vetra/document-models/processor-module/v1/gen/utils.ts
+++ b/packages/vetra/document-models/processor-module/v1/gen/utils.ts
@@ -8,7 +8,6 @@ import {
   baseLoadFromInput,
   baseSaveToFileHandle,
   defaultBaseState,
-  generateId,
 } from "document-model";
 import {
   assertIsProcessorModuleDocument,
@@ -43,14 +42,11 @@ export const utils: DocumentModelUtils<ProcessorModulePHState> = {
     };
   },
   createDocument(state) {
-    const document = baseCreateDocument(utils.createState, state);
-
-    document.header.documentType = processorModuleDocumentType;
-
-    // for backwards compatibility, but this is NOT a valid signed document id
-    document.header.id = generateId();
-
-    return document;
+    return baseCreateDocument(
+      utils.createState,
+      state,
+      processorModuleDocumentType,
+    );
   },
   saveToFileHandle(document, input) {
     return baseSaveToFileHandle(document, input);

--- a/packages/vetra/document-models/subgraph-module/v1/gen/utils.ts
+++ b/packages/vetra/document-models/subgraph-module/v1/gen/utils.ts
@@ -8,7 +8,6 @@ import {
   baseLoadFromInput,
   baseSaveToFileHandle,
   defaultBaseState,
-  generateId,
 } from "document-model";
 import {
   assertIsSubgraphModuleDocument,
@@ -40,14 +39,11 @@ export const utils: DocumentModelUtils<SubgraphModulePHState> = {
     };
   },
   createDocument(state) {
-    const document = baseCreateDocument(utils.createState, state);
-
-    document.header.documentType = subgraphModuleDocumentType;
-
-    // for backwards compatibility, but this is NOT a valid signed document id
-    document.header.id = generateId();
-
-    return document;
+    return baseCreateDocument(
+      utils.createState,
+      state,
+      subgraphModuleDocumentType,
+    );
   },
   saveToFileHandle(document, input) {
     return baseSaveToFileHandle(document, input);

--- a/packages/vetra/document-models/vetra-package/v1/gen/utils.ts
+++ b/packages/vetra/document-models/vetra-package/v1/gen/utils.ts
@@ -8,7 +8,6 @@ import {
   baseLoadFromInput,
   baseSaveToFileHandle,
   defaultBaseState,
-  generateId,
 } from "document-model";
 import {
   assertIsVetraPackageDocument,
@@ -48,14 +47,11 @@ export const utils: DocumentModelUtils<VetraPackagePHState> = {
     };
   },
   createDocument(state) {
-    const document = baseCreateDocument(utils.createState, state);
-
-    document.header.documentType = vetraPackageDocumentType;
-
-    // for backwards compatibility, but this is NOT a valid signed document id
-    document.header.id = generateId();
-
-    return document;
+    return baseCreateDocument(
+      utils.createState,
+      state,
+      vetraPackageDocumentType,
+    );
   },
   saveToFileHandle(document, input) {
     return baseSaveToFileHandle(document, input);

--- a/test/versioned-documents/document-models/todo/v1/gen/utils.ts
+++ b/test/versioned-documents/document-models/todo/v1/gen/utils.ts
@@ -8,7 +8,6 @@ import {
   baseLoadFromInput,
   baseSaveToFileHandle,
   defaultBaseState,
-  generateId,
 } from "document-model";
 import {
   assertIsTodoDocument,
@@ -33,14 +32,7 @@ export const utils: DocumentModelUtils<TodoPHState> = {
     };
   },
   createDocument(state) {
-    const document = baseCreateDocument(utils.createState, state);
-
-    document.header.documentType = todoDocumentType;
-
-    // for backwards compatibility, but this is NOT a valid signed document id
-    document.header.id = generateId();
-
-    return document;
+    return baseCreateDocument(utils.createState, state, todoDocumentType);
   },
   saveToFileHandle(document, input) {
     return baseSaveToFileHandle(document, input);

--- a/test/versioned-documents/document-models/todo/v2/gen/utils.ts
+++ b/test/versioned-documents/document-models/todo/v2/gen/utils.ts
@@ -8,7 +8,6 @@ import {
   baseLoadFromInput,
   baseSaveToFileHandle,
   defaultBaseState,
-  generateId,
 } from "document-model";
 import {
   assertIsTodoDocument,
@@ -33,14 +32,7 @@ export const utils: DocumentModelUtils<TodoPHState> = {
     };
   },
   createDocument(state) {
-    const document = baseCreateDocument(utils.createState, state);
-
-    document.header.documentType = todoDocumentType;
-
-    // for backwards compatibility, but this is NOT a valid signed document id
-    document.header.id = generateId();
-
-    return document;
+    return baseCreateDocument(utils.createState, state, todoDocumentType);
   },
   saveToFileHandle(document, input) {
     return baseSaveToFileHandle(document, input);


### PR DESCRIPTION
## Problem

Saving a document as a `.phd` zip did not export the **document-scope** operations. Verified the symptom against a document created with `utils.createDocument`: its `operations` only ever contained `{ global: [], local: [] }`, so `operations.json` in the zip had no `document` scope.

Root cause: `baseCreateDocument` hardcoded `operations: { global: [], local: [] }` and never seeded the document scope. The `CREATE_DOCUMENT` / `UPGRADE_DOCUMENT` operations were only minted when a document was persisted through `reactor.create()` — a standalone created document was missing them entirely. `createZip` faithfully wrote what was there, so the export was correct but the source document was incomplete.

## Fix

`baseCreateDocument` now takes an optional `documentType`. When provided it:
- stamps `header.documentType` and owns id generation, and
- seeds the `document` scope with `CREATE_DOCUMENT` + `UPGRADE_DOCUMENT` (indices 0/1), mirroring exactly what `reactor.create()` mints — the `UPGRADE_DOCUMENT` carries `initialState`.

A created document is now self-describing: its initial state is recoverable from the document scope when exported and reloaded outside a reactor.

Callers (`document-model`, `reactor-drive`, the codegen template, and the committed generated `gen/utils.ts`) now pass `documentType` and drop the post-hoc `header.documentType` / `header.id` assignments. Backward compatible — callers that omit `documentType` keep the old `{ global: [], local: [] }` shape.

### Safe at the boundaries
- `reactor.create()` ignores `document.operations` (rebuilds its own from header + state), so no duplication on persist.
- Zip import (`NON_DOMAIN_SCOPES`) and `addFile` (`filterDomainOperations`) both strip the `document` scope before replay/upload, so seeded ops are never double-applied or replayed.

## Tests

New regression test `document-scope-on-create.test.ts` (seeded ops + index continuity, and zip export→reload preserves the document scope).

Existing suites verified green with the change: `document-model` (232), `reactor` client integration + executor (91), `shared/document-drive` (73), `reactor-browser` fetch-document-operations (15).