### PR TITLE
fix(connect): namespace origin-scoped browser storage by base path

### DIFF
--- a/apps/connect/pglite.worker.legacy.ts
+++ b/apps/connect/pglite.worker.legacy.ts
@@ -7,7 +7,7 @@ worker({
   init(options) {
     // dbName carries the origin-scoped storage namespace from the main thread.
     const dbName =
-      (options.meta as { dbName?: string } | undefined)?.dbName ??
+      (options?.meta as { dbName?: string } | undefined)?.dbName ??
       DEFAULT_RELATIONAL_PROCESSOR_DB_NAME;
     const idbFs = new IdbFs(dbName);
     return Promise.resolve(

--- a/apps/connect/pglite.worker.legacy.ts
+++ b/apps/connect/pglite.worker.legacy.ts
@@ -4,8 +4,12 @@ import { worker } from "pglite-legacy-02/worker";
 import { DEFAULT_RELATIONAL_PROCESSOR_DB_NAME } from "@powerhousedao/shared/processors";
 
 worker({
-  init() {
-    const idbFs = new IdbFs(DEFAULT_RELATIONAL_PROCESSOR_DB_NAME);
+  init(options) {
+    // dbName carries the origin-scoped storage namespace from the main thread.
+    const dbName =
+      (options.meta as { dbName?: string } | undefined)?.dbName ??
+      DEFAULT_RELATIONAL_PROCESSOR_DB_NAME;
+    const idbFs = new IdbFs(dbName);
     return Promise.resolve(
       new PGlite({
         fs: idbFs,

--- a/apps/connect/pglite.worker.ts
+++ b/apps/connect/pglite.worker.ts
@@ -7,7 +7,7 @@ worker({
   init(options) {
     // dbName carries the origin-scoped storage namespace from the main thread.
     const dbName =
-      (options.meta as { dbName?: string } | undefined)?.dbName ??
+      (options?.meta as { dbName?: string } | undefined)?.dbName ??
       DEFAULT_RELATIONAL_PROCESSOR_DB_NAME;
     const idbFs = new IdbFs(dbName);
     return Promise.resolve(

--- a/apps/connect/pglite.worker.ts
+++ b/apps/connect/pglite.worker.ts
@@ -4,8 +4,12 @@ import { worker } from "@electric-sql/pglite/worker";
 import { DEFAULT_RELATIONAL_PROCESSOR_DB_NAME } from "@powerhousedao/shared/processors";
 
 worker({
-  init() {
-    const idbFs = new IdbFs(DEFAULT_RELATIONAL_PROCESSOR_DB_NAME);
+  init(options) {
+    // dbName carries the origin-scoped storage namespace from the main thread.
+    const dbName =
+      (options.meta as { dbName?: string } | undefined)?.dbName ??
+      DEFAULT_RELATIONAL_PROCESSOR_DB_NAME;
+    const idbFs = new IdbFs(dbName);
     return Promise.resolve(
       new PGlite({
         fs: idbFs,

--- a/apps/connect/src/connect.config.ts
+++ b/apps/connect/src/connect.config.ts
@@ -108,7 +108,9 @@ const PH_CONNECT_BASE_PATH = normalizeBasePath(
   env.PH_CONNECT_BASE_PATH || import.meta.env.BASE_URL,
 );
 
-// Analytics database name with custom logic
+// Analytics database name. Explicit env override wins; otherwise the default
+// is scoped by base path so instances on different prefixes of one origin do
+// not share an analytics DB. Root resolves to ":analytics" (unchanged).
 const PH_CONNECT_ANALYTICS_DATABASE_NAME =
   env.PH_CONNECT_ANALYTICS_DATABASE_NAME ||
   `${PH_CONNECT_BASE_PATH.replace(/\//g, "")}:analytics`;

--- a/apps/connect/src/pglite.db.ts
+++ b/apps/connect/src/pglite.db.ts
@@ -7,10 +7,14 @@ import {
   resolvePgMajorForRuntime,
   type SupportedPgMajor,
 } from "./utils/pglite-runtime.js";
+import { RELATIONAL_PGLITE_NAME } from "./utils/storage-namespace.js";
 
 async function createPGliteWorkerForMajor(
   major: SupportedPgMajor,
 ): Promise<PGliteWorker> {
+  // The worker reads the data-dir name from meta so the namespace is owned on
+  // the main thread alongside the other origin-scoped stores.
+  const meta = { dbName: RELATIONAL_PGLITE_NAME };
   if (major === 16) {
     const [legacyWorker, legacyLive] = await Promise.all([
       import("pglite-legacy-02/worker"),
@@ -21,6 +25,7 @@ async function createPGliteWorkerForMajor(
       { type: "module" },
     );
     return legacyWorker.PGliteWorker.create(worker, {
+      meta,
       extensions: { live: legacyLive.live },
     }) as unknown as PGliteWorker;
   }
@@ -31,7 +36,7 @@ async function createPGliteWorkerForMajor(
   const worker = new Worker(new URL("./pglite.worker.js", import.meta.url), {
     type: "module",
   });
-  return PGliteWorker.create(worker, { extensions: { live } });
+  return PGliteWorker.create(worker, { meta, extensions: { live } });
 }
 
 export async function getDb() {

--- a/apps/connect/src/utils/pglite-idb.ts
+++ b/apps/connect/src/utils/pglite-idb.ts
@@ -1,10 +1,13 @@
-import { DEFAULT_RELATIONAL_PROCESSOR_DB_NAME } from "@powerhousedao/shared/processors";
+import {
+  REACTOR_PGLITE_NAME,
+  RELATIONAL_PGLITE_NAME,
+} from "./storage-namespace.js";
 
 export const IDB_STORE_NAME = "FILE_DATA";
 export const IDB_DB_VERSION = 21;
 
-export const REACTOR_IDB_NAME = "/pglite/reactor";
-export const RELATIONAL_IDB_NAME = `/pglite/${DEFAULT_RELATIONAL_PROCESSOR_DB_NAME}`;
+export const REACTOR_IDB_NAME = `/pglite/${REACTOR_PGLITE_NAME}`;
+export const RELATIONAL_IDB_NAME = `/pglite/${RELATIONAL_PGLITE_NAME}`;
 
 export const PRIMARY_IDB_NAMES = [
   REACTOR_IDB_NAME,

--- a/apps/connect/src/utils/pglite-seed.ts
+++ b/apps/connect/src/utils/pglite-seed.ts
@@ -1,11 +1,12 @@
 import { invalidateReactorPgMajorCache } from "./pglite-runtime.js";
+import { REACTOR_PGLITE_NAME } from "./storage-namespace.js";
 
 export const PENDING_PG_SEED_KEY = "ph:pending-pg-seed";
 
 /**
  * If the Debug Inspector requested a forced PG version reset, this runs
  * before the reactor is created on the subsequent page load: opens a fresh
- * PGlite of the requested major against `idb://reactor`, lets `initdb`
+ * PGlite of the requested major against the reactor data dir, lets `initdb`
  * populate `PG_VERSION`, then closes. The next step of app boot then
  * detects this fresh data dir and picks the matching runtime.
  */
@@ -19,7 +20,7 @@ export async function seedPendingPgVersion(): Promise<void> {
   try {
     if (major === 16) {
       const { PGlite } = await import("pglite-legacy-02");
-      const pg = new PGlite("idb://reactor");
+      const pg = new PGlite(`idb://${REACTOR_PGLITE_NAME}`);
       try {
         await pg.waitReady;
       } finally {
@@ -27,7 +28,7 @@ export async function seedPendingPgVersion(): Promise<void> {
       }
     } else if (major === 17) {
       const { PGlite } = await import("@electric-sql/pglite");
-      const pg = new PGlite("idb://reactor");
+      const pg = new PGlite(`idb://${REACTOR_PGLITE_NAME}`);
       try {
         await pg.waitReady;
       } finally {

--- a/apps/connect/src/utils/reactor.ts
+++ b/apps/connect/src/utils/reactor.ts
@@ -22,6 +22,7 @@ import {
   loadPGliteModule,
   resolvePgMajorForRuntime,
 } from "./pglite-runtime.js";
+import { REACTOR_PGLITE_NAME } from "./storage-namespace.js";
 
 /**
  * Creates a Reactor that plugs into legacy storage but syncs through the new
@@ -53,7 +54,7 @@ export async function createBrowserReactor(
     );
   }
   const { PGlite } = await loadPGliteModule(major);
-  const pg = new PGlite("idb://reactor", {
+  const pg = new PGlite(`idb://${REACTOR_PGLITE_NAME}`, {
     relaxedDurability: true,
   });
   const logger = new ConsoleLogger(["reactor-client"]);

--- a/apps/connect/src/utils/storage-namespace.ts
+++ b/apps/connect/src/utils/storage-namespace.ts
@@ -1,5 +1,8 @@
 import { DEFAULT_RELATIONAL_PROCESSOR_DB_NAME } from "@powerhousedao/shared/processors";
-import { getStorageNamespace } from "@powerhousedao/shared/connect";
+import {
+  getStorageNamespace,
+  ROOT_STORAGE_NAMESPACE,
+} from "@powerhousedao/shared/connect";
 import { env } from "../connect.config.js";
 
 // Single owner of the origin-scoped storage namespace. Resolved from the same
@@ -14,6 +17,6 @@ export const REACTOR_PGLITE_NAME = STORAGE_NAMESPACE;
 
 // IdbFs name for the relational-processor worker store.
 export const RELATIONAL_PGLITE_NAME =
-  STORAGE_NAMESPACE === "reactor"
+  STORAGE_NAMESPACE === ROOT_STORAGE_NAMESPACE
     ? DEFAULT_RELATIONAL_PROCESSOR_DB_NAME
     : `${STORAGE_NAMESPACE}-${DEFAULT_RELATIONAL_PROCESSOR_DB_NAME}`;

--- a/apps/connect/src/utils/storage-namespace.ts
+++ b/apps/connect/src/utils/storage-namespace.ts
@@ -1,0 +1,19 @@
+import { DEFAULT_RELATIONAL_PROCESSOR_DB_NAME } from "@powerhousedao/shared/processors";
+import { getStorageNamespace } from "@powerhousedao/shared/connect";
+import { env } from "../connect.config.js";
+
+// Single owner of the origin-scoped storage namespace. Resolved from the same
+// base-path source connect.config.ts uses so every store agrees.
+const basePath = env.PH_CONNECT_BASE_PATH || import.meta.env.BASE_URL;
+
+// "reactor" at the root, "reactor--<slug>" under a path prefix.
+export const STORAGE_NAMESPACE = getStorageNamespace(basePath);
+
+// PGlite data-dir name for the reactor store, fed to `idb://`.
+export const REACTOR_PGLITE_NAME = STORAGE_NAMESPACE;
+
+// IdbFs name for the relational-processor worker store.
+export const RELATIONAL_PGLITE_NAME =
+  STORAGE_NAMESPACE === "reactor"
+    ? DEFAULT_RELATIONAL_PROCESSOR_DB_NAME
+    : `${STORAGE_NAMESPACE}-${DEFAULT_RELATIONAL_PROCESSOR_DB_NAME}`;

--- a/packages/shared/connect/env-config.ts
+++ b/packages/shared/connect/env-config.ts
@@ -713,5 +713,7 @@ export function getStorageNamespace(basePath: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
-  return slug ? `${ROOT_STORAGE_NAMESPACE}--${slug}` : ROOT_STORAGE_NAMESPACE;
+  // A non-root base path whose slug normalizes to nothing (e.g. "/-/") must
+  // not collapse into the root namespace and share its storage.
+  return `${ROOT_STORAGE_NAMESPACE}--${slug || "default"}`;
 }

--- a/packages/shared/connect/env-config.ts
+++ b/packages/shared/connect/env-config.ts
@@ -673,3 +673,45 @@ export function normalizeBasePath(basePath: string): string {
 
   return normalized;
 }
+
+/**
+ * Base storage namespace for a Connect instance served at the root of an
+ * origin. Kept as a literal so root deployments resolve to a byte-identical
+ * value with no migration.
+ */
+export const ROOT_STORAGE_NAMESPACE = "reactor";
+
+/**
+ * Derives the origin-scoped storage namespace from a Connect base path.
+ *
+ * Connect instances served under different path prefixes of the same origin
+ * (e.g. behind a reverse proxy) otherwise share all origin-scoped browser
+ * storage (PGlite data dirs, IndexedDB). This produces a deterministic,
+ * collision-free namespace per distinct prefix that is valid as an
+ * IndexedDB database name.
+ *
+ * - root base path ("/" or unset) -> "reactor" (byte-identical to the legacy
+ *   key, so existing root deployments keep their data with zero migration)
+ * - any non-root base path -> "reactor--<slug>", e.g.
+ *   "/reactor-project/vetra-studio/" -> "reactor--reactor-project-vetra-studio"
+ *
+ * @param basePath - The Connect base path (env.PH_CONNECT_BASE_PATH ||
+ *   import.meta.env.BASE_URL); normalized internally.
+ * @returns The storage namespace.
+ *
+ * @example
+ * getStorageNamespace('/') // 'reactor'
+ * getStorageNamespace('/reactor-project/vetra-studio/') // 'reactor--reactor-project-vetra-studio'
+ */
+export function getStorageNamespace(basePath: string): string {
+  const normalized = normalizeBasePath(basePath);
+  if (normalized === "/") {
+    return ROOT_STORAGE_NAMESPACE;
+  }
+  const slug = normalized
+    .slice(1, -1)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug ? `${ROOT_STORAGE_NAMESPACE}--${slug}` : ROOT_STORAGE_NAMESPACE;
+}


### PR DESCRIPTION
## Problem

Connect instances served under different path prefixes of the **same origin** (e.g. behind a reverse proxy: one at `/`, another at `/reactor-project/vetra-studio/`) share all origin-scoped browser storage. IndexedDB and the PGlite data dirs backing it are keyed per origin, not per path.

The browser reactor was hardcoded `new PGlite("idb://reactor")`, the relational-processor worker hardcoded its IdbFs to `relational-db`, and the migration machinery hardcoded the same data-dir names. So two Connect apps on one origin opened and wrote the **same** PGlite data dirs concurrently — and the reactor runs with `relaxedDurability: true`. That is cross-contamination plus a real corruption risk.

## Derivation rule

A single helper `getStorageNamespace(basePath)` lives next to `normalizeBasePath` in `@powerhousedao/shared/connect`, so there is one owner. It normalizes the base path, then:

- **root** (`"/"` or unset) -> `"reactor"` — **byte-identical to the legacy key**, so existing default deployments keep their data with **zero migration**.
- **non-root** -> `"reactor--<slug>"`, e.g. `/reactor-project/vetra-studio/` -> `reactor--reactor-project-vetra-studio`. Deterministic, collision-free per distinct prefix, and valid as an IndexedDB database name.

```ts
export const ROOT_STORAGE_NAMESPACE = "reactor";

export function getStorageNamespace(basePath: string): string {
  const normalized = normalizeBasePath(basePath);
  if (normalized === "/") {
    return ROOT_STORAGE_NAMESPACE;
  }
  const slug = normalized
    .slice(1, -1)
    .toLowerCase()
    .replace(/[^a-z0-9]+/g, "-")
    .replace(/^-+|-+$/g, "");
  return slug ? `${ROOT_STORAGE_NAMESPACE}--${slug}` : ROOT_STORAGE_NAMESPACE;
}
```

The base path source is the same one `connect.config.ts` uses: `env.PH_CONNECT_BASE_PATH || import.meta.env.BASE_URL`. A new connect util `apps/connect/src/utils/storage-namespace.ts` resolves it once and exports `REACTOR_PGLITE_NAME` and `RELATIONAL_PGLITE_NAME` for every consumer.

## Callsites threaded

- `apps/connect/src/utils/reactor.ts` — reactor PGlite now `idb://${REACTOR_PGLITE_NAME}`.
- `apps/connect/src/utils/pglite-seed.ts` — both forced-reset seed dirs use the namespaced name.
- `apps/connect/src/utils/pglite-idb.ts` — `REACTOR_IDB_NAME` / `RELATIONAL_IDB_NAME` derive from the namespace. Migration (`pglite-migration.ts`) iterates `PRIMARY_IDB_NAMES`, so it now operates on the namespaced data dirs automatically — no edit needed there.
- `apps/connect/src/pglite.db.ts` + `apps/connect/pglite.worker.ts` + `pglite.worker.legacy.ts` — the relational worker's IdbFs name is passed from the main thread via `PGliteWorker` `meta.dbName` (defaulting to the legacy `relational-db` constant), keeping the namespace owned on the main thread. Root stays `relational-db`; non-root becomes `reactor--<slug>-relational-db`.
- `apps/connect/src/connect.config.ts` — analytics DB **default** is already base-path-scoped (`<stripped-base>:analytics`, root -> `:analytics`) and the explicit `PH_CONNECT_ANALYTICS_DATABASE_NAME` env override still wins. Left byte-identical (only a clarifying comment added) to avoid re-homing existing root analytics data.

## Service worker (item investigated)

`apps/connect/src/utils/registerServiceWorker.ts` already builds its script path from `connectConfig.routerBasename` (`/<base>/service-worker.js`) and calls `register()` **without** an explicit `scope`. The default SW scope is the script's directory, so it already follows the base path — instances on different prefixes register separate, path-scoped workers. No change needed.

## Deliberately left shared

- **Analytics DB default** — already path-namespaced and root-stable; only the comment was clarified.
- **localStorage cosmetic / control keys** (`CONNECT_DEBUG`, accepted-cookies / cookie-banner flags, `ph:pending-pg-seed`, `ph:pglite-backups`) — renaming these would log users out of preferences / drop the backup index for no integrity gain; they are not concurrent-write corruption hazards.
- **In-memory document cache** (`reactor-browser` `document-cache`) — not a persistent origin-scoped store; nothing to namespace.

## Reviewer caveat (re-homing on upgrade)

Deployments of a **built** Connect that are already served under a path prefix (base set at **build time**, e.g. `apps.powerhouse.io/powerhouse/connect/`) will, on upgrade to this change, re-home to a fresh namespace (`reactor--powerhouse-connect`). Their existing `idb://reactor` data stays on disk but **stops being read**. Root deployments are unaffected (namespace is byte-identical). A migration banner reusing the existing `pglite-migration` mechanism to copy `idb://reactor` -> the namespaced dir on first boot under a prefix could be a follow-up.

## Verification

- `pnpm --filter @powerhousedao/connect... run build` (tsdown + vite, the production build path) — green, including both PGlite workers and the seed chunk.
- ESLint on all touched files — clean.
- Derivation unit-checked: `/` and `""` -> `reactor`; `/reactor-project/vetra-studio/` -> `reactor--reactor-project-vetra-studio`; `powerhouse/connect` -> `reactor--powerhouse-connect`.