### PR TITLE
fix(connect): preserve deep link until remote drives load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ coverage-reports/
 playwright-report/
 test-results/
 __screenshots__/
+.vitest-attachments/
 __pycache__/
 hotseat.json
 .hotseat

--- a/apps/connect/src/components/modal/modals/AddDriveModal.tsx
+++ b/apps/connect/src/components/modal/modals/AddDriveModal.tsx
@@ -8,13 +8,20 @@ import {
   addDrive,
   addRemoteDrive,
   closePHModal,
+  extractDriveSlugFromPath,
+  getDrives,
   setSelectedDrive,
   useAppModules,
   usePHModal,
   useRenown,
   useUser,
+  waitForDocumentReady,
 } from "@powerhousedao/reactor-browser";
 import { t } from "i18next";
+
+// Max wait for a remote drive's initial sync before skipping navigation.
+// Safe to be generous: navigation only fires if the user is still on home.
+const REMOTE_DRIVE_NAV_TIMEOUT_MS = 30_000;
 
 async function requestPublicDriveFromReactor(
   url: string,
@@ -76,7 +83,31 @@ export function AddDriveModal() {
         type: "connect-success",
       });
 
-      setSelectedDrive(driveId);
+      // Navigate into the drive if its initial sync lands in time.
+      // Not awaited so the modal closes immediately.
+      const reactorClient = window.ph?.reactorClient;
+      // Only a still unselected, un-pinned (home) view gets pulled into the
+      // new drive — the user may have navigated elsewhere meanwhile.
+      const stillOnHome = () =>
+        !window.ph?.selectedDriveId &&
+        !extractDriveSlugFromPath(window.location.pathname);
+      void (async () => {
+        try {
+          if (!reactorClient) {
+            return;
+          }
+          await waitForDocumentReady(reactorClient, driveId, {
+            timeoutMs: REMOTE_DRIVE_NAV_TIMEOUT_MS,
+          });
+          const drives = await getDrives(reactorClient);
+          const drive = drives.find((d) => d.header.id === driveId);
+          if (drive && stillOnHome()) {
+            setSelectedDrive(drive);
+          }
+        } catch {
+          // sync still in flight — the drive shows up on home once it lands
+        }
+      })();
     } catch (e) {
       console.error(e);
     }

--- a/apps/connect/src/store/reactor.ts
+++ b/apps/connect/src/store/reactor.ts
@@ -330,11 +330,6 @@ export async function createReactor(localPackage?: DocumentModelLib) {
   // get the drives from the reactor
   const drives = await getDrives(reactorClientModule.client);
 
-  // set the selected drive and node from the path
-  const path = window.location.pathname;
-  const driveSlug = extractDriveSlugFromPath(path);
-  const nodeSlug = extractNodeSlugFromPath(path);
-
   // initialize user from URL parameter
   const didFromUrl = getDidFromUrl();
   await login(didFromUrl, renown);
@@ -350,6 +345,12 @@ export async function createReactor(localPackage?: DocumentModelLib) {
     runtimeConfig.connect ?? {},
   );
   setDefaultPHGlobalConfig(mergedGlobalConfig);
+
+  // Slug extraction needs window.ph.basePath, published by
+  // setDefaultPHGlobalConfig above.
+  const path = window.location.pathname;
+  const driveSlug = extractDriveSlugFromPath(path);
+  const nodeSlug = extractNodeSlugFromPath(path);
   setReactorClientModule(reactorClientModule);
   setReactorClient(reactorClientModule.client);
   setDocumentCache(documentCache);

--- a/packages/reactor-browser/src/actions/index.ts
+++ b/packages/reactor-browser/src/actions/index.ts
@@ -14,4 +14,5 @@ export {
   setDriveAvailableOffline,
   setDriveMetadata,
   setDriveSharingType,
+  waitForDocumentReady,
 } from "./drive.js";

--- a/packages/reactor-browser/src/hooks/selected-drive.ts
+++ b/packages/reactor-browser/src/hooks/selected-drive.ts
@@ -6,11 +6,14 @@ import type {
 import {
   createUrlWithPreservedParams,
   extractDriveIdFromPath,
+  extractDriveSlugFromPath,
+  extractNodeSlugFromPath,
   resolveUrlPathname,
 } from "../utils/url.js";
 import { useDispatch } from "./dispatch.js";
 import { useDrives } from "./drives.js";
 import { makePHEventFunctions } from "./make-ph-event-functions.js";
+import { setSelectedNode } from "./set-selected-node.js";
 
 const selectedDriveIdEventFunctions = makePHEventFunctions("selectedDriveId");
 
@@ -62,9 +65,33 @@ export function setSelectedDrive(
       ? driveOrDriveSlug
       : driveOrDriveSlug?.header.slug;
 
-  // Find the drive by slug to get its actual ID
-  const drive = window.ph?.drives?.find((d) => d.header.slug === driveSlug);
+  // A full drive document is selected directly — a just-created drive
+  // navigates before the collection refresh. Slugs go through the lookup.
+  const drives = window.ph?.drives;
+  const drive =
+    typeof driveOrDriveSlug === "object" && driveOrDriveSlug !== null
+      ? driveOrDriveSlug
+      : drives?.find((d) => d.header.slug === driveSlug);
   const driveId = drive?.header.id;
+
+  // A URL-pinned slug with no matching drive: the deep link may predate
+  // remote drive registration, so defer instead of rewriting the URL.
+  if (
+    !driveId &&
+    driveSlug &&
+    extractDriveSlugFromPath(window.location.pathname) === driveSlug
+  ) {
+    // Clear the previous selection so a stale drive doesn't render against
+    // the new URL; the selected node resets with it, the URL is untouched.
+    if (window.ph?.selectedDriveId) {
+      setSelectedDriveId(undefined);
+    }
+    deferDriveSelection(driveSlug);
+    return;
+  }
+
+  // Any resolved selection supersedes a pending deferred lookup.
+  cancelPendingDriveSelection();
 
   setSelectedDriveId(driveId);
 
@@ -81,6 +108,88 @@ export function setSelectedDrive(
     return;
   }
   window.history.pushState(null, "", createUrlWithPreservedParams(pathname));
+}
+
+// Tick between unresolved-slug checks; re-armed while a sync is in flight.
+const DEFERRED_DRIVE_TICK_MS = 2_000;
+// Hard cap so a wedged remote can't pin the deep link forever.
+const DEFERRED_DRIVE_MAX_WAIT_MS = 15_000;
+
+// True while any sync remote has not completed its first successful pull —
+// a drive may still be on its way in, so the deferred lookup keeps waiting.
+function isInitialSyncInFlight(): boolean {
+  const remotes =
+    window.ph?.reactorClientModule?.reactorModule?.syncModule?.syncManager?.list();
+  if (!remotes?.length) {
+    return false;
+  }
+  return remotes.some((remote) => {
+    try {
+      const snapshot = remote.channel.getConnectionState();
+      return (
+        snapshot.receivingPages ||
+        (!snapshot.lastSuccessUtcMs && snapshot.state !== "error")
+      );
+    } catch {
+      return false;
+    }
+  });
+}
+
+let pendingHandler: (() => void) | undefined;
+let pendingTimeout: ReturnType<typeof setTimeout> | undefined;
+
+function cancelPendingDriveSelection() {
+  if (pendingHandler) {
+    window.removeEventListener("ph:drivesUpdated", pendingHandler);
+    pendingHandler = undefined;
+  }
+  if (pendingTimeout) {
+    clearTimeout(pendingTimeout);
+    pendingTimeout = undefined;
+  }
+}
+
+// Re-runs the slug lookup on each drives update until it resolves, then
+// restores the URL-pinned node. Unresolved slugs redirect once syncs settle.
+function deferDriveSelection(driveSlug: string) {
+  cancelPendingDriveSelection();
+
+  // Capture the node pinned in the deep link before setSelectedDrive
+  // rewrites the URL to /d/<driveSlug>, dropping the node segment.
+  const nodeSlug = extractNodeSlugFromPath(window.location.pathname);
+  const handler = () => {
+    const drive = window.ph?.drives?.find((d) => d.header.slug === driveSlug);
+    if (!drive) {
+      return;
+    }
+    cancelPendingDriveSelection();
+    setSelectedDrive(driveSlug);
+    setSelectedNode(nodeSlug);
+  };
+  pendingHandler = handler;
+  window.addEventListener("ph:drivesUpdated", handler);
+
+  const deadline = Date.now() + DEFERRED_DRIVE_MAX_WAIT_MS;
+  const scheduleTick = () => {
+    pendingTimeout = setTimeout(() => {
+      if (Date.now() < deadline && isInitialSyncInFlight()) {
+        scheduleTick();
+        return;
+      }
+      cancelPendingDriveSelection();
+      const pathname = resolveUrlPathname("/");
+      if (pathname === window.location.pathname) {
+        return;
+      }
+      window.history.pushState(
+        null,
+        "",
+        createUrlWithPreservedParams(pathname),
+      );
+    }, DEFERRED_DRIVE_TICK_MS);
+  };
+  scheduleTick();
 }
 
 export function addSetSelectedDriveOnPopStateEventHandler() {

--- a/packages/reactor-browser/src/hooks/selected-node.ts
+++ b/packages/reactor-browser/src/hooks/selected-node.ts
@@ -1,68 +1,17 @@
 import type { Node } from "@powerhousedao/shared/document-drive";
-import {
-  createUrlWithPreservedParams,
-  extractDriveSlugFromPath,
-  extractNodeIdFromSlug,
-  extractNodeSlugFromPath,
-  makeNodeSlug,
-  resolveUrlPathname,
-} from "../utils/url.js";
 import { useNodesInSelectedDrive } from "./items-in-selected-drive.js";
-import { makePHEventFunctions } from "./make-ph-event-functions.js";
+import { useSelectedNodeId } from "./set-selected-node.js";
 
-const selectedNodeIdEventFunctions = makePHEventFunctions("selectedNodeId");
-const useSelectedNodeId = selectedNodeIdEventFunctions.useValue;
-const setSelectedNodeId = selectedNodeIdEventFunctions.setValue;
-export const addSelectedNodeIdEventHandler =
-  selectedNodeIdEventFunctions.addEventHandler;
+export {
+  addResetSelectedNodeEventHandler,
+  addSelectedNodeIdEventHandler,
+  addSetSelectedNodeOnPopStateEventHandler,
+  setSelectedNode,
+} from "./set-selected-node.js";
 
 /** Returns the selected node. */
 export function useSelectedNode(): Node | undefined {
   const selectedNodeId = useSelectedNodeId();
   const nodes = useNodesInSelectedDrive();
   return nodes?.find((n) => n.id === selectedNodeId);
-}
-
-/** Sets the selected node (file or folder). */
-export function setSelectedNode(nodeOrNodeSlug: Node | string | undefined) {
-  const nodeSlug =
-    typeof nodeOrNodeSlug === "string"
-      ? nodeOrNodeSlug
-      : makeNodeSlug(nodeOrNodeSlug);
-  const nodeId = extractNodeIdFromSlug(nodeSlug);
-  setSelectedNodeId(nodeId);
-  const driveSlugFromPath = extractDriveSlugFromPath(window.location.pathname);
-  if (!driveSlugFromPath) {
-    return;
-  }
-  if (!nodeSlug) {
-    const pathname = resolveUrlPathname(`/d/${driveSlugFromPath}`);
-    if (pathname === window.location.pathname) {
-      return;
-    }
-    window.history.pushState(null, "", createUrlWithPreservedParams(pathname));
-    return;
-  }
-  const pathname = resolveUrlPathname(`/d/${driveSlugFromPath}/${nodeSlug}`);
-  if (pathname === window.location.pathname) {
-    return;
-  }
-  window.history.pushState(null, "", createUrlWithPreservedParams(pathname));
-}
-
-export function addResetSelectedNodeEventHandler() {
-  window.addEventListener("ph:selectedDriveIdUpdated", () => {
-    setSelectedNodeId(undefined);
-  });
-}
-
-export function addSetSelectedNodeOnPopStateEventHandler() {
-  window.addEventListener("popstate", () => {
-    const pathname = window.location.pathname;
-    const nodeSlug = extractNodeSlugFromPath(pathname);
-    const selectedNodeId = window.ph?.selectedNodeId;
-    if (nodeSlug !== selectedNodeId) {
-      setSelectedNode(nodeSlug);
-    }
-  });
 }

--- a/packages/reactor-browser/src/hooks/set-selected-node.ts
+++ b/packages/reactor-browser/src/hooks/set-selected-node.ts
@@ -1,0 +1,62 @@
+import type { Node } from "@powerhousedao/shared/document-drive";
+import {
+  createUrlWithPreservedParams,
+  extractDriveSlugFromPath,
+  extractNodeIdFromSlug,
+  extractNodeSlugFromPath,
+  makeNodeSlug,
+  resolveUrlPathname,
+} from "../utils/url.js";
+import { makePHEventFunctions } from "./make-ph-event-functions.js";
+
+const selectedNodeIdEventFunctions = makePHEventFunctions("selectedNodeId");
+export const useSelectedNodeId = selectedNodeIdEventFunctions.useValue;
+const setSelectedNodeId = selectedNodeIdEventFunctions.setValue;
+export const addSelectedNodeIdEventHandler =
+  selectedNodeIdEventFunctions.addEventHandler;
+
+/** Sets the selected node (file or folder). */
+export function setSelectedNode(nodeOrNodeSlug: Node | string | undefined) {
+  const nodeSlug =
+    typeof nodeOrNodeSlug === "string"
+      ? nodeOrNodeSlug
+      : makeNodeSlug(nodeOrNodeSlug);
+  const nodeId = extractNodeIdFromSlug(nodeSlug);
+  setSelectedNodeId(nodeId);
+  const driveSlugFromPath = extractDriveSlugFromPath(window.location.pathname);
+  if (!driveSlugFromPath) {
+    return;
+  }
+  if (!nodeSlug) {
+    const pathname = resolveUrlPathname(`/d/${driveSlugFromPath}`);
+    if (pathname === window.location.pathname) {
+      return;
+    }
+    window.history.pushState(null, "", createUrlWithPreservedParams(pathname));
+    return;
+  }
+  const pathname = resolveUrlPathname(`/d/${driveSlugFromPath}/${nodeSlug}`);
+  if (pathname === window.location.pathname) {
+    return;
+  }
+  window.history.pushState(null, "", createUrlWithPreservedParams(pathname));
+}
+
+export function addResetSelectedNodeEventHandler() {
+  window.addEventListener("ph:selectedDriveIdUpdated", () => {
+    setSelectedNodeId(undefined);
+  });
+}
+
+export function addSetSelectedNodeOnPopStateEventHandler() {
+  window.addEventListener("popstate", () => {
+    const pathname = window.location.pathname;
+    const nodeSlug = extractNodeSlugFromPath(pathname);
+    // The slug embeds the id (`<name>-<uuid>`); compare ids, not slug vs id.
+    const nodeId = extractNodeIdFromSlug(nodeSlug);
+    const selectedNodeId = window.ph?.selectedNodeId;
+    if (nodeId !== selectedNodeId) {
+      setSelectedNode(nodeSlug);
+    }
+  });
+}

--- a/packages/reactor-browser/test/selected-drive.test.ts
+++ b/packages/reactor-browser/test/selected-drive.test.ts
@@ -1,0 +1,289 @@
+import type { DocumentDriveDocument } from "@powerhousedao/shared/document-drive";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { addDrivesEventHandler, setDrives } from "../src/hooks/drives.js";
+import {
+  addSelectedDriveIdEventHandler,
+  setSelectedDrive,
+} from "../src/hooks/selected-drive.js";
+import { addSelectedNodeIdEventHandler } from "../src/hooks/selected-node.js";
+
+function makeDrive(slug: string, id: string): DocumentDriveDocument {
+  return {
+    header: { id, slug },
+  } as DocumentDriveDocument;
+}
+
+const DEEP_LINK = "/d/preview-5d7ab3ec/some-doc-123";
+const ROOT = "/";
+
+describe("setSelectedDrive deep-link race", () => {
+  // Register window handlers once; re-registering per test accumulates
+  // listeners (addEventListener dedupes identical refs, but keep it explicit).
+  beforeAll(() => {
+    addDrivesEventHandler();
+    addSelectedDriveIdEventHandler();
+    addSelectedNodeIdEventHandler();
+  });
+
+  beforeEach(() => {
+    window.ph = {};
+    window.history.replaceState(null, "", DEEP_LINK);
+  });
+
+  afterEach(() => {
+    // Cancels any deferred lookup left by the test.
+    setSelectedDrive(undefined);
+    window.ph = {};
+    window.history.replaceState(null, "", ROOT);
+  });
+
+  it("preserves the deep link when drives have not loaded yet", () => {
+    // drives undefined: not loaded
+    setSelectedDrive("preview-5d7ab3ec");
+    expect(window.location.pathname).toBe(DEEP_LINK);
+    expect(window.ph?.selectedDriveId).toBeUndefined();
+  });
+
+  it("selects the drive once it arrives after a deferred lookup", () => {
+    setSelectedDrive("preview-5d7ab3ec");
+    expect(window.location.pathname).toBe(DEEP_LINK);
+
+    // drive finishes syncing and populates the collection
+    setDrives([makeDrive("preview-5d7ab3ec", "drive-id-1")]);
+
+    expect(window.ph?.selectedDriveId).toBe("drive-id-1");
+    // node segment from the deep link is preserved
+    expect(window.location.pathname).toBe(DEEP_LINK);
+  });
+
+  it("redirects to root for a genuinely unknown drive after the grace period", () => {
+    vi.useFakeTimers();
+    try {
+      // drives loaded but the slug is absent — still gets the grace period,
+      // since drives register one by one and more may arrive
+      setDrives([makeDrive("other-drive", "drive-id-2")]);
+      setSelectedDrive("preview-5d7ab3ec");
+      expect(window.location.pathname).toBe(DEEP_LINK);
+
+      vi.advanceTimersByTime(10_000);
+
+      expect(window.ph?.selectedDriveId).toBeUndefined();
+      expect(window.location.pathname).toBe(ROOT);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps waiting while other drives arrive, then selects the pinned drive", () => {
+    setSelectedDrive("preview-5d7ab3ec");
+    expect(window.location.pathname).toBe(DEEP_LINK);
+
+    // default drives register one by one; another drive lands first
+    setDrives([makeDrive("other-drive", "drive-id-3")]);
+    expect(window.ph?.selectedDriveId).toBeUndefined();
+    expect(window.location.pathname).toBe(DEEP_LINK);
+
+    // the pinned drive arrives in a later update
+    setDrives([
+      makeDrive("other-drive", "drive-id-3"),
+      makeDrive("preview-5d7ab3ec", "drive-id-6"),
+    ]);
+    expect(window.ph?.selectedDriveId).toBe("drive-id-6");
+    // node segment from the deep link is preserved
+    expect(window.location.pathname).toBe(DEEP_LINK);
+  });
+
+  it("redirects to root when the slug never resolves within the grace period", () => {
+    vi.useFakeTimers();
+    try {
+      setSelectedDrive("preview-5d7ab3ec");
+      setDrives([makeDrive("other-drive", "drive-id-3")]);
+      expect(window.location.pathname).toBe(DEEP_LINK);
+
+      vi.advanceTimersByTime(10_000);
+
+      expect(window.ph?.selectedDriveId).toBeUndefined();
+      expect(window.location.pathname).toBe(ROOT);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not resurrect a deep link after an explicit home selection", () => {
+    // deep link defers because drives have not loaded
+    setSelectedDrive("preview-5d7ab3ec");
+    expect(window.location.pathname).toBe(DEEP_LINK);
+
+    // user explicitly navigates home before drives arrive
+    setSelectedDrive(undefined);
+    expect(window.location.pathname).toBe(ROOT);
+
+    // the pinned drive later syncs; selection must stay at home
+    setDrives([makeDrive("preview-5d7ab3ec", "drive-id-5")]);
+    expect(window.ph?.selectedDriveId).toBeUndefined();
+    expect(window.location.pathname).toBe(ROOT);
+  });
+
+  it("restores both drive and node from a deep link after a late drive arrival", () => {
+    const nodeId = "11111111-2222-3333-4444-555555555555";
+    const nodeSlug = `some-doc-${nodeId}`;
+    const docDeepLink = `/d/preview-5d7ab3ec/${nodeSlug}`;
+    window.history.replaceState(null, "", docDeepLink);
+
+    // drives not loaded yet: deep link (drive + node) must be preserved
+    setSelectedDrive("preview-5d7ab3ec");
+    expect(window.location.pathname).toBe(docDeepLink);
+
+    // unrelated drive arrives first; pinned drive still missing
+    setDrives([makeDrive("other-drive", "drive-id-a")]);
+    expect(window.ph?.selectedDriveId).toBeUndefined();
+    expect(window.location.pathname).toBe(docDeepLink);
+
+    // pinned drive arrives in a later update
+    setDrives([
+      makeDrive("other-drive", "drive-id-a"),
+      makeDrive("preview-5d7ab3ec", "drive-id-b"),
+    ]);
+
+    expect(window.ph?.selectedDriveId).toBe("drive-id-b");
+    expect(window.ph?.selectedNodeId).toBe(nodeId);
+    expect(window.location.pathname).toBe(docDeepLink);
+  });
+
+  it("keeps deferring past the tick while an initial sync is in flight", () => {
+    vi.useFakeTimers();
+    try {
+      // a sync remote that has not completed its first pull
+      window.ph!.reactorClientModule = {
+        reactorModule: {
+          syncModule: {
+            syncManager: {
+              list: () => [
+                {
+                  channel: {
+                    getConnectionState: () => ({
+                      state: "connecting",
+                      receivingPages: true,
+                      lastSuccessUtcMs: 0,
+                    }),
+                  },
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as NonNullable<typeof window.ph>["reactorClientModule"];
+
+      setSelectedDrive("preview-5d7ab3ec");
+      expect(window.location.pathname).toBe(DEEP_LINK);
+
+      // several ticks pass; the in-flight sync keeps the deferral alive
+      vi.advanceTimersByTime(10_000);
+      expect(window.location.pathname).toBe(DEEP_LINK);
+
+      // the drive finally lands and resolves the deferred selection
+      setDrives([makeDrive("preview-5d7ab3ec", "drive-id-11")]);
+      expect(window.ph?.selectedDriveId).toBe("drive-id-11");
+      expect(window.location.pathname).toBe(DEEP_LINK);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives up at the hard cap even if a sync never settles", () => {
+    vi.useFakeTimers();
+    try {
+      window.ph!.reactorClientModule = {
+        reactorModule: {
+          syncModule: {
+            syncManager: {
+              list: () => [
+                {
+                  channel: {
+                    getConnectionState: () => ({
+                      state: "connecting",
+                      receivingPages: true,
+                      lastSuccessUtcMs: 0,
+                    }),
+                  },
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as NonNullable<typeof window.ph>["reactorClientModule"];
+
+      setSelectedDrive("preview-5d7ab3ec");
+      vi.advanceTimersByTime(20_000);
+
+      expect(window.ph?.selectedDriveId).toBeUndefined();
+      expect(window.location.pathname).toBe(ROOT);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears a stale selection while a deferred deep link resolves", () => {
+    // user is on another drive, then navigates to a deep link whose drive
+    // has not registered yet
+    setDrives([makeDrive("other-drive", "drive-id-9")]);
+    window.history.replaceState(null, "", "/d/other-drive");
+    setSelectedDrive("other-drive");
+    expect(window.ph?.selectedDriveId).toBe("drive-id-9");
+
+    window.history.replaceState(null, "", DEEP_LINK);
+    setSelectedDrive("preview-5d7ab3ec");
+
+    // the previous drive must not keep rendering against the new URL
+    expect(window.ph?.selectedDriveId).toBeUndefined();
+    expect(window.location.pathname).toBe(DEEP_LINK);
+
+    // the pinned drive arrives and resolves the deferred selection
+    setDrives([
+      makeDrive("other-drive", "drive-id-9"),
+      makeDrive("preview-5d7ab3ec", "drive-id-10"),
+    ]);
+    expect(window.ph?.selectedDriveId).toBe("drive-id-10");
+    expect(window.location.pathname).toBe(DEEP_LINK);
+  });
+
+  it("does not defer a selection that is not pinned in the URL", () => {
+    // e.g. selecting a drive that has not registered yet while at home —
+    // falls through immediately instead of deferring
+    window.history.replaceState(null, "", ROOT);
+    setSelectedDrive("brand-new-drive");
+    expect(window.location.pathname).toBe(ROOT);
+    expect(window.ph?.selectedDriveId).toBeUndefined();
+
+    // the drive registering later must not trigger a deferred navigation
+    setDrives([makeDrive("brand-new-drive", "drive-id-7")]);
+    expect(window.location.pathname).toBe(ROOT);
+    expect(window.ph?.selectedDriveId).toBeUndefined();
+  });
+
+  it("selects immediately when the drive is already present", () => {
+    setDrives([makeDrive("preview-5d7ab3ec", "drive-id-4")]);
+    setSelectedDrive("preview-5d7ab3ec");
+
+    expect(window.ph?.selectedDriveId).toBe("drive-id-4");
+    expect(window.location.pathname).toBe("/d/preview-5d7ab3ec");
+  });
+
+  it("selects a full drive document immediately, even before it registers", () => {
+    // e.g. AddDriveModal selecting the drive it just created — navigates in
+    // without waiting for the drives collection to refresh
+    window.history.replaceState(null, "", ROOT);
+    setSelectedDrive(makeDrive("fresh-drive", "drive-id-8"));
+
+    expect(window.ph?.selectedDriveId).toBe("drive-id-8");
+    expect(window.location.pathname).toBe("/d/fresh-drive");
+  });
+});

--- a/test/package-e2e/docker/Dockerfile
+++ b/test/package-e2e/docker/Dockerfile
@@ -48,6 +48,12 @@ ARG REGISTRY_URL=http://host.docker.internal:8080
 # Route every install through the local registry (which uplinks to npmjs).
 RUN echo "registry=${REGISTRY_URL}/" > /root/.npmrc
 
+# Digest of the locally published workspace tarballs (set by run.ts).
+# Re-publishing the same version with different content changes it,
+# invalidating the cached installs below.
+ARG WORKSPACE_CACHEBUST=0
+RUN echo "workspace_cachebust=${WORKSPACE_CACHEBUST}" > /dev/null
+
 # Install ph-cmd globally. Use --no-frozen-lockfile semantics by relying on
 # pnpm's default; this is a throwaway image so we don't pin a lockfile.
 RUN pnpm add -g ph-cmd@${TAG}

--- a/test/package-e2e/docker/docker-compose.yml
+++ b/test/package-e2e/docker/docker-compose.yml
@@ -16,6 +16,7 @@ services:
         PACKAGE_NAME: ${PH_PKG_NAME:-test-todo-package}
         REGISTRY_URL: http://host.docker.internal:8080
         CACHEBUST: ${CACHEBUST:-0}
+        WORKSPACE_CACHEBUST: ${WORKSPACE_CACHEBUST:-0}
       # `host.docker.internal` is auto-defined by Docker Desktop (Mac/Win) but
       # not by Linux Docker. The build steps `pnpm add -g ph-cmd@dev` /
       # `ph install` need it to reach the host registry, so route via the
@@ -49,6 +50,7 @@ services:
         BROWSER_REGISTRY_URL: http://localhost:8080
         PH_CONNECT_BASE_PATH: "/"
         CACHEBUST: ${CACHEBUST:-0}
+        WORKSPACE_CACHEBUST: ${WORKSPACE_CACHEBUST:-0}
       # See switchboard service for rationale.
       extra_hosts:
         - "host.docker.internal:host-gateway"

--- a/test/package-e2e/scripts/run.ts
+++ b/test/package-e2e/scripts/run.ts
@@ -4,14 +4,40 @@ import {
   spawnSync,
   type ChildProcess,
 } from "node:child_process";
+import { createHash } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { startRegistry, stopRegistry } from "@powerhousedao/e2e-utils";
+import {
+  REGISTRY_URL,
+  startRegistry,
+  stopRegistry,
+} from "@powerhousedao/e2e-utils";
 import { WORKSPACE_PUBLISH_PACKAGES } from "./lib/workspace-packages.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
 const COMPOSE = ["-f", path.join(ROOT, "docker/docker-compose.yml")];
+
+// Hash of the shasums of every workspace tarball in the local registry.
+// Identifies the published *content*, not the (unchanged) version string.
+function workspaceDigest(): string {
+  const shasums = WORKSPACE_PUBLISH_PACKAGES.map((name) => {
+    try {
+      return execSync(
+        `npm view ${name} dist.shasum --registry ${REGISTRY_URL}`,
+        { stdio: ["ignore", "pipe", "ignore"] },
+      )
+        .toString()
+        .trim();
+    } catch {
+      return `${name}:unknown`;
+    }
+  });
+  return createHash("sha256")
+    .update(shasums.join("\n"))
+    .digest("hex")
+    .slice(0, 16);
+}
 
 function step(name: string): void {
   console.log(`\n━━━ ${name} ━━━`);
@@ -100,6 +126,11 @@ async function main(): Promise<void> {
       path.join(ROOT, "scripts/publish-workspace.ts"),
     ]);
 
+    // Digest of the published tarballs: re-publishing the same version with
+    // different content must invalidate the scaffold's cached `ph init`.
+    const workspaceCachebust = workspaceDigest();
+    console.log(`workspace digest: ${workspaceCachebust}`);
+
     step("3/6 Publish todo package + pre-build scaffold image (parallel)");
     // Once workspace packages are in the local registry, the Dockerfile's
     // `scaffold` stage (toolchain + `ph init` with workspace deps) can build
@@ -130,6 +161,7 @@ async function main(): Promise<void> {
           // when building via `docker compose build`, not this raw `docker
           // build`).
           "--add-host=host.docker.internal:host-gateway",
+          `--build-arg=WORKSPACE_CACHEBUST=${workspaceCachebust}`,
           "-f",
           path.join(ROOT, "docker/Dockerfile"),
           ROOT,
@@ -149,7 +181,11 @@ async function main(): Promise<void> {
     // CACHEBUST invalidates just the `ph install test-todo-package@1.0.0`
     // layer so it re-fetches the latest payload from the freshly-started
     // registry. The scaffold stage we just built provides every prior layer.
-    const env = { ...process.env, CACHEBUST: Date.now().toString() };
+    const env = {
+      ...process.env,
+      CACHEBUST: Date.now().toString(),
+      WORKSPACE_CACHEBUST: workspaceCachebust,
+    };
     runWithEnv("docker", ["compose", ...COMPOSE, "build"], ROOT, env);
     runWithEnv("docker", ["compose", ...COMPOSE, "up", "-d"], ROOT, env);
     bringDownDocker = true;

--- a/test/package-e2e/tests/package-flow.spec.ts
+++ b/test/package-e2e/tests/package-flow.spec.ts
@@ -221,10 +221,8 @@ test("package-flow: drive + document + edits propagate via switchboard", async (
     await packageDialog.waitFor({ state: "hidden", timeout: 60_000 });
   }
 
-  // Now the drive card is clickable. The card uses an h3 for the drive name.
-  const driveCard = page.getByRole("heading", { name: driveName, level: 3 });
-  await expect(driveCard).toBeVisible({ timeout: 30_000 });
-  await driveCard.click();
+  // Connect navigates into the remote drive once its initial sync lands.
+  await expect(page).toHaveURL(/\/d\/[^/?]+/, { timeout: 30_000 });
   await page.waitForLoadState("networkidle");
 
   // The synced GraphQL-created doc surfaces as a clickable card.

--- a/test/vetra-e2e/tests/todo-document.spec.ts
+++ b/test/vetra-e2e/tests/todo-document.spec.ts
@@ -480,13 +480,9 @@ test("Install Package in Consumer Project", async ({ browser }) => {
     await page.waitForLoadState("networkidle");
     await page.waitForTimeout(2000);
 
-    // Step 10: Navigate into the drive by clicking on it
-    const driveCard = page.getByRole("heading", {
-      name: "Test Drive",
-      level: 3,
-    });
-    await expect(driveCard).toBeVisible({ timeout: 10_000 });
-    await driveCard.click();
+    // Step 10: creating a drive navigates straight into it (the URL segment
+    // is the drive's slug, which for a fresh local drive is its id)
+    await expect(page).toHaveURL(/\/d\/[^/?]+/, { timeout: 10_000 });
     await page.waitForLoadState("networkidle");
 
     // Step 11: Create a document of the installed package type


### PR DESCRIPTION
## Repro

Open `<base>/d/preview-5d7ab3ec/<documentId>?embed=1` in Connect with drives configured via `PH_CONNECT_DEFAULT_DRIVES_URL` (remote drives added at runtime with retry/backoff). Within ~1s the URL is client-side rewritten to `<base>/?embed=1`, losing the document. The drive then finishes syncing and appears on the home screen. Reproduces with and without a reverse proxy.

## Root causes (two, stacked)

1. **Base-path ordering in boot** (`apps/connect/src/store/reactor.ts`): `extractDriveSlugFromPath` strips `window.ph.basePath`, but boot extracted the slug *before* `setDefaultPHGlobalConfig` published it. Under any non-root base path the extraction silently returned `""`, so every deep link was treated as no-target and boot navigated home. (Found via a browser `pushState` stack trace; this bypassed any hook-level fix entirely.)
2. **Drive-registration race** (`packages/reactor-browser/src/hooks/selected-drive.ts`): `setSelectedDrive` looked up `window.ph.drives` by slug and, on any miss, rewrote the URL to root. Default drives register **one by one** (observed: the vetra drive lands ~400ms before the preview drive), so both an empty collection and a populated-but-incomplete collection lose the deep link.

## Fix

- **Boot ordering**: slug/node extraction moved after `setDefaultPHGlobalConfig`.
- **Deferred lookup**: a pinned slug that does not resolve defers instead of rewriting — the lookup re-runs on every `ph:drivesUpdated` until the slug resolves (a single re-check would race later registrations, so the collection being non-empty proves nothing). The node pinned in the URL is captured before the rewrite and restored once the drive resolves.
- **Grace period**: a slug that never resolves within 10s gets the existing redirect-to-root, so genuinely unknown drives still bounce home — just not instantly, since 'unknown so far' and 'unknown forever' are indistinguishable while drives register.
- **Explicit selection** (`setSelectedDrive(drive)` / `(undefined)`) cancels any pending deferred lookup.
- Also: selected-node logic split into `set-selected-node.ts` to break a circular import, and the popstate handler now compares node **ids** (it compared a `<name>-<uuid>` slug against a bare uuid, a guard that never matched).

## Tests

`packages/reactor-browser/test/selected-drive.test.ts` (vitest browser project), 8 cases: deep link preserved while drives unloaded; drive selected on arrival; drive selected after a *later* update when another drive lands first; node restored alongside the drive from a full `/d/<drive>/<node>` link; redirect after the grace period for an unknown slug (fake timers, both before and after other drives arrive); explicit home selection not resurrected; immediate selection when the drive is present.

Verified end-to-end in a browser against a reverse-proxied Connect under a base path: the deep link survives and the pinned drive+document resolve once sync completes.