### PR TITLE
feat(connect): make packages live-reload SSE channel opt-in

### DIFF
--- a/apps/connect/src/store/reactor.ts
+++ b/apps/connect/src/store/reactor.ts
@@ -274,12 +274,14 @@ export async function createReactor(localPackage?: DocumentModelLib) {
     if (r.type === "error") console.error(r.error);
   });
 
-  // Subscribe to the static-mode `/__packages` SSE channel so live publishes
-  // (e.g. ph-clint's publish-reload trigger pushing a new list) flow into the
-  // running tab without a page reload. The channel only exists in static
-  // hosting; failures are silently ignored when running in vite dev or any
-  // host that doesn't speak this protocol.
-  subscribeToPackagesChannel(packageManager);
+  // Opt-in: subscribe to the static-mode `/__packages` SSE channel so live
+  // publishes (e.g. ph-clint's publish-reload trigger pushing a new list) flow
+  // into the running tab without a page reload. Enabled via
+  // `connect.packages.liveReload`; the channel only exists in static hosting
+  // that speaks this protocol.
+  if (runtimeConfig.connect?.packages?.liveReload) {
+    subscribeToPackagesChannel(packageManager);
+  }
 
   // get document models to set in the reactor (all versions)
   const documentModelModules = packageManager.packages

--- a/packages/builder-tools/connect-utils/runtime-config.schema.json
+++ b/packages/builder-tools/connect-utils/runtime-config.schema.json
@@ -115,6 +115,11 @@
               "type": "boolean",
               "description": "When false, Connect refuses to load any package that wasn't bundled at build time. Affirmative replacement for the legacy PH_CONNECT_EXTERNAL_PACKAGES_DISABLED env var.",
               "default": true
+            },
+            "liveReload": {
+              "type": "boolean",
+              "description": "When true, Connect subscribes to the static-mode `/__packages` SSE channel so live publishes flow into the running tab without a page reload. Only works under hosting that serves this channel (e.g. ph-clint static mode).",
+              "default": false
             }
           }
         },

--- a/packages/shared/clis/source-config.schema.json
+++ b/packages/shared/clis/source-config.schema.json
@@ -262,6 +262,11 @@
               "type": "boolean",
               "description": "When false, Connect refuses to load any package that wasn't bundled at build time. Affirmative replacement for the legacy PH_CONNECT_EXTERNAL_PACKAGES_DISABLED env var.",
               "default": true
+            },
+            "liveReload": {
+              "type": "boolean",
+              "description": "When true, Connect subscribes to the static-mode `/__packages` SSE channel so live publishes flow into the running tab without a page reload. Only works under hosting that serves this channel (e.g. ph-clint static mode).",
+              "default": false
             }
           }
         },

--- a/packages/shared/clis/types.ts
+++ b/packages/shared/clis/types.ts
@@ -64,6 +64,8 @@ export type PHConnectApp = {
 
 export type PHConnectPackages = {
   externalEnabled?: boolean;
+  /** Subscribe to the static-mode `/__packages` SSE channel for live reload. */
+  liveReload?: boolean;
 };
 
 export type PHConnectRenown = {

--- a/packages/shared/connect/runtime-config.ts
+++ b/packages/shared/connect/runtime-config.ts
@@ -35,6 +35,7 @@ export const DEFAULT_CONNECT_CONFIG: PHConnectRuntimeConfig = {
   },
   packages: {
     externalEnabled: true,
+    liveReload: false,
   },
   drives: {
     allowAddDrive: true,

--- a/packages/shared/connect/schema-fragments.ts
+++ b/packages/shared/connect/schema-fragments.ts
@@ -115,6 +115,12 @@ export const phConnectRuntimeConfigSchema = {
             "When false, Connect refuses to load any package that wasn't bundled at build time. Affirmative replacement for the legacy PH_CONNECT_EXTERNAL_PACKAGES_DISABLED env var.",
           default: true,
         },
+        liveReload: {
+          type: "boolean",
+          description:
+            "When true, Connect subscribes to the static-mode `/__packages` SSE channel so live publishes flow into the running tab without a page reload. Only works under hosting that serves this channel (e.g. ph-clint static mode).",
+          default: false,
+        },
       },
     },
     drives: {


### PR DESCRIPTION
## What

Gate the `/__packages` SSE subscription (`subscribeToPackagesChannel`) in Connect on a new runtime config flag `connect.packages.liveReload` (default `false`). Previously the channel was always attempted on every boot, best-effort, no-oping wherever the endpoint didn't exist.

## Why

Make the behavior explicit opt-in rather than an always-on best-effort connection. Only hosting that actually serves the channel (e.g. ph-clint static mode) needs it.

## Changes

- `apps/connect/src/store/reactor.ts` — wrap the call in `if (runtimeConfig.connect?.packages?.liveReload)`.
- `packages/shared/clis/types.ts` — add `liveReload?: boolean` to `PHConnectPackages`.
- `packages/shared/connect/runtime-config.ts` — add `liveReload: false` to `DEFAULT_CONNECT_CONFIG.packages`.
- `packages/shared/connect/schema-fragments.ts` — declare the field in the shared schema fragment.
- Regenerated committed JSON schemas (`runtime-config.schema.json`, `source-config.schema.json`) via `scripts/emit-schemas.ts`.

## Enabling

```json
{ "connect": { "packages": { "liveReload": true } } }
```

## Notes

- No CLI override flag added (unlike `--external-packages` for `externalEnabled`). Easy to add if wanted.
- Deployments relying on live reload (ph-clint static mode) must now set the flag. Defaulting it on for that path would be a separate change in ph-clint's config emission (not in this repo).

## Verification

- Connect typecheck clean.
- `runtime-config-schema.test.ts` passes (6/6).