### PR TITLE
docs(connect): document how to add a runtime config field

### DIFF
--- a/apps/connect/CLAUDE.md
+++ b/apps/connect/CLAUDE.md
@@ -1,0 +1,11 @@
+# Connect
+
+## Runtime configuration
+Connect reads all its runtime settings from a single `powerhouse.config.json`
+(fetched once at boot, no env vars in the SPA). To **add or change a
+`connect.*` config field**, follow the developer steps in
+[`RUNTIME-CONFIG.md`](./RUNTIME-CONFIG.md) — the TS types/defaults and the two
+committed `*.schema.json` files must stay in lockstep, which means rebuilding
+`@powerhousedao/shared` + `@powerhousedao/builder-tools` and running
+`pnpm tsx scripts/emit-schemas.ts`. That doc also covers the operator-facing
+precedence ladder (`defaults < source < CLI override`, plus deploy-time env).

--- a/apps/connect/RUNTIME-CONFIG.md
+++ b/apps/connect/RUNTIME-CONFIG.md
@@ -207,6 +207,46 @@ docker run -e PH_CONNECT_CONFIG_JSON='{
 **"I want to verify what Connect will actually use without booting it."**
 `ph connect config` (no args) prints the effective `connect.*` block (defaults merged with source). `ph connect config connect.renown.url` (or the equivalent `--get connect.renown.url`) prints a single value.
 
+## Adding or changing a config field (developers)
+
+A `connect.*` field has five artefacts that must stay in lockstep. The TS
+constants are the source of truth; the two committed `*.schema.json` files are
+generated from them. Miss a step and the schemas silently drift from the types.
+
+1. **Type** — `packages/shared/clis/types.ts`. Add the field to the relevant
+   `PHConnect*` type (e.g. `PHConnectPackages`).
+2. **Default** — `packages/shared/connect/runtime-config.ts`. Add the field's
+   default to `DEFAULT_CONNECT_CONFIG` so the SPA never sees it undefined.
+3. **Schema fragment** — `packages/shared/connect/schema-fragments.ts`. Declare
+   the field (type, description, `default`) in `phConnectRuntimeConfigSchema`.
+   Both committed schemas import this fragment, so declaring it once keeps the
+   source-config and runtime-config schemas in sync by construction.
+4. **Rebuild** the source-of-truth packages so the emit script sees the change:
+   ```bash
+   pnpm --filter=@powerhousedao/shared --filter=@powerhousedao/builder-tools build
+   ```
+5. **Regenerate** the committed JSON schemas:
+   ```bash
+   pnpm tsx scripts/emit-schemas.ts
+   ```
+   This rewrites `packages/builder-tools/connect-utils/runtime-config.schema.json`
+   and `packages/shared/clis/source-config.schema.json`. Commit both.
+
+Then consume it in the SPA via `getRuntimeConfig().connect?.<block>?.<field>`
+(or add a typed accessor in `apps/connect/src/connect.config.ts`).
+
+Optional, depending on the field:
+
+- **CLI flag** — to expose `ph connect config/build --<field>`, wire it through
+  `packages/shared/clis/args/connect.ts` and `clis/ph-cli/src/utils/cli-connect-override.ts`
+  (see `externalEnabled` → `--external-packages` for the pattern).
+- **Scaffold default** — if new projects should ship the field, add it to the
+  `ph init` template at `packages/codegen/src/templates/boilerplate/powerhouse.config.json.ts`.
+
+The `runtime-config-schema.test.ts` coverage test asserts every key emitted from
+`DEFAULT_CONNECT_CONFIG` has a matching schema declaration — it fails loudly if
+you add a default (step 2) but skip the schema fragment (step 3).
+
 ## Reference: key files
 
 ```

--- a/packages/builder-tools/CLAUDE.md
+++ b/packages/builder-tools/CLAUDE.md
@@ -1,0 +1,9 @@
+# @powerhousedao/builder-tools
+
+## Connect runtime config schema
+`connect-utils/runtime-config-schema.ts` is the source of truth for the
+Connect dist `powerhouse.config.json` JSON Schema; it imports field shapes from
+`@powerhousedao/shared`. The committed `connect-utils/runtime-config.schema.json`
+is **generated** — never hand-edit it. After changing a config field rebuild
+this package and run `pnpm tsx scripts/emit-schemas.ts` from the repo root.
+Full workflow: `apps/connect/RUNTIME-CONFIG.md` → "Adding or changing a config field".

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -1,0 +1,14 @@
+# @powerhousedao/shared
+
+## Connect runtime config
+Source of truth for Connect's `powerhouse.config.json`:
+- `clis/types.ts` — `PHConnect*` TS types.
+- `connect/schema-fragments.ts` — JSON Schema field shapes. `clis/source-config-schema.ts`
+  imports these to build `clis/source-config.schema.json`, which is **generated** —
+  never hand-edit it.
+- `connect/runtime-config.ts` — `DEFAULT_CONNECT_CONFIG` runtime defaults (merged
+  into the config at boot; not part of schema generation).
+
+After changing a config field, rebuild and run `pnpm tsx scripts/emit-schemas.ts`
+from the repo root. Full workflow: `apps/connect/RUNTIME-CONFIG.md` →
+"Adding or changing a config field".


### PR DESCRIPTION
## What

Follow-up to #2699. Documents the **developer workflow** for adding or changing a Connect `connect.*` runtime config field — the chain that #2699 had to be reverse-engineered to do correctly.

## Changes

- `apps/connect/RUNTIME-CONFIG.md` — new "Adding or changing a config field (developers)" section: TS type → `DEFAULT_CONNECT_CONFIG` default → `schema-fragments.ts` declaration → rebuild `shared` + `builder-tools` → `pnpm tsx scripts/emit-schemas.ts` to regenerate the two committed `*.schema.json` files. Plus optional CLI-flag and scaffold-default steps, and a note on the coverage test that catches drift.
- `apps/connect/CLAUDE.md`, `packages/shared/CLAUDE.md`, `packages/builder-tools/CLAUDE.md` — terse pointers to that section, flagging that the `*.schema.json` files are generated (never hand-edit).

`CLAUDE.md` is globally gitignored; these were `git add -f`'d, matching the existing tracked `packages/reactor/CLAUDE.md`.

## Why

The non-obvious part of the config system isn't setting values (already well documented for operators) — it's keeping the TS source of truth and the generated JSON schemas in lockstep. Miss the rebuild + regen and the committed schemas silently drift.