### PR TITLE
fix(renown): export credential module from node entrypoint

### DIFF
--- a/packages/renown/src/node.ts
+++ b/packages/renown/src/node.ts
@@ -1,4 +1,5 @@
 export * from "./common.js";
+export * from "./credential.js";
 export * from "./crypto/node.js";
 export * from "./event/event.node.js";
 export * from "./init.node.js";


### PR DESCRIPTION
## Summary
Follow-up to #2674: `src/index.ts` re-exports the new credential module but `src/node.ts` didn't, so `@renown/sdk/node` consumers couldn't see `buildAndSignCredential`/`verifyCredentialSignature`/`recoverCredentialSigner`. The module is platform-agnostic (viem only), so it belongs in both entrypoints.

## Test plan
- Built and verified `import('@renown/sdk/node')` exposes all three functions
- `pnpm --filter @renown/sdk test` — 80 passed