### PR TITLE
fix(registry): address remaining CDN review feedback

### DIFF
--- a/packages/registry/src/cdn.ts
+++ b/packages/registry/src/cdn.ts
@@ -37,7 +37,12 @@ export function parsePackageSpec(spec: string): {
 
 /** True when tag is a concrete semver, false for dist-tag names or undefined. */
 export function isExactVersion(tag?: string): boolean {
-  return !!tag && /^\d+\.\d+\.\d+(?:[-+].+)?$/.test(tag);
+  // Strict semver charset: the version flows into the ETag header, so
+  // arbitrary characters after the prerelease/build separator must not match.
+  return (
+    !!tag &&
+    /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(tag)
+  );
 }
 
 export class CdnCache {

--- a/packages/registry/src/middleware.ts
+++ b/packages/registry/src/middleware.ts
@@ -66,16 +66,22 @@ async function resolvePackageVersion(
   }
 }
 
+/** Strip the weak-validator prefix: weak comparison is correct for GET/HEAD. */
+function opaqueTag(tag: string): string {
+  return tag.startsWith("W/") ? tag.slice(2) : tag;
+}
+
 /** RFC 9110 If-None-Match: a comma-separated list of entity-tags or "*". */
 function etagMatches(
   header: string | string[] | undefined,
   etag: string,
 ): boolean {
   if (!header) return false;
+  const target = opaqueTag(etag);
   const value = Array.isArray(header) ? header.join(",") : header;
   return value.split(",").some((candidate) => {
     const tag = candidate.trim();
-    return tag === etag || tag === "*";
+    return tag === "*" || opaqueTag(tag) === target;
   });
 }
 

--- a/packages/registry/src/warmup.ts
+++ b/packages/registry/src/warmup.ts
@@ -67,11 +67,13 @@ export function createWarmer(
       });
       await Promise.all(workers);
       console.log(`[registry] /packages warm-up done (${targets.length} pkgs)`);
+      // Throttle only after a successful cycle so failures (e.g. registry
+      // not listening yet during startup) retry on the next call.
+      lastWarmAt = Date.now();
     } catch (err) {
       console.error("[registry] /packages warm-up failed:", err);
     } finally {
       warmInFlight = false;
-      lastWarmAt = Date.now();
     }
   };
 }

--- a/packages/registry/tests/serve.test.ts
+++ b/packages/registry/tests/serve.test.ts
@@ -117,6 +117,13 @@ describe("isExactVersion", () => {
     expect(isExactVersion(undefined)).toBe(false);
     expect(isExactVersion("")).toBe(false);
   });
+
+  it("rejects non-semver characters that could reach the ETag header", () => {
+    expect(isExactVersion('1.2.3-"evil"')).toBe(false);
+    expect(isExactVersion("1.2.3-a b")).toBe(false);
+    expect(isExactVersion("1.2.3-x\r\ny")).toBe(false);
+    expect(isExactVersion("1.2.3+x;y")).toBe(false);
+  });
 });
 
 // Real CdnCache pointed at a dead registry port: no mocks. Verifies the
@@ -286,6 +293,14 @@ describe("registry CDN serving", () => {
     );
     expect(wildcard.status).toBe(304);
     await wildcard.text();
+
+    // RFC 9110 weak comparison: the strong form of a weak ETag still matches.
+    const strong = await fetch(
+      `${REGISTRY_URL}/-/cdn/${PKG_NAME}@${PKG_VERSION}/index.js`,
+      { headers: { "If-None-Match": etag!.replace(/^W\//, "") } },
+    );
+    expect(strong.status).toBe(304);
+    await strong.text();
   });
 
   it("returns 404 for a genuinely missing package", async () => {

--- a/packages/registry/tests/warmup.test.ts
+++ b/packages/registry/tests/warmup.test.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { CdnCache } from "../src/cdn.js";
 import {
   DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME,
@@ -174,5 +174,20 @@ describe("warmup", () => {
     // Second call inside the 30s window must not re-extract.
     await warm();
     expect(existsSync(path.join(cdnCachePath, "warm-pkg-b"))).toBe(false);
+  });
+
+  it("does not throttle retries after a failed warm-up", async () => {
+    // Port 1 has nothing listening, so every cycle fails.
+    const warm = createWarmer({ ...config, port: 1 }, cdn);
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await warm();
+      await warm();
+      // Both calls attempted (and failed) — a failure must not start the
+      // 30s throttle window.
+      expect(spy).toHaveBeenCalledTimes(2);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to #2675 — three review comments landed minutes before the merge:

- **`isExactVersion` strict semver charset**: `(?:[-+].+)?` matched arbitrary characters (quotes, whitespace, CR/LF) after the prerelease separator, classifying junk as pinned and letting it reach the `ETag` header
- **Weak ETag comparison**: `etagMatches` now strips the `W/` prefix per RFC 9110 (weak comparison is correct for GET/HEAD), so clients sending the strong form still get 304s
- **Warm-up throttle on failure**: `lastWarmAt` was set in `finally`, so a failed cycle (e.g. registry not listening during startup) throttled retries for 30s; now it's set only after a successful cycle

## Test plan
- New tests: non-semver charset rejection, strong-form If-None-Match 304, failed warm-up not throttled
- `pnpm --filter @powerhousedao/registry test` — 45 passed, 3 skipped
- `tsc -b` + eslint clean