### PR TITLE
fix(builder-tools): pass PH_CONNECT_BASE_PATH to vite base so connect serves under a path prefix

### DIFF
--- a/packages/builder-tools/connect-utils/vite-config.ts
+++ b/packages/builder-tools/connect-utils/vite-config.ts
@@ -1,6 +1,10 @@
 import type { PowerhouseConfig } from "@powerhousedao/config";
 import { getConfig } from "@powerhousedao/config/node";
-import { loadConnectEnv, setConnectEnv } from "@powerhousedao/shared/connect";
+import {
+  loadConnectEnv,
+  normalizeBasePath,
+  setConnectEnv,
+} from "@powerhousedao/shared/connect";
 import tailwind from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { realpathSync } from "node:fs";
@@ -315,8 +319,11 @@ export function getConnectBaseViteConfig(options: IConnectOptions) {
     configFile: false,
     mode,
     // Prefix served/built asset URLs so Connect can run under a path prefix
-    // (reverse proxy). Mirrors the client router basename.
-    base: env.PH_CONNECT_BASE_PATH,
+    // (reverse proxy). Mirrors the client router basename; normalize so a bare
+    // `app` or `/app` becomes `/app/` and matches the router.
+    base: env.PH_CONNECT_BASE_PATH
+      ? normalizeBasePath(env.PH_CONNECT_BASE_PATH)
+      : undefined,
     server: {
       watch: {
         ignored: ["**/backup-documents/**", "**/.ph/**"],

--- a/packages/builder-tools/connect-utils/vite-config.ts
+++ b/packages/builder-tools/connect-utils/vite-config.ts
@@ -314,6 +314,9 @@ export function getConnectBaseViteConfig(options: IConnectOptions) {
   const config: InlineConfig = {
     configFile: false,
     mode,
+    // Prefix served/built asset URLs so Connect can run under a path prefix
+    // (reverse proxy). Mirrors the client router basename.
+    base: env.PH_CONNECT_BASE_PATH,
     server: {
       watch: {
         ignored: ["**/backup-documents/**", "**/.ph/**"],


### PR DESCRIPTION
## Problem

Connect's `--base` flag (`connectBasePath`, env `PH_CONNECT_BASE_PATH`) was only half-plumbed:

- The env var is parsed into the Connect env schema (`packages/shared/connect/env-config.ts`) and `ph-cli` assigns it (`clis/ph-cli/src/utils/assign-env-vars.ts`).
- Connect's client runtime reads it for the router basename (`apps/connect/src/connect.config.ts`).
- BUT `getConnectBaseViteConfig` (`packages/builder-tools/connect-utils/vite-config.ts`) never set Vite's own `base`, so the dev server emitted index HTML asset URLs root-relative (`/@vite/client`, `/main.tsx`, `/style.css`). Serving the app behind a reverse-proxy path prefix therefore broke — the flag was ineffective for the actual serving layer.

## Fix

One line in the returned `InlineConfig`:

```ts
base: env.PH_CONNECT_BASE_PATH,
```

`env` is the result of `loadConnectEnv(...)` already computed in the function; `PH_CONNECT_BASE_PATH` is already in the env schema. When unset, `base` is `undefined` and Vite keeps its default (`/`), so no behavior change for the common case.

## Build path

The build command (`clis/ph-cli/src/services/connect-build.ts` → `runConnectBuild`) builds its config from `getConnectBaseViteConfig(...)` and only `mergeConfig`s a `build.outDir` override on top. It does not set `base` separately, so it inherits this fix and `ph connect build` now also prefixes built asset URLs when `PH_CONNECT_BASE_PATH` is set. No separate change needed there.

## Validation

Empirically tested by patching the installed dist in a consumer project, then running `ph vetra --base /testbase/`:

- App serves at `/testbase/` with all asset URLs prefixed (`/testbase/@vite/client`, `/testbase/main.tsx`).
- Prefixed asset fetches return 200.
- `/` 302-redirects into the base.
- Without the line, asset URLs stay root-relative and the prefixed paths 404.

Sanity build: `pnpm --filter @powerhousedao/builder-tools build` passes.

## Motivation

Serving project Connect behind vetra-cli's embedded reverse proxy under `/reactor-project/vetra-studio/`.