### PR TITLE
feat(renown): verify EIP-712 credential signature on login

### DIFF
--- a/packages/reactor-browser/package.json
+++ b/packages/reactor-browser/package.json
@@ -93,10 +93,11 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "tsdown": "catalog:",
+    "type-fest": "catalog:",
+    "viem": "~2.50.4",
     "vite": "catalog:",
     "vitest": "catalog:",
-    "vitest-browser-react": "^1.0.1",
-    "type-fest": "catalog:"
+    "vitest-browser-react": "^1.0.1"
   },
   "peerDependencies": {
     "graphql": "^16",

--- a/packages/reactor-browser/src/renown/constants.ts
+++ b/packages/reactor-browser/src/renown/constants.ts
@@ -2,44 +2,12 @@ export const RENOWN_URL = "https://www.renown.id";
 export const RENOWN_NETWORK_ID = "eip155";
 export const RENOWN_CHAIN_ID = "1";
 
-export const DOMAIN_TYPE = [
-  { name: "name", type: "string" },
-  { name: "version", type: "string" },
-  { name: "chainId", type: "uint256" },
-  { name: "verifyingContract", type: "address" },
-] as const;
-
-export const VERIFIABLE_CREDENTIAL_EIP712_TYPE = [
-  { name: "@context", type: "string[]" },
-  { name: "type", type: "string[]" },
-  { name: "id", type: "string" },
-  { name: "issuer", type: "Issuer" },
-  { name: "credentialSubject", type: "CredentialSubject" },
-  { name: "credentialSchema", type: "CredentialSchema" },
-  { name: "issuanceDate", type: "string" },
-  { name: "expirationDate", type: "string" },
-] as const;
-
-export const CREDENTIAL_SCHEMA_EIP712_TYPE = [
-  { name: "id", type: "string" },
-  { name: "type", type: "string" },
-] as const;
-
-export const CREDENTIAL_SUBJECT_TYPE = [
-  { name: "app", type: "string" },
-  { name: "id", type: "string" },
-  { name: "name", type: "string" },
-] as const;
-
-export const ISSUER_TYPE = [
-  { name: "id", type: "string" },
-  { name: "ethereumAddress", type: "string" },
-] as const;
-
-export const CREDENTIAL_TYPES = {
-  EIP712Domain: DOMAIN_TYPE,
-  VerifiableCredential: VERIFIABLE_CREDENTIAL_EIP712_TYPE,
-  CredentialSchema: CREDENTIAL_SCHEMA_EIP712_TYPE,
-  CredentialSubject: CREDENTIAL_SUBJECT_TYPE,
-  Issuer: ISSUER_TYPE,
-} as const;
+// EIP-712 credential types are canonical in @renown/sdk; re-export to avoid drift.
+export {
+  CREDENTIAL_TYPES,
+  DOMAIN_TYPE,
+  VERIFIABLE_CREDENTIAL_EIP712_TYPE,
+  CREDENTIAL_SCHEMA_EIP712_TYPE,
+  CREDENTIAL_SUBJECT_TYPE,
+  ISSUER_TYPE,
+} from "@renown/sdk";

--- a/packages/reactor-browser/test/renown/components.test.tsx
+++ b/packages/reactor-browser/test/renown/components.test.tsx
@@ -1,7 +1,9 @@
-import type {
-  PowerhouseVerifiableCredential,
-  RenownProfile,
+import {
+  CREDENTIAL_TYPES,
+  type PowerhouseVerifiableCredential,
+  type RenownProfile,
 } from "@renown/sdk";
+import { privateKeyToAccount } from "viem/accounts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { addRenownEventHandler, setRenown } from "../../src/hooks/renown.js";
@@ -11,7 +13,10 @@ import { RenownUserButton } from "../../src/renown/components/RenownUserButton.j
 import { Renown } from "../../src/renown/renown-init.js";
 
 const TEST_BASE_URL = "https://test.renown.id";
-const TEST_ADDRESS = "0x9aDdcBbaA28F7eB5f75E023F7C1Fcb13C9DFD8F7" as const;
+const TEST_ACCOUNT = privateKeyToAccount(
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+);
+const TEST_ADDRESS = TEST_ACCOUNT.address;
 const TEST_USER_DID = `did:pkh:eip155:1:${TEST_ADDRESS}`;
 
 /** Resolve a `fetch` input (string | URL | Request) to its URL string. */
@@ -22,42 +27,48 @@ const requestUrl = (input: RequestInfo | URL): string =>
       ? input.toString()
       : input.url;
 
-function createMockCredential(
+async function createMockCredential(
   userDid: string,
   appDid: string,
-): PowerhouseVerifiableCredential {
-  return {
+): Promise<PowerhouseVerifiableCredential> {
+  const issuanceDate = new Date().toISOString();
+  const expirationDate = new Date(
+    Date.now() + 7 * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  const message = {
     "@context": ["https://www.w3.org/2018/credentials/v1"],
-    id: "test-credential-id",
     type: ["VerifiableCredential"],
-    issuer: {
-      id: userDid,
-      ethereumAddress: TEST_ADDRESS,
-    },
-    issuanceDate: new Date().toISOString(),
-    credentialSubject: {
-      id: appDid,
-      app: "test-app",
-    },
+    id: "test-credential-id",
+    issuer: { id: userDid, ethereumAddress: TEST_ADDRESS },
+    credentialSubject: { id: appDid, app: "test-app" },
     credentialSchema: {
       id: "https://schema.org",
       type: "JsonSchemaValidator2018",
     },
+    issuanceDate,
+    expirationDate,
+  };
+  const domain = { version: "1", chainId: 1 };
+  const { EIP712Domain, ...types } = CREDENTIAL_TYPES;
+  void EIP712Domain;
+  const proofValue = await TEST_ACCOUNT.signTypedData({
+    domain,
+    types,
+    primaryType: "VerifiableCredential",
+    message,
+  } as Parameters<typeof TEST_ACCOUNT.signTypedData>[0]);
+  return {
+    ...message,
     proof: {
-      verificationMethod: "test",
+      verificationMethod: userDid,
       ethereumAddress: TEST_ADDRESS,
-      created: new Date().toISOString(),
+      created: issuanceDate,
       proofPurpose: "assertionMethod",
       type: "EthereumEip712Signature2021",
-      proofValue: "0xtest",
+      proofValue,
       eip712: {
-        domain: {
-          name: "Renown",
-          version: "1",
-          chainId: 1,
-          verifyingContract: "0x0000000000000000000000000000000000000000",
-        },
-        types: {} as PowerhouseVerifiableCredential["proof"]["eip712"]["types"],
+        domain,
+        types: CREDENTIAL_TYPES,
         primaryType: "VerifiableCredential",
       },
     },
@@ -82,17 +93,17 @@ function mockFetchForLogin(options?: { profile?: RenownProfile | null }) {
   const { profile = MOCK_PROFILE } = options ?? {};
   let capturedAppDid: string | undefined;
 
-  vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = requestUrl(input);
 
     if (url.includes("/api/auth/credential")) {
       const params = new URL(url).searchParams;
       capturedAppDid = params.get("connectId") ?? undefined;
-      const credential = createMockCredential(
+      const credential = await createMockCredential(
         TEST_USER_DID,
         capturedAppDid ?? "",
       );
-      return Promise.resolve(Response.json({ credential }));
+      return Response.json({ credential });
     }
 
     if (url.includes("/api/profile")) {
@@ -176,7 +187,8 @@ describe("RenownUserButton", () => {
     const usernameElements = screen.getByText("testuser").elements();
     expect(usernameElements.length).toBeGreaterThanOrEqual(2);
     // Address should be truncated in the dropdown
-    await expect.element(screen.getByText("0x9aDdc...FD8F7")).toBeVisible();
+    const truncated = `${TEST_ADDRESS.slice(0, 7)}...${TEST_ADDRESS.slice(-5)}`;
+    await expect.element(screen.getByText(truncated)).toBeVisible();
   });
 
   it("should show 'View Profile' when userId is provided", async () => {

--- a/packages/renown/package.json
+++ b/packages/renown/package.json
@@ -53,6 +53,7 @@
     "did-jwt-vc": "^4.0.12",
     "did-resolver": "^4.1.0",
     "key-did-resolver": "^4.0.0",
-    "uint8arrays": "^5.1.0"
+    "uint8arrays": "^5.1.0",
+    "viem": "~2.50.4"
   }
 }

--- a/packages/renown/src/common.ts
+++ b/packages/renown/src/common.ts
@@ -14,6 +14,7 @@ import type {
   RenownStorageMap,
   User,
 } from "./types.js";
+import { verifyCredentialSignature } from "./credential.js";
 import { parsePkhDid, verifyAuthBearerToken } from "./utils.js";
 export * from "./constants.js";
 
@@ -114,6 +115,16 @@ export class Renown implements IRenown {
         )
       ) {
         throw new Error("Invalid credential");
+      }
+
+      // Verify the EIP-712 proof was signed by the DID's address on its chain.
+      if (
+        credential.issuer.ethereumAddress.toLowerCase() !==
+          result.address.toLowerCase() ||
+        credential.proof.eip712.domain.chainId !== result.chainId ||
+        !(await verifyCredentialSignature(credential))
+      ) {
+        throw new Error("Invalid credential signature");
       }
 
       const user: User = {

--- a/packages/renown/src/constants.ts
+++ b/packages/renown/src/constants.ts
@@ -3,10 +3,8 @@ export const DEFAULT_RENOWN_NETWORK_ID = "eip155";
 export const DEFAULT_RENOWN_CHAIN_ID = "1";
 
 export const DOMAIN_TYPE = [
-  { name: "name", type: "string" },
   { name: "version", type: "string" },
   { name: "chainId", type: "uint256" },
-  { name: "verifyingContract", type: "address" },
 ] as const;
 
 export const VERIFIABLE_CREDENTIAL_EIP712_TYPE = [
@@ -28,7 +26,6 @@ export const CREDENTIAL_SCHEMA_EIP712_TYPE = [
 export const CREDENTIAL_SUBJECT_TYPE = [
   { name: "app", type: "string" },
   { name: "id", type: "string" },
-  { name: "name", type: "string" },
 ] as const;
 
 export const ISSUER_TYPE = [

--- a/packages/renown/src/credential.ts
+++ b/packages/renown/src/credential.ts
@@ -1,0 +1,143 @@
+import {
+  recoverTypedDataAddress,
+  type Hex,
+  type TypedDataDomain,
+  type TypedDataParameter,
+} from "viem";
+import { CREDENTIAL_TYPES, DEFAULT_RENOWN_NETWORK_ID } from "./constants.js";
+import type { PowerhouseVerifiableCredential } from "./types.js";
+
+/** EIP-712 domain as signed by the credential issuer. */
+export type CredentialDomain = {
+  version: string;
+  chainId: number;
+};
+
+/** The credential body that is EIP-712 signed (everything except `proof`). */
+export type CredentialMessage = {
+  "@context": string[];
+  type: string[];
+  id: string;
+  issuer: { id: string; ethereumAddress: Hex };
+  credentialSubject: { id: string; app: string };
+  credentialSchema: { id: string; type: string };
+  issuanceDate: string;
+  expirationDate: string;
+};
+
+/** Typed-data signer; matches the loose shape used by wallet adapters. */
+export type SignCredentialTypedData = (args: {
+  domain: TypedDataDomain;
+  types: Record<string, readonly TypedDataParameter[]>;
+  primaryType: string;
+  message: Record<string, unknown>;
+}) => Promise<Hex>;
+
+export interface BuildCredentialParams {
+  signTypedData: SignCredentialTypedData;
+  address: Hex;
+  chainId: number;
+  app: string;
+  /** Credential subject id: the app/client DID the credential delegates to. */
+  appId: string;
+  expiresInDays?: number;
+}
+
+/** Assemble a Renown delegation VC and sign it with the provided signer. */
+export async function buildAndSignCredential(
+  params: BuildCredentialParams,
+): Promise<PowerhouseVerifiableCredential> {
+  const {
+    signTypedData,
+    address,
+    chainId,
+    app,
+    appId,
+    expiresInDays = 7,
+  } = params;
+
+  const issuerId = `did:pkh:${DEFAULT_RENOWN_NETWORK_ID}:${chainId}:${address.toLowerCase()}`;
+  const credentialId = `urn:uuid:${globalThis.crypto.randomUUID()}`;
+  const now = new Date();
+  const expirationDate = new Date(
+    now.getTime() + expiresInDays * 24 * 60 * 60 * 1000,
+  );
+
+  const message: CredentialMessage = {
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    type: ["VerifiableCredential", "RenownCredential"],
+    id: credentialId,
+    issuer: { id: issuerId, ethereumAddress: address },
+    credentialSubject: { id: appId, app },
+    credentialSchema: {
+      id: "https://renown.id/schemas/renown-credential/v1",
+      type: "JsonSchemaValidator2018",
+    },
+    issuanceDate: now.toISOString(),
+    expirationDate: expirationDate.toISOString(),
+  };
+
+  const domain: CredentialDomain = { version: "1", chainId };
+
+  // viem and most wallet adapters reserve EIP712Domain and derive it from
+  // `domain` — passing it explicitly makes them throw.
+  const { EIP712Domain, ...signTypes } = CREDENTIAL_TYPES;
+  void EIP712Domain;
+  const signature = await signTypedData({
+    domain,
+    types: signTypes,
+    primaryType: "VerifiableCredential",
+    message,
+  });
+
+  return {
+    ...message,
+    proof: {
+      type: "EthereumEip712Signature2021",
+      created: message.issuanceDate,
+      verificationMethod: issuerId,
+      proofPurpose: "assertionMethod",
+      proofValue: signature,
+      ethereumAddress: address,
+      eip712: {
+        domain,
+        types: CREDENTIAL_TYPES,
+        primaryType: "VerifiableCredential",
+      },
+    },
+  };
+}
+
+/** Recover the address that signed a credential's EIP-712 proof. */
+export async function recoverCredentialSigner(
+  credential: PowerhouseVerifiableCredential,
+): Promise<Hex> {
+  const { proof, ...message } = credential;
+  // Drop EIP712Domain so viem derives it from `domain`; viem ignores
+  // message keys not present in the types, so the proof is excluded too.
+  const { EIP712Domain, ...types } = CREDENTIAL_TYPES;
+  void EIP712Domain;
+  return recoverTypedDataAddress({
+    domain: proof.eip712.domain,
+    types,
+    primaryType: "VerifiableCredential",
+    message,
+    signature: proof.proofValue as Hex,
+  } as Parameters<typeof recoverTypedDataAddress>[0]);
+}
+
+/** True when the proof was signed by the credential's declared issuer address. */
+export async function verifyCredentialSignature(
+  credential: PowerhouseVerifiableCredential,
+): Promise<boolean> {
+  try {
+    const recovered = await recoverCredentialSigner(credential);
+    return (
+      recovered.toLowerCase() ===
+      credential.issuer.ethereumAddress.toLowerCase()
+    );
+  } catch {
+    // Malformed proof (bad hex, missing fields) is an invalid signature.
+    return false;
+  }
+}

--- a/packages/renown/src/index.ts
+++ b/packages/renown/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./common.js";
+export * from "./credential.js";
 export * from "./crypto/index.js";
 export * from "./init.browser.js";
 export * from "./profile.js";

--- a/packages/renown/src/types.ts
+++ b/packages/renown/src/types.ts
@@ -307,10 +307,8 @@ export interface IProof {
   proofValue: string;
   eip712: {
     domain: {
-      name: string;
       version: string;
       chainId: number;
-      verifyingContract: string;
     };
     types: typeof CREDENTIAL_TYPES;
     primaryType: "VerifiableCredential";
@@ -327,7 +325,6 @@ export interface IVerifiableCredential<
 export interface IPowerhouseCredentialSubject {
   id: string;
   app: string;
-  name?: string;
 }
 
 export interface IPowerhouseIssuerType {

--- a/packages/renown/test/credential.test.ts
+++ b/packages/renown/test/credential.test.ts
@@ -1,0 +1,79 @@
+import { privateKeyToAccount } from "viem/accounts";
+import { describe, expect, it } from "vitest";
+import {
+  buildAndSignCredential,
+  recoverCredentialSigner,
+  verifyCredentialSignature,
+  type SignCredentialTypedData,
+} from "../src/credential.js";
+
+// Well-known Anvil dev keys; never used for anything real.
+const KEY_1 =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const KEY_2 =
+  "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+
+const account = privateKeyToAccount(KEY_1);
+
+// A plain viem local account works directly: the SDK strips the reserved
+// EIP712Domain key before calling the signer.
+const sign: SignCredentialTypedData = (args) =>
+  account.signTypedData(args as Parameters<typeof account.signTypedData>[0]);
+
+describe("credential", () => {
+  it("builds, signs, and verifies a credential round-trip", async () => {
+    const credential = await buildAndSignCredential({
+      signTypedData: sign,
+      address: account.address,
+      chainId: 1,
+      app: "test-app",
+      appId: "did:key:test-app",
+    });
+
+    expect(credential.proof.type).toBe("EthereumEip712Signature2021");
+    expect(credential.issuer.ethereumAddress).toBe(account.address);
+
+    const recovered = await recoverCredentialSigner(credential);
+    expect(recovered.toLowerCase()).toBe(account.address.toLowerCase());
+    expect(await verifyCredentialSignature(credential)).toBe(true);
+  });
+
+  it("rejects a tampered credential body", async () => {
+    const credential = await buildAndSignCredential({
+      signTypedData: sign,
+      address: account.address,
+      chainId: 1,
+      app: "test-app",
+      appId: "did:key:test-app",
+    });
+
+    credential.credentialSubject.app = "did:test:evil-app";
+    expect(await verifyCredentialSignature(credential)).toBe(false);
+  });
+
+  it("rejects an issuer-address swap", async () => {
+    const credential = await buildAndSignCredential({
+      signTypedData: sign,
+      address: account.address,
+      chainId: 1,
+      app: "test-app",
+      appId: "did:key:test-app",
+    });
+
+    credential.issuer.ethereumAddress = privateKeyToAccount(KEY_2).address;
+    expect(await verifyCredentialSignature(credential)).toBe(false);
+  });
+
+  it("returns false for a malformed proof instead of throwing", async () => {
+    const credential = await buildAndSignCredential({
+      signTypedData: sign,
+      address: account.address,
+      chainId: 1,
+      app: "test-app",
+      appId: "did:key:test-app",
+    });
+
+    credential.proof.proofValue = "not-hex";
+    expect(await verifyCredentialSignature(credential)).toBe(false);
+  });
+});

--- a/packages/renown/test/renown.test.ts
+++ b/packages/renown/test/renown.test.ts
@@ -1,5 +1,7 @@
+import { privateKeyToAccount } from "viem/accounts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Renown, RenownMemoryStorage } from "../src/common.js";
+import { CREDENTIAL_TYPES } from "../src/constants.js";
 import { MemoryKeyStorage, RenownCryptoBuilder } from "../src/crypto/index.js";
 import { MemoryEventEmitter } from "../src/event/memory.js";
 import { fetchRenownProfile } from "../src/profile.js";
@@ -11,7 +13,10 @@ import type {
 } from "../src/types.js";
 
 const TEST_BASE_URL = "https://test.renown.id";
-const TEST_ADDRESS = "0x9aDdcBbaA28F7eB5f75E023F7C1Fcb13C9DFD8F7" as const;
+const TEST_ACCOUNT = privateKeyToAccount(
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+);
+const TEST_ADDRESS = TEST_ACCOUNT.address;
 const TEST_USER_DID = `did:pkh:eip155:1:${TEST_ADDRESS}`;
 
 /** Resolve a `fetch` input (string | URL | Request) to its URL string. */
@@ -22,42 +27,48 @@ const requestUrl = (input: RequestInfo | URL): string =>
       ? input.toString()
       : input.url;
 
-function createMockCredential(
+async function createMockCredential(
   userDid: string,
   appDid: string,
-): PowerhouseVerifiableCredential {
-  return {
+): Promise<PowerhouseVerifiableCredential> {
+  const issuanceDate = new Date().toISOString();
+  const expirationDate = new Date(
+    Date.now() + 7 * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  const message = {
     "@context": ["https://www.w3.org/2018/credentials/v1"],
-    id: "test-credential-id",
     type: ["VerifiableCredential"],
-    issuer: {
-      id: userDid,
-      ethereumAddress: TEST_ADDRESS,
-    },
-    issuanceDate: new Date().toISOString(),
-    credentialSubject: {
-      id: appDid,
-      app: "test-app",
-    },
+    id: "test-credential-id",
+    issuer: { id: userDid, ethereumAddress: TEST_ADDRESS },
+    credentialSubject: { id: appDid, app: "test-app" },
     credentialSchema: {
       id: "https://schema.org",
       type: "JsonSchemaValidator2018",
     },
+    issuanceDate,
+    expirationDate,
+  };
+  const domain = { version: "1", chainId: 1 };
+  const { EIP712Domain, ...types } = CREDENTIAL_TYPES;
+  void EIP712Domain;
+  const proofValue = await TEST_ACCOUNT.signTypedData({
+    domain,
+    types,
+    primaryType: "VerifiableCredential",
+    message,
+  } as Parameters<typeof TEST_ACCOUNT.signTypedData>[0]);
+  return {
+    ...message,
     proof: {
-      verificationMethod: "test",
+      verificationMethod: userDid,
       ethereumAddress: TEST_ADDRESS,
-      created: new Date().toISOString(),
+      created: issuanceDate,
       proofPurpose: "assertionMethod",
       type: "EthereumEip712Signature2021",
-      proofValue: "0xtest",
+      proofValue,
       eip712: {
-        domain: {
-          name: "Renown",
-          version: "1",
-          chainId: 1,
-          verifyingContract: "0x0000000000000000000000000000000000000000",
-        },
-        types: {} as PowerhouseVerifiableCredential["proof"]["eip712"]["types"],
+        domain,
+        types: CREDENTIAL_TYPES,
         primaryType: "VerifiableCredential",
       },
     },
@@ -138,7 +149,7 @@ describe("Renown login flow", () => {
 
   describe("successful login", () => {
     it("should authenticate user and transition through status states", async () => {
-      const credential = createMockCredential(TEST_USER_DID, appDid);
+      const credential = await createMockCredential(TEST_USER_DID, appDid);
       mockFetch({ credential });
 
       const statuses: LoginStatus[] = [];
@@ -158,7 +169,7 @@ describe("Renown login flow", () => {
     });
 
     it("should emit user event on login", async () => {
-      const credential = createMockCredential(TEST_USER_DID, appDid);
+      const credential = await createMockCredential(TEST_USER_DID, appDid);
       mockFetch({ credential });
 
       const users: (User | undefined)[] = [];
@@ -171,7 +182,7 @@ describe("Renown login flow", () => {
     });
 
     it("should persist user in storage", async () => {
-      const credential = createMockCredential(TEST_USER_DID, appDid);
+      const credential = await createMockCredential(TEST_USER_DID, appDid);
       mockFetch({ credential });
 
       await renown.login(TEST_USER_DID);
@@ -181,7 +192,7 @@ describe("Renown login flow", () => {
     });
 
     it("should call credential API with correct parameters", async () => {
-      const credential = createMockCredential(TEST_USER_DID, appDid);
+      const credential = await createMockCredential(TEST_USER_DID, appDid);
       mockFetch({ credential });
 
       await renown.login(TEST_USER_DID);
@@ -205,7 +216,7 @@ describe("Renown login flow", () => {
 
   describe("profile fetching", () => {
     it("should enrich user with profile data in the background", async () => {
-      const credential = createMockCredential(TEST_USER_DID, appDid);
+      const credential = await createMockCredential(TEST_USER_DID, appDid);
       mockFetch({ credential });
 
       await renown.login(TEST_USER_DID);
@@ -224,7 +235,7 @@ describe("Renown login flow", () => {
     });
 
     it("should emit a second user event after profile fetch", async () => {
-      const credential = createMockCredential(TEST_USER_DID, appDid);
+      const credential = await createMockCredential(TEST_USER_DID, appDid);
       mockFetch({ credential });
 
       const users: (User | undefined)[] = [];
@@ -243,7 +254,7 @@ describe("Renown login flow", () => {
     });
 
     it("should call profile API with correct parameters", async () => {
-      const credential = createMockCredential(TEST_USER_DID, appDid);
+      const credential = await createMockCredential(TEST_USER_DID, appDid);
       mockFetch({ credential });
 
       await renown.login(TEST_USER_DID);
@@ -265,7 +276,7 @@ describe("Renown login flow", () => {
     });
 
     it("should handle profile fetch failure gracefully", async () => {
-      const credential = createMockCredential(TEST_USER_DID, appDid);
+      const credential = await createMockCredential(TEST_USER_DID, appDid);
       mockFetch({ credential, profileStatus: 500 });
 
       const user = await renown.login(TEST_USER_DID);
@@ -282,7 +293,7 @@ describe("Renown login flow", () => {
     });
 
     it("should not update user if they logged out before profile returns", async () => {
-      const credential = createMockCredential(TEST_USER_DID, appDid);
+      const credential = await createMockCredential(TEST_USER_DID, appDid);
 
       // Make profile fetch slow
       vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
@@ -320,7 +331,7 @@ describe("Renown login flow", () => {
     });
 
     it("should throw when credential issuer does not match userDid", async () => {
-      const credential = createMockCredential(
+      const credential = await createMockCredential(
         "did:pkh:eip155:1:0xDEADBEEF",
         appDid,
       );
@@ -333,11 +344,36 @@ describe("Renown login flow", () => {
     });
 
     it("should throw when credential subject does not match app DID", async () => {
-      const credential = createMockCredential(TEST_USER_DID, "did:key:wrong");
+      const credential = await createMockCredential(
+        TEST_USER_DID,
+        "did:key:wrong",
+      );
       mockFetch({ credential });
 
       await expect(renown.login(TEST_USER_DID)).rejects.toThrow(
         "Invalid credential",
+      );
+      expect(renown.status).toBe("not-authorized");
+    });
+
+    it("should throw when proof domain chainId does not match the DID", async () => {
+      const credential = await createMockCredential(TEST_USER_DID, appDid);
+      credential.proof.eip712.domain.chainId = 5;
+      mockFetch({ credential });
+
+      await expect(renown.login(TEST_USER_DID)).rejects.toThrow(
+        "Invalid credential signature",
+      );
+      expect(renown.status).toBe("not-authorized");
+    });
+
+    it("should throw when proof signature is invalid", async () => {
+      const credential = await createMockCredential(TEST_USER_DID, appDid);
+      credential.proof.proofValue = "0xtest";
+      mockFetch({ credential });
+
+      await expect(renown.login(TEST_USER_DID)).rejects.toThrow(
+        "Invalid credential signature",
       );
       expect(renown.status).toBe("not-authorized");
     });
@@ -366,7 +402,7 @@ describe("Renown login flow", () => {
 
   describe("logout", () => {
     it("should clear user and set status to not-authorized", async () => {
-      const credential = createMockCredential(TEST_USER_DID, appDid);
+      const credential = await createMockCredential(TEST_USER_DID, appDid);
       mockFetch({ credential });
 
       await renown.login(TEST_USER_DID);
@@ -380,7 +416,7 @@ describe("Renown login flow", () => {
     });
 
     it("should emit user and status events on logout", async () => {
-      const credential = createMockCredential(TEST_USER_DID, appDid);
+      const credential = await createMockCredential(TEST_USER_DID, appDid);
       mockFetch({ credential });
 
       await renown.login(TEST_USER_DID);
@@ -399,7 +435,7 @@ describe("Renown login flow", () => {
 
   describe("event subscriptions", () => {
     it("should return unsubscribe function from on()", async () => {
-      const credential = createMockCredential(TEST_USER_DID, appDid);
+      const credential = await createMockCredential(TEST_USER_DID, appDid);
       mockFetch({ credential });
 
       const statuses: LoginStatus[] = [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,7 +594,7 @@ importers:
         version: 4.2.2
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@5.9.3)
+        version: 0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@5.9.3)
       vite:
         specifier: 'catalog:'
         version: 8.0.8(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -1506,7 +1506,7 @@ importers:
         version: 4.2.2
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@6.0.3)
+        version: 0.21.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@6.0.3)
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
@@ -2101,6 +2101,9 @@ importers:
       type-fest:
         specifier: 'catalog:'
         version: 5.6.0
+      viem:
+        specifier: ~2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.3.6)
       vite:
         specifier: 'catalog:'
         version: 8.0.8(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -2337,6 +2340,9 @@ importers:
       uint8arrays:
         specifier: ^5.1.0
         version: 5.1.0
+      viem:
+        specifier: ~2.50.4
+        version: 2.50.4(typescript@5.9.3)(zod@4.3.6)
     devDependencies:
       tsdown:
         specifier: 'catalog:'
@@ -2437,7 +2443,7 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: ^3.11.8
-        version: 3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(@fastify/websocket@11.2.0)(graphql@16.12.0)(ws@8.20.0))(graphql@16.12.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(@fastify/websocket@11.2.0)(graphql@16.12.0)(ws@8.20.1))(graphql@16.12.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@heroicons/react':
         specifier: ^2.1.5
         version: 2.2.0(react@19.2.6)
@@ -3237,6 +3243,9 @@ packages:
 
   '@adraffy/ens-normalize@1.10.1':
     resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
   '@algolia/abtesting@1.15.1':
     resolution: {integrity: sha512-2yuIC48rUuHGhU1U5qJ9kJHaxYpJ0jpDHJVI5ekOxSMYXlH4+HP+pA31G820lsAznfmu2nzDV7n5RO44zIY1zw==}
@@ -6375,6 +6384,10 @@ packages:
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
@@ -8454,8 +8467,17 @@ packages:
   '@rspack/lite-tapable@1.1.0':
     resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
 
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
   '@scure/base@2.0.0':
     resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -10209,6 +10231,17 @@ packages:
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
+
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -12595,6 +12628,9 @@ packages:
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
@@ -15600,6 +15636,14 @@ packages:
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
+
+  ox@0.14.22:
+    resolution: {integrity: sha512-nb5msL8qWbPglhIfZbGJAfw3cqiJjFMiWmACt7kgyWtLib12tcctbHufMT9Hb0Lr6Pt4k9I3dbpueTpbhvbqvA==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   oxc-resolver@11.19.0:
     resolution: {integrity: sha512-oEe42WEoZc2T5sCQqgaRBx8huzP4cJvrnm+BfNTJESdtM633Tqs6iowkpsMTXgnb7SLwU6N6D9bqwW/PULjo6A==}
@@ -18772,6 +18816,14 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  viem@2.50.4:
+    resolution: {integrity: sha512-rf98F4s3Vlb+uJZEKfay3IbBw3CNCbVtx5Y3UIljlO2tSX420g/J0WQSYsjzBSasUFgxgsXabji14O9kGbiqgg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite-bundle-analyzer@1.3.6:
     resolution: {integrity: sha512-elFXkF9oGy4CJEeOdP1DSEHRDKWfmaEDfT9/GuF4jmyfmUF6nC//iN+ythqMEVvrtchOEHGKLumZwnu1NjoI0w==}
     hasBin: true
@@ -19217,6 +19269,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
@@ -19399,6 +19463,8 @@ snapshots:
 
   '@adraffy/ens-normalize@1.10.1': {}
 
+  '@adraffy/ens-normalize@1.11.1': {}
+
   '@algolia/abtesting@1.15.1':
     dependencies:
       '@algolia/client-common': 5.49.1
@@ -19511,7 +19577,7 @@ snapshots:
     dependencies:
       graphql: 16.12.0
 
-  '@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(@fastify/websocket@11.2.0)(graphql@16.12.0)(ws@8.20.0))(graphql@16.12.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@apollo/client@3.14.0(@types/react@19.2.14)(graphql-ws@6.0.7(@fastify/websocket@11.2.0)(graphql@16.12.0)(ws@8.20.1))(graphql@16.12.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
       '@wry/caches': 1.0.1
@@ -19528,7 +19594,7 @@ snapshots:
       tslib: 2.8.1
       zen-observable-ts: 1.2.5
     optionalDependencies:
-      graphql-ws: 6.0.7(@fastify/websocket@11.2.0)(graphql@16.12.0)(ws@8.20.0)
+      graphql-ws: 6.0.7(@fastify/websocket@11.2.0)(graphql@16.12.0)(ws@8.20.1)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
@@ -22951,10 +23017,10 @@ snapshots:
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
       '@whatwg-node/disposablestack': 0.0.6
       graphql: 16.12.0
-      graphql-ws: 6.0.7(@fastify/websocket@11.2.0)(graphql@16.12.0)(ws@8.20.0)
-      isomorphic-ws: 5.0.0(ws@8.20.0)
+      graphql-ws: 6.0.7(@fastify/websocket@11.2.0)(graphql@16.12.0)(ws@8.20.1)
+      isomorphic-ws: 5.0.0(ws@8.20.1)
       tslib: 2.8.1
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - '@fastify/websocket'
       - bufferutil
@@ -22967,10 +23033,10 @@ snapshots:
       '@graphql-tools/utils': 11.0.0(graphql@16.12.0)
       '@whatwg-node/disposablestack': 0.0.6
       graphql: 16.12.0
-      graphql-ws: 6.0.7(@fastify/websocket@11.2.0)(graphql@16.12.0)(ws@8.20.0)
-      isows: 1.0.7(ws@8.20.0)
+      graphql-ws: 6.0.7(@fastify/websocket@11.2.0)(graphql@16.12.0)(ws@8.20.1)
+      isows: 1.0.7(ws@8.20.1)
       tslib: 2.8.1
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - '@fastify/websocket'
       - bufferutil
@@ -23042,9 +23108,9 @@ snapshots:
       '@graphql-tools/utils': 11.0.0(graphql@16.12.0)
       '@types/ws': 8.18.1
       graphql: 16.12.0
-      isomorphic-ws: 5.0.0(ws@8.20.0)
+      isomorphic-ws: 5.0.0(ws@8.20.1)
       tslib: 2.8.1
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -23202,10 +23268,10 @@ snapshots:
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.12.0
-      isomorphic-ws: 5.0.0(ws@8.20.0)
+      isomorphic-ws: 5.0.0(ws@8.20.1)
       sync-fetch: 0.6.0-2
       tslib: 2.8.1
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - '@fastify/websocket'
       - '@types/node'
@@ -23224,10 +23290,10 @@ snapshots:
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.12.0
-      isomorphic-ws: 5.0.0(ws@8.20.0)
+      isomorphic-ws: 5.0.0(ws@8.20.1)
       sync-fetch: 0.6.0-2
       tslib: 2.8.1
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - '@fastify/websocket'
       - '@types/node'
@@ -23246,10 +23312,10 @@ snapshots:
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.12.0
-      isomorphic-ws: 5.0.0(ws@8.20.0)
+      isomorphic-ws: 5.0.0(ws@8.20.1)
       sync-fetch: 0.6.0
       tslib: 2.8.1
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - '@fastify/websocket'
       - '@types/node'
@@ -23268,10 +23334,10 @@ snapshots:
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.12.0
-      isomorphic-ws: 5.0.0(ws@8.20.0)
+      isomorphic-ws: 5.0.0(ws@8.20.1)
       sync-fetch: 0.6.0
       tslib: 2.8.1
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - '@fastify/websocket'
       - '@types/node'
@@ -24278,6 +24344,10 @@ snapshots:
   '@noble/curves@1.2.0':
     dependencies:
       '@noble/hashes': 1.3.2
+
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@noble/curves@1.9.7':
     dependencies:
@@ -26479,7 +26549,20 @@ snapshots:
 
   '@rspack/lite-tapable@1.1.0': {}
 
+  '@scure/base@1.2.6': {}
+
   '@scure/base@2.0.0': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -27385,7 +27468,7 @@ snapshots:
       lightningcss: 1.32.0
       postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(yaml@2.8.3)
       rolldown: 1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      tsdown: 0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@6.0.3)
+      tsdown: 0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@5.9.3)
     optionalDependencies:
       postcss: 8.5.12
     transitivePeerDependencies:
@@ -28768,6 +28851,11 @@ snapshots:
     dependencies:
       jsonparse: 1.3.1
       through: 2.3.8
+
+  abitype@1.2.3(typescript@5.9.3)(zod@4.3.6):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.3.6
 
   abort-controller@3.0.0:
     dependencies:
@@ -31614,6 +31702,8 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
+  eventemitter3@5.0.1: {}
+
   eventemitter3@5.0.4: {}
 
   events-universal@1.0.1:
@@ -32532,6 +32622,13 @@ snapshots:
       '@fastify/websocket': 11.2.0
       ws: 8.20.0
 
+  graphql-ws@6.0.7(@fastify/websocket@11.2.0)(graphql@16.12.0)(ws@8.20.1):
+    dependencies:
+      graphql: 16.12.0
+    optionalDependencies:
+      '@fastify/websocket': 11.2.0
+      ws: 8.20.1
+
   graphql@16.12.0: {}
 
   gray-matter@4.0.3:
@@ -33374,13 +33471,13 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  isomorphic-ws@5.0.0(ws@8.20.0):
+  isomorphic-ws@5.0.0(ws@8.20.1):
     dependencies:
-      ws: 8.20.0
+      ws: 8.20.1
 
-  isows@1.0.7(ws@8.20.0):
+  isows@1.0.7(ws@8.20.1):
     dependencies:
-      ws: 8.20.0
+      ws: 8.20.1
 
   isstream@0.1.2: {}
 
@@ -35734,6 +35831,21 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  ox@0.14.22(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
   oxc-resolver@11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.19.0
@@ -37580,7 +37692,24 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown-plugin-dts@0.22.5(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(rolldown@1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3):
+  rolldown-plugin-dts@0.22.5(oxc-resolver@11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-rc.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
+    dependencies:
+      '@babel/generator': 8.0.0-rc.2
+      '@babel/helper-validator-identifier': 8.0.0-rc.2
+      '@babel/parser': 8.0.0-rc.2
+      '@babel/types': 8.0.0-rc.2
+      ast-kit: 3.0.0-beta.1
+      birpc: 4.0.0
+      dts-resolver: 2.1.3(oxc-resolver@11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
+      get-tsconfig: 4.13.7
+      obug: 2.1.1
+      rolldown: 1.0.0-rc.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - oxc-resolver
+
+  rolldown-plugin-dts@0.22.5(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(rolldown@1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@5.9.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.2
       '@babel/helper-validator-identifier': 8.0.0-rc.2
@@ -37593,7 +37722,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -38933,7 +39062,37 @@ snapshots:
       - synckit
       - vue-tsc
 
-  tsdown@0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@6.0.3):
+  tsdown@0.21.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@6.0.3):
+    dependencies:
+      ansis: 4.2.0
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.0
+      hookable: 6.1.1
+      import-without-cache: 0.2.5
+      obug: 2.1.1
+      picomatch: 4.0.4
+      rolldown: 1.0.0-rc.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      rolldown-plugin-dts: 0.22.5(oxc-resolver@11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-rc.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+      semver: 7.7.4
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      unrun: 0.2.36(synckit@0.11.12)
+    optionalDependencies:
+      '@tsdown/css': 0.21.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(jiti@2.6.1)(postcss@8.5.12)(tsdown@0.21.1)(tsx@4.21.0)(yaml@2.8.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - synckit
+      - vue-tsc
+
+  tsdown@0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@5.9.3):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -38944,7 +39103,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      rolldown-plugin-dts: 0.22.5(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(rolldown@1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
+      rolldown-plugin-dts: 0.22.5(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(rolldown@1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@5.9.3)
       semver: 7.7.4
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
@@ -38953,7 +39112,7 @@ snapshots:
       unrun: 0.2.36(synckit@0.11.12)
     optionalDependencies:
       '@tsdown/css': 0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(jiti@2.6.1)(postcss@8.5.12)(tsdown@0.21.1)(tsx@4.21.0)(yaml@2.8.3)
-      typescript: 6.0.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -39505,6 +39664,23 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  viem@2.50.4(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      isows: 1.0.7(ws@8.20.1)
+      ox: 0.14.22(typescript@5.9.3)(zod@4.3.6)
+      ws: 8.20.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
 
   vite-bundle-analyzer@1.3.6: {}
 
@@ -40215,6 +40391,8 @@ snapshots:
   ws@8.19.0: {}
 
   ws@8.20.0: {}
+
+  ws@8.20.1: {}
 
   wsl-utils@0.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- New `credential` module in `@renown/sdk`: `buildAndSignCredential`, `recoverCredentialSigner`, `verifyCredentialSignature` (viem-based)
- `Renown.login` now rejects credentials whose EIP-712 proof doesn't recover to the issuer's address
- Canonical EIP-712 domain: drops `name`/`verifyingContract` from the domain type and the optional `name` from the credential subject
- `reactor-browser` re-exports the credential types from `@renown/sdk` instead of duplicating them
- Test fixtures now sign credentials with a viem test account (fake `proofValue` no longer passes)

## Notes
- viem pinned to `~2.50.4`: 2.51.x is blocked by `minimumReleaseAge` and 2.51.0 has a URL-resolved `ox` subdep blocked by `blockExoticSubdeps`
- 4 pre-existing reactor-browser failures (document-cache/switchboard) reproduce on `main` and are unrelated

## Test plan
- `pnpm --filter @renown/sdk test` — 77 passed
- `pnpm --filter @powerhousedao/reactor-browser vitest run test/renown` — 14 passed
- `tsc -b` + lint clean for both packages