### PR TITLE
feat(document-drive): allow unicode in document names

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "tsc": "tsc --build",
     "test": "pnpm test:ci",
-    "test:ci": "CI=true pnpm --filter=document-model --filter=@powerhousedao/pglite-fs --filter=@powerhousedao/registry --filter=@powerhousedao/reactor-api --filter=@powerhousedao/reactor-hypercore --filter=@powerhousedao/reactor-mcp --filter=@powerhousedao/vetra --filter=@powerhousedao/versioned-documents --filter=@powerhousedao/switchboard --filter=@powerhousedao/connect --filter=@powerhousedao/design-system --filter=@powerhousedao/analytics-engine-core --filter=@powerhousedao/analytics-engine-graphql --filter=@powerhousedao/analytics-engine-knex --filter=@powerhousedao/load-test-connect --filter=ph-cmd --filter=@renown/sdk --no-bail run test",
+    "test:ci": "CI=true pnpm --filter=document-model --filter=@powerhousedao/shared --filter=@powerhousedao/pglite-fs --filter=@powerhousedao/registry --filter=@powerhousedao/reactor-api --filter=@powerhousedao/reactor-hypercore --filter=@powerhousedao/reactor-mcp --filter=@powerhousedao/vetra --filter=@powerhousedao/versioned-documents --filter=@powerhousedao/switchboard --filter=@powerhousedao/connect --filter=@powerhousedao/design-system --filter=@powerhousedao/analytics-engine-core --filter=@powerhousedao/analytics-engine-graphql --filter=@powerhousedao/analytics-engine-knex --filter=@powerhousedao/load-test-connect --filter=ph-cmd --filter=@renown/sdk --no-bail run test",
     "test:codegen": "pnpm --filter=test-codegen run test",
     "test:e2e:vetra": "pnpm --filter=test-package-vetra run test",
     "test:e2e:package": "pnpm --filter=test-package-e2e run test",

--- a/packages/design-system/src/connect/components/modal/create-document-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/create-document-modal.tsx
@@ -69,7 +69,7 @@ export function CreateDocumentModal(props: CreateDocumentModalProps) {
         <div className="my-6">
           {!isValid && nodeName && (
             <div className="mb-2 text-red-500">
-              Document name must be valid URL characters.
+              Document name cannot contain '/' or '\'.
             </div>
           )}
           <FormInput

--- a/packages/reactor-mcp/src/tools/reactor.ts
+++ b/packages/reactor-mcp/src/tools/reactor.ts
@@ -407,10 +407,17 @@ export async function createReactorMcpProvider(
           (p) => p.header.documentType === DRIVE_DOCUMENT_TYPE,
         );
         if (driveParent) {
-          await client.drives.removeNode(
-            driveParent.header.id,
-            params.documentId,
-          );
+          try {
+            await client.drives.removeNode(
+              driveParent.header.id,
+              params.documentId,
+            );
+          } catch {
+            // Orphaned document: associated with the drive but with no FileNode
+            // in the tree, so removeNode throws. Fall back to a direct delete,
+            // which also clears the dangling relationship.
+            await client.deleteDocument(params.documentId);
+          }
         } else {
           await client.deleteDocument(params.documentId);
         }

--- a/packages/reactor-mcp/test/reactor.test.ts
+++ b/packages/reactor-mcp/test/reactor.test.ts
@@ -269,6 +269,66 @@ describe("ReactorMcpProvider", () => {
         success: false,
       });
     });
+
+    it("should fall back to deleteDocument for an orphaned document whose node is missing", async () => {
+      const removeNode = vi
+        .fn()
+        .mockRejectedValue(new Error("Node doc-1 not found in drive drive-1"));
+      const deleteDocument = vi.fn().mockResolvedValue(undefined);
+      const orphanClient = {
+        getIncomingRelationships: vi.fn().mockResolvedValue({
+          results: [
+            {
+              header: {
+                id: "drive-1",
+                documentType: "powerhouse/document-drive",
+              },
+            },
+          ],
+          options: { cursor: "", limit: 10 },
+        }),
+        drives: { removeNode },
+        deleteDocument,
+      } as unknown as IReactorClient;
+
+      const provider = await createReactorMcpProvider({ client: orphanClient });
+      const result = await provider.tools.deleteDocument.callback({
+        documentId: "doc-1",
+      });
+
+      expect(removeNode).toHaveBeenCalledWith("drive-1", "doc-1");
+      expect(deleteDocument).toHaveBeenCalledWith("doc-1");
+      expect(result.structuredContent).toMatchObject({ success: true });
+    });
+
+    it("should not delete the document directly when its node is removed normally", async () => {
+      const removeNode = vi.fn().mockResolvedValue(undefined);
+      const deleteDocument = vi.fn().mockResolvedValue(undefined);
+      const filedClient = {
+        getIncomingRelationships: vi.fn().mockResolvedValue({
+          results: [
+            {
+              header: {
+                id: "drive-1",
+                documentType: "powerhouse/document-drive",
+              },
+            },
+          ],
+          options: { cursor: "", limit: 10 },
+        }),
+        drives: { removeNode },
+        deleteDocument,
+      } as unknown as IReactorClient;
+
+      const provider = await createReactorMcpProvider({ client: filedClient });
+      const result = await provider.tools.deleteDocument.callback({
+        documentId: "doc-1",
+      });
+
+      expect(removeNode).toHaveBeenCalledWith("drive-1", "doc-1");
+      expect(deleteDocument).not.toHaveBeenCalled();
+      expect(result.structuredContent).toMatchObject({ success: true });
+    });
   });
 
   describe("addActions tool", () => {

--- a/packages/shared/document-drive/src/reducers/node.ts
+++ b/packages/shared/document-drive/src/reducers/node.ts
@@ -22,7 +22,7 @@ export const nodeReducer: DocumentDriveNodeOperations = {
 
     if (!isValidName(action.input.name)) {
       throw new Error(
-        `Invalid name: '${action.input.name}'. Names must be valid URL characters.`,
+        `Invalid name: '${action.input.name}'. Names cannot be empty or contain control characters, '/' or '\\'.`,
       );
     }
 
@@ -60,7 +60,7 @@ export const nodeReducer: DocumentDriveNodeOperations = {
 
     if (!isValidName(action.input.name)) {
       throw new Error(
-        `Invalid name: '${action.input.name}'. Names must be valid URL characters.`,
+        `Invalid name: '${action.input.name}'. Names cannot be empty or contain control characters, '/' or '\\'.`,
       );
     }
 
@@ -107,7 +107,7 @@ export const nodeReducer: DocumentDriveNodeOperations = {
   updateFileOperation(state, action) {
     if (action.input.name && !isValidName(action.input.name)) {
       throw new Error(
-        `Invalid name: '${action.input.name}'. Names must be valid URL characters.`,
+        `Invalid name: '${action.input.name}'. Names cannot be empty or contain control characters, '/' or '\\'.`,
       );
     }
 
@@ -136,7 +136,7 @@ export const nodeReducer: DocumentDriveNodeOperations = {
   updateNodeOperation(state, action) {
     if (action.input.name && !isValidName(action.input.name)) {
       throw new Error(
-        `Invalid name: '${action.input.name}'. Names must be valid URL characters.`,
+        `Invalid name: '${action.input.name}'. Names cannot be empty or contain control characters, '/' or '\\'.`,
       );
     }
 

--- a/packages/shared/document-drive/src/tests/node.test.ts
+++ b/packages/shared/document-drive/src/tests/node.test.ts
@@ -73,9 +73,10 @@ describe("Node Operations", () => {
       (node) => node.name,
     );
     expect(new Set(nodeNames).size).toBe(nodeNames.length);
-    expect(nodeNames[0]).toBe("test");
-    expect(nodeNames[1]).toBe("test (copy) 1");
-    expect(nodeNames[2]).toBe("test (copy) 1 (copy) 1");
+    // Nodes are stored id-sorted, not insertion-ordered, so assert the set.
+    expect(new Set(nodeNames)).toEqual(
+      new Set(["test", "test (copy) 1", "test (copy) 1 (copy) 1"]),
+    );
   });
   it("should prevent name collisions in addFile operation when parent is a drive", () => {
     const firstInput = generateMock(AddFileInputSchema());
@@ -103,9 +104,10 @@ describe("Node Operations", () => {
       (node) => node.name,
     );
     expect(new Set(nodeNames).size).toBe(nodeNames.length);
-    expect(nodeNames[0]).toBe("test");
-    expect(nodeNames[1]).toBe("test (copy) 1");
-    expect(nodeNames[2]).toBe("test (copy) 1 (copy) 1");
+    // Nodes are stored id-sorted, not insertion-ordered, so assert the set.
+    expect(new Set(nodeNames)).toEqual(
+      new Set(["test", "test (copy) 1", "test (copy) 1 (copy) 1"]),
+    );
   });
   it("should handle addFolder operation", () => {
     const input = generateMock(AddFolderInputSchema());
@@ -145,9 +147,10 @@ describe("Node Operations", () => {
       (node) => node.name,
     );
     expect(new Set(nodeNames).size).toBe(nodeNames.length);
-    expect(nodeNames[0]).toBe("test");
-    expect(nodeNames[1]).toBe("test (copy) 1");
-    expect(nodeNames[2]).toBe("test (copy) 1 (copy) 1");
+    // Nodes are stored id-sorted, not insertion-ordered, so assert the set.
+    expect(new Set(nodeNames)).toEqual(
+      new Set(["test", "test (copy) 1", "test (copy) 1 (copy) 1"]),
+    );
   });
 
   it("should prevent name collisions in addFolder operation when parent is a drive", () => {
@@ -176,9 +179,10 @@ describe("Node Operations", () => {
       (node) => node.name,
     );
     expect(new Set(nodeNames).size).toBe(nodeNames.length);
-    expect(nodeNames[0]).toBe("test");
-    expect(nodeNames[1]).toBe("test (copy) 1");
-    expect(nodeNames[2]).toBe("test (copy) 1 (copy) 1");
+    // Nodes are stored id-sorted, not insertion-ordered, so assert the set.
+    expect(new Set(nodeNames)).toEqual(
+      new Set(["test", "test (copy) 1", "test (copy) 1 (copy) 1"]),
+    );
   });
 
   it("should handle deleteNode operation", () => {
@@ -226,8 +230,9 @@ describe("Node Operations", () => {
       (node) => node.name,
     );
     expect(new Set(nodeNames).size).toBe(nodeNames.length);
-    expect(nodeNames[0]).toBe(existingFile1.name);
-    expect(nodeNames[1]).toBe(input.name + " (copy) 1");
+    expect(new Set(nodeNames)).toEqual(
+      new Set([existingFile1.name, input.name + " (copy) 1"]),
+    );
   });
   it("should handle updateNode operation", () => {
     const input = generateMock(UpdateNodeInputSchema());
@@ -259,8 +264,9 @@ describe("Node Operations", () => {
       (node) => node.name,
     );
     expect(new Set(nodeNames).size).toBe(nodeNames.length);
-    expect(nodeNames[0]).toBe(existingNode1.name);
-    expect(nodeNames[1]).toBe(input.name + " (copy) 1");
+    expect(new Set(nodeNames)).toEqual(
+      new Set([existingNode1.name, input.name + " (copy) 1"]),
+    );
   });
   it("should not add (copy) when renaming a node to its current name", () => {
     const existingNode = generateMock(NodeSchema());
@@ -416,8 +422,9 @@ describe("Node Operations", () => {
       (node) => node.name,
     );
     expect(new Set(nodeNames).size).toBe(nodeNames.length);
-    expect(nodeNames[0]).toBe(existingNode.name);
-    expect(nodeNames[1]).toBe(input.targetName + " (copy) 1");
+    expect(new Set(nodeNames)).toEqual(
+      new Set([existingNode.name, input.targetName + " (copy) 1"]),
+    );
   });
   it("should handle name collisions in copyNode operation when parent is drive", () => {
     const existingNode = generateMock(NodeSchema());
@@ -434,8 +441,9 @@ describe("Node Operations", () => {
       (node) => node.name,
     );
     expect(new Set(nodeNames).size).toBe(nodeNames.length);
-    expect(nodeNames[0]).toBe(existingNode.name);
-    expect(nodeNames[1]).toBe(input.targetName + " (copy) 1");
+    expect(new Set(nodeNames)).toEqual(
+      new Set([existingNode.name, input.targetName + " (copy) 1"]),
+    );
   });
   it("should handle name collisions in copyNode operation", () => {
     const existingNode = generateMock(NodeSchema());
@@ -451,8 +459,9 @@ describe("Node Operations", () => {
       (node) => node.name,
     );
     expect(new Set(nodeNames).size).toBe(nodeNames.length);
-    expect(nodeNames[0]).toBe(existingNode.name);
-    expect(nodeNames[1]).toBe(input.targetName + " (copy) 1");
+    expect(new Set(nodeNames)).toEqual(
+      new Set([existingNode.name, input.targetName + " (copy) 1"]),
+    );
   });
   it("should handle moveNode operation", () => {
     const input = generateMock(MoveNodeInputSchema());
@@ -492,8 +501,7 @@ describe("Node Operations", () => {
       (node) => node.name,
     );
     expect(new Set(nodeNames).size).toBe(nodeNames.length);
-    expect(nodeNames[0]).toBe("test");
-    expect(nodeNames[1]).toBe("test (copy) 1");
+    expect(new Set(nodeNames)).toEqual(new Set(["test", "test (copy) 1"]));
   });
   it("should handle name collisions in moveNode operation when parent is drive", () => {
     const existingNode = generateMock(NodeSchema());
@@ -513,8 +521,7 @@ describe("Node Operations", () => {
       (node) => node.name,
     );
     expect(new Set(nodeNames).size).toBe(nodeNames.length);
-    expect(nodeNames[0]).toBe("test");
-    expect(nodeNames[1]).toBe("test (copy) 1");
+    expect(new Set(nodeNames)).toEqual(new Set(["test", "test (copy) 1"]));
   });
   it("should not allow moving folder to descendent", () => {
     // Mock data setup
@@ -691,6 +698,46 @@ describe("Node Operations", () => {
     );
     expect(copied?.name).toBe("Reports (copy) 1");
     expect(copied?.kind).toBe("file");
+  });
+
+  it("should add a file whose name contains a non-ASCII character (em-dash)", () => {
+    const input = generateMock(AddFileInputSchema());
+    input.name = "Concord v1 — delivery plan"; // U+2014 em-dash
+    input.parentFolder = null;
+
+    const updatedDocument = driveDocumentReducer(document, addFile(input));
+
+    const operation = updatedDocument.operations.global![0];
+    expect(operation.error).toBeUndefined();
+    const node = updatedDocument.state.global.nodes.find(
+      (n) => n.id === input.id,
+    );
+    expect(node).toBeDefined();
+    expect(node?.name).toBe("Concord v1 — delivery plan");
+  });
+
+  it("should add files with smart quotes, accents, CJK and emoji names", () => {
+    const names = [
+      "“Smart quotes”",
+      "Café résumé",
+      "予算レポート",
+      "Budget 📊 2026",
+    ];
+    let doc = document;
+    names.forEach((name, i) => {
+      const input = generateMock(AddFileInputSchema());
+      input.name = name;
+      input.parentFolder = null;
+      input.id = `unicode-${i}`;
+      doc = driveDocumentReducer(doc, addFile(input));
+    });
+
+    names.forEach((name, i) => {
+      const node = doc.state.global.nodes.find((n) => n.id === `unicode-${i}`);
+      expect(node, `node for "${name}"`).toBeDefined();
+      expect(node?.name).toBe(name);
+    });
+    expect(doc.operations.global!.every((op) => !op.error)).toBe(true);
   });
 
   it("should still rename when adding a second file with the same name (regression)", () => {

--- a/packages/shared/document-drive/src/utils.ts
+++ b/packages/shared/document-drive/src/utils.ts
@@ -147,6 +147,8 @@ export function handleTargetNameCollisions(params: {
 }
 
 export const isValidName = (name: string) => {
-  // only allow characters that are valid in a URL
-  return /^[a-zA-Z0-9-_.\s()]+$/.test(name);
+  // Display label; URL slugs are derived from node ids, not names.
+  // Reject only empty names, control characters, and path separators.
+  // eslint-disable-next-line no-control-regex
+  return name.length > 0 && !/[\x00-\x1f\x7f/\\]/.test(name);
 };

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,7 +14,8 @@
     "url": "https://github.com/powerhouse-inc/powerhouse"
   },
   "scripts": {
-    "build": "tsx ./bundle.ts"
+    "build": "tsx ./bundle.ts",
+    "test": "vitest --run"
   },
   "exports": {
     ".": {

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath } from "node:url";
+import { defineProject } from "vitest/config";
+
+const resolvePath = (p: string) => fileURLToPath(new URL(p, import.meta.url));
+
+export default defineProject({
+  resolve: {
+    // Resolve workspace packages to their TS source; document-model and the
+    // `types` path alias aren't symlinked into this package's node_modules.
+    conditions: ["source"],
+    alias: {
+      "document-model": resolvePath("./document-model/index.ts"),
+      types: resolvePath("./types/index.ts"),
+    },
+  },
+  test: {
+    globals: true,
+    include: ["document-drive/src/tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Document/folder names can now contain unicode (accents, CJK, emoji), smart quotes, and common punctuation. Previously `isValidName` only allowed `a-z A-Z 0-9 - _ . space ( )`, so e.g. `Café résumé`, `予算レポート`, `Q3 report: revenue & costs` were rejected.

The new rule rejects only empty names, control characters, and the path separators `/` and `\` (kept as a defensive guard — node ids, not names, are used for URLs/paths).

## Changes

- **`isValidName`** (`document-drive/src/utils.ts`): URL-charset regex → minimal blocklist.
- **Error messages**: updated the stale "must be valid URL characters" text in the drive reducer and the design-system create-document modal.
- **reactor-mcp orphan delete** (separate commit): `removeNode` throws for a document associated with a drive but missing a FileNode; fall back to a direct `deleteDocument` that also clears the dangling relationship.
- **Test suite wiring**: `packages/shared/document-drive/src/tests/**` previously ran in **no** CI job (`@powerhousedao/shared` had no `test` script / vitest config and wasn't in `test:ci`). Added `packages/shared/vitest.config.ts`, a `test` script, and the `--filter` to `test:ci`.
- **Flaky assertions fixed**: the drive reducer stores nodes id-sorted (intentional, for convergence), but collision tests asserted positional order against `generateMock` random ids — converted to order-independent set assertions.

## Testing

- `pnpm --filter=@powerhousedao/shared run test` → 7 files / 75 tests pass (stable across repeated runs; previously 7–8 flaky failures).
- `pnpm --filter=@powerhousedao/reactor-mcp run test` → 39 tests pass.
- Verified end-to-end in Connect: created documents named `予算レポート`, em-dash, emoji, etc.; `foo/bar` and `back\slash` still rejected with the updated error.
- Lint clean on edited files.