### PR TITLE
fix(builder-tools): make dev vite plugin URLs base-path-aware

### DIFF
--- a/packages/builder-tools/connect-utils/vite-plugins/dev-external-react.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/dev-external-react.ts
@@ -10,8 +10,14 @@ const REACT_DEPS = [
   "react-dom/client",
 ];
 
-const SHIM_PREFIX = "/__ph/dev-react-shim/";
-const VITE_DEPS_PREFIX = "/node_modules/.vite/deps";
+const SHIM_PATH = "__ph/dev-react-shim/";
+const VITE_DEPS_PATH = "node_modules/.vite/deps";
+
+// Vite serves dev module URLs under the resolved `base`. Join base + path
+// while collapsing the double slash so `base: "/"` stays byte-identical.
+function withBase(base: string, p: string): string {
+  return `${base}${p}`.replace(/\/{2,}/g, "/");
+}
 
 /**
  * Dev-only sibling of `esmExternalRequirePlugin`. The build path externalizes
@@ -32,11 +38,15 @@ const VITE_DEPS_PREFIX = "/node_modules/.vite/deps";
  */
 export function devReactImportmapPlugin(): Plugin {
   let namedExports = new Map<string, string[]>();
+  let base = "/";
 
   return {
     name: "ph-dev-react-importmap",
     apply: "serve",
     config: () => ({ optimizeDeps: { include: REACT_DEPS } }),
+    configResolved(config) {
+      base = config.base;
+    },
     configureServer(server) {
       // Resolve React's named exports from the consumer project so we don't
       // hardcode lists that drift across React versions.
@@ -54,11 +64,12 @@ export function devReactImportmapPlugin(): Plugin {
         }),
       );
 
+      // Match the base-prefixed shim URL, and the bare path for robustness.
+      const shimPrefixes = [withBase(base, SHIM_PATH), `/${SHIM_PATH}`];
       server.middlewares.use((req, res, next) => {
-        if (!req.url?.startsWith(SHIM_PREFIX)) return next();
-        const id = req.url
-          .slice(SHIM_PREFIX.length)
-          .replace(/\.js(\?.*)?$/, "");
+        const prefix = shimPrefixes.find((p) => req.url?.startsWith(p));
+        if (!prefix) return next();
+        const id = req.url!.slice(prefix.length).replace(/\.js(\?.*)?$/, "");
         if (!REACT_DEPS.includes(id)) return next();
 
         const optimizer = server.environments.client.depsOptimizer;
@@ -72,7 +83,7 @@ export function devReactImportmapPlugin(): Plugin {
         }
 
         const browserHash = info.browserHash ?? optimizer.metadata.browserHash;
-        const depUrl = `${VITE_DEPS_PREFIX}/${path.basename(info.file)}?v=${browserHash}`;
+        const depUrl = `${withBase(base, VITE_DEPS_PATH)}/${path.basename(info.file)}?v=${browserHash}`;
         const names = namedExports.get(id) ?? [];
 
         res.setHeader("Content-Type", "application/javascript");
@@ -92,10 +103,11 @@ export function devReactImportmapPlugin(): Plugin {
         const browserHash =
           ctx.server?.environments.client.depsOptimizer?.metadata.browserHash;
         if (!browserHash) return;
+        const shimPrefix = withBase(base, SHIM_PATH);
         const imports = Object.fromEntries(
           REACT_DEPS.map((id) => [
             id,
-            `${SHIM_PREFIX}${id}.js?v=${browserHash}`,
+            `${shimPrefix}${id}.js?v=${browserHash}`,
           ]),
         );
         return html.replace(

--- a/packages/builder-tools/connect-utils/vite-plugins/favicon.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/favicon.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import type { Plugin } from "vite";
+import type { Connect, Plugin } from "vite";
 
 /**
  * Vite plugin to serve the Connect favicon (icon.ico) from the connect package.
@@ -9,16 +9,11 @@ export function connectFaviconPlugin(): Plugin {
   return {
     name: "copy-connect-favicon",
     configureServer(server) {
-      // Vite rewrites the favicon link against `base`, so match the
+      // Vite rewrites the favicon link against `base`, so serve the
       // base-prefixed path. Keep the bare path for robustness.
       const base = server.config.base;
       const faviconPath = `${base}icon.ico`.replace(/\/{2,}/g, "/");
-      // Serve icon.ico before Vite's static middleware so it acts as a fallback
-      server.middlewares.use((req, res, next) => {
-        const pathname = req.url?.split("?")[0];
-        if (pathname !== faviconPath && pathname !== "/icon.ico") {
-          return next();
-        }
+      const handler: Connect.NextHandleFunction = (_req, res, next) => {
         server.pluginContainer
           .resolveId("@powerhousedao/connect/assets/icon.ico")
           .then((resolved) => {
@@ -27,7 +22,14 @@ export function connectFaviconPlugin(): Plugin {
             res.end(readFileSync(resolved.id));
           })
           .catch(() => next());
-      });
+      };
+      // Mount on the exact route(s) so the handler only runs for icon.ico.
+      // Connect strips the mount prefix before matching, so mounting on
+      // "/icon.ico" matches that path exactly.
+      const paths = new Set([faviconPath, "/icon.ico"]);
+      for (const path of paths) {
+        server.middlewares.use(path, handler);
+      }
     },
     async generateBundle(_options, bundle) {
       try {

--- a/packages/builder-tools/connect-utils/vite-plugins/favicon.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/favicon.ts
@@ -9,8 +9,16 @@ export function connectFaviconPlugin(): Plugin {
   return {
     name: "copy-connect-favicon",
     configureServer(server) {
+      // Vite rewrites the favicon link against `base`, so match the
+      // base-prefixed path. Keep the bare path for robustness.
+      const base = server.config.base;
+      const faviconPath = `${base}icon.ico`.replace(/\/{2,}/g, "/");
       // Serve icon.ico before Vite's static middleware so it acts as a fallback
-      server.middlewares.use("/icon.ico", (_req, res, next) => {
+      server.middlewares.use((req, res, next) => {
+        const pathname = req.url?.split("?")[0];
+        if (pathname !== faviconPath && pathname !== "/icon.ico") {
+          return next();
+        }
         server.pluginContainer
           .resolveId("@powerhousedao/connect/assets/icon.ico")
           .then((resolved) => {


### PR DESCRIPTION
## Symptom

When Connect's dev server runs under a Vite `base` (e.g. `ph vetra --base /reactor-project/vetra-studio/`, behind a path-prefix reverse proxy), dynamic package loading breaks. Firefox reports:

> Loading module from "http://localhost:8090/__ph/dev-react-shim/react.js?v=..." was blocked because of a disallowed MIME type ("text/html")

followed by `[Connect][PackageManager] Failed to install package "@powerhousedao/clint-common"`. The favicon also 404s.

## Cause

Two builder-tools dev Vite plugins emitted and matched **root-relative** URLs that ignore the resolved `base`:

- `devReactImportmapPlugin` (`connect-utils/vite-plugins/dev-external-react.ts`) wrote the React importmap to `/__ph/dev-react-shim/<dep>.js?v=...` and the shim re-imported from `/node_modules/.vite/deps/...`. Behind a prefix proxy these fall outside the app's path prefix, hit a different upstream, and return HTML (hence the MIME-type module block).
- `connectFaviconPlugin` (`connect-utils/vite-plugins/favicon.ts`) mounted its middleware at the bare `/icon.ico`, but Vite rewrites the favicon `<link>` against `base`, so the request never matched.

## Fix

- Resolve `base` via `configResolved` (importmap plugin) / `server.config.base` (favicon plugin).
- Prefix the emitted importmap shim URLs, the shim's vite-deps import URL, and the favicon route with the resolved `base`.
- Dev middleware still matches the bare path in addition to the base-prefixed path for robustness.

`ph-packages.json` middleware already matched via `endsWith("/ph-packages.json")`, which the base-prefixed URL satisfies, so it is left unchanged.

## No-change guarantee for `base: "/"`

All base joins collapse the leading double slash, so with `base: "/"` every emitted URL and matched route is byte-identical to before this change.

## Scope

`packages/builder-tools` only. The `/__packages` and `/__packages/error` beacon endpoints mentioned in the report live in `apps/connect` / `packages/reactor-browser`, which are owned by sibling worktrees and intentionally untouched here.

## Verification

`pnpm --filter @powerhousedao/builder-tools build` passes.