### PR TITLE
feat(registry): cache headers on CDN responses, 503 on upstream error, leaner warm-up

### DIFF
--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -30,6 +30,8 @@ Serves files from the CDN cache. On first request, fetches and extracts the tarb
 
 If the package is not published locally, Verdaccio transparently proxies metadata and tarballs from the configured upstream (`--uplink`, default `https://registry.npmjs.org/`). The CDN then extracts the upstream tarball into `cdn-cache/<pkg>/<version>/` exactly as it does for locally-published packages, so subsequent requests are served from the local cache without re-hitting the upstream. The same fallback applies to `@powerhousedao/*` packages: the registry prefers its local copy, and falls back to the upstream when the package isn't published locally.
 
+Responses carry caching headers keyed on the request shape. Version-pinned requests (`<pkg>@1.2.3/...`) are served `Cache-Control: public, max-age=31536000, immutable`; moving requests (a dist-tag like `@dev`/`@latest`, or untagged) get `public, max-age=60, must-revalidate`. A version-derived weak `ETag` is sent, and a matching `If-None-Match` returns `304`. When the upstream metadata lookup fails (as opposed to a genuine not-found), the endpoint serves the latest cached version if present, otherwise responds `503` rather than a cacheable `404`.
+
 ### Publish Notifications
 
 When a package is published, the registry can notify subscribers in real time via Server-Sent Events (SSE) and webhooks.

--- a/packages/registry/src/cdn.ts
+++ b/packages/registry/src/cdn.ts
@@ -35,6 +35,11 @@ export function parsePackageSpec(spec: string): {
   return { name: spec, tag: undefined };
 }
 
+/** True when tag is a concrete semver, false for dist-tag names or undefined. */
+export function isExactVersion(tag?: string): boolean {
+  return !!tag && /^\d+\.\d+\.\d+(?:[-+].+)?$/.test(tag);
+}
+
 export class CdnCache {
   #extractionLocks = new Map<string, Promise<void>>();
 
@@ -110,40 +115,43 @@ export class CdnCache {
    * in the registry, return it directly. If tag is a dist-tag name (e.g.
    * "dev", "latest"), resolve it to the concrete version. If no tag is
    * provided, prefer "latest", then fall back to any available dist-tag.
+   * Returns null only for genuine not-found (404, or absent tag/version).
+   * Throws on network errors and non-OK responses other than 404.
    */
   async resolveVersion(
     packageName: string,
     tag?: string,
   ): Promise<string | null> {
-    try {
-      const url = `${this.registryUrl}/${encodeURIComponent(packageName)}`;
-      const res = await fetch(url, {
-        headers: { Accept: "application/json" },
-      });
-      if (!res.ok) return null;
-      const metadata = (await res.json()) as Record<string, unknown>;
-      const distTags = metadata["dist-tags"] as
-        | Record<string, string>
-        | undefined;
-      const versions = metadata["versions"] as
-        | Record<string, unknown>
-        | undefined;
+    const url = `${this.registryUrl}/${encodeURIComponent(packageName)}`;
+    const res = await fetch(url, {
+      headers: { Accept: "application/json" },
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      throw new Error(
+        `Upstream metadata for ${packageName} returned ${res.status}`,
+      );
+    }
+    const metadata = (await res.json()) as Record<string, unknown>;
+    const distTags = metadata["dist-tags"] as
+      | Record<string, string>
+      | undefined;
+    const versions = metadata["versions"] as
+      | Record<string, unknown>
+      | undefined;
 
-      if (tag) {
-        // If the tag matches an exact version in the registry, use it directly
-        if (versions && tag in versions) return tag;
-        // Otherwise treat it as a dist-tag name
-        if (distTags && tag in distTags) return distTags[tag];
-        // Tag not found
-        return null;
-      }
-
-      if (!distTags) return null;
-      // No tag specified: prefer "latest", fall back to any available tag
-      return distTags.latest ?? Object.values(distTags)[0] ?? null;
-    } catch {
+    if (tag) {
+      // If the tag matches an exact version in the registry, use it directly
+      if (versions && tag in versions) return tag;
+      // Otherwise treat it as a dist-tag name
+      if (distTags && tag in distTags) return distTags[tag];
+      // Tag not found
       return null;
     }
+
+    if (!distTags) return null;
+    // No tag specified: prefer "latest", fall back to any available tag
+    return distTags.latest ?? Object.values(distTags)[0] ?? null;
   }
 
   async extractTarball(packageName: string, version: string): Promise<void> {

--- a/packages/registry/src/middleware.ts
+++ b/packages/registry/src/middleware.ts
@@ -4,9 +4,11 @@ import express, {
   type Request,
   type Response,
 } from "express";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { CdnCache, parsePackageSpec } from "./cdn.js";
+import { pipeline } from "node:stream/promises";
+import { CdnCache, isExactVersion, parsePackageSpec } from "./cdn.js";
 import type { SSEChannel } from "./notifications/sse.js";
 import type { NotificationChannel } from "./notifications/types.js";
 import type { WebhookChannel } from "./notifications/webhook.js";
@@ -16,6 +18,7 @@ import {
   scanPackages,
 } from "./packages.js";
 import type { RegistryConfig } from "./types.js";
+import { createWarmer } from "./warmup.js";
 
 const MIME_TYPES: Record<string, string> = {
   ".js": "application/javascript",
@@ -31,6 +34,49 @@ const MIME_TYPES: Record<string, string> = {
 function getContentType(filePath: string): string {
   const ext = path.extname(filePath).toLowerCase();
   return MIME_TYPES[ext] ?? "application/octet-stream";
+}
+
+type VersionResolution =
+  | { kind: "ok"; version: string }
+  | { kind: "not-found" }
+  | { kind: "upstream-error" };
+
+/**
+ * Resolve a package version. Exact versions skip the network call. Upstream
+ * errors fall back to the latest cached version; genuine not-found falls back
+ * too, then reports not-found.
+ */
+async function resolvePackageVersion(
+  cdn: CdnCache,
+  packageName: string,
+  tag: string | undefined,
+): Promise<VersionResolution> {
+  if (tag && isExactVersion(tag)) return { kind: "ok", version: tag };
+
+  try {
+    const resolved =
+      (await cdn.resolveVersion(packageName, tag)) ??
+      cdn.getLatestCachedVersion(packageName);
+    if (!resolved) return { kind: "not-found" };
+    return { kind: "ok", version: resolved };
+  } catch {
+    const cached = cdn.getLatestCachedVersion(packageName);
+    if (!cached) return { kind: "upstream-error" };
+    return { kind: "ok", version: cached };
+  }
+}
+
+/** RFC 9110 If-None-Match: a comma-separated list of entity-tags or "*". */
+function etagMatches(
+  header: string | string[] | undefined,
+  etag: string,
+): boolean {
+  if (!header) return false;
+  const value = Array.isArray(header) ? header.join(",") : header;
+  return value.split(",").some((candidate) => {
+    const tag = candidate.trim();
+    return tag === etag || tag === "*";
+  });
 }
 
 export function createPowerhouseRouter(
@@ -91,66 +137,11 @@ export function createPowerhouseRouter(
     },
   );
 
-  // Throttle warm-up to once every WARM_INTERVAL_MS, plus an in-flight guard
-  // so the worker pool doesn't double-up. Why both:
-  //   - The in-flight guard alone can't stop us from kicking a fresh warm
-  //     the instant the previous one finishes. With kubelet readiness
-  //     probes hitting /packages every 5s × N pods, that's a steady drumbeat
-  //     of fan-out work for no benefit.
-  //   - The interval guard skips redundant cycles when we've recently warmed.
-  // The first call after startup, after invalidation, or after the interval
-  // elapses still kicks a real warm.
-  const WARM_INTERVAL_MS = 30_000;
-  let warmInFlight = false;
-  let lastWarmAt = 0;
-  async function warmCdnCacheFromVerdaccio(): Promise<void> {
-    if (warmInFlight) return;
-    if (Date.now() - lastWarmAt < WARM_INTERVAL_MS) return;
-    warmInFlight = true;
-    try {
-      const r = await fetch(
-        `http://localhost:${config.port}/-/verdaccio/data/packages`,
-      );
-      if (!r.ok) {
-        console.error(
-          `[registry] verdaccio package listing returned ${r.status}`,
-        );
-        return;
-      }
-      const known = (await r.json()) as Array<{
-        name: string;
-        version?: string;
-      }>;
-      const concurrency = 8;
-      let cursor = 0;
-      const workers = Array.from({ length: concurrency }).map(async () => {
-        while (cursor < known.length) {
-          const idx = cursor++;
-          const pkg = known[idx];
-          if (!pkg.version) continue;
-          try {
-            await cdn.extractTarball(pkg.name, pkg.version);
-          } catch (err) {
-            console.error(
-              `[registry] failed to warm cache for ${pkg.name}@${pkg.version}:`,
-              err,
-            );
-          }
-        }
-      });
-      await Promise.all(workers);
-      console.log(`[registry] /packages warm-up done (${known.length} pkgs)`);
-    } catch (err) {
-      console.error("[registry] /packages warm-up failed:", err);
-    } finally {
-      warmInFlight = false;
-      lastWarmAt = Date.now();
-    }
-  }
+  const warm = createWarmer(config, cdn);
 
   // Kick off an initial warm so /packages is useful soon after pod start
   // even if no clients hit it. Fire-and-forget — must not block the listener.
-  void warmCdnCacheFromVerdaccio();
+  void warm();
 
   // Package listing API.
   // Returns whatever's currently in the local cdn-cache (instant response —
@@ -159,7 +150,7 @@ export function createPowerhouseRouter(
   // a background warm-up so newly-published packages appear in the listing
   // without operator intervention.
   router.get("/packages", (req: Request, res: Response) => {
-    void warmCdnCacheFromVerdaccio();
+    void warm();
     const packages = scanPackages(config.cdnCachePath, config.storagePath);
     const documentType = req.query.documentType as string | undefined;
     if (documentType) {
@@ -193,9 +184,13 @@ export function createPowerhouseRouter(
   router.get("/packages/*", async (req: Request, res: Response) => {
     const raw = (req.params as Record<string, string>)[0];
     const { name, tag } = parsePackageSpec(raw);
-    const version =
-      (await cdn.resolveVersion(name, tag)) ?? cdn.getLatestCachedVersion(name);
-    const pkg = loadPackage(config.cdnCachePath, name, version ?? undefined);
+    const resolution = await resolvePackageVersion(cdn, name, tag);
+    if (resolution.kind === "upstream-error") {
+      res.status(503).send("Upstream registry unavailable");
+      return;
+    }
+    const version = resolution.kind === "ok" ? resolution.version : undefined;
+    const pkg = loadPackage(config.cdnCachePath, name, version);
     if (!pkg) {
       res.status(404).send("Package not found");
       return;
@@ -228,23 +223,66 @@ export function createPowerhouseRouter(
     }
 
     const { name: packageName, tag } = parsePackageSpec(packageSpec);
-    const version =
-      (await cdn.resolveVersion(packageName, tag)) ??
-      cdn.getLatestCachedVersion(packageName);
-    if (!version) {
+    const pinned = isExactVersion(tag);
+    const resolution = await resolvePackageVersion(cdn, packageName, tag);
+    if (resolution.kind === "upstream-error") {
+      res.status(503).send("Upstream registry unavailable");
+      return;
+    }
+    if (resolution.kind === "not-found") {
+      res.status(404).send("File not found");
+      return;
+    }
+    const version = resolution.version;
+
+    const resolved = await cdn.getFileByVersion(packageName, version, filePath);
+    if (!resolved) {
+      // Pinned requests skip the metadata lookup above, so a miss here may be
+      // an upstream failure rather than a genuine 404 — probe to distinguish,
+      // otherwise the CDN would cache a 404 while upstream is merely down.
+      if (pinned) {
+        try {
+          await cdn.resolveVersion(packageName, tag);
+        } catch {
+          res.status(503).send("Upstream registry unavailable");
+          return;
+        }
+      }
       res.status(404).send("File not found");
       return;
     }
 
-    const resolved = await cdn.getFileByVersion(packageName, version, filePath);
-    if (!resolved) {
-      res.status(404).send("File not found");
+    // Cache based on the request shape: pinned requests are immutable, moving
+    // ones (dist-tag / untagged) must revalidate frequently.
+    res.setHeader(
+      "Cache-Control",
+      pinned
+        ? "public, max-age=31536000, immutable"
+        : "public, max-age=60, must-revalidate",
+    );
+
+    // Hash the file path: it comes from the URL and may contain characters
+    // that are invalid in header values.
+    const fileHash = crypto
+      .createHash("sha1")
+      .update(filePath)
+      .digest("hex")
+      .slice(0, 16);
+    const etag = `W/"${version}-${fileHash}"`;
+    res.setHeader("ETag", etag);
+    if (etagMatches(req.headers["if-none-match"], etag)) {
+      res.status(304).end();
       return;
     }
 
     res.setHeader("Content-Type", getContentType(filePath));
-    const content = fs.readFileSync(resolved);
-    res.send(content);
+    try {
+      await pipeline(fs.createReadStream(resolved), res);
+    } catch {
+      // Stream failure (I/O error, client abort) after headers may already
+      // be sent — destroy the socket so the request doesn't hang.
+      res.destroy();
+    }
   });
 
   return router;

--- a/packages/registry/src/packages.ts
+++ b/packages/registry/src/packages.ts
@@ -51,6 +51,18 @@ function readPackageMetadata(
   }
 }
 
+/**
+ * Locally-published check for a package, from verdaccio storage metadata.
+ * Returns the same tri-state as `readPackageMetadata.locallyPublished`:
+ * `true` (has `_attachments`), `false` (proxy-only), `undefined` (unreadable).
+ */
+export function isLocallyPublished(
+  storagePath: string | undefined,
+  packageName: string,
+): boolean | undefined {
+  return readPackageMetadata(storagePath, packageName).locallyPublished;
+}
+
 function readManifest(dir: string): Manifest | null {
   const candidates = [
     path.join(dir, "powerhouse.manifest.json"),

--- a/packages/registry/src/warmup.ts
+++ b/packages/registry/src/warmup.ts
@@ -1,0 +1,77 @@
+import type { CdnCache } from "./cdn.js";
+import { isLocallyPublished } from "./packages.js";
+import type { RegistryConfig } from "./types.js";
+
+// The verdaccio listing already yields local-only, latest-per-name entries;
+// we re-filter by `_attachments` and dedupe as a guard against backend changes.
+const WARM_INTERVAL_MS = 30_000;
+const WARM_CONCURRENCY = 8;
+
+interface VerdaccioPackage {
+  name: string;
+  version?: string;
+}
+
+/**
+ * Build a throttled warmer that extracts locally-published package tarballs
+ * into the CDN cache. 30s minimum interval plus an in-flight guard prevent
+ * redundant fan-out from readiness-probe traffic across pods.
+ */
+export function createWarmer(
+  config: RegistryConfig,
+  cdn: CdnCache,
+): () => Promise<void> {
+  let warmInFlight = false;
+  let lastWarmAt = 0;
+
+  return async function warm(): Promise<void> {
+    if (warmInFlight) return;
+    if (Date.now() - lastWarmAt < WARM_INTERVAL_MS) return;
+    warmInFlight = true;
+    try {
+      const r = await fetch(
+        `http://localhost:${config.port}/-/verdaccio/data/packages`,
+      );
+      if (!r.ok) {
+        console.error(
+          `[registry] verdaccio package listing returned ${r.status}`,
+        );
+        return;
+      }
+      const listed = (await r.json()) as VerdaccioPackage[];
+
+      // Latest version per name (the listing yields one entry per package;
+      // dedupe defensively), scoped to locally-published packages only.
+      const latestByName = new Map<string, string>();
+      for (const pkg of listed) {
+        if (!pkg.version) continue;
+        if (isLocallyPublished(config.storagePath, pkg.name) === false)
+          continue;
+        latestByName.set(pkg.name, pkg.version);
+      }
+
+      const targets = [...latestByName.entries()];
+      let cursor = 0;
+      const workers = Array.from({ length: WARM_CONCURRENCY }).map(async () => {
+        while (cursor < targets.length) {
+          const [name, version] = targets[cursor++];
+          try {
+            await cdn.extractTarball(name, version);
+          } catch (err) {
+            console.error(
+              `[registry] failed to warm cache for ${name}@${version}:`,
+              err,
+            );
+          }
+        }
+      });
+      await Promise.all(workers);
+      console.log(`[registry] /packages warm-up done (${targets.length} pkgs)`);
+    } catch (err) {
+      console.error("[registry] /packages warm-up failed:", err);
+    } finally {
+      warmInFlight = false;
+      lastWarmAt = Date.now();
+    }
+  };
+}

--- a/packages/registry/tests/serve.test.ts
+++ b/packages/registry/tests/serve.test.ts
@@ -1,0 +1,297 @@
+import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { CdnCache, isExactVersion } from "../src/cdn.js";
+import {
+  DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME,
+  DEFAULT_STORAGE_DIR_NAME,
+} from "../src/constants.js";
+import { runRegistry } from "../src/run.js";
+
+const REGISTRY_PORT = 8281;
+const REGISTRY_URL = `http://localhost:${REGISTRY_PORT}`;
+const PKG_NAME = "serve-test-pkg";
+const PKG_VERSION = "1.0.0";
+const POLL_TIMEOUT = 15000;
+const POLL_INTERVAL = 200;
+
+let authToken: string;
+
+async function ensureTestUser(): Promise<void> {
+  if (authToken) return;
+  const res = await fetch(`${REGISTRY_URL}/-/user/org.couchdb.user:serveuser`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "serveuser", password: "servepassword" }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to create test user: ${res.status}`);
+  }
+  const body = (await res.json()) as { token?: string };
+  if (!body.token) {
+    throw new Error("Test user creation returned no token");
+  }
+  authToken = body.token;
+}
+
+/** Publish a package with a custom file so CDN streaming can be asserted. */
+async function publishPackage(
+  name: string,
+  version: string,
+  files: Record<string, string>,
+): Promise<void> {
+  const tmpDir = path.join(import.meta.dirname, ".tmp-serve-publish");
+  execSync(`rm -rf "${tmpDir}" && mkdir -p "${tmpDir}"`);
+  writeFileSync(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ name, version, description: "test" }),
+  );
+  for (const [relPath, content] of Object.entries(files)) {
+    const target = path.join(tmpDir, relPath);
+    execSync(`mkdir -p "${path.dirname(target)}"`);
+    writeFileSync(target, content);
+  }
+
+  const tarballName = execSync("npm pack --pack-destination .", {
+    cwd: tmpDir,
+    encoding: "utf-8",
+  }).trim();
+  const tarball = readFileSync(path.join(tmpDir, tarballName));
+  execSync(`rm -rf "${tmpDir}"`);
+
+  const shasum = createHash("sha1").update(tarball).digest("hex");
+  const tarballBase64 = tarball.toString("base64");
+  const shortName = name.startsWith("@") ? name.split("/")[1] : name;
+
+  const res = await fetch(`${REGISTRY_URL}/${encodeURIComponent(name)}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
+    },
+    body: JSON.stringify({
+      _id: name,
+      name,
+      "dist-tags": { latest: version },
+      versions: {
+        [version]: {
+          name,
+          version,
+          description: "test",
+          dist: {
+            tarball: `${REGISTRY_URL}/${name}/-/${shortName}-${version}.tgz`,
+            shasum,
+          },
+        },
+      },
+      _attachments: {
+        [`${shortName}-${version}.tgz`]: {
+          content_type: "application/octet-stream",
+          data: tarballBase64,
+          length: tarball.length,
+        },
+      },
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Publish failed (${res.status}): ${body}`);
+  }
+}
+
+describe("isExactVersion", () => {
+  it("returns true for concrete semver", () => {
+    expect(isExactVersion("1.0.0")).toBe(true);
+    expect(isExactVersion("10.20.30")).toBe(true);
+    expect(isExactVersion("1.2.3-dev.4")).toBe(true);
+    expect(isExactVersion("1.2.3+build.5")).toBe(true);
+  });
+
+  it("returns false for dist-tags and undefined", () => {
+    expect(isExactVersion("dev")).toBe(false);
+    expect(isExactVersion("latest")).toBe(false);
+    expect(isExactVersion("1.2")).toBe(false);
+    expect(isExactVersion(undefined)).toBe(false);
+    expect(isExactVersion("")).toBe(false);
+  });
+});
+
+// Real CdnCache pointed at a dead registry port: no mocks. Verifies the
+// resolveVersion contract the 503 fallback in middleware depends on — a
+// network failure throws (distinct from a 404 not-found), and the cached
+// fallback is found from disk.
+describe("resolveVersion upstream failure (real, dead upstream)", () => {
+  const testDir = import.meta.dirname;
+  const cacheDir = path.join(testDir, "./.test-output-resolve");
+
+  beforeAll(async () => {
+    await rm(cacheDir, { recursive: true, force: true });
+    await mkdir(cacheDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await rm(cacheDir, { recursive: true, force: true });
+  });
+
+  it("throws on a network error rather than returning null", async () => {
+    // Port 1 has nothing listening — fetch rejects.
+    const cdn = new CdnCache("http://127.0.0.1:1", cacheDir);
+    await expect(cdn.resolveVersion("any-pkg", "latest")).rejects.toThrow();
+  });
+
+  it("getLatestCachedVersion supplies the 503 fallback from disk", () => {
+    const cdn = new CdnCache("http://127.0.0.1:1", cacheDir);
+    expect(cdn.getLatestCachedVersion("cached-pkg")).toBeNull();
+    mkdirSync(path.join(cacheDir, "cached-pkg", "2.0.0"), { recursive: true });
+    mkdirSync(path.join(cacheDir, "cached-pkg", "1.0.0"), { recursive: true });
+    expect(cdn.getLatestCachedVersion("cached-pkg")).toBe("2.0.0");
+  });
+});
+
+describe("registry CDN serving", () => {
+  const testDir = import.meta.dirname;
+  const workDir = path.join(testDir, "./.test-output-serve");
+  let server: Awaited<ReturnType<typeof runRegistry>>;
+
+  beforeAll(async () => {
+    await rm(workDir, { recursive: true, force: true });
+    await mkdir(path.join(workDir, DEFAULT_STORAGE_DIR_NAME), {
+      recursive: true,
+    });
+    await mkdir(path.join(workDir, DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME), {
+      recursive: true,
+    });
+
+    server = await runRegistry({
+      port: REGISTRY_PORT,
+      storageDir: path.join(workDir, DEFAULT_STORAGE_DIR_NAME),
+      cdnCacheDir: path.join(workDir, DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME),
+      uplink: undefined,
+      s3Bucket: undefined,
+      s3Endpoint: undefined,
+      s3Region: undefined,
+      s3AccessKeyId: undefined,
+      s3SecretAccessKey: undefined,
+      s3KeyPrefix: undefined,
+      s3ForcePathStyle: true,
+      webEnabled: false,
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+    await ensureTestUser();
+    await publishPackage(PKG_NAME, PKG_VERSION, {
+      "index.js": "export const hello = 'serve';",
+      "data.wasm": "WASMBYTES",
+    });
+
+    // Wait for the CDN cache to be populated by the publish hook.
+    await vi.waitFor(
+      async () => {
+        const res = await fetch(
+          `${REGISTRY_URL}/-/cdn/${PKG_NAME}@${PKG_VERSION}/index.js`,
+        );
+        expect(res.ok).toBe(true);
+      },
+      { timeout: POLL_TIMEOUT, interval: POLL_INTERVAL },
+    );
+  }, 30000);
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it("serves file bytes with the correct Content-Type", async () => {
+    const res = await fetch(
+      `${REGISTRY_URL}/-/cdn/${PKG_NAME}@${PKG_VERSION}/index.js`,
+    );
+    expect(res.ok).toBe(true);
+    expect(res.headers.get("content-type")).toBe("application/javascript");
+    expect(await res.text()).toBe("export const hello = 'serve';");
+  });
+
+  it("uses the MIME_TYPES map for .wasm", async () => {
+    const res = await fetch(
+      `${REGISTRY_URL}/-/cdn/${PKG_NAME}@${PKG_VERSION}/data.wasm`,
+    );
+    expect(res.ok).toBe(true);
+    expect(res.headers.get("content-type")).toBe("application/wasm");
+    expect(await res.text()).toBe("WASMBYTES");
+  });
+
+  it("sets immutable Cache-Control for a version-pinned request", async () => {
+    const res = await fetch(
+      `${REGISTRY_URL}/-/cdn/${PKG_NAME}@${PKG_VERSION}/index.js`,
+    );
+    expect(res.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable",
+    );
+  });
+
+  it("sets revalidating Cache-Control for a dist-tag request", async () => {
+    const res = await fetch(
+      `${REGISTRY_URL}/-/cdn/${PKG_NAME}@latest/index.js`,
+    );
+    expect(res.ok).toBe(true);
+    expect(res.headers.get("cache-control")).toBe(
+      "public, max-age=60, must-revalidate",
+    );
+  });
+
+  it("sets revalidating Cache-Control for an untagged request", async () => {
+    const res = await fetch(`${REGISTRY_URL}/-/cdn/${PKG_NAME}/index.js`);
+    expect(res.ok).toBe(true);
+    expect(res.headers.get("cache-control")).toBe(
+      "public, max-age=60, must-revalidate",
+    );
+  });
+
+  it("returns 304 when If-None-Match matches the ETag", async () => {
+    const first = await fetch(
+      `${REGISTRY_URL}/-/cdn/${PKG_NAME}@${PKG_VERSION}/index.js`,
+    );
+    const etag = first.headers.get("etag");
+    expect(etag).toBeTruthy();
+    await first.text();
+
+    const second = await fetch(
+      `${REGISTRY_URL}/-/cdn/${PKG_NAME}@${PKG_VERSION}/index.js`,
+      { headers: { "If-None-Match": etag! } },
+    );
+    expect(second.status).toBe(304);
+    expect(await second.text()).toBe("");
+  });
+
+  it("returns 304 when If-None-Match is a list or wildcard", async () => {
+    const first = await fetch(
+      `${REGISTRY_URL}/-/cdn/${PKG_NAME}@${PKG_VERSION}/index.js`,
+    );
+    const etag = first.headers.get("etag");
+    await first.text();
+
+    const list = await fetch(
+      `${REGISTRY_URL}/-/cdn/${PKG_NAME}@${PKG_VERSION}/index.js`,
+      { headers: { "If-None-Match": `W/"other", ${etag!}` } },
+    );
+    expect(list.status).toBe(304);
+    await list.text();
+
+    const wildcard = await fetch(
+      `${REGISTRY_URL}/-/cdn/${PKG_NAME}@${PKG_VERSION}/index.js`,
+      { headers: { "If-None-Match": "*" } },
+    );
+    expect(wildcard.status).toBe(304);
+    await wildcard.text();
+  });
+
+  it("returns 404 for a genuinely missing package", async () => {
+    const res = await fetch(
+      `${REGISTRY_URL}/-/cdn/this-pkg-does-not-exist/index.js`,
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/registry/tests/warmup.test.ts
+++ b/packages/registry/tests/warmup.test.ts
@@ -1,0 +1,178 @@
+import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CdnCache } from "../src/cdn.js";
+import {
+  DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME,
+  DEFAULT_STORAGE_DIR_NAME,
+} from "../src/constants.js";
+import { runRegistry } from "../src/run.js";
+import type { RegistryConfig } from "../src/types.js";
+import { createWarmer } from "../src/warmup.js";
+
+const REGISTRY_PORT = 8282;
+const REGISTRY_URL = `http://localhost:${REGISTRY_PORT}`;
+
+let authToken: string;
+
+async function ensureTestUser(): Promise<void> {
+  if (authToken) return;
+  const res = await fetch(`${REGISTRY_URL}/-/user/org.couchdb.user:testuser`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "testuser", password: "testpassword" }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to create test user: ${res.status}`);
+  }
+  const body = (await res.json()) as { token?: string };
+  if (!body.token) {
+    throw new Error("Test user creation returned no token");
+  }
+  authToken = body.token;
+}
+
+/** Publish a real npm-pack tarball to the running registry. */
+async function publishPackage(name: string, version: string): Promise<void> {
+  const tmpDir = path.join(import.meta.dirname, ".tmp-warmup-publish");
+  execSync(`rm -rf "${tmpDir}" && mkdir -p "${tmpDir}"`);
+  writeFileSync(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ name, version, description: "warmup test" }),
+  );
+  writeFileSync(
+    path.join(tmpDir, "index.js"),
+    `export const v = "${version}";`,
+  );
+  const tarballName = execSync("npm pack --pack-destination .", {
+    cwd: tmpDir,
+    encoding: "utf-8",
+  }).trim();
+  const tarball = readFileSync(path.join(tmpDir, tarballName));
+  execSync(`rm -rf "${tmpDir}"`);
+
+  const shasum = createHash("sha1").update(tarball).digest("hex");
+  const shortName = name.startsWith("@") ? name.split("/")[1] : name;
+  const res = await fetch(`${REGISTRY_URL}/${encodeURIComponent(name)}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
+    },
+    body: JSON.stringify({
+      _id: name,
+      name,
+      "dist-tags": { latest: version },
+      versions: {
+        [version]: {
+          name,
+          version,
+          dist: {
+            tarball: `${REGISTRY_URL}/${name}/-/${shortName}-${version}.tgz`,
+            shasum,
+          },
+        },
+      },
+      _attachments: {
+        [`${shortName}-${version}.tgz`]: {
+          content_type: "application/octet-stream",
+          data: tarball.toString("base64"),
+          length: tarball.length,
+        },
+      },
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Publish failed (${res.status}): ${await res.text()}`);
+  }
+}
+
+describe("warmup", () => {
+  const testDir = import.meta.dirname;
+  const workDir = path.join(testDir, "./.test-output-warmup");
+  const storagePath = path.join(workDir, DEFAULT_STORAGE_DIR_NAME);
+  const cdnCachePath = path.join(workDir, DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME);
+  let server: Awaited<ReturnType<typeof runRegistry>>;
+
+  const config: RegistryConfig = {
+    port: REGISTRY_PORT,
+    storagePath,
+    cdnCachePath,
+  };
+  const cdn = new CdnCache(REGISTRY_URL, cdnCachePath);
+
+  beforeAll(async () => {
+    await rm(workDir, { recursive: true, force: true });
+    await mkdir(storagePath, { recursive: true });
+    await mkdir(cdnCachePath, { recursive: true });
+
+    server = await runRegistry({
+      port: REGISTRY_PORT,
+      storageDir: storagePath,
+      cdnCacheDir: cdnCachePath,
+      uplink: undefined,
+      s3Bucket: undefined,
+      s3Endpoint: undefined,
+      s3Region: undefined,
+      s3AccessKeyId: undefined,
+      s3SecretAccessKey: undefined,
+      s3KeyPrefix: undefined,
+      s3ForcePathStyle: true,
+      // Web API must be on for /-/verdaccio/data/packages to respond.
+      webEnabled: true,
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+    await ensureTestUser();
+
+    await publishPackage("warm-pkg-a", "1.0.0");
+    await publishPackage("warm-pkg-a", "2.0.0");
+    await publishPackage("warm-pkg-b", "0.1.0");
+  }, 60000);
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it("extracts only the latest version of each locally-published package", async () => {
+    // Clear anything the publish hook already extracted so we observe the
+    // warmer's own effect on an empty cache.
+    cdn.invalidate("warm-pkg-a");
+    cdn.invalidate("warm-pkg-b");
+    expect(existsSync(path.join(cdnCachePath, "warm-pkg-a"))).toBe(false);
+
+    const warm = createWarmer(config, cdn);
+    await warm();
+
+    // Latest version present for both packages.
+    expect(
+      existsSync(
+        path.join(cdnCachePath, "warm-pkg-a", "2.0.0", "package.json"),
+      ),
+    ).toBe(true);
+    expect(
+      existsSync(
+        path.join(cdnCachePath, "warm-pkg-b", "0.1.0", "package.json"),
+      ),
+    ).toBe(true);
+
+    // Older version is NOT warmed — it extracts lazily on demand instead.
+    expect(existsSync(path.join(cdnCachePath, "warm-pkg-a", "1.0.0"))).toBe(
+      false,
+    );
+  });
+
+  it("is a no-op within the throttle interval", async () => {
+    const warm = createWarmer(config, cdn);
+    await warm();
+    cdn.invalidate("warm-pkg-b");
+    // Second call inside the 30s window must not re-extract.
+    await warm();
+    expect(existsSync(path.join(cdnCachePath, "warm-pkg-b"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- `/-/cdn/*` sends `Cache-Control` (immutable for pinned versions, short TTL for moving tags), weak ETag + 304 support, and streams files instead of buffering
- `resolveVersion` throws on upstream failure so handlers return 503 (with cached fallback) instead of a cacheable 404
- Exact-version requests skip the packument lookup
- Warm-up extracts only locally-published latest versions (extracted to `src/warmup.ts`)

## Test plan
- `pnpm --filter @powerhousedao/registry test` — 42 passed, 3 skipped (includes new `serve.test.ts` covering cache headers, 304s, and upstream-error behavior)
- `tsc -b packages/registry` clean