### PR TITLE
refactor: remove legacy attachment system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+.cache
 .tsbuild
 .out
 test/**/temp

--- a/apps/academy/docs/academy/04-APIReferences/09-AttachmentService.md
+++ b/apps/academy/docs/academy/04-APIReferences/09-AttachmentService.md
@@ -227,17 +227,17 @@ In render, read the lifecycle straight off the hook:
 
 ## Declaring attachment fields in a document model
 
-The integration surface between document models and the attachment system is a single GraphQL scalar: `Attachment`. Declare attachment-bearing fields with it, and codegen will emit a TypeScript `string` (specifically `AttachmentRef`).
+The integration surface between document models and the attachment system is a single GraphQL scalar: `AttachmentRef`. Declare attachment-bearing fields with it, and codegen will emit a branded TypeScript string (`` `attachment://v${number}:${string}` ``) plus a Zod validator that enforces the ref protocol.
 
 ```graphql
-scalar Attachment
+scalar AttachmentRef
 
 input SetAgentImageInput {
-  attachment: Attachment!
+  attachment: AttachmentRef!
 }
 
 type AgentInfo {
-  attachment: Attachment
+  attachment: AttachmentRef
 }
 ```
 
@@ -245,7 +245,7 @@ The reducer stores the value verbatim — no special handling needed:
 
 ```typescript
 setAgentImageOperation(state, action) {
-  state.agent.attachment = action.input.attachment; // AttachmentRef string
+  state.agent.attachment = action.input.attachment; // AttachmentRef
 }
 ```
 

--- a/apps/academy/llms-full.txt
+++ b/apps/academy/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-06-02T16:54:52.898Z
+> Generated: 2026-06-05T18:44:06.547Z
 > Total Documents: 87
 > Source: https://powerhouse.academy/llms-full.txt
 
@@ -17830,17 +17830,17 @@ Initialize a new project
 
 
 ### Options
-**Name** - The name of your project. A new directory will be created in your current directory with this name. - Usage: `--name, -n <str>`
+**Name** - The name of your project. A new directory will be created in your current directory with this name. - Usage: `--name, -n \<str\>`
 
-**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p <value>`
+**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p \<value\>`
 
-**Tag** - Specify the release tag to use for your project. Can be one of: "latest", "staging", or "dev". - Usage: `--tag, -t <value>`
+**Tag** - Specify the release tag to use for your project. Can be one of: "latest", "staging", or "dev". - Usage: `--tag, -t \<value\>`
 
-**Version** - Specify the exact semver release version to use for your project. - Usage: `--version, -v <str>`
+**Version** - Specify the exact semver release version to use for your project. - Usage: `--version, -v \<str\>`
 
-**Remote Drive** - Remote drive identifier. - Usage: `--remote-drive, -r <str>`
+**Remote Drive** - Remote drive identifier. - Usage: `--remote-drive, -r \<str\>`
 
-**Clone** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--clone <str>`
+**Clone** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--clone \<str\>`
 
 
 ### Flags
@@ -17874,9 +17874,9 @@ Specify the release version of Powerhouse dependencies to use.
 
 
 ### Options
-**Tag** - Specify the release tag to use for your project. Can be one of: "latest", "staging", or "dev". - Usage: `--tag, -t <value>`
+**Tag** - Specify the release tag to use for your project. Can be one of: "latest", "staging", or "dev". - Usage: `--tag, -t \<value\>`
 
-**Version** - Specify the exact semver release version to use for your project. - Usage: `--version, -v <str>`
+**Version** - Specify the exact semver release version to use for your project. - Usage: `--version, -v \<str\>`
 
 
 ### Flags
@@ -17912,17 +17912,17 @@ Initialize a new global project
 
 
 ### Options
-**Name** - The name of your project. A new directory will be created in your current directory with this name. - Usage: `--name, -n <str>`
+**Name** - The name of your project. A new directory will be created in your current directory with this name. - Usage: `--name, -n \<str\>`
 
-**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p <value>`
+**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p \<value\>`
 
-**Tag** - Specify the release tag to use for your project. Can be one of: "latest", "staging", or "dev". - Usage: `--tag, -t <value>`
+**Tag** - Specify the release tag to use for your project. Can be one of: "latest", "staging", or "dev". - Usage: `--tag, -t \<value\>`
 
-**Version** - Specify the exact semver release version to use for your project. - Usage: `--version, -v <str>`
+**Version** - Specify the exact semver release version to use for your project. - Usage: `--version, -v \<str\>`
 
-**Remote Drive** - Remote drive identifier. - Usage: `--remote-drive, -r <str>`
+**Remote Drive** - Remote drive identifier. - Usage: `--remote-drive, -r \<str\>`
 
-**Clone** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--clone <str>`
+**Clone** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--clone \<str\>`
 
 
 ### Flags
@@ -17956,7 +17956,7 @@ Use your local `powerhouse` monorepo dependencies the current project.
 
 
 ### Options
-**Path** - Path to your local powerhouse monorepo relative to this project - Usage: `--path, -p <str>`
+**Path** - Path to your local powerhouse monorepo relative to this project - Usage: `--path, -p \<str\>`
 
 
 ### Flags
@@ -18009,9 +18009,9 @@ Generate a document model
 
 
 ### Options
-**Document** - Path to a document model spec (.phd or .json) to generate from - Usage: `--document, -d <file>`
+**Document** - Path to a document model spec (.phd or .json) to generate from - Usage: `--document, -d \<file\>`
 
-**Dir** - Name of the directory of an existing document model to re-generate - Usage: `--dir <dir>`
+**Dir** - Name of the directory of an existing document model to re-generate - Usage: `--dir \<dir\>`
 
 
 ### Flags
@@ -18029,13 +18029,13 @@ Generate a document editor
 
 
 ### Options
-**Name** - The name of the document editor to generate - Usage: `--name, -n <str>`
+**Name** - The name of the document editor to generate - Usage: `--name, -n \<str\>`
 
-**Document Type** - The document type for the new editor - Usage: `--document-type, -t <str>`
+**Document Type** - The document type for the new editor - Usage: `--document-type, -t \<str\>`
 
-**Document** - Path to a powerhouse/document-editor spec file (.phd or .json) to drive codegen - Usage: `--document, -d <file>`
+**Document** - Path to a powerhouse/document-editor spec file (.phd or .json) to drive codegen - Usage: `--document, -d \<file\>`
 
-**Dir** - Name of the directory of an existing editor to re-generate - Usage: `--dir <dir>`
+**Dir** - Name of the directory of an existing editor to re-generate - Usage: `--dir \<dir\>`
 
 
 ### Flags
@@ -18053,13 +18053,13 @@ Generate a drive app
 
 
 ### Options
-**Name** - The name of the drive app to generate - Usage: `--name, -n <str>`
+**Name** - The name of the drive app to generate - Usage: `--name, -n \<str\>`
 
-**Document Types** - The document types allowed by the new app - Usage: `--document-types <str>, -t=<str>`
+**Document Types** - The document types allowed by the new app - Usage: `--document-types \<str\>, -t=\<str\>`
 
-**Document** - Path to a powerhouse/app spec file (.phd or .json) to drive codegen - Usage: `--document, -d <file>`
+**Document** - Path to a powerhouse/app spec file (.phd or .json) to drive codegen - Usage: `--document, -d \<file\>`
 
-**Dir** - Name of the directory of an existing app to re-generate - Usage: `--dir <dir>`
+**Dir** - Name of the directory of an existing app to re-generate - Usage: `--dir \<dir\>`
 
 
 ### Flags
@@ -18080,20 +18080,20 @@ Generate a processor
 
 
 ### Options
-**Name** - The name of the processor to generate - Usage: `--name, -n <str>`
+**Name** - The name of the processor to generate - Usage: `--name, -n \<str\>`
 
-**Type** - The type of processor to generate - Usage: `--type <value>`
+**Type** - The type of processor to generate - Usage: `--type \<value\>`
 
 **Default:** `analytics`
-**Document Types** - The document types the processor will run on - Usage: `--document-types <str>, -t=<str>`
+**Document Types** - The document types the processor will run on - Usage: `--document-types \<str\>, -t=\<str\>`
 
 **Default:** ``
-**Apps** - Whether the processor will run in switchboard (nodejs), connect (browser), or both - Usage: `--apps <value>`
+**Apps** - Whether the processor will run in switchboard (nodejs), connect (browser), or both - Usage: `--apps \<value\>`
 
 **Default:** `switchboard,connect`
-**Document** - Path to a powerhouse/processor spec file (.phd or .json) to drive codegen - Usage: `--document, -d <file>`
+**Document** - Path to a powerhouse/processor spec file (.phd or .json) to drive codegen - Usage: `--document, -d \<file\>`
 
-**Dir** - Name of the directory of an existing processor to re-generate - Usage: `--dir <dir>`
+**Dir** - Name of the directory of an existing processor to re-generate - Usage: `--dir \<dir\>`
 
 
 ### Flags
@@ -18111,11 +18111,11 @@ Generate a subgraph
 
 
 ### Options
-**Name** - The name of the subgraph to generate - Usage: `--name, -n <str>`
+**Name** - The name of the subgraph to generate - Usage: `--name, -n \<str\>`
 
-**Document** - Path to a powerhouse/subgraph spec file (.phd or .json) to drive codegen - Usage: `--document, -d <file>`
+**Document** - Path to a powerhouse/subgraph spec file (.phd or .json) to drive codegen - Usage: `--document, -d \<file\>`
 
-**Dir** - Name of the directory of an existing subgraph to re-generate - Usage: `--dir <dir>`
+**Dir** - Name of the directory of an existing subgraph to re-generate - Usage: `--dir \<dir\>`
 
 
 ### Flags
@@ -18133,9 +18133,9 @@ Generate a migration file
 
 
 ### Options
-**Path *[required]*** - Path to the migration file - Usage: `--path, -p <str>`
+**Path *[required]*** - Path to the migration file - Usage: `--path, -p \<str\>`
 
-**Schema File** - Path to the output file. Defaults to './schema.ts' - Usage: `--schema-file <str>`
+**Schema File** - Path to the output file. Defaults to './schema.ts' - Usage: `--schema-file \<str\>`
 
 
 ### Flags
@@ -18158,42 +18158,42 @@ and real-time processing with a "Vetra" drive or connection to remote drives.
 
 
 ### Options
-**Switchboard Port** - port to use for the Vetra Switchboard - Usage: `--switchboard-port <number>`
+**Switchboard Port** - port to use for the Vetra Switchboard - Usage: `--switchboard-port \<number\>`
 
-**Connect Port** - port to use for the Vetra Connect - Usage: `--connect-port <number>`
+**Connect Port** - port to use for the Vetra Connect - Usage: `--connect-port \<number\>`
 
 **Default:** `3001`
-**Remote Drive** - URL of remote drive to connect to (skips switchboard initialization) - Usage: `--remote-drive <str>`
+**Remote Drive** - URL of remote drive to connect to (skips switchboard initialization) - Usage: `--remote-drive \<str\>`
 
-**Db Path** - Database path or connection string. Use a `postgres://` URL for Postgres; otherwise treated as a PGlite filesystem path. Leave unset for in-memory PGlite. - Usage: `--db-path <str>`
+**Db Path** - Database path or connection string. Use a `postgres://` URL for Postgres; otherwise treated as a PGlite filesystem path. Leave unset for in-memory PGlite. - Usage: `--db-path \<str\>`
 
-**Base** - Base path for the app - Usage: `--base <str>`
+**Base** - Base path for the app - Usage: `--base \<str\>`
 
-**Log Level** - Log level for the application - Usage: `--log-level <value>`
+**Log Level** - Log level for the application - Usage: `--log-level \<value\>`
 
 **Environment:** `PH_CONNECT_LOG_LEVEL`
 **Default:** `info`
-**Packages** - Comma-separated list of package names to load - Usage: `--packages <str>`
+**Packages** - Comma-separated list of package names to load - Usage: `--packages \<str\>`
 
 **Environment:** `PH_PACKAGES`
-**Local Package** - Path to local package to load during development - Usage: `--local-package <str>`
+**Local Package** - Path to local package to load during development - Usage: `--local-package \<str\>`
 
 **Environment:** `PH_LOCAL_PACKAGE`
-**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url <str>`
+**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url \<str\>`
 
-**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy <value>`
+**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy \<value\>`
 
 **Default:** `preserve-by-url-and-detach`
-**Host** - Expose the server to the network. Pass an IP (e.g. 0.0.0.0) to bind to a specific address. - Usage: `--host <str>`
+**Host** - Expose the server to the network. Pass an IP (e.g. 0.0.0.0) to bind to a specific address. - Usage: `--host \<str\>`
 
-**Watch Timeout** - Amount of time to wait before a file is considered changed - Usage: `--watch-timeout <number>`
+**Watch Timeout** - Amount of time to wait before a file is considered changed - Usage: `--watch-timeout \<number\>`
 
 **Default:** `300`
-**Https Key File** - path to the ssl key file - Usage: `--https-key-file <str>`
+**Https Key File** - path to the ssl key file - Usage: `--https-key-file \<str\>`
 
-**Https Cert File** - path to the ssl cert file - Usage: `--https-cert-file <str>`
+**Https Cert File** - path to the ssl cert file - Usage: `--https-cert-file \<str\>`
 
-**Remote Drives** - Specify remote drive URLs to use - Usage: `--remote-drives <str>`
+**Remote Drives** - Specify remote drive URLs to use - Usage: `--remote-drives \<str\>`
 
 
 ### Flags
@@ -18250,29 +18250,29 @@ your project.
 
 
 ### Options
-**Port** - Port to run the dev server on. - Usage: `--port <number>`
+**Port** - Port to run the dev server on. - Usage: `--port \<number\>`
 
 **Default:** `3000`
-**Base** - Base path for the app - Usage: `--base <str>`
+**Base** - Base path for the app - Usage: `--base \<str\>`
 
-**Log Level** - Log level for the application - Usage: `--log-level <value>`
+**Log Level** - Log level for the application - Usage: `--log-level \<value\>`
 
 **Environment:** `PH_CONNECT_LOG_LEVEL`
 **Default:** `info`
-**Packages** - Comma-separated list of package names to load - Usage: `--packages <str>`
+**Packages** - Comma-separated list of package names to load - Usage: `--packages \<str\>`
 
 **Environment:** `PH_PACKAGES`
-**Local Package** - Path to local package to load during development - Usage: `--local-package <str>`
+**Local Package** - Path to local package to load during development - Usage: `--local-package \<str\>`
 
 **Environment:** `PH_LOCAL_PACKAGE`
-**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url <str>`
+**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url \<str\>`
 
-**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy <value>`
+**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy \<value\>`
 
 **Default:** `preserve-by-url-and-detach`
-**Host** - Expose the server to the network. Pass an IP (e.g. 0.0.0.0) to bind to a specific address. - Usage: `--host <str>`
+**Host** - Expose the server to the network. Pass an IP (e.g. 0.0.0.0) to bind to a specific address. - Usage: `--host \<str\>`
 
-**Watch Timeout** - Amount of time to wait before a file is considered changed - Usage: `--watch-timeout <number>`
+**Watch Timeout** - Amount of time to wait before a file is considered changed - Usage: `--watch-timeout \<number\>`
 
 **Default:** `300`
 
@@ -18305,68 +18305,68 @@ external packages included.
 
 Runtime-config overrides (all combinable — last wins on collision):
   ph connect build                                    Build with the current source config.
-  ph connect build <key> <value>                      Build with a positional override applied (e.g. ph connect build connect.renown.url https://renown.staging).
-  ph connect build --<field> <value>                  Build with a per-field flag override (e.g. --renown-url https://renown.staging).
+  ph connect build \<key\> \<value\>                      Build with a positional override applied (e.g. ph connect build connect.renown.url https://renown.staging).
+  ph connect build --\<field\> \<value\>                  Build with a per-field flag override (e.g. --renown-url https://renown.staging).
   ph connect build --json '\{"…":"…"\}'                Build with a bulk override.
 
-Build has no read mode; passing only <key> without <value> errors out (use `ph connect config <key>` to read).
+Build has no read mode; passing only \<key\> without \<value\> errors out (use `ph connect config \<key\>` to read).
 
 
 ### Options
-**Out Dir** - Output directory - Usage: `--outDir <str>`
+**Out Dir** - Output directory - Usage: `--outDir \<str\>`
 
 **Default:** `.ph/connect-build/dist/`
-**Json** - Inline JSON override for the runtime connect.* block, e.g. '\{"renown":\{"url":"..."\}\}'. Validated against the runtime schema; deep-merged on top of env seeds and source powerhouse.config.json. Individual --flag values beat --json on collision. - Usage: `--json <str>`
+**Json** - Inline JSON override for the runtime connect.* block, e.g. '\{"renown":\{"url":"..."\}\}'. Validated against the runtime schema; deep-merged on top of env seeds and source powerhouse.config.json. Individual --flag values beat --json on collision. - Usage: `--json \<str\>`
 
-**Renown Url** - Override connect.renown.url. - Usage: `--renown-url <str>`
+**Renown Url** - Override connect.renown.url. - Usage: `--renown-url \<str\>`
 
-**Renown Network Id** - Override connect.renown.networkId. - Usage: `--renown-network-id <str>`
+**Renown Network Id** - Override connect.renown.networkId. - Usage: `--renown-network-id \<str\>`
 
-**Renown Chain Id** - Override connect.renown.chainId. - Usage: `--renown-chain-id <number>`
+**Renown Chain Id** - Override connect.renown.chainId. - Usage: `--renown-chain-id \<number\>`
 
-**Allow Add Drive** - Override connect.drives.allowAddDrive (top-level add-drive toggle). - Usage: `--allow-add-drive <value>`
+**Allow Add Drive** - Override connect.drives.allowAddDrive (top-level add-drive toggle). - Usage: `--allow-add-drive \<value\>`
 
-**External Packages** - Override connect.packages.externalEnabled. - Usage: `--external-packages <value>`
+**External Packages** - Override connect.packages.externalEnabled. - Usage: `--external-packages \<value\>`
 
-**Remote Drives Enabled** - Override connect.drives.sections.remote.enabled (the unified cloud+public section). - Usage: `--remote-drives-enabled <value>`
+**Remote Drives Enabled** - Override connect.drives.sections.remote.enabled (the unified cloud+public section). - Usage: `--remote-drives-enabled \<value\>`
 
-**Remote Drives Allow Add** - Override connect.drives.sections.remote.allowAdd. - Usage: `--remote-drives-allow-add <value>`
+**Remote Drives Allow Add** - Override connect.drives.sections.remote.allowAdd. - Usage: `--remote-drives-allow-add \<value\>`
 
-**Remote Drives Allow Delete** - Override connect.drives.sections.remote.allowDelete. - Usage: `--remote-drives-allow-delete <value>`
+**Remote Drives Allow Delete** - Override connect.drives.sections.remote.allowDelete. - Usage: `--remote-drives-allow-delete \<value\>`
 
-**Local Drives Enabled** - Override connect.drives.sections.local.enabled. - Usage: `--local-drives-enabled <value>`
+**Local Drives Enabled** - Override connect.drives.sections.local.enabled. - Usage: `--local-drives-enabled \<value\>`
 
-**Local Drives Allow Add** - Override connect.drives.sections.local.allowAdd. - Usage: `--local-drives-allow-add <value>`
+**Local Drives Allow Add** - Override connect.drives.sections.local.allowAdd. - Usage: `--local-drives-allow-add \<value\>`
 
-**Local Drives Allow Delete** - Override connect.drives.sections.local.allowDelete. - Usage: `--local-drives-allow-delete <value>`
+**Local Drives Allow Delete** - Override connect.drives.sections.local.allowDelete. - Usage: `--local-drives-allow-delete \<value\>`
 
-**Packages Registry** - Override the top-level packageRegistryUrl. - Usage: `--packages-registry <str>`
+**Packages Registry** - Override the top-level packageRegistryUrl. - Usage: `--packages-registry \<str\>`
 
-**App Name** - Override connect.branding.appName. - Usage: `--app-name <str>`
+**App Name** - Override connect.branding.appName. - Usage: `--app-name \<str\>`
 
-**Home Background** - Override connect.branding.homeBackground. URL or path to an image; pass an empty string ("") to reset to the bundled default. - Usage: `--home-background <str>`
+**Home Background** - Override connect.branding.homeBackground. URL or path to an image; pass an empty string ("") to reset to the bundled default. - Usage: `--home-background \<str\>`
 
-**Sentry Dsn** - Override connect.sentry.dsn (Sentry DSN URL). Pass an empty string ("") to set null and disable Sentry. - Usage: `--sentry-dsn <str>`
+**Sentry Dsn** - Override connect.sentry.dsn (Sentry DSN URL). Pass an empty string ("") to set null and disable Sentry. - Usage: `--sentry-dsn \<str\>`
 
-**Sentry Env** - Override connect.sentry.env (Sentry environment label). - Usage: `--sentry-env <str>`
+**Sentry Env** - Override connect.sentry.env (Sentry environment label). - Usage: `--sentry-env \<str\>`
 
-**Sentry Tracing Enabled** - Override connect.sentry.tracing (Sentry performance tracing). - Usage: `--sentry-tracing-enabled <value>`
+**Sentry Tracing Enabled** - Override connect.sentry.tracing (Sentry performance tracing). - Usage: `--sentry-tracing-enabled \<value\>`
 
-**Base** - Base path for the app - Usage: `--base <str>`
+**Base** - Base path for the app - Usage: `--base \<str\>`
 
-**Log Level** - Log level for the application - Usage: `--log-level <value>`
+**Log Level** - Log level for the application - Usage: `--log-level \<value\>`
 
 **Environment:** `PH_CONNECT_LOG_LEVEL`
 **Default:** `info`
-**Packages** - Comma-separated list of package names to load - Usage: `--packages <str>`
+**Packages** - Comma-separated list of package names to load - Usage: `--packages \<str\>`
 
 **Environment:** `PH_PACKAGES`
-**Local Package** - Path to local package to load during development - Usage: `--local-package <str>`
+**Local Package** - Path to local package to load during development - Usage: `--local-package \<str\>`
 
 **Environment:** `PH_LOCAL_PACKAGE`
-**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url <str>`
+**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url \<str\>`
 
-**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy <value>`
+**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy \<value\>`
 
 **Default:** `preserve-by-url-and-detach`
 
@@ -18376,9 +18376,9 @@ Build has no read mode; passing only <key> without <value> errors out (use `ph c
 ## Parameters
 
 ### Arguments
-**Key** - Dotted path inside the runtime config (e.g. connect.renown.url). Pair with <value> to set; pass alone to `ph connect config` to read. - Usage: `[key]`
+**Key** - Dotted path inside the runtime config (e.g. connect.renown.url). Pair with \<value\> to set; pass alone to `ph connect config` to read. - Usage: `[key]`
 
-**Value** - Value to set at <key>. Coerced against the runtime schema (string, bool, number, enum). Arrays and objects require --json instead. - Usage: `[value]`
+**Value** - Value to set at \<key\>. Coerced against the runtime schema (string, bool, number, enum). Arrays and objects require --json instead. - Usage: `[value]`
 
 
 ### Flags
@@ -18397,32 +18397,32 @@ NOTE: You must run `ph connect build` first
 
 
 ### Options
-**Port** - Port to run the preview server on. - Usage: `--port <number>`
+**Port** - Port to run the preview server on. - Usage: `--port \<number\>`
 
 **Default:** `4173`
-**Out Dir** - Output directory - Usage: `--outDir <str>`
+**Out Dir** - Output directory - Usage: `--outDir \<str\>`
 
 **Default:** `.ph/connect-build/dist/`
-**Base** - Base path for the app - Usage: `--base <str>`
+**Base** - Base path for the app - Usage: `--base \<str\>`
 
-**Log Level** - Log level for the application - Usage: `--log-level <value>`
+**Log Level** - Log level for the application - Usage: `--log-level \<value\>`
 
 **Environment:** `PH_CONNECT_LOG_LEVEL`
 **Default:** `info`
-**Packages** - Comma-separated list of package names to load - Usage: `--packages <str>`
+**Packages** - Comma-separated list of package names to load - Usage: `--packages \<str\>`
 
 **Environment:** `PH_PACKAGES`
-**Local Package** - Path to local package to load during development - Usage: `--local-package <str>`
+**Local Package** - Path to local package to load during development - Usage: `--local-package \<str\>`
 
 **Environment:** `PH_LOCAL_PACKAGE`
-**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url <str>`
+**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url \<str\>`
 
-**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy <value>`
+**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy \<value\>`
 
 **Default:** `preserve-by-url-and-detach`
-**Host** - Expose the server to the network. Pass an IP (e.g. 0.0.0.0) to bind to a specific address. - Usage: `--host <str>`
+**Host** - Expose the server to the network. Pass an IP (e.g. 0.0.0.0) to bind to a specific address. - Usage: `--host \<str\>`
 
-**Watch Timeout** - Amount of time to wait before a file is considered changed - Usage: `--watch-timeout <number>`
+**Watch Timeout** - Amount of time to wait before a file is considered changed - Usage: `--watch-timeout \<number\>`
 
 **Default:** `300`
 
@@ -18499,10 +18499,10 @@ Notes:
 
 
 ### Options
-**Expiry** - Token expiry duration. Supports: "7d" (days), "24h" (hours), "3600" or "3600s" (seconds) - Usage: `--expiry <str>`
+**Expiry** - Token expiry duration. Supports: "7d" (days), "24h" (hours), "3600" or "3600s" (seconds) - Usage: `--expiry \<str\>`
 
 **Default:** `7d`
-**Audience** - Target audience URL for the token - Usage: `--audience <str>`
+**Audience** - Target audience URL for the token - Usage: `--audience \<str\>`
 
 
 ### Flags
@@ -18529,7 +18529,7 @@ your project.
 ## Parameters
 
 ### Arguments
-**Package Name *[required]*** - The name of the package to inspect - Usage: `<package-name>`
+**Package Name *[required]*** - The name of the package to inspect - Usage: `\<package-name\>`
 
 
 ### Flags
@@ -18569,7 +18569,7 @@ Run migrations
 
 
 ### Options
-**Version** - The version to migrate to. Accepts a valid semver version or `staging`, `dev`, `latest`. - Usage: `--version, -v <str>`
+**Version** - The version to migrate to. Accepts a valid semver version or `staging`, `dev`, `latest`. - Usage: `--version, -v \<str\>`
 
 **Default:** `latest`
 
@@ -18627,26 +18627,26 @@ models, processors, and real-time updates.
 
 
 ### Options
-**Https Key File** - path to the ssl key file - Usage: `--https-key-file <str>`
+**Https Key File** - path to the ssl key file - Usage: `--https-key-file \<str\>`
 
-**Https Cert File** - path to the ssl cert file - Usage: `--https-cert-file <str>`
+**Https Cert File** - path to the ssl cert file - Usage: `--https-cert-file \<str\>`
 
-**Remote Drives** - Specify remote drive URLs to use - Usage: `--remote-drives <str>`
+**Remote Drives** - Specify remote drive URLs to use - Usage: `--remote-drives \<str\>`
 
-**Packages** - Comma-separated list of package names to load - Usage: `--packages <str>`
+**Packages** - Comma-separated list of package names to load - Usage: `--packages \<str\>`
 
 **Environment:** `PH_PACKAGES`
-**Port** - Port to host the api - Usage: `--port <number>`
+**Port** - Port to host the api - Usage: `--port \<number\>`
 
 **Default:** `4001`
-**Base Path** - base path for the API endpoints (sets the BASE_PATH environment variable) - Usage: `--base-path <str>`
+**Base Path** - base path for the API endpoints (sets the BASE_PATH environment variable) - Usage: `--base-path \<str\>`
 
-**Keypair Path** - path to custom keypair file for identity - Usage: `--keypair-path <str>`
+**Keypair Path** - path to custom keypair file for identity - Usage: `--keypair-path \<str\>`
 
-**Vetra Drive Id** - Specify a Vetra drive ID - Usage: `--vetra-drive-id <str>`
+**Vetra Drive Id** - Specify a Vetra drive ID - Usage: `--vetra-drive-id \<str\>`
 
 **Default:** `vetra`
-**Db Path** - path to the database - Usage: `--db-path <str>`
+**Db Path** - path to the database - Usage: `--db-path \<str\>`
 
 
 ## Login
@@ -18663,11 +18663,11 @@ the CLI to act on behalf of your Ethereum identity for authenticated operations.
 
 
 ### Options
-**Renown Url** - Renown server URL. - Usage: `--renown-url <str>`
+**Renown Url** - Renown server URL. - Usage: `--renown-url \<str\>`
 
 **Environment:** `PH_CONNECT_RENOWN_URL`
 **Default:** `https//www.renown.id`
-**Timeout** - Authentication timeout in seconds. - Usage: `--timeout <number>`
+**Timeout** - Authentication timeout in seconds. - Usage: `--timeout \<number\>`
 
 **Default:** `300`
 
@@ -18696,7 +18696,7 @@ as provider "local" — it will be bundled into ph connect build so the
 preview works without the registry being reachable.
 
 Resolution order for the registry URL:
-  --registry flag > PH_REGISTRY_URL env > powerhouse.config.json > default
+  --registry flag \> PH_REGISTRY_URL env \> powerhouse.config.json \> default
   
 
 
@@ -18709,11 +18709,11 @@ Resolution order for the registry URL:
 
 
 ### Options
-**Registry** - Registry URL to install from (overrides config and environment) - Usage: `--registry <str>`
+**Registry** - Registry URL to install from (overrides config and environment) - Usage: `--registry \<str\>`
 
-**Allow Build** - A list of package names that are allowed to run postinstall scripts during installation. - Usage: `--allow-build <str>`
+**Allow Build** - A list of package names that are allowed to run postinstall scripts during installation. - Usage: `--allow-build \<str\>`
 
-**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p <value>`
+**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p \<value\>`
 
 
 ### Flags
@@ -18753,7 +18753,7 @@ removal of packages, updates configuration files, and ensures proper cleanup.
 
 
 ### Options
-**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p <value>`
+**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p \<value\>`
 
 
 ### Flags
@@ -23708,7 +23708,19 @@ The `@powerhousedao/reactor-attachments` package decouples large binaries (image
 } from "@powerhousedao/reactor-attachments";
 ```
 
-For an architectural overview see [Working with the Reactor](/academy/Architecture/WorkingWithTheReactor). For the full design — storage layout, eviction, transports, the planned S3 backend — see the deep-dive doc at `packages/reactor/docs/attachments.md` in the monorepo.
+The package exposes two layers. `IAttachmentService` is the low-level, transport-facing interface — reserve a slot, stream the bytes, read them back by ref. `IAttachmentClient` wraps a service with convenience helpers; most notably `preprocess()`, which hashes a file up front so its ref is known before the bytes are uploaded. Build a client with `createAttachmentClient(service)`, and import it from the `/client` entrypoint:
+
+```typescript
+
+  createAttachmentClient,
+  type IAttachmentClient,
+  type PreprocessResult,
+} from "@powerhousedao/reactor-attachments/client";
+```
+
+The React hooks in `@powerhousedao/reactor-browser` are built on the client.
+
+For an architectural overview see [Working with the Reactor](/academy/Architecture/WorkingWithTheReactor). For the full design — storage layout, eviction, transports, the hash-first/pending protocol, and the planned S3 backend — see the deep-dive docs `packages/reactor/docs/attachments.md` and `packages/reactor/docs/attachments-hash-first.md` in the monorepo.
 
 ## When to use it
 
@@ -23740,11 +23752,18 @@ const attachments = createRemoteAttachmentService({
 The switchboard remote service is the supported client implementation right now. Other transports (S3, peer-to-peer) are designed but not yet stable — prefer `createRemoteAttachmentService` until these docs call out a replacement.
 
 
-On the server side (inside a subgraph, processor, or trigger), the service is already wired into `ReactorContext` by `@powerhousedao/reactor-api` and is available as `reactor.attachments`. There is no need to construct one yourself — see `packages/reactor-api/src/server.ts` for the wiring.
+On the server side (inside a subgraph, processor, or trigger), an `IAttachmentClient` is already wired into the host context by `@powerhousedao/reactor-api` and is available as `context.attachments`. There is no need to construct one yourself — the server builds the service and wraps it with `createAttachmentClient(...)`; see `packages/reactor-api/src/server.ts` for the wiring.
 
 ## The general flow
 
-Every interaction with the package is one of three operations on `IAttachmentService`: reserve a slot, send the bytes, then later read them back by ref.
+Every interaction with the package comes down to three operations: reserve a slot, send the bytes, then later read them back by ref.
+
+There are two reservation modes. They are equivalent in capability — neither is preferred, so pick whichever fits the caller:
+
+- **Upload-first** — reserve with just `{ mimeType, fileName }`. The content hash, and therefore the final ref, is only known *after* `send()` completes. Simplest when you can stream the bytes straight through and do not need the ref until the upload finishes.
+- **Hash-first** — hash the content up front and reserve with `{ clientHash, sizeBytes, ... }`. The ref is known at reservation time, so it can be written into document state before (or in parallel with) the upload, and dedup can short-circuit before any bytes are sent. The trade-off is that the whole file must be read to hash it. `IAttachmentClient.preprocess()` does that hashing for you.
+
+The walkthrough below uses the low-level service in upload-first mode. The [attachment client](#the-attachment-client) section shows the hash-first flow.
 
 ### 1. Reserve an upload slot
 
@@ -23827,21 +23846,92 @@ const objectUrl = URL.createObjectURL(blob);
 // ...later: URL.revokeObjectURL(objectUrl);
 ```
 
-`get()` always succeeds for a known ref. If the bytes were evicted from local storage, the service transparently re-fetches them through the transport.
+`get()` succeeds for any ref whose bytes are available. If the bytes were evicted from local storage, the service transparently re-fetches them through the transport. A hash-first ref can also be *pending* — reserved, with state already referencing it, but the bytes not yet uploaded. During that window `get()` throws `AttachmentPending`, while `stat()` succeeds and reports the declared size.
+
+## The attachment client
+
+`IAttachmentClient` wraps an `IAttachmentService` with the hash-first flow. Build one with `createAttachmentClient(service)` (server code already receives one as `context.attachments`).
+
+`preprocess(file)` reads the whole file, computes its SHA-256, and returns everything you need to both reference and upload it:
+
+```typescript
+const attachments = createAttachmentClient(service);
+
+const results = await attachments.preprocess(file);
+// results: { ref, hash, sizeBytes, options, data, stream }
+```
+
+Because it has to read the entire file to hash it, `preprocess` is async and buffers the bytes in memory — `file` is a `Blob`, not a stream.
+
+With the ref in hand you can write it into document state through a normal action, then upload the bytes:
+
+```typescript
+await client.execute(documentId, "main", [
+  attachInvoice({ scan: results.ref, vendorName: "Acme" }),
+]);
+
+await attachments.reserve(results.options, (handle) => handle.send(results.stream()));
+```
+
+`client.reserve(options, send)` reserves the slot and hands the upload handle to your `send` callback. If an attachment with the same hash already exists it short-circuits and returns the existing ref without uploading. Pass `results.stream()` — which returns a fresh `ReadableStream` on each call — rather than the single-use `results.data` if the upload might be retried. `send()` accepts any `ReadableStream<Uint8Array>`, so on the server you can stream from the original source instead of the buffered copy.
+
+Execute and reserve are awaited separately so each failure is handled on its own — a failed upload does not roll back the action, and a failed action does not strand an upload. If you do not need that separation, run them concurrently:
+
+```typescript
+await Promise.all([
+  client.execute(documentId, "main", [
+    attachInvoice({ scan: results.ref, vendorName: "Acme" }),
+  ]),
+  attachments.reserve(results.options, (handle) => handle.send(results.stream())),
+]);
+```
+
+### React
+
+`@powerhousedao/reactor-browser` exposes hooks built on the client. `useAttachments()` returns an `IAttachmentClient` for the current service (or `undefined` if none is configured). `useAttachmentUpload()` drives the full preprocess + upload lifecycle and tracks its status:
+
+```tsx
+const client = useReactorClient();
+const { preprocess, upload, status, progress, error } = useAttachmentUpload();
+
+const submit = useCallback(async () => {
+  // Buffers the file in memory and hands back the ref. Async because it has to
+  // read the whole file to hash it.
+  const results = await preprocess(file);
+
+  // Execute with the generated ref. `scan` is just a string here; the action
+  // and codegen never see the file or the attachments package.
+  await client.execute(documentId, "main", [
+    attachInvoice({ scan: results.ref, vendorName: "Acme" }),
+  ]);
+
+  // Upload the bytes. Awaited separately from execute() so each failure is
+  // handled on its own.
+  await upload(results);
+}, [client, preprocess, upload, documentId, file]);
+```
+
+In render, read the lifecycle straight off the hook:
+
+- `status` — `UploadStatus`: `None | Hashing | Uploading | Done | Error`
+- `progress` — coarse/stage-based; the remote transport buffers then issues a single PUT, so byte-level progress is not available yet
+- `error` — the upload failure, if any
+
+`preprocess` and `upload` are stable callbacks. `upload(results)` wraps `client.reserve(results.options, (handle) => handle.send(results.stream()))` and updates `status`/`progress`/`error`. Because React runs in the browser, this mirrors the buffered flow above; the ref still only exists after `preprocess` resolves, so submission is async — you cannot produce a ref inside the synchronous action input.
 
 ## Declaring attachment fields in a document model
 
-The integration surface between document models and the attachment system is a single GraphQL scalar: `Attachment`. Declare attachment-bearing fields with it, and codegen will emit a TypeScript `string` (specifically `AttachmentRef`).
+The integration surface between document models and the attachment system is a single GraphQL scalar: `AttachmentRef`. Declare attachment-bearing fields with it, and codegen will emit a branded TypeScript string (`` `attachment://v${number}:${string}` ``) plus a Zod validator that enforces the ref protocol.
 
 ```graphql
-scalar Attachment
+scalar AttachmentRef
 
 input SetAgentImageInput {
-  attachment: Attachment!
+  attachment: AttachmentRef!
 }
 
 type AgentInfo {
-  attachment: Attachment
+  attachment: AttachmentRef
 }
 ```
 
@@ -23849,7 +23939,7 @@ The reducer stores the value verbatim — no special handling needed:
 
 ```typescript
 setAgentImageOperation(state, action) {
-  state.agent.attachment = action.input.attachment; // AttachmentRef string
+  state.agent.attachment = action.input.attachment; // AttachmentRef
 }
 ```
 
@@ -23870,12 +23960,22 @@ setAgentImageOperation(state, action) {
 | `reservationId`    | `string`                                                        | Unique identifier for this reservation.                                                                           |
 | `send(data)`       | `(ReadableStream<Uint8Array>) => Promise<AttachmentUploadResult>` | Stream the bytes through the handle. Returns `{ hash, ref, header }`. Dedup against existing hashes is automatic. |
 
+### `IAttachmentClient`
+
+| Method                    | Returns                            | Description                                                                                                                                                                          |
+| ------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `preprocess(file, opts?)` | `Promise<PreprocessResult>`        | Read and hash a `Blob` up front. Returns the ref, hash, declared size, hash-first reserve options, and the buffered bytes (as a single-use `data` stream and a re-readable `stream()` factory). `opts` may override `{ fileName, mimeType }`. |
+| `reserve(options, send)`  | `Promise<AttachmentUploadResult>`  | Reserve a hash-first slot and run `send(handle)`. Short-circuits to the existing ref if the hash is already stored (`AttachmentAlreadyExists` is handled internally).                |
+
 ### Key types
 
 | Type                       | Shape                                                                                                                     |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `AttachmentRef`            | `` `attachment://v${number}:${string}` `` — opaque ref string used in document state.                                     |
-| `ReserveAttachmentOptions` | `{ mimeType: string; fileName: string; extension?: string \| null }`                                                      |
+| `ReserveAttachmentOptions` | `UploadFirstReserveAttachmentOptions \| HashFirstReserveAttachmentOptions` — discriminated on `clientHash`.                |
+| `UploadFirstReserveAttachmentOptions` | `{ mimeType: string; fileName: string; extension?: string \| null }` — no `clientHash`; ref known only after `send()`. |
+| `HashFirstReserveAttachmentOptions`   | `{ mimeType: string; fileName: string; extension?: string \| null; clientHash: AttachmentHash; sizeBytes: number }` — ref known at reserve time. |
+| `PreprocessResult`         | `{ ref: AttachmentRef; hash: AttachmentHash; sizeBytes: number; options: HashFirstReserveAttachmentOptions; data: ReadableStream<Uint8Array>; stream: () => ReadableStream<Uint8Array> }` |
 | `AttachmentUploadResult`   | `{ hash: AttachmentHash; ref: AttachmentRef; header: AttachmentHeader }`                                                  |
 | `AttachmentHeader`         | `{ hash; mimeType; fileName; sizeBytes; extension; status; source; createdAtUtc; lastAccessedAtUtc }`                     |
 | `AttachmentResponse`       | `{ header: AttachmentHeader; body: ReadableStream<Uint8Array> }`                                                          |
@@ -23888,6 +23988,10 @@ setAgentImageOperation(state, action) {
 | `InvalidAttachmentRef` | A string passed where a ref is expected does not match `attachment://v<N>:<hash>`. |
 | `UploadTooLarge`       | `upload.send()` exceeded the server's configured byte cap. Maps to HTTP 413.       |
 | `ReservationNotFound`  | `upload.send()` after the reservation expired or was deleted.                      |
+| `AttachmentAlreadyExists` | Hash-first `reserve()` for content whose hash is already stored. The client's `reserve()` catches this and returns the existing ref instead of uploading. |
+| `AttachmentPending`    | `get(ref)` for a hash that is reserved but whose bytes have not finished uploading. |
+| `HashMismatch`         | Hash-first `send()` whose uploaded bytes do not match the claimed `clientHash`.    |
+| `SizeMismatch`         | Hash-first `send()` whose actual byte count differs from the declared `sizeBytes`. |
 
 ### Helpers
 
@@ -23898,13 +24002,13 @@ setAgentImageOperation(state, action) {
 If a document model previously inlined binary content, the migration is small and mechanical:
 
 - **Schema** — replace `data: String` (or composite fields like `{ image, imageMediaType, imageUrl }`) with a single `attachment: Attachment` field on the input and the state type.
-- **Write path** — replace the base64-encoding step with `attachments.reserve({ mimeType, fileName })` followed by `upload.send(stream)`. Dispatch the action with `result.ref`.
+- **Write path** — replace the base64-encoding step with a reservation and upload. Either reserve on the service directly (`attachments.reserve({ mimeType, fileName })` then `upload.send(stream)`, dispatching with `result.ref`), or use the client (`attachments.preprocess(file)` then `client.execute(...)` with `results.ref` and `attachments.reserve(results.options, ...)`). In the browser, `useAttachmentUpload()` wraps the client flow.
 - **Read path** — replace data-URI assembly with `attachments.get(ref)`. In a browser, drain the stream into a `Blob` and use `URL.createObjectURL` (remember to `revokeObjectURL` on cleanup).
 - **Graceful degradation** — code paths that may run without an attachment service (mock environments, tests, off-line previews) should branch on `if (!attachments)`. Writers should surface a clear error to the user; readers should skip the attachment and render a placeholder.
 
 ## Deep dive
 
-See `packages/reactor/docs/attachments.md` in the monorepo for the full design: storage internals, the LRU eviction policy, the `IAttachmentStore` and `IAttachmentTransport` interfaces, the switchboard upload protocol, and the planned S3 backend.
+See `packages/reactor/docs/attachments.md` in the monorepo for the full design: storage internals, the LRU eviction policy, the `IAttachmentStore` and `IAttachmentTransport` interfaces, the switchboard upload protocol, and the planned S3 backend. For the hash-first reservation mode, hash/size verification on ingest, and the pending-upload lifecycle, see `packages/reactor/docs/attachments-hash-first.md`.
 
 ---
 

--- a/apps/academy/static/llms-full.txt
+++ b/apps/academy/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-06-02T16:54:52.898Z
+> Generated: 2026-06-05T18:44:06.547Z
 > Total Documents: 87
 > Source: https://powerhouse.academy/llms-full.txt
 
@@ -17830,17 +17830,17 @@ Initialize a new project
 
 
 ### Options
-**Name** - The name of your project. A new directory will be created in your current directory with this name. - Usage: `--name, -n <str>`
+**Name** - The name of your project. A new directory will be created in your current directory with this name. - Usage: `--name, -n \<str\>`
 
-**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p <value>`
+**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p \<value\>`
 
-**Tag** - Specify the release tag to use for your project. Can be one of: "latest", "staging", or "dev". - Usage: `--tag, -t <value>`
+**Tag** - Specify the release tag to use for your project. Can be one of: "latest", "staging", or "dev". - Usage: `--tag, -t \<value\>`
 
-**Version** - Specify the exact semver release version to use for your project. - Usage: `--version, -v <str>`
+**Version** - Specify the exact semver release version to use for your project. - Usage: `--version, -v \<str\>`
 
-**Remote Drive** - Remote drive identifier. - Usage: `--remote-drive, -r <str>`
+**Remote Drive** - Remote drive identifier. - Usage: `--remote-drive, -r \<str\>`
 
-**Clone** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--clone <str>`
+**Clone** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--clone \<str\>`
 
 
 ### Flags
@@ -17874,9 +17874,9 @@ Specify the release version of Powerhouse dependencies to use.
 
 
 ### Options
-**Tag** - Specify the release tag to use for your project. Can be one of: "latest", "staging", or "dev". - Usage: `--tag, -t <value>`
+**Tag** - Specify the release tag to use for your project. Can be one of: "latest", "staging", or "dev". - Usage: `--tag, -t \<value\>`
 
-**Version** - Specify the exact semver release version to use for your project. - Usage: `--version, -v <str>`
+**Version** - Specify the exact semver release version to use for your project. - Usage: `--version, -v \<str\>`
 
 
 ### Flags
@@ -17912,17 +17912,17 @@ Initialize a new global project
 
 
 ### Options
-**Name** - The name of your project. A new directory will be created in your current directory with this name. - Usage: `--name, -n <str>`
+**Name** - The name of your project. A new directory will be created in your current directory with this name. - Usage: `--name, -n \<str\>`
 
-**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p <value>`
+**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p \<value\>`
 
-**Tag** - Specify the release tag to use for your project. Can be one of: "latest", "staging", or "dev". - Usage: `--tag, -t <value>`
+**Tag** - Specify the release tag to use for your project. Can be one of: "latest", "staging", or "dev". - Usage: `--tag, -t \<value\>`
 
-**Version** - Specify the exact semver release version to use for your project. - Usage: `--version, -v <str>`
+**Version** - Specify the exact semver release version to use for your project. - Usage: `--version, -v \<str\>`
 
-**Remote Drive** - Remote drive identifier. - Usage: `--remote-drive, -r <str>`
+**Remote Drive** - Remote drive identifier. - Usage: `--remote-drive, -r \<str\>`
 
-**Clone** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--clone <str>`
+**Clone** - Path to an existing scaffolded project to clone instead of resolving deps from scratch. Install runs offline from the cloned project's pnpm-lock.yaml (requires --pnpm; --version/--tag are ignored). - Usage: `--clone \<str\>`
 
 
 ### Flags
@@ -17956,7 +17956,7 @@ Use your local `powerhouse` monorepo dependencies the current project.
 
 
 ### Options
-**Path** - Path to your local powerhouse monorepo relative to this project - Usage: `--path, -p <str>`
+**Path** - Path to your local powerhouse monorepo relative to this project - Usage: `--path, -p \<str\>`
 
 
 ### Flags
@@ -18009,9 +18009,9 @@ Generate a document model
 
 
 ### Options
-**Document** - Path to a document model spec (.phd or .json) to generate from - Usage: `--document, -d <file>`
+**Document** - Path to a document model spec (.phd or .json) to generate from - Usage: `--document, -d \<file\>`
 
-**Dir** - Name of the directory of an existing document model to re-generate - Usage: `--dir <dir>`
+**Dir** - Name of the directory of an existing document model to re-generate - Usage: `--dir \<dir\>`
 
 
 ### Flags
@@ -18029,13 +18029,13 @@ Generate a document editor
 
 
 ### Options
-**Name** - The name of the document editor to generate - Usage: `--name, -n <str>`
+**Name** - The name of the document editor to generate - Usage: `--name, -n \<str\>`
 
-**Document Type** - The document type for the new editor - Usage: `--document-type, -t <str>`
+**Document Type** - The document type for the new editor - Usage: `--document-type, -t \<str\>`
 
-**Document** - Path to a powerhouse/document-editor spec file (.phd or .json) to drive codegen - Usage: `--document, -d <file>`
+**Document** - Path to a powerhouse/document-editor spec file (.phd or .json) to drive codegen - Usage: `--document, -d \<file\>`
 
-**Dir** - Name of the directory of an existing editor to re-generate - Usage: `--dir <dir>`
+**Dir** - Name of the directory of an existing editor to re-generate - Usage: `--dir \<dir\>`
 
 
 ### Flags
@@ -18053,13 +18053,13 @@ Generate a drive app
 
 
 ### Options
-**Name** - The name of the drive app to generate - Usage: `--name, -n <str>`
+**Name** - The name of the drive app to generate - Usage: `--name, -n \<str\>`
 
-**Document Types** - The document types allowed by the new app - Usage: `--document-types <str>, -t=<str>`
+**Document Types** - The document types allowed by the new app - Usage: `--document-types \<str\>, -t=\<str\>`
 
-**Document** - Path to a powerhouse/app spec file (.phd or .json) to drive codegen - Usage: `--document, -d <file>`
+**Document** - Path to a powerhouse/app spec file (.phd or .json) to drive codegen - Usage: `--document, -d \<file\>`
 
-**Dir** - Name of the directory of an existing app to re-generate - Usage: `--dir <dir>`
+**Dir** - Name of the directory of an existing app to re-generate - Usage: `--dir \<dir\>`
 
 
 ### Flags
@@ -18080,20 +18080,20 @@ Generate a processor
 
 
 ### Options
-**Name** - The name of the processor to generate - Usage: `--name, -n <str>`
+**Name** - The name of the processor to generate - Usage: `--name, -n \<str\>`
 
-**Type** - The type of processor to generate - Usage: `--type <value>`
+**Type** - The type of processor to generate - Usage: `--type \<value\>`
 
 **Default:** `analytics`
-**Document Types** - The document types the processor will run on - Usage: `--document-types <str>, -t=<str>`
+**Document Types** - The document types the processor will run on - Usage: `--document-types \<str\>, -t=\<str\>`
 
 **Default:** ``
-**Apps** - Whether the processor will run in switchboard (nodejs), connect (browser), or both - Usage: `--apps <value>`
+**Apps** - Whether the processor will run in switchboard (nodejs), connect (browser), or both - Usage: `--apps \<value\>`
 
 **Default:** `switchboard,connect`
-**Document** - Path to a powerhouse/processor spec file (.phd or .json) to drive codegen - Usage: `--document, -d <file>`
+**Document** - Path to a powerhouse/processor spec file (.phd or .json) to drive codegen - Usage: `--document, -d \<file\>`
 
-**Dir** - Name of the directory of an existing processor to re-generate - Usage: `--dir <dir>`
+**Dir** - Name of the directory of an existing processor to re-generate - Usage: `--dir \<dir\>`
 
 
 ### Flags
@@ -18111,11 +18111,11 @@ Generate a subgraph
 
 
 ### Options
-**Name** - The name of the subgraph to generate - Usage: `--name, -n <str>`
+**Name** - The name of the subgraph to generate - Usage: `--name, -n \<str\>`
 
-**Document** - Path to a powerhouse/subgraph spec file (.phd or .json) to drive codegen - Usage: `--document, -d <file>`
+**Document** - Path to a powerhouse/subgraph spec file (.phd or .json) to drive codegen - Usage: `--document, -d \<file\>`
 
-**Dir** - Name of the directory of an existing subgraph to re-generate - Usage: `--dir <dir>`
+**Dir** - Name of the directory of an existing subgraph to re-generate - Usage: `--dir \<dir\>`
 
 
 ### Flags
@@ -18133,9 +18133,9 @@ Generate a migration file
 
 
 ### Options
-**Path *[required]*** - Path to the migration file - Usage: `--path, -p <str>`
+**Path *[required]*** - Path to the migration file - Usage: `--path, -p \<str\>`
 
-**Schema File** - Path to the output file. Defaults to './schema.ts' - Usage: `--schema-file <str>`
+**Schema File** - Path to the output file. Defaults to './schema.ts' - Usage: `--schema-file \<str\>`
 
 
 ### Flags
@@ -18158,42 +18158,42 @@ and real-time processing with a "Vetra" drive or connection to remote drives.
 
 
 ### Options
-**Switchboard Port** - port to use for the Vetra Switchboard - Usage: `--switchboard-port <number>`
+**Switchboard Port** - port to use for the Vetra Switchboard - Usage: `--switchboard-port \<number\>`
 
-**Connect Port** - port to use for the Vetra Connect - Usage: `--connect-port <number>`
+**Connect Port** - port to use for the Vetra Connect - Usage: `--connect-port \<number\>`
 
 **Default:** `3001`
-**Remote Drive** - URL of remote drive to connect to (skips switchboard initialization) - Usage: `--remote-drive <str>`
+**Remote Drive** - URL of remote drive to connect to (skips switchboard initialization) - Usage: `--remote-drive \<str\>`
 
-**Db Path** - Database path or connection string. Use a `postgres://` URL for Postgres; otherwise treated as a PGlite filesystem path. Leave unset for in-memory PGlite. - Usage: `--db-path <str>`
+**Db Path** - Database path or connection string. Use a `postgres://` URL for Postgres; otherwise treated as a PGlite filesystem path. Leave unset for in-memory PGlite. - Usage: `--db-path \<str\>`
 
-**Base** - Base path for the app - Usage: `--base <str>`
+**Base** - Base path for the app - Usage: `--base \<str\>`
 
-**Log Level** - Log level for the application - Usage: `--log-level <value>`
+**Log Level** - Log level for the application - Usage: `--log-level \<value\>`
 
 **Environment:** `PH_CONNECT_LOG_LEVEL`
 **Default:** `info`
-**Packages** - Comma-separated list of package names to load - Usage: `--packages <str>`
+**Packages** - Comma-separated list of package names to load - Usage: `--packages \<str\>`
 
 **Environment:** `PH_PACKAGES`
-**Local Package** - Path to local package to load during development - Usage: `--local-package <str>`
+**Local Package** - Path to local package to load during development - Usage: `--local-package \<str\>`
 
 **Environment:** `PH_LOCAL_PACKAGE`
-**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url <str>`
+**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url \<str\>`
 
-**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy <value>`
+**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy \<value\>`
 
 **Default:** `preserve-by-url-and-detach`
-**Host** - Expose the server to the network. Pass an IP (e.g. 0.0.0.0) to bind to a specific address. - Usage: `--host <str>`
+**Host** - Expose the server to the network. Pass an IP (e.g. 0.0.0.0) to bind to a specific address. - Usage: `--host \<str\>`
 
-**Watch Timeout** - Amount of time to wait before a file is considered changed - Usage: `--watch-timeout <number>`
+**Watch Timeout** - Amount of time to wait before a file is considered changed - Usage: `--watch-timeout \<number\>`
 
 **Default:** `300`
-**Https Key File** - path to the ssl key file - Usage: `--https-key-file <str>`
+**Https Key File** - path to the ssl key file - Usage: `--https-key-file \<str\>`
 
-**Https Cert File** - path to the ssl cert file - Usage: `--https-cert-file <str>`
+**Https Cert File** - path to the ssl cert file - Usage: `--https-cert-file \<str\>`
 
-**Remote Drives** - Specify remote drive URLs to use - Usage: `--remote-drives <str>`
+**Remote Drives** - Specify remote drive URLs to use - Usage: `--remote-drives \<str\>`
 
 
 ### Flags
@@ -18250,29 +18250,29 @@ your project.
 
 
 ### Options
-**Port** - Port to run the dev server on. - Usage: `--port <number>`
+**Port** - Port to run the dev server on. - Usage: `--port \<number\>`
 
 **Default:** `3000`
-**Base** - Base path for the app - Usage: `--base <str>`
+**Base** - Base path for the app - Usage: `--base \<str\>`
 
-**Log Level** - Log level for the application - Usage: `--log-level <value>`
+**Log Level** - Log level for the application - Usage: `--log-level \<value\>`
 
 **Environment:** `PH_CONNECT_LOG_LEVEL`
 **Default:** `info`
-**Packages** - Comma-separated list of package names to load - Usage: `--packages <str>`
+**Packages** - Comma-separated list of package names to load - Usage: `--packages \<str\>`
 
 **Environment:** `PH_PACKAGES`
-**Local Package** - Path to local package to load during development - Usage: `--local-package <str>`
+**Local Package** - Path to local package to load during development - Usage: `--local-package \<str\>`
 
 **Environment:** `PH_LOCAL_PACKAGE`
-**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url <str>`
+**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url \<str\>`
 
-**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy <value>`
+**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy \<value\>`
 
 **Default:** `preserve-by-url-and-detach`
-**Host** - Expose the server to the network. Pass an IP (e.g. 0.0.0.0) to bind to a specific address. - Usage: `--host <str>`
+**Host** - Expose the server to the network. Pass an IP (e.g. 0.0.0.0) to bind to a specific address. - Usage: `--host \<str\>`
 
-**Watch Timeout** - Amount of time to wait before a file is considered changed - Usage: `--watch-timeout <number>`
+**Watch Timeout** - Amount of time to wait before a file is considered changed - Usage: `--watch-timeout \<number\>`
 
 **Default:** `300`
 
@@ -18305,68 +18305,68 @@ external packages included.
 
 Runtime-config overrides (all combinable — last wins on collision):
   ph connect build                                    Build with the current source config.
-  ph connect build <key> <value>                      Build with a positional override applied (e.g. ph connect build connect.renown.url https://renown.staging).
-  ph connect build --<field> <value>                  Build with a per-field flag override (e.g. --renown-url https://renown.staging).
+  ph connect build \<key\> \<value\>                      Build with a positional override applied (e.g. ph connect build connect.renown.url https://renown.staging).
+  ph connect build --\<field\> \<value\>                  Build with a per-field flag override (e.g. --renown-url https://renown.staging).
   ph connect build --json '\{"…":"…"\}'                Build with a bulk override.
 
-Build has no read mode; passing only <key> without <value> errors out (use `ph connect config <key>` to read).
+Build has no read mode; passing only \<key\> without \<value\> errors out (use `ph connect config \<key\>` to read).
 
 
 ### Options
-**Out Dir** - Output directory - Usage: `--outDir <str>`
+**Out Dir** - Output directory - Usage: `--outDir \<str\>`
 
 **Default:** `.ph/connect-build/dist/`
-**Json** - Inline JSON override for the runtime connect.* block, e.g. '\{"renown":\{"url":"..."\}\}'. Validated against the runtime schema; deep-merged on top of env seeds and source powerhouse.config.json. Individual --flag values beat --json on collision. - Usage: `--json <str>`
+**Json** - Inline JSON override for the runtime connect.* block, e.g. '\{"renown":\{"url":"..."\}\}'. Validated against the runtime schema; deep-merged on top of env seeds and source powerhouse.config.json. Individual --flag values beat --json on collision. - Usage: `--json \<str\>`
 
-**Renown Url** - Override connect.renown.url. - Usage: `--renown-url <str>`
+**Renown Url** - Override connect.renown.url. - Usage: `--renown-url \<str\>`
 
-**Renown Network Id** - Override connect.renown.networkId. - Usage: `--renown-network-id <str>`
+**Renown Network Id** - Override connect.renown.networkId. - Usage: `--renown-network-id \<str\>`
 
-**Renown Chain Id** - Override connect.renown.chainId. - Usage: `--renown-chain-id <number>`
+**Renown Chain Id** - Override connect.renown.chainId. - Usage: `--renown-chain-id \<number\>`
 
-**Allow Add Drive** - Override connect.drives.allowAddDrive (top-level add-drive toggle). - Usage: `--allow-add-drive <value>`
+**Allow Add Drive** - Override connect.drives.allowAddDrive (top-level add-drive toggle). - Usage: `--allow-add-drive \<value\>`
 
-**External Packages** - Override connect.packages.externalEnabled. - Usage: `--external-packages <value>`
+**External Packages** - Override connect.packages.externalEnabled. - Usage: `--external-packages \<value\>`
 
-**Remote Drives Enabled** - Override connect.drives.sections.remote.enabled (the unified cloud+public section). - Usage: `--remote-drives-enabled <value>`
+**Remote Drives Enabled** - Override connect.drives.sections.remote.enabled (the unified cloud+public section). - Usage: `--remote-drives-enabled \<value\>`
 
-**Remote Drives Allow Add** - Override connect.drives.sections.remote.allowAdd. - Usage: `--remote-drives-allow-add <value>`
+**Remote Drives Allow Add** - Override connect.drives.sections.remote.allowAdd. - Usage: `--remote-drives-allow-add \<value\>`
 
-**Remote Drives Allow Delete** - Override connect.drives.sections.remote.allowDelete. - Usage: `--remote-drives-allow-delete <value>`
+**Remote Drives Allow Delete** - Override connect.drives.sections.remote.allowDelete. - Usage: `--remote-drives-allow-delete \<value\>`
 
-**Local Drives Enabled** - Override connect.drives.sections.local.enabled. - Usage: `--local-drives-enabled <value>`
+**Local Drives Enabled** - Override connect.drives.sections.local.enabled. - Usage: `--local-drives-enabled \<value\>`
 
-**Local Drives Allow Add** - Override connect.drives.sections.local.allowAdd. - Usage: `--local-drives-allow-add <value>`
+**Local Drives Allow Add** - Override connect.drives.sections.local.allowAdd. - Usage: `--local-drives-allow-add \<value\>`
 
-**Local Drives Allow Delete** - Override connect.drives.sections.local.allowDelete. - Usage: `--local-drives-allow-delete <value>`
+**Local Drives Allow Delete** - Override connect.drives.sections.local.allowDelete. - Usage: `--local-drives-allow-delete \<value\>`
 
-**Packages Registry** - Override the top-level packageRegistryUrl. - Usage: `--packages-registry <str>`
+**Packages Registry** - Override the top-level packageRegistryUrl. - Usage: `--packages-registry \<str\>`
 
-**App Name** - Override connect.branding.appName. - Usage: `--app-name <str>`
+**App Name** - Override connect.branding.appName. - Usage: `--app-name \<str\>`
 
-**Home Background** - Override connect.branding.homeBackground. URL or path to an image; pass an empty string ("") to reset to the bundled default. - Usage: `--home-background <str>`
+**Home Background** - Override connect.branding.homeBackground. URL or path to an image; pass an empty string ("") to reset to the bundled default. - Usage: `--home-background \<str\>`
 
-**Sentry Dsn** - Override connect.sentry.dsn (Sentry DSN URL). Pass an empty string ("") to set null and disable Sentry. - Usage: `--sentry-dsn <str>`
+**Sentry Dsn** - Override connect.sentry.dsn (Sentry DSN URL). Pass an empty string ("") to set null and disable Sentry. - Usage: `--sentry-dsn \<str\>`
 
-**Sentry Env** - Override connect.sentry.env (Sentry environment label). - Usage: `--sentry-env <str>`
+**Sentry Env** - Override connect.sentry.env (Sentry environment label). - Usage: `--sentry-env \<str\>`
 
-**Sentry Tracing Enabled** - Override connect.sentry.tracing (Sentry performance tracing). - Usage: `--sentry-tracing-enabled <value>`
+**Sentry Tracing Enabled** - Override connect.sentry.tracing (Sentry performance tracing). - Usage: `--sentry-tracing-enabled \<value\>`
 
-**Base** - Base path for the app - Usage: `--base <str>`
+**Base** - Base path for the app - Usage: `--base \<str\>`
 
-**Log Level** - Log level for the application - Usage: `--log-level <value>`
+**Log Level** - Log level for the application - Usage: `--log-level \<value\>`
 
 **Environment:** `PH_CONNECT_LOG_LEVEL`
 **Default:** `info`
-**Packages** - Comma-separated list of package names to load - Usage: `--packages <str>`
+**Packages** - Comma-separated list of package names to load - Usage: `--packages \<str\>`
 
 **Environment:** `PH_PACKAGES`
-**Local Package** - Path to local package to load during development - Usage: `--local-package <str>`
+**Local Package** - Path to local package to load during development - Usage: `--local-package \<str\>`
 
 **Environment:** `PH_LOCAL_PACKAGE`
-**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url <str>`
+**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url \<str\>`
 
-**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy <value>`
+**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy \<value\>`
 
 **Default:** `preserve-by-url-and-detach`
 
@@ -18376,9 +18376,9 @@ Build has no read mode; passing only <key> without <value> errors out (use `ph c
 ## Parameters
 
 ### Arguments
-**Key** - Dotted path inside the runtime config (e.g. connect.renown.url). Pair with <value> to set; pass alone to `ph connect config` to read. - Usage: `[key]`
+**Key** - Dotted path inside the runtime config (e.g. connect.renown.url). Pair with \<value\> to set; pass alone to `ph connect config` to read. - Usage: `[key]`
 
-**Value** - Value to set at <key>. Coerced against the runtime schema (string, bool, number, enum). Arrays and objects require --json instead. - Usage: `[value]`
+**Value** - Value to set at \<key\>. Coerced against the runtime schema (string, bool, number, enum). Arrays and objects require --json instead. - Usage: `[value]`
 
 
 ### Flags
@@ -18397,32 +18397,32 @@ NOTE: You must run `ph connect build` first
 
 
 ### Options
-**Port** - Port to run the preview server on. - Usage: `--port <number>`
+**Port** - Port to run the preview server on. - Usage: `--port \<number\>`
 
 **Default:** `4173`
-**Out Dir** - Output directory - Usage: `--outDir <str>`
+**Out Dir** - Output directory - Usage: `--outDir \<str\>`
 
 **Default:** `.ph/connect-build/dist/`
-**Base** - Base path for the app - Usage: `--base <str>`
+**Base** - Base path for the app - Usage: `--base \<str\>`
 
-**Log Level** - Log level for the application - Usage: `--log-level <value>`
+**Log Level** - Log level for the application - Usage: `--log-level \<value\>`
 
 **Environment:** `PH_CONNECT_LOG_LEVEL`
 **Default:** `info`
-**Packages** - Comma-separated list of package names to load - Usage: `--packages <str>`
+**Packages** - Comma-separated list of package names to load - Usage: `--packages \<str\>`
 
 **Environment:** `PH_PACKAGES`
-**Local Package** - Path to local package to load during development - Usage: `--local-package <str>`
+**Local Package** - Path to local package to load during development - Usage: `--local-package \<str\>`
 
 **Environment:** `PH_LOCAL_PACKAGE`
-**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url <str>`
+**Default Drives Url** - The default drives url to use in connect - Usage: `--default-drives-url \<str\>`
 
-**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy <value>`
+**Drive Preserve Strategy** - The preservation strategy to use on default drives - Usage: `--drive-preserve-strategy \<value\>`
 
 **Default:** `preserve-by-url-and-detach`
-**Host** - Expose the server to the network. Pass an IP (e.g. 0.0.0.0) to bind to a specific address. - Usage: `--host <str>`
+**Host** - Expose the server to the network. Pass an IP (e.g. 0.0.0.0) to bind to a specific address. - Usage: `--host \<str\>`
 
-**Watch Timeout** - Amount of time to wait before a file is considered changed - Usage: `--watch-timeout <number>`
+**Watch Timeout** - Amount of time to wait before a file is considered changed - Usage: `--watch-timeout \<number\>`
 
 **Default:** `300`
 
@@ -18499,10 +18499,10 @@ Notes:
 
 
 ### Options
-**Expiry** - Token expiry duration. Supports: "7d" (days), "24h" (hours), "3600" or "3600s" (seconds) - Usage: `--expiry <str>`
+**Expiry** - Token expiry duration. Supports: "7d" (days), "24h" (hours), "3600" or "3600s" (seconds) - Usage: `--expiry \<str\>`
 
 **Default:** `7d`
-**Audience** - Target audience URL for the token - Usage: `--audience <str>`
+**Audience** - Target audience URL for the token - Usage: `--audience \<str\>`
 
 
 ### Flags
@@ -18529,7 +18529,7 @@ your project.
 ## Parameters
 
 ### Arguments
-**Package Name *[required]*** - The name of the package to inspect - Usage: `<package-name>`
+**Package Name *[required]*** - The name of the package to inspect - Usage: `\<package-name\>`
 
 
 ### Flags
@@ -18569,7 +18569,7 @@ Run migrations
 
 
 ### Options
-**Version** - The version to migrate to. Accepts a valid semver version or `staging`, `dev`, `latest`. - Usage: `--version, -v <str>`
+**Version** - The version to migrate to. Accepts a valid semver version or `staging`, `dev`, `latest`. - Usage: `--version, -v \<str\>`
 
 **Default:** `latest`
 
@@ -18627,26 +18627,26 @@ models, processors, and real-time updates.
 
 
 ### Options
-**Https Key File** - path to the ssl key file - Usage: `--https-key-file <str>`
+**Https Key File** - path to the ssl key file - Usage: `--https-key-file \<str\>`
 
-**Https Cert File** - path to the ssl cert file - Usage: `--https-cert-file <str>`
+**Https Cert File** - path to the ssl cert file - Usage: `--https-cert-file \<str\>`
 
-**Remote Drives** - Specify remote drive URLs to use - Usage: `--remote-drives <str>`
+**Remote Drives** - Specify remote drive URLs to use - Usage: `--remote-drives \<str\>`
 
-**Packages** - Comma-separated list of package names to load - Usage: `--packages <str>`
+**Packages** - Comma-separated list of package names to load - Usage: `--packages \<str\>`
 
 **Environment:** `PH_PACKAGES`
-**Port** - Port to host the api - Usage: `--port <number>`
+**Port** - Port to host the api - Usage: `--port \<number\>`
 
 **Default:** `4001`
-**Base Path** - base path for the API endpoints (sets the BASE_PATH environment variable) - Usage: `--base-path <str>`
+**Base Path** - base path for the API endpoints (sets the BASE_PATH environment variable) - Usage: `--base-path \<str\>`
 
-**Keypair Path** - path to custom keypair file for identity - Usage: `--keypair-path <str>`
+**Keypair Path** - path to custom keypair file for identity - Usage: `--keypair-path \<str\>`
 
-**Vetra Drive Id** - Specify a Vetra drive ID - Usage: `--vetra-drive-id <str>`
+**Vetra Drive Id** - Specify a Vetra drive ID - Usage: `--vetra-drive-id \<str\>`
 
 **Default:** `vetra`
-**Db Path** - path to the database - Usage: `--db-path <str>`
+**Db Path** - path to the database - Usage: `--db-path \<str\>`
 
 
 ## Login
@@ -18663,11 +18663,11 @@ the CLI to act on behalf of your Ethereum identity for authenticated operations.
 
 
 ### Options
-**Renown Url** - Renown server URL. - Usage: `--renown-url <str>`
+**Renown Url** - Renown server URL. - Usage: `--renown-url \<str\>`
 
 **Environment:** `PH_CONNECT_RENOWN_URL`
 **Default:** `https//www.renown.id`
-**Timeout** - Authentication timeout in seconds. - Usage: `--timeout <number>`
+**Timeout** - Authentication timeout in seconds. - Usage: `--timeout \<number\>`
 
 **Default:** `300`
 
@@ -18696,7 +18696,7 @@ as provider "local" — it will be bundled into ph connect build so the
 preview works without the registry being reachable.
 
 Resolution order for the registry URL:
-  --registry flag > PH_REGISTRY_URL env > powerhouse.config.json > default
+  --registry flag \> PH_REGISTRY_URL env \> powerhouse.config.json \> default
   
 
 
@@ -18709,11 +18709,11 @@ Resolution order for the registry URL:
 
 
 ### Options
-**Registry** - Registry URL to install from (overrides config and environment) - Usage: `--registry <str>`
+**Registry** - Registry URL to install from (overrides config and environment) - Usage: `--registry \<str\>`
 
-**Allow Build** - A list of package names that are allowed to run postinstall scripts during installation. - Usage: `--allow-build <str>`
+**Allow Build** - A list of package names that are allowed to run postinstall scripts during installation. - Usage: `--allow-build \<str\>`
 
-**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p <value>`
+**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p \<value\>`
 
 
 ### Flags
@@ -18753,7 +18753,7 @@ removal of packages, updates configuration files, and ensures proper cleanup.
 
 
 ### Options
-**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p <value>`
+**Package Manager** - Specify the package manager to use for your project. Can be one of: `npm`, `pnpm`, `yarn`, or `bun`. Defaults to your environment package manager. - Usage: `--package-manager, -p \<value\>`
 
 
 ### Flags
@@ -23708,7 +23708,19 @@ The `@powerhousedao/reactor-attachments` package decouples large binaries (image
 } from "@powerhousedao/reactor-attachments";
 ```
 
-For an architectural overview see [Working with the Reactor](/academy/Architecture/WorkingWithTheReactor). For the full design — storage layout, eviction, transports, the planned S3 backend — see the deep-dive doc at `packages/reactor/docs/attachments.md` in the monorepo.
+The package exposes two layers. `IAttachmentService` is the low-level, transport-facing interface — reserve a slot, stream the bytes, read them back by ref. `IAttachmentClient` wraps a service with convenience helpers; most notably `preprocess()`, which hashes a file up front so its ref is known before the bytes are uploaded. Build a client with `createAttachmentClient(service)`, and import it from the `/client` entrypoint:
+
+```typescript
+
+  createAttachmentClient,
+  type IAttachmentClient,
+  type PreprocessResult,
+} from "@powerhousedao/reactor-attachments/client";
+```
+
+The React hooks in `@powerhousedao/reactor-browser` are built on the client.
+
+For an architectural overview see [Working with the Reactor](/academy/Architecture/WorkingWithTheReactor). For the full design — storage layout, eviction, transports, the hash-first/pending protocol, and the planned S3 backend — see the deep-dive docs `packages/reactor/docs/attachments.md` and `packages/reactor/docs/attachments-hash-first.md` in the monorepo.
 
 ## When to use it
 
@@ -23740,11 +23752,18 @@ const attachments = createRemoteAttachmentService({
 The switchboard remote service is the supported client implementation right now. Other transports (S3, peer-to-peer) are designed but not yet stable — prefer `createRemoteAttachmentService` until these docs call out a replacement.
 
 
-On the server side (inside a subgraph, processor, or trigger), the service is already wired into `ReactorContext` by `@powerhousedao/reactor-api` and is available as `reactor.attachments`. There is no need to construct one yourself — see `packages/reactor-api/src/server.ts` for the wiring.
+On the server side (inside a subgraph, processor, or trigger), an `IAttachmentClient` is already wired into the host context by `@powerhousedao/reactor-api` and is available as `context.attachments`. There is no need to construct one yourself — the server builds the service and wraps it with `createAttachmentClient(...)`; see `packages/reactor-api/src/server.ts` for the wiring.
 
 ## The general flow
 
-Every interaction with the package is one of three operations on `IAttachmentService`: reserve a slot, send the bytes, then later read them back by ref.
+Every interaction with the package comes down to three operations: reserve a slot, send the bytes, then later read them back by ref.
+
+There are two reservation modes. They are equivalent in capability — neither is preferred, so pick whichever fits the caller:
+
+- **Upload-first** — reserve with just `{ mimeType, fileName }`. The content hash, and therefore the final ref, is only known *after* `send()` completes. Simplest when you can stream the bytes straight through and do not need the ref until the upload finishes.
+- **Hash-first** — hash the content up front and reserve with `{ clientHash, sizeBytes, ... }`. The ref is known at reservation time, so it can be written into document state before (or in parallel with) the upload, and dedup can short-circuit before any bytes are sent. The trade-off is that the whole file must be read to hash it. `IAttachmentClient.preprocess()` does that hashing for you.
+
+The walkthrough below uses the low-level service in upload-first mode. The [attachment client](#the-attachment-client) section shows the hash-first flow.
 
 ### 1. Reserve an upload slot
 
@@ -23827,21 +23846,92 @@ const objectUrl = URL.createObjectURL(blob);
 // ...later: URL.revokeObjectURL(objectUrl);
 ```
 
-`get()` always succeeds for a known ref. If the bytes were evicted from local storage, the service transparently re-fetches them through the transport.
+`get()` succeeds for any ref whose bytes are available. If the bytes were evicted from local storage, the service transparently re-fetches them through the transport. A hash-first ref can also be *pending* — reserved, with state already referencing it, but the bytes not yet uploaded. During that window `get()` throws `AttachmentPending`, while `stat()` succeeds and reports the declared size.
+
+## The attachment client
+
+`IAttachmentClient` wraps an `IAttachmentService` with the hash-first flow. Build one with `createAttachmentClient(service)` (server code already receives one as `context.attachments`).
+
+`preprocess(file)` reads the whole file, computes its SHA-256, and returns everything you need to both reference and upload it:
+
+```typescript
+const attachments = createAttachmentClient(service);
+
+const results = await attachments.preprocess(file);
+// results: { ref, hash, sizeBytes, options, data, stream }
+```
+
+Because it has to read the entire file to hash it, `preprocess` is async and buffers the bytes in memory — `file` is a `Blob`, not a stream.
+
+With the ref in hand you can write it into document state through a normal action, then upload the bytes:
+
+```typescript
+await client.execute(documentId, "main", [
+  attachInvoice({ scan: results.ref, vendorName: "Acme" }),
+]);
+
+await attachments.reserve(results.options, (handle) => handle.send(results.stream()));
+```
+
+`client.reserve(options, send)` reserves the slot and hands the upload handle to your `send` callback. If an attachment with the same hash already exists it short-circuits and returns the existing ref without uploading. Pass `results.stream()` — which returns a fresh `ReadableStream` on each call — rather than the single-use `results.data` if the upload might be retried. `send()` accepts any `ReadableStream<Uint8Array>`, so on the server you can stream from the original source instead of the buffered copy.
+
+Execute and reserve are awaited separately so each failure is handled on its own — a failed upload does not roll back the action, and a failed action does not strand an upload. If you do not need that separation, run them concurrently:
+
+```typescript
+await Promise.all([
+  client.execute(documentId, "main", [
+    attachInvoice({ scan: results.ref, vendorName: "Acme" }),
+  ]),
+  attachments.reserve(results.options, (handle) => handle.send(results.stream())),
+]);
+```
+
+### React
+
+`@powerhousedao/reactor-browser` exposes hooks built on the client. `useAttachments()` returns an `IAttachmentClient` for the current service (or `undefined` if none is configured). `useAttachmentUpload()` drives the full preprocess + upload lifecycle and tracks its status:
+
+```tsx
+const client = useReactorClient();
+const { preprocess, upload, status, progress, error } = useAttachmentUpload();
+
+const submit = useCallback(async () => {
+  // Buffers the file in memory and hands back the ref. Async because it has to
+  // read the whole file to hash it.
+  const results = await preprocess(file);
+
+  // Execute with the generated ref. `scan` is just a string here; the action
+  // and codegen never see the file or the attachments package.
+  await client.execute(documentId, "main", [
+    attachInvoice({ scan: results.ref, vendorName: "Acme" }),
+  ]);
+
+  // Upload the bytes. Awaited separately from execute() so each failure is
+  // handled on its own.
+  await upload(results);
+}, [client, preprocess, upload, documentId, file]);
+```
+
+In render, read the lifecycle straight off the hook:
+
+- `status` — `UploadStatus`: `None | Hashing | Uploading | Done | Error`
+- `progress` — coarse/stage-based; the remote transport buffers then issues a single PUT, so byte-level progress is not available yet
+- `error` — the upload failure, if any
+
+`preprocess` and `upload` are stable callbacks. `upload(results)` wraps `client.reserve(results.options, (handle) => handle.send(results.stream()))` and updates `status`/`progress`/`error`. Because React runs in the browser, this mirrors the buffered flow above; the ref still only exists after `preprocess` resolves, so submission is async — you cannot produce a ref inside the synchronous action input.
 
 ## Declaring attachment fields in a document model
 
-The integration surface between document models and the attachment system is a single GraphQL scalar: `Attachment`. Declare attachment-bearing fields with it, and codegen will emit a TypeScript `string` (specifically `AttachmentRef`).
+The integration surface between document models and the attachment system is a single GraphQL scalar: `AttachmentRef`. Declare attachment-bearing fields with it, and codegen will emit a branded TypeScript string (`` `attachment://v${number}:${string}` ``) plus a Zod validator that enforces the ref protocol.
 
 ```graphql
-scalar Attachment
+scalar AttachmentRef
 
 input SetAgentImageInput {
-  attachment: Attachment!
+  attachment: AttachmentRef!
 }
 
 type AgentInfo {
-  attachment: Attachment
+  attachment: AttachmentRef
 }
 ```
 
@@ -23849,7 +23939,7 @@ The reducer stores the value verbatim — no special handling needed:
 
 ```typescript
 setAgentImageOperation(state, action) {
-  state.agent.attachment = action.input.attachment; // AttachmentRef string
+  state.agent.attachment = action.input.attachment; // AttachmentRef
 }
 ```
 
@@ -23870,12 +23960,22 @@ setAgentImageOperation(state, action) {
 | `reservationId`    | `string`                                                        | Unique identifier for this reservation.                                                                           |
 | `send(data)`       | `(ReadableStream<Uint8Array>) => Promise<AttachmentUploadResult>` | Stream the bytes through the handle. Returns `{ hash, ref, header }`. Dedup against existing hashes is automatic. |
 
+### `IAttachmentClient`
+
+| Method                    | Returns                            | Description                                                                                                                                                                          |
+| ------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `preprocess(file, opts?)` | `Promise<PreprocessResult>`        | Read and hash a `Blob` up front. Returns the ref, hash, declared size, hash-first reserve options, and the buffered bytes (as a single-use `data` stream and a re-readable `stream()` factory). `opts` may override `{ fileName, mimeType }`. |
+| `reserve(options, send)`  | `Promise<AttachmentUploadResult>`  | Reserve a hash-first slot and run `send(handle)`. Short-circuits to the existing ref if the hash is already stored (`AttachmentAlreadyExists` is handled internally).                |
+
 ### Key types
 
 | Type                       | Shape                                                                                                                     |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `AttachmentRef`            | `` `attachment://v${number}:${string}` `` — opaque ref string used in document state.                                     |
-| `ReserveAttachmentOptions` | `{ mimeType: string; fileName: string; extension?: string \| null }`                                                      |
+| `ReserveAttachmentOptions` | `UploadFirstReserveAttachmentOptions \| HashFirstReserveAttachmentOptions` — discriminated on `clientHash`.                |
+| `UploadFirstReserveAttachmentOptions` | `{ mimeType: string; fileName: string; extension?: string \| null }` — no `clientHash`; ref known only after `send()`. |
+| `HashFirstReserveAttachmentOptions`   | `{ mimeType: string; fileName: string; extension?: string \| null; clientHash: AttachmentHash; sizeBytes: number }` — ref known at reserve time. |
+| `PreprocessResult`         | `{ ref: AttachmentRef; hash: AttachmentHash; sizeBytes: number; options: HashFirstReserveAttachmentOptions; data: ReadableStream<Uint8Array>; stream: () => ReadableStream<Uint8Array> }` |
 | `AttachmentUploadResult`   | `{ hash: AttachmentHash; ref: AttachmentRef; header: AttachmentHeader }`                                                  |
 | `AttachmentHeader`         | `{ hash; mimeType; fileName; sizeBytes; extension; status; source; createdAtUtc; lastAccessedAtUtc }`                     |
 | `AttachmentResponse`       | `{ header: AttachmentHeader; body: ReadableStream<Uint8Array> }`                                                          |
@@ -23888,6 +23988,10 @@ setAgentImageOperation(state, action) {
 | `InvalidAttachmentRef` | A string passed where a ref is expected does not match `attachment://v<N>:<hash>`. |
 | `UploadTooLarge`       | `upload.send()` exceeded the server's configured byte cap. Maps to HTTP 413.       |
 | `ReservationNotFound`  | `upload.send()` after the reservation expired or was deleted.                      |
+| `AttachmentAlreadyExists` | Hash-first `reserve()` for content whose hash is already stored. The client's `reserve()` catches this and returns the existing ref instead of uploading. |
+| `AttachmentPending`    | `get(ref)` for a hash that is reserved but whose bytes have not finished uploading. |
+| `HashMismatch`         | Hash-first `send()` whose uploaded bytes do not match the claimed `clientHash`.    |
+| `SizeMismatch`         | Hash-first `send()` whose actual byte count differs from the declared `sizeBytes`. |
 
 ### Helpers
 
@@ -23898,13 +24002,13 @@ setAgentImageOperation(state, action) {
 If a document model previously inlined binary content, the migration is small and mechanical:
 
 - **Schema** — replace `data: String` (or composite fields like `{ image, imageMediaType, imageUrl }`) with a single `attachment: Attachment` field on the input and the state type.
-- **Write path** — replace the base64-encoding step with `attachments.reserve({ mimeType, fileName })` followed by `upload.send(stream)`. Dispatch the action with `result.ref`.
+- **Write path** — replace the base64-encoding step with a reservation and upload. Either reserve on the service directly (`attachments.reserve({ mimeType, fileName })` then `upload.send(stream)`, dispatching with `result.ref`), or use the client (`attachments.preprocess(file)` then `client.execute(...)` with `results.ref` and `attachments.reserve(results.options, ...)`). In the browser, `useAttachmentUpload()` wraps the client flow.
 - **Read path** — replace data-URI assembly with `attachments.get(ref)`. In a browser, drain the stream into a `Blob` and use `URL.createObjectURL` (remember to `revokeObjectURL` on cleanup).
 - **Graceful degradation** — code paths that may run without an attachment service (mock environments, tests, off-line previews) should branch on `if (!attachments)`. Writers should surface a clear error to the user; readers should skip the attachment and render a placeholder.
 
 ## Deep dive
 
-See `packages/reactor/docs/attachments.md` in the monorepo for the full design: storage internals, the LRU eviction policy, the `IAttachmentStore` and `IAttachmentTransport` interfaces, the switchboard upload protocol, and the planned S3 backend.
+See `packages/reactor/docs/attachments.md` in the monorepo for the full design: storage internals, the LRU eviction policy, the `IAttachmentStore` and `IAttachmentTransport` interfaces, the switchboard upload protocol, and the planned S3 backend. For the hash-first reservation mode, hash/size verification on ingest, and the pending-upload lifecycle, see `packages/reactor/docs/attachments-hash-first.md`.
 
 ---
 

--- a/apps/switchboard/src/server.mts
+++ b/apps/switchboard/src/server.mts
@@ -543,6 +543,8 @@ async function initServer(
 
   const { client, graphqlManager, documentModelRegistry } = api;
 
+  const lateSubgraphs: Promise<unknown>[] = [];
+
   // Wire up dynamic package management if HTTP loader is configured
   if (httpLoader) {
     const packageManagementService = new PackageManagementService({
@@ -565,12 +567,13 @@ async function initServer(
       packageManagementService,
     });
 
-    void graphqlManager
-      .registerSubgraphInstance(packagesSubgraph, "graphql", false)
-      .then(() => graphqlManager.updateRouter())
-      .catch((error: unknown) => {
-        logger.error("Failed to register packages subgraph: @error", error);
-      });
+    lateSubgraphs.push(
+      graphqlManager
+        .registerSubgraphInstance(packagesSubgraph, "graphql", false)
+        .catch((error: unknown) => {
+          logger.error("Failed to register packages subgraph: @error", error);
+        }),
+    );
   }
 
   if (driveNodeView) {
@@ -587,16 +590,30 @@ async function initServer(
       relationalDb: undefined as never,
     };
 
-    void graphqlManager
-      .registerSubgraphInstance(reactorDriveSubgraph, "graphql", false)
-      .then(() => graphqlManager.updateRouter())
-      .catch((error: unknown) => {
-        logger.error(
-          "Failed to register reactor-drive subgraph: @error",
-          error,
-        );
-      });
+    lateSubgraphs.push(
+      graphqlManager
+        .registerSubgraphInstance(reactorDriveSubgraph, "graphql", false)
+        .catch((error: unknown) => {
+          logger.error(
+            "Failed to register reactor-drive subgraph: @error",
+            error,
+          );
+        }),
+    );
   }
+
+  void (async () => {
+    await Promise.all(lateSubgraphs);
+    try {
+      await graphqlManager.updateRouter(true);
+    } catch (error) {
+      logger.error(
+        "Final router update before readiness failed: @error",
+        error,
+      );
+    }
+    api.readiness.markReady();
+  })();
 
   // Create default drive if provided
   if (options.drive) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,11 @@
     "count-classes": "tsx scripts/dark-mode/count-classes.ts",
     "add-classes": "tsx scripts/dark-mode/add-classes.ts",
     "replace-classes": "tsx scripts/dark-mode/replace-classes.ts",
-    "remove-classes": "tsx scripts/dark-mode/remove-classes.ts"
+    "remove-classes": "tsx scripts/dark-mode/remove-classes.ts",
+    "audit:download": "tsx tools/registry-audit/download.ts",
+    "audit:extract": "tsx tools/registry-audit/extract.ts",
+    "audit:analyze": "tsx tools/registry-audit/analyze.ts",
+    "audit:typecheck": "tsx tools/registry-audit/typecheck.ts"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "audit:extract": "tsx tools/registry-audit/extract.ts",
     "audit:analyze": "tsx tools/registry-audit/analyze.ts",
     "audit:typecheck": "tsx tools/registry-audit/typecheck.ts",
-    "audit:load": "tsx tools/registry-audit/load.ts"
+    "audit:load": "tsx tools/registry-audit/load.ts",
+    "audit:create-query": "tsx tools/registry-audit/create-query.ts"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "audit:download": "tsx tools/registry-audit/download.ts",
     "audit:extract": "tsx tools/registry-audit/extract.ts",
     "audit:analyze": "tsx tools/registry-audit/analyze.ts",
-    "audit:typecheck": "tsx tools/registry-audit/typecheck.ts"
+    "audit:typecheck": "tsx tools/registry-audit/typecheck.ts",
+    "audit:load": "tsx tools/registry-audit/load.ts"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/packages/codegen/src/codegen/graphql.ts
+++ b/packages/codegen/src/codegen/graphql.ts
@@ -18,17 +18,18 @@ import { format } from "prettier";
 export const scalars = {
   Unknown: "unknown",
   DateTime: "string",
-  Attachment: "string",
   Address: "`${string}:0x${string}`",
+  AttachmentRef: "`attachment://v${number}:${string}`",
   ...(generatorTypeDefs as Record<string, string>),
 };
 
 export const scalarsValidation = {
   Unknown: "z.unknown()",
   DateTime: "z.string().datetime()",
-  Attachment: "z.string()",
   Address:
     "z.custom<`${string}:0x${string}`>((val) => /^[a-zA-Z0-9]+:0x[a-fA-F0-9]{40}$/.test(val as string))",
+  AttachmentRef:
+    "z.custom<`attachment://v${number}:${string}`>((val) => /^attachment:\\/\\/v\\d+:.+$/.test(val as string))",
   ...(validationSchema as Record<string, string>),
 };
 

--- a/packages/codegen/src/file-builders/document-model/utils.ts
+++ b/packages/codegen/src/file-builders/document-model/utils.ts
@@ -11,7 +11,3 @@ export function operationHasEmptyInput(operation: OperationSpecification) {
     !operation.schema.replace(/_empty:\s*Boolean/, "").match(/\w+:\s*\w+/)
   );
 }
-
-export function operationHasAttachment(operation: OperationSpecification) {
-  return operation.schema?.includes(": Attachment");
-}

--- a/packages/codegen/src/templates/document-model/gen/modules/actions.ts
+++ b/packages/codegen/src/templates/document-model/gen/modules/actions.ts
@@ -2,7 +2,6 @@ import type { DocumentModelModuleFileMakerArgs } from "@powerhousedao/codegen";
 import type { OperationSpecification } from "@powerhousedao/shared";
 import { ts } from "@tmpl/core";
 import { pascalCase } from "change-case";
-import { operationHasAttachment } from "file-builders";
 import {
   getActionInputName,
   getActionInputTypeNames,
@@ -11,14 +10,11 @@ import {
 } from "name-builders";
 
 function getActionTypeExport(operation: OperationSpecification) {
-  const baseActionTypeName = operationHasAttachment(operation)
-    ? "ActionWithAttachment"
-    : "Action";
   const actionTypeName = getActionTypeName(operation);
   const actionInputName = getActionInputName(operation) ?? `"{}"`;
   const actionType = getActionType(operation);
 
-  return ts`export type ${actionTypeName} = ${baseActionTypeName} & { type: "${actionType}"; input: ${actionInputName} };`
+  return ts`export type ${actionTypeName} = Action & { type: "${actionType}"; input: ${actionInputName} };`
     .raw;
 }
 
@@ -33,18 +29,6 @@ export function getModuleExportType(args: DocumentModelModuleFileMakerArgs) {
     .raw;
 }
 
-function getDocumentModelActionTypeImportNames(
-  args: DocumentModelModuleFileMakerArgs,
-) {
-  const actionTypeImports = ["Action"];
-  const anyActionHasAttachment = args.module.operations.some((a) =>
-    operationHasAttachment(a),
-  );
-  if (anyActionHasAttachment) {
-    actionTypeImports.push("ActionWithAttachment");
-  }
-  return actionTypeImports.join(",\n");
-}
 export const documentModelOperationModuleActionsFileTemplate = (
   v: DocumentModelModuleFileMakerArgs,
 ) =>
@@ -53,7 +37,7 @@ export const documentModelOperationModuleActionsFileTemplate = (
  * WARNING: DO NOT EDIT
  * This file is auto-generated and updated by codegen
  */
-import type { ${getDocumentModelActionTypeImportNames(v)} } from 'document-model';
+import type { Action } from 'document-model';
 import type {
   ${getActionInputTypeNames(v)}
 } from '../types.js';

--- a/packages/codegen/src/templates/document-model/gen/modules/creators.ts
+++ b/packages/codegen/src/templates/document-model/gen/modules/creators.ts
@@ -2,19 +2,8 @@ import type { DocumentModelModuleFileMakerArgs } from "@powerhousedao/codegen";
 import type { OperationSpecification } from "@powerhousedao/shared";
 import { ts } from "@tmpl/core";
 import { camelCase, constantCase, pascalCase } from "change-case";
-import { operationHasAttachment, operationHasEmptyInput } from "file-builders";
+import { operationHasEmptyInput } from "file-builders";
 import { isTruthy } from "remeda";
-
-function makeDocumentModelTypeImports(args: DocumentModelModuleFileMakerArgs) {
-  const actionTypeImports = ["createAction"];
-  const anyActionHasAttachment = args.module.operations.some((a) =>
-    operationHasAttachment(a),
-  );
-  if (anyActionHasAttachment) {
-    actionTypeImports.push("AttachmentInput");
-  }
-  return actionTypeImports.join(",\n");
-}
 
 function makeActionInputSchemaName(action: OperationSpecification) {
   if (!action.name || !action.schema) return;
@@ -58,23 +47,17 @@ function makeActionCreatorWithInput(operation: OperationSpecification) {
   const actionTypeName = makeActionTypeName(operation);
   const inputSchemaName = makeActionInputSchemaName(operation)!;
   const inputTypeName = makeActionInputTypeName(operation)!;
-  const hasAttachment = operationHasAttachment(operation);
   const isEmptyInput = operationHasEmptyInput(operation);
   const inputArg = isEmptyInput
     ? `input: ${inputTypeName} = {}`
     : `input: ${inputTypeName}`;
-  const argsArray = [inputArg];
-  if (hasAttachment) {
-    argsArray.push(`attachments: AttachmentInput[]`);
-  }
-  const args = argsArray.join(", ");
 
   return ts`
-  export const ${camelCaseActionName} = (${args}) =>
+  export const ${camelCaseActionName} = (${inputArg}) =>
     createAction<${actionTypeName}>(
       "${constantCaseActionName}",
       {...input},
-      ${hasAttachment ? "attachments" : "undefined"},
+      undefined,
       ${inputSchemaName},
       "${operation.scope}"
     );`.raw;
@@ -116,7 +99,7 @@ export const documentModelOperationsModuleCreatorsFileTemplate = (
  * WARNING: DO NOT EDIT
  * This file is auto-generated and updated by codegen
  */
-import { ${makeDocumentModelTypeImports(v)} } from "document-model";
+import { createAction } from "document-model";
 import {
 ${makeActionInputSchemaImports(v)}
 } from '../schema/zod.js';

--- a/packages/codegen/src/ts-morph-generator/core/GenerationContext.ts
+++ b/packages/codegen/src/ts-morph-generator/core/GenerationContext.ts
@@ -17,7 +17,6 @@ export type CodegenOperation = {
   schema: string | null;
   template: string | null;
   hasInput: boolean;
-  hasAttachment: boolean | undefined;
   scope: string;
   state: string;
   errors?: OperationErrorSpecification[];

--- a/packages/codegen/src/ts-morph-generator/core/TSMorphCodeGenerator.ts
+++ b/packages/codegen/src/ts-morph-generator/core/TSMorphCodeGenerator.ts
@@ -131,7 +131,6 @@ export class TSMorphCodeGenerator {
     const operations: CodegenOperation[] = module.operations.map((op) => ({
       ...op,
       hasInput: op.schema !== null,
-      hasAttachment: op.schema?.includes(": Attachment"),
       scope: op.scope || "global",
       state: op.scope === "global" ? "" : op.scope,
     }));

--- a/packages/document-model/node.mts
+++ b/packages/document-model/node.mts
@@ -2,59 +2,17 @@ import {
   baseLoadFromInput,
   createMinimalZip,
   createZip,
-  type Attachment,
-  type AttachmentInput,
   type MinimalBackupData,
   type PHBaseState,
   type PHDocument,
   type Reducer,
   type ReplayDocumentOptions,
 } from "@powerhousedao/shared/document-model";
-import mime from "mime/lite";
 import type { BinaryLike } from "node:crypto";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import https from "node:https";
 import { join } from "node:path";
-
-function getFileAttributes(
-  file: string,
-): Omit<Attachment, "data" | "mimeType"> {
-  const extension = file.replace(/^.*\./, "") || undefined;
-  const fileName = file.replace(/^.*[/\\]/, "") || undefined;
-  return { extension, fileName };
-}
-
-/**
- * Reads an attachment from a file and returns its base64-encoded data and MIME type.
- * @param path - The path of the attachment file to read.
- * @returns A Promise that resolves to an object containing the base64-encoded data and MIME type of the attachment.
- */
-export async function getLocalFile(path: string): Promise<AttachmentInput> {
-  const buffer = await getFileNode(path);
-  const mimeType = mime.getType(path) || "application/octet-stream";
-  const attributes = getFileAttributes(path);
-  const data = buffer.toString("base64");
-  return { data, hash: hashNode(data), mimeType, ...attributes };
-}
-
-/**
- * Fetches an attachment from a URL and returns its base64-encoded data and MIME type.
- * @param url - The URL of the attachment to fetch.
- * @returns A Promise that resolves to an object containing the base64-encoded data and MIME type of the attachment.
- */
-export async function getRemoteFile(url: string): Promise<AttachmentInput> {
-  const { buffer, mimeType = "application/octet-stream" } =
-    await fetchFileNode(url);
-  const attributes = getFileAttributes(url);
-  const data = buffer.toString("base64");
-  return {
-    data,
-    hash: hashNode(data),
-    mimeType,
-    ...attributes,
-  };
-}
 
 export function writeFileNode(
   path: string,
@@ -186,8 +144,8 @@ export async function baseMinimalSaveToFile(
  * Saves a document to a ZIP file.
  *
  * @remarks
- * This function creates a ZIP file containing the document's state, operations,
- * and file attachments. The file is saved to the specified path.
+ * This function creates a ZIP file containing the document's state and
+ * operations. The file is saved to the specified path.
  *
  * @param document - The document to save to the file.
  * @param path - The path to save the file to.

--- a/packages/document-model/package.json
+++ b/packages/document-model/package.json
@@ -55,7 +55,6 @@
   },
   "dependencies": {
     "@powerhousedao/shared": "workspace:*",
-    "jszip": "^3.10.1",
-    "mime": "^4.0.4"
+    "jszip": "^3.10.1"
   }
 }

--- a/packages/document-model/schemas/document/index.graphql
+++ b/packages/document-model/schemas/document/index.graphql
@@ -1,7 +1,7 @@
 scalar DateTime
 scalar Address
 scalar Unknown
-scalar Attachment
+scalar AttachmentRef
 
 directive @equals(
   value: String = ""
@@ -27,13 +27,6 @@ type Operation implements IOperation {
   index: Int!
   timestamp: DateTime!
   hash: String!
-}
-
-type DocumentFile {
-  data: String!
-  mimeType: String!
-  extension: String
-  fileName: String
 }
 
 interface IDocument {

--- a/packages/document-model/test/document/utils.test.ts
+++ b/packages/document-model/test/document/utils.test.ts
@@ -7,9 +7,8 @@ import {
   replayDocument,
   validateOperations,
 } from "@powerhousedao/shared/document-model";
-import fs from "fs";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { getLocalFile, hashNode } from "../../node.mjs";
+import { describe, expect, it } from "vitest";
+import { hashNode } from "../../node.mjs";
 import type { CountPHState } from "../helpers.js";
 import {
   countReducer,
@@ -22,36 +21,6 @@ import {
 } from "../helpers.js";
 
 describe("Base utils", () => {
-  const tempDir = "./test/document/temp/utils/";
-  const tempFile = `${tempDir}report.pdf`;
-
-  beforeAll(() => {
-    if (!fs.existsSync(tempDir))
-      fs.mkdirSync(tempDir, {
-        recursive: true,
-      });
-    fs.writeFileSync(tempFile, "TEST");
-  });
-
-  afterAll(() => {
-    fs.rmSync(tempDir, { recursive: true, force: true });
-  });
-
-  it("should parse file attributes", async () => {
-    const file = await getLocalFile(tempFile);
-    expect(file).toStrictEqual({
-      data: "VEVTVA==",
-      hash: "Q1pqSc2iiEdpNLjRefhjnQ3nNc8=",
-      mimeType: "application/pdf",
-      extension: "pdf",
-      fileName: "report.pdf",
-    });
-  });
-
-  it("should throw exception when file doesn't exists", async () => {
-    await expect(getLocalFile("as")).rejects.toBeDefined();
-  });
-
   it("should return uuidv4 on generateId", () => {
     expect(generateId()).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,

--- a/packages/reactor-api/src/graphql/reactor/gen/graphql.ts
+++ b/packages/reactor-api/src/graphql/reactor/gen/graphql.ts
@@ -42,7 +42,6 @@ export type Scalars = {
 };
 
 export type Action = {
-  readonly attachments?: Maybe<ReadonlyArray<Attachment>>;
   readonly context?: Maybe<ActionContext>;
   readonly id: Scalars["String"]["output"];
   readonly input: Scalars["JSONObject"]["output"];
@@ -60,29 +59,12 @@ export type ActionContextInput = {
 };
 
 export type ActionInput = {
-  readonly attachments?: InputMaybe<ReadonlyArray<AttachmentInput>>;
   readonly context?: InputMaybe<ActionContextInput>;
   readonly id: Scalars["String"]["input"];
   readonly input: Scalars["JSONObject"]["input"];
   readonly scope: Scalars["String"]["input"];
   readonly timestampUtcMs: Scalars["String"]["input"];
   readonly type: Scalars["String"]["input"];
-};
-
-export type Attachment = {
-  readonly data: Scalars["String"]["output"];
-  readonly extension?: Maybe<Scalars["String"]["output"]>;
-  readonly fileName?: Maybe<Scalars["String"]["output"]>;
-  readonly hash: Scalars["String"]["output"];
-  readonly mimeType: Scalars["String"]["output"];
-};
-
-export type AttachmentInput = {
-  readonly data: Scalars["String"]["input"];
-  readonly extension?: InputMaybe<Scalars["String"]["input"]>;
-  readonly fileName?: InputMaybe<Scalars["String"]["input"]>;
-  readonly hash: Scalars["String"]["input"];
-  readonly mimeType: Scalars["String"]["input"];
 };
 
 export type ChannelMeta = {
@@ -646,16 +628,6 @@ export type GetDocumentWithOperationsQuery = {
                     readonly timestampUtcMs: string;
                     readonly input: NonNullable<unknown>;
                     readonly scope: string;
-                    readonly attachments?:
-                      | ReadonlyArray<{
-                          readonly data: string;
-                          readonly mimeType: string;
-                          readonly hash: string;
-                          readonly extension?: string | null | undefined;
-                          readonly fileName?: string | null | undefined;
-                        }>
-                      | null
-                      | undefined;
                     readonly context?:
                       | {
                           readonly signer?:
@@ -807,16 +779,6 @@ export type GetDocumentOperationsQuery = {
         readonly timestampUtcMs: string;
         readonly input: NonNullable<unknown>;
         readonly scope: string;
-        readonly attachments?:
-          | ReadonlyArray<{
-              readonly data: string;
-              readonly mimeType: string;
-              readonly hash: string;
-              readonly extension?: string | null | undefined;
-              readonly fileName?: string | null | undefined;
-            }>
-          | null
-          | undefined;
         readonly context?:
           | {
               readonly signer?:
@@ -1154,16 +1116,6 @@ export type PollSyncEnvelopesQuery = {
                 readonly timestampUtcMs: string;
                 readonly input: NonNullable<unknown>;
                 readonly scope: string;
-                readonly attachments?:
-                  | ReadonlyArray<{
-                      readonly data: string;
-                      readonly mimeType: string;
-                      readonly hash: string;
-                      readonly extension?: string | null | undefined;
-                      readonly fileName?: string | null | undefined;
-                    }>
-                  | null
-                  | undefined;
                 readonly context?:
                   | {
                       readonly signer?:
@@ -1357,8 +1309,6 @@ export type ResolversTypes = ResolversObject<{
   ActionContext: ResolverTypeWrapper<ActionContext>;
   ActionContextInput: ActionContextInput;
   ActionInput: ActionInput;
-  Attachment: ResolverTypeWrapper<Attachment>;
-  AttachmentInput: AttachmentInput;
   Boolean: ResolverTypeWrapper<Scalars["Boolean"]["output"]>;
   ChannelMeta: ResolverTypeWrapper<ChannelMeta>;
   ChannelMetaInput: ChannelMetaInput;
@@ -1418,8 +1368,6 @@ export type ResolversParentTypes = ResolversObject<{
   ActionContext: ActionContext;
   ActionContextInput: ActionContextInput;
   ActionInput: ActionInput;
-  Attachment: Attachment;
-  AttachmentInput: AttachmentInput;
   Boolean: Scalars["Boolean"]["output"];
   ChannelMeta: ChannelMeta;
   ChannelMetaInput: ChannelMetaInput;
@@ -1475,11 +1423,6 @@ export type ActionResolvers<
   ParentType extends ResolversParentTypes["Action"] =
     ResolversParentTypes["Action"],
 > = ResolversObject<{
-  attachments?: Resolver<
-    Maybe<ReadonlyArray<ResolversTypes["Attachment"]>>,
-    ParentType,
-    ContextType
-  >;
   context?: Resolver<
     Maybe<ResolversTypes["ActionContext"]>,
     ParentType,
@@ -1502,22 +1445,6 @@ export type ActionContextResolvers<
     ParentType,
     ContextType
   >;
-}>;
-
-export type AttachmentResolvers<
-  ContextType = Context,
-  ParentType extends ResolversParentTypes["Attachment"] =
-    ResolversParentTypes["Attachment"],
-> = ResolversObject<{
-  data?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
-  extension?: Resolver<
-    Maybe<ResolversTypes["String"]>,
-    ParentType,
-    ContextType
-  >;
-  fileName?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
-  hash?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
-  mimeType?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
 }>;
 
 export type ChannelMetaResolvers<
@@ -2110,7 +2037,6 @@ export type TouchChannelResultResolvers<
 export type Resolvers<ContextType = Context> = ResolversObject<{
   Action?: ActionResolvers<ContextType>;
   ActionContext?: ActionContextResolvers<ContextType>;
-  Attachment?: AttachmentResolvers<ContextType>;
   ChannelMeta?: ChannelMetaResolvers<ContextType>;
   DateTime?: GraphQLScalarType;
   DeadLetterInfo?: DeadLetterInfoResolvers<ContextType>;
@@ -2171,25 +2097,12 @@ export function ActionContextInputSchema(): z.ZodObject<
 
 export function ActionInputSchema(): z.ZodObject<Properties<ActionInput>> {
   return z.object({
-    attachments: z.array(z.lazy(() => AttachmentInputSchema())).nullish(),
     context: z.lazy(() => ActionContextInputSchema().nullish()),
     id: z.string(),
     input: z.custom<NonNullable<unknown>>((v) => v != null),
     scope: z.string(),
     timestampUtcMs: z.string(),
     type: z.string(),
-  });
-}
-
-export function AttachmentInputSchema(): z.ZodObject<
-  Properties<AttachmentInput>
-> {
-  return z.object({
-    data: z.string(),
-    extension: z.string().nullish(),
-    fileName: z.string().nullish(),
-    hash: z.string(),
-    mimeType: z.string(),
   });
 }
 
@@ -2433,13 +2346,6 @@ export const GetDocumentWithOperationsDocument = gql`
               timestampUtcMs
               input
               scope
-              attachments {
-                data
-                mimeType
-                hash
-                extension
-                fileName
-              }
               context {
                 signer {
                   user {
@@ -2552,13 +2458,6 @@ export const GetDocumentOperationsDocument = gql`
           timestampUtcMs
           input
           scope
-          attachments {
-            data
-            mimeType
-            hash
-            extension
-            fileName
-          }
           context {
             signer {
               user {
@@ -2809,13 +2708,6 @@ export const PollSyncEnvelopesDocument = gql`
               timestampUtcMs
               input
               scope
-              attachments {
-                data
-                mimeType
-                hash
-                extension
-                fileName
-              }
               context {
                 signer {
                   user {

--- a/packages/reactor-api/src/graphql/reactor/operations.graphql
+++ b/packages/reactor-api/src/graphql/reactor/operations.graphql
@@ -62,13 +62,6 @@ query GetDocumentWithOperations(
             timestampUtcMs
             input
             scope
-            attachments {
-              data
-              mimeType
-              hash
-              extension
-              fileName
-            }
             context {
               signer {
                 user {
@@ -173,13 +166,6 @@ query GetDocumentOperations(
         timestampUtcMs
         input
         scope
-        attachments {
-          data
-          mimeType
-          hash
-          extension
-          fileName
-        }
         context {
           signer {
             user {
@@ -409,13 +395,6 @@ query PollSyncEnvelopes(
             timestampUtcMs
             input
             scope
-            attachments {
-              data
-              mimeType
-              hash
-              extension
-              fileName
-            }
             context {
               signer {
                 user {

--- a/packages/reactor-api/src/graphql/reactor/schema.graphql
+++ b/packages/reactor-api/src/graphql/reactor/schema.graphql
@@ -189,16 +189,7 @@ type Action {
   timestampUtcMs: String!
   input: JSONObject!
   scope: String!
-  attachments: [Attachment!]
   context: ActionContext
-}
-
-type Attachment {
-  data: String!
-  mimeType: String!
-  hash: String!
-  extension: String
-  fileName: String
 }
 
 # Input types for sync operations
@@ -229,16 +220,7 @@ input ActionInput {
   timestampUtcMs: String!
   input: JSONObject!
   scope: String!
-  attachments: [AttachmentInput!]
   context: ActionContextInput
-}
-
-input AttachmentInput {
-  data: String!
-  mimeType: String!
-  hash: String!
-  extension: String
-  fileName: String
 }
 
 # Synchronization types

--- a/packages/reactor-api/src/graphql/reactor/validation.ts
+++ b/packages/reactor-api/src/graphql/reactor/validation.ts
@@ -109,16 +109,6 @@ export const ActionContextDTO = z
   })
   .strip();
 
-export const AttachmentDTO = z
-  .object({
-    data: z.string(),
-    mimeType: z.string(),
-    hash: z.string(),
-    extension: z.string().nullable().optional(),
-    fileName: z.string().nullable().optional(),
-  })
-  .strip();
-
 export const OperationActionDTO = z
   .object({
     id: z.string(),
@@ -126,7 +116,6 @@ export const OperationActionDTO = z
     timestampUtcMs: z.string(),
     input: z.unknown(),
     scope: z.string(),
-    attachments: z.array(AttachmentDTO).nullable().optional(),
     context: ActionContextDTO.nullable().optional(),
   })
   .strip();

--- a/packages/reactor-api/src/server.ts
+++ b/packages/reactor-api/src/server.ts
@@ -59,6 +59,7 @@ import type {
   Processor,
   ProcessorDriveFactory,
   ProcessorFactoryBuilder,
+  ReadinessGate,
 } from "./types.js";
 import {
   getDbClient,
@@ -118,6 +119,16 @@ type Options = {
 type ProcessorInitializer = ProcessorFactoryBuilder;
 
 const DEFAULT_PORT = 4000;
+
+function createReadinessGate(): ReadinessGate {
+  let ready = false;
+  return {
+    isReady: () => ready,
+    markReady: () => {
+      ready = true;
+    },
+  };
+}
 
 function resolveAttachmentStoragePath(options: Options): string {
   if (options.attachmentStoragePath) return options.attachmentStoragePath;
@@ -383,6 +394,7 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
   attachments: AttachmentBuildResult;
   packages: PackageManager;
   dbClosers: Array<() => Promise<void>>;
+  readiness: ReadinessGate;
 }> {
   const port = options.port ?? DEFAULT_PORT;
   const { adapter: httpAdapter } = await createHttpAdapter("express");
@@ -437,6 +449,13 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
 
   // Health check endpoint (registered directly on adapter, before auth)
   httpAdapter.getRoute("/health", () => new Response("OK", { status: 200 }));
+
+  const readiness = createReadinessGate();
+  httpAdapter.getRoute("/ready", () =>
+    readiness.isReady()
+      ? new Response("OK", { status: 200 })
+      : new Response("starting", { status: 503 }),
+  );
 
   // Explorer route
   const explorerPrefix = `${config.basePath}/explorer`;
@@ -553,6 +572,7 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
     attachments,
     packages,
     dbClosers,
+    readiness,
   };
 }
 
@@ -841,6 +861,7 @@ export async function initializeAndStartAPI(
     client: IReactorClient;
     syncManager: ISyncManager;
     documentModelRegistry: IDocumentModelRegistry;
+    readiness: ReadinessGate;
   }
 > {
   const {
@@ -856,6 +877,7 @@ export async function initializeAndStartAPI(
     attachments,
     packages,
     dbClosers,
+    readiness,
   } = await _setupCommonInfrastructure(options);
 
   const { documentModels, processors, subgraphs } = await packages.init();
@@ -920,5 +942,6 @@ export async function initializeAndStartAPI(
     client: reactorClient,
     syncManager,
     documentModelRegistry,
+    readiness,
   };
 }

--- a/packages/reactor-api/src/types.ts
+++ b/packages/reactor-api/src/types.ts
@@ -22,6 +22,11 @@ export interface IReactorProcessorHostModule extends IProcessorHostModule {
   attachments: IAttachmentClient;
 }
 
+export type ReadinessGate = {
+  isReady: () => boolean;
+  markReady: () => void;
+};
+
 export type API = {
   httpAdapter: IHttpAdapter;
   graphqlManager: GraphQLManager;

--- a/packages/reactor-api/test/document-model-subgraph-permissions.test.ts
+++ b/packages/reactor-api/test/document-model-subgraph-permissions.test.ts
@@ -72,7 +72,6 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         global: [],
         local: [],
       },
-      attachments: {},
       clipboard: [],
     }) as unknown as PHDocument;
 

--- a/packages/reactor-api/test/permissions-integration.test.ts
+++ b/packages/reactor-api/test/permissions-integration.test.ts
@@ -43,7 +43,6 @@ describe("Permissions Integration Tests", () => {
         global: [],
         local: [],
       },
-      attachments: {},
       clipboard: [],
     }) as unknown as PHDocument;
 

--- a/packages/reactor-api/test/reactor-client.test.ts
+++ b/packages/reactor-api/test/reactor-client.test.ts
@@ -233,7 +233,6 @@ describe("ReactorSDK", () => {
                 timestampUtcMs: "1000",
                 input: { name: "Test" },
                 scope: "global",
-                attachments: null,
                 context: {
                   signer: {
                     signatures: ["a, b, c, d, e"],
@@ -306,7 +305,6 @@ describe("ReactorSDK", () => {
                     timestampUtcMs: "1000",
                     input: { name: "Test" },
                     scope: "global",
-                    attachments: null,
                     context: null,
                   },
                 },

--- a/packages/reactor-api/test/reactor-subgraph-permissions.test.ts
+++ b/packages/reactor-api/test/reactor-subgraph-permissions.test.ts
@@ -34,7 +34,6 @@ describe("ReactorSubgraph Permission Checks", () => {
         global: [],
         local: [],
       },
-      attachments: {},
       clipboard: [],
     }) as unknown as PHDocument;
 

--- a/packages/reactor-browser/src/graphql/gen/schema.ts
+++ b/packages/reactor-browser/src/graphql/gen/schema.ts
@@ -33,7 +33,6 @@ export type Scalars = {
 };
 
 export type Action = {
-  readonly attachments?: Maybe<ReadonlyArray<Attachment>>;
   readonly context?: Maybe<ActionContext>;
   readonly id: Scalars["String"]["output"];
   readonly input: Scalars["JSONObject"]["output"];
@@ -51,29 +50,12 @@ export type ActionContextInput = {
 };
 
 export type ActionInput = {
-  readonly attachments?: InputMaybe<ReadonlyArray<AttachmentInput>>;
   readonly context?: InputMaybe<ActionContextInput>;
   readonly id: Scalars["String"]["input"];
   readonly input: Scalars["JSONObject"]["input"];
   readonly scope: Scalars["String"]["input"];
   readonly timestampUtcMs: Scalars["String"]["input"];
   readonly type: Scalars["String"]["input"];
-};
-
-export type Attachment = {
-  readonly data: Scalars["String"]["output"];
-  readonly extension?: Maybe<Scalars["String"]["output"]>;
-  readonly fileName?: Maybe<Scalars["String"]["output"]>;
-  readonly hash: Scalars["String"]["output"];
-  readonly mimeType: Scalars["String"]["output"];
-};
-
-export type AttachmentInput = {
-  readonly data: Scalars["String"]["input"];
-  readonly extension?: InputMaybe<Scalars["String"]["input"]>;
-  readonly fileName?: InputMaybe<Scalars["String"]["input"]>;
-  readonly hash: Scalars["String"]["input"];
-  readonly mimeType: Scalars["String"]["input"];
 };
 
 export type ChannelMeta = {
@@ -637,16 +619,6 @@ export type GetDocumentWithOperationsQuery = {
                     readonly timestampUtcMs: string;
                     readonly input: NonNullable<unknown>;
                     readonly scope: string;
-                    readonly attachments?:
-                      | ReadonlyArray<{
-                          readonly data: string;
-                          readonly mimeType: string;
-                          readonly hash: string;
-                          readonly extension?: string | null | undefined;
-                          readonly fileName?: string | null | undefined;
-                        }>
-                      | null
-                      | undefined;
                     readonly context?:
                       | {
                           readonly signer?:
@@ -798,16 +770,6 @@ export type GetDocumentOperationsQuery = {
         readonly timestampUtcMs: string;
         readonly input: NonNullable<unknown>;
         readonly scope: string;
-        readonly attachments?:
-          | ReadonlyArray<{
-              readonly data: string;
-              readonly mimeType: string;
-              readonly hash: string;
-              readonly extension?: string | null | undefined;
-              readonly fileName?: string | null | undefined;
-            }>
-          | null
-          | undefined;
         readonly context?:
           | {
               readonly signer?:
@@ -1145,16 +1107,6 @@ export type PollSyncEnvelopesQuery = {
                 readonly timestampUtcMs: string;
                 readonly input: NonNullable<unknown>;
                 readonly scope: string;
-                readonly attachments?:
-                  | ReadonlyArray<{
-                      readonly data: string;
-                      readonly mimeType: string;
-                      readonly hash: string;
-                      readonly extension?: string | null | undefined;
-                      readonly fileName?: string | null | undefined;
-                    }>
-                  | null
-                  | undefined;
                 readonly context?:
                   | {
                       readonly signer?:
@@ -1289,13 +1241,6 @@ export const GetDocumentWithOperationsDocument = gql`
               timestampUtcMs
               input
               scope
-              attachments {
-                data
-                mimeType
-                hash
-                extension
-                fileName
-              }
               context {
                 signer {
                   user {
@@ -1408,13 +1353,6 @@ export const GetDocumentOperationsDocument = gql`
           timestampUtcMs
           input
           scope
-          attachments {
-            data
-            mimeType
-            hash
-            extension
-            fileName
-          }
           context {
             signer {
               user {
@@ -1665,13 +1603,6 @@ export const PollSyncEnvelopesDocument = gql`
               timestampUtcMs
               input
               scope
-              attachments {
-                data
-                mimeType
-                hash
-                extension
-                fileName
-              }
               context {
                 signer {
                   user {

--- a/packages/reactor-browser/src/remote-controller/utils.ts
+++ b/packages/reactor-browser/src/remote-controller/utils.ts
@@ -40,13 +40,6 @@ export function remoteOperationToLocal(remote: RemoteOperation): Operation {
       timestampUtcMs: remote.action.timestampUtcMs,
       input: remote.action.input,
       scope: remote.action.scope,
-      attachments: remote.action.attachments?.map((a) => ({
-        data: a.data,
-        mimeType: a.mimeType,
-        hash: a.hash,
-        extension: a.extension ?? undefined,
-        fileName: a.fileName ?? undefined,
-      })),
       context: remote.action.context?.signer
         ? {
             signer: {

--- a/packages/reactor-browser/test/remote-controller/remote-client.test.ts
+++ b/packages/reactor-browser/test/remote-controller/remote-client.test.ts
@@ -60,7 +60,6 @@ function makeRemoteOp(index: number, scope = "global") {
       timestampUtcMs: Date.now().toString(),
       input: { name: `name-${index}` },
       scope,
-      attachments: null,
       context: null,
     },
   };

--- a/packages/reactor-browser/test/remote-controller/remote-controller.test.ts
+++ b/packages/reactor-browser/test/remote-controller/remote-controller.test.ts
@@ -555,7 +555,6 @@ describe("RemoteDocumentController", () => {
                   timestampUtcMs: "1000",
                   input: { description: "remote change" },
                   scope: "global",
-                  attachments: null,
                   context: null,
                 },
               },
@@ -873,7 +872,6 @@ describe("RemoteDocumentController", () => {
         timestampUtcMs: String(index * 1000),
         input: { name: `Name ${index}` },
         scope: "global",
-        attachments: null,
         context: null,
       },
     });

--- a/packages/reactor-browser/test/remote-controller/utils.test.ts
+++ b/packages/reactor-browser/test/remote-controller/utils.test.ts
@@ -35,7 +35,6 @@ function makeRemoteOp(
       timestampUtcMs: "1000",
       input: { name: `name-${overrides.index}` },
       scope: "global",
-      attachments: null,
       context: null,
     },
     ...overrides,
@@ -165,34 +164,6 @@ describe("remoteOperationToLocal", () => {
   it("preserves error string", () => {
     const remote = makeRemoteOp({ index: 0, error: "some error" });
     expect(remoteOperationToLocal(remote).error).toBe("some error");
-  });
-
-  it("converts attachments", () => {
-    const remote: RemoteOperation = {
-      ...makeRemoteOp({ index: 0 }),
-      action: {
-        ...makeRemoteOp({ index: 0 }).action,
-        attachments: [
-          {
-            data: "base64data",
-            mimeType: "image/png",
-            hash: "att-hash",
-            extension: "png",
-            fileName: "image.png",
-          },
-        ],
-      },
-    };
-
-    const local = remoteOperationToLocal(remote);
-    expect(local.action.attachments).toHaveLength(1);
-    expect(local.action.attachments![0]).toEqual({
-      data: "base64data",
-      mimeType: "image/png",
-      hash: "att-hash",
-      extension: "png",
-      fileName: "image.png",
-    });
   });
 
   it("converts signer context with signatures", () => {

--- a/packages/reactor/docs/attachments.md
+++ b/packages/reactor/docs/attachments.md
@@ -46,40 +46,40 @@ type AttachmentInput = Attachment & {
 
 2. **Transport-agnostic.** The mechanism for moving bytes between reactors is pluggable (`IAttachmentTransport`), just as `IChannel`/`IChannelFactory` is pluggable for operation sync.
 
-3. **Refs are values.** An `AttachmentRef` is a plain string that travels inside domain action inputs. Document model schemas declare attachment fields using the `Attachment` scalar. The reducer stores the ref in state like any other field. There are no special core actions, no attachment set on the document, and no read model for reference tracking.
+3. **Refs are values.** An `AttachmentRef` is a protocol-prefixed string (`attachment://v<version>:<hash>`) that travels inside domain action inputs. Document model schemas declare attachment fields using the `AttachmentRef` scalar. The reducer stores the ref in state like any other field. There are no special core actions, no attachment set on the document, and no read model for reference tracking.
 
 4. **Lazy data availability.** A reactor may have an `AttachmentRef` in document state before the binary data is available locally. This is expected. When the data is needed, the attachment service fetches it from a peer via the transport layer. The data and the ref are independent concerns.
 
 5. **LRU eviction.** Garbage collection is storage-pressure-driven, not reference-count-driven. The store evicts least-recently-accessed data when storage limits are reached. Evicted data retains its metadata and can be re-fetched from any peer that has the bytes.
 
-### The Attachment Scalar
+### The AttachmentRef Scalar
 
-The `Attachment` scalar in a document model GraphQL schema declares that a field holds an `AttachmentRef`. The codegen pipeline already detects `": Attachment"` in operation schemas and generates appropriate types.
+The `AttachmentRef` scalar in a document model GraphQL schema declares that a field holds an attachment reference of the form `attachment://v<version>:<hash>`. Codegen maps it to a branded TypeScript string type and a Zod validator that enforces the protocol prefix.
 
 ```graphql
 # In a document model schema
-scalar Attachment
+scalar AttachmentRef
 
 input AttachInvoiceInput {
   vendorName: String!
   amount: Float!
-  scan: Attachment!
+  scan: AttachmentRef!
 }
 ```
 
-The generated TypeScript type maps `Attachment` to `string` (specifically `AttachmentRef`). The reducer treats it as an opaque string:
+The generated TypeScript type for `AttachmentRef` is the branded string `` `attachment://v${number}:${string}` ``. The reducer treats it as an opaque ref:
 
 ```ts
 attachInvoiceOperation(state, action) {
   state.invoices.push({
     vendorName: action.input.vendorName,
     amount: action.input.amount,
-    scan: action.input.scan, // AttachmentRef string
+    scan: action.input.scan, // AttachmentRef
   });
 }
 ```
 
-The `Attachment` scalar is the entire integration surface between document models and the attachment system. Document model authors do not interact with `IAttachmentService`, `IAttachmentStore`, or `IAttachmentTransport` -- they just declare `Attachment` fields and use the refs they receive from the upload flow.
+The `AttachmentRef` scalar is the entire integration surface between document models and the attachment system. Document model authors do not interact with `IAttachmentService`, `IAttachmentStore`, or `IAttachmentTransport` -- they just declare `AttachmentRef` fields and use the refs they receive from the upload flow.
 
 ### Attachment Lifecycle
 
@@ -849,23 +849,20 @@ S3 lifecycle rules can handle optional physical cleanup:
 
 ## Migration from Inline Attachments
 
-The inline base64 attachment format will coexist with `AttachmentRef` during a transition period.
+The legacy inline base64 attachment format has been removed. Attachment references now flow exclusively through the `AttachmentRef` scalar and the attachment service.
 
-### Phase 1: Add attachment service (non-breaking)
+### Phase 1: Add attachment service (done)
 
-- Deploy `IAttachmentService` and `IAttachmentStore` alongside the existing inline mechanism.
-- Actions can contain either inline `AttachmentInput[]` or `AttachmentRef` values in their input fields.
-- Inline attachments are processed as today. Refs resolve through the attachment service.
-- New attachments should use the multi-phase upload flow. The codegen `Attachment` scalar resolves to `AttachmentRef` (string).
+- `IAttachmentService` and `IAttachmentStore` are deployed.
+- New attachments use the multi-phase upload flow; the codegen `AttachmentRef` scalar resolves to a protocol-prefixed string.
 
 ### Phase 2: Migrate sync to use refs
 
-- Sync channels stop transferring inline attachment data.
+- Sync channels no longer transfer inline attachment data.
 - Attachment data moves between reactors via `IAttachmentTransport` (lazy fetch or eager push).
 - The transport config becomes part of the remote/channel configuration.
 
-### Phase 3: Remove inline support
+### Phase 3: Remove inline support (done)
 
-- The `attachments` field on `Action` is removed.
+- The `attachments` field on `Action` and the inline `AttachmentInput` / `Attachment` types have been removed.
 - All attachment data flows through `IAttachmentService`, `IAttachmentStore`, and `IAttachmentTransport`.
-- The `Attachment` type with inline `data: string` is deprecated and removed.

--- a/packages/reactor/src/sync/channels/gql-req-channel.ts
+++ b/packages/reactor/src/sync/channels/gql-req-channel.ts
@@ -521,13 +521,6 @@ export class GqlRequestChannel implements IChannel {
                   timestampUtcMs
                   input
                   scope
-                  attachments {
-                    data
-                    mimeType
-                    hash
-                    extension
-                    fileName
-                  }
                   context {
                     signer {
                       user {

--- a/packages/reactor/src/sync/channels/utils.ts
+++ b/packages/reactor/src/sync/channels/utils.ts
@@ -12,15 +12,28 @@ let syncOpCounter = 0;
 
 /**
  * Serializes an action for GraphQL transport, converting signature tuples to strings.
+ *
+ * Only the fields declared by the GraphQL `ActionInput` type are forwarded. This
+ * guards against stale runtime-only fields (e.g. a legacy `attachments` array on
+ * operations persisted before the attachment-system removal) leaking into the
+ * mutation variables, where the tightened schema would reject them.
  */
 export function serializeAction(action: Action): unknown {
+  const base = {
+    id: action.id,
+    type: action.type,
+    timestampUtcMs: action.timestampUtcMs,
+    input: action.input,
+    scope: action.scope,
+  };
+
   const signer = action.context?.signer;
   if (!signer?.signatures) {
-    return action;
+    return action.context ? { ...base, context: action.context } : base;
   }
 
   return {
-    ...action,
+    ...base,
     context: {
       ...action.context,
       signer: {

--- a/packages/shared/document-model/actions.ts
+++ b/packages/shared/document-model/actions.ts
@@ -255,10 +255,10 @@ export const noop = (scope = "global") =>
  *
  * @param type - The type of the action.
  * @param input - The input properties of the action.
- * @param attachments - The attachments included in the action.
+ * @param _attachments - Deprecated and ignored. Retained so action creators
+ *   generated before the attachment-system removal keep their 5-argument shape.
  * @param validator - The validator to use for the input properties.
  * @param scope - The scope of the action, can either be 'global' or 'local'.
- * @param skip - The number of operations to skip before this new action is applied.
  *
  * @throws Error if the type is empty or not a string.
  *
@@ -267,7 +267,9 @@ export const noop = (scope = "global") =>
 export function createAction<TAction extends Action>(
   type: TAction["type"],
   input?: TAction["input"],
-  attachments?: TAction["attachments"],
+  // Deprecated, ignored. Retained so action creators generated before the
+  // legacy attachment system was removed keep their 5-argument call shape.
+  _attachments?: unknown,
   validator?: () => { parse(v: unknown): TAction["input"] },
   scope: Action["scope"] = "global",
 ): TAction {
@@ -282,8 +284,6 @@ export function createAction<TAction extends Action>(
     input,
     scope,
   };
-
-  if (attachments) action.attachments = attachments;
 
   try {
     validator?.().parse(action.input);
@@ -309,7 +309,6 @@ export const actionFromAction = (action: Action): Action => {
     input: action.input,
     scope: action.scope,
     context: action.context,
-    attachments: action.attachments,
   };
 };
 
@@ -983,46 +982,6 @@ export type Action = {
   /** The scope of the action */
   scope: string;
 
-  /**
-   * The attachments included in the action.
-   *
-   * This will be refactored in a future release.
-   */
-  attachments?: AttachmentInput[];
-
   /** The context of the action. */
   context?: ActionContext;
 };
-
-/**
- * The attributes stored for a file. Namely, attachments of a document.
- */
-export type Attachment = {
-  /** The binary data of the attachment in Base64 */
-  data: string;
-
-  /** The MIME type of the attachment */
-  mimeType: string;
-
-  // The extension of the attachment.
-  extension?: string | null;
-
-  // The file name of the attachment.
-  fileName?: string | null;
-};
-
-export type AttachmentInput = Attachment & {
-  hash: string;
-};
-
-export type ActionWithAttachment = Action & {
-  attachments: AttachmentInput[];
-};
-
-/**
- * String type representing an attachment in a Document.
- *
- * @remarks
- * Attachment string is formatted as `attachment://<filename>`.
- */
-export type AttachmentRef = string; // TODO `attachment://${string}`;

--- a/packages/shared/document-model/documents.ts
+++ b/packages/shared/document-model/documents.ts
@@ -469,7 +469,6 @@ export function replayDocument<TState extends PHBaseState = PHBaseState>(
         );
         documentState = {
           ...documentState,
-          // TODO how to deal with attachments?
           [scope]: scopeState,
         };
         const scopeInitialOps =

--- a/packages/shared/document-model/schemas.ts
+++ b/packages/shared/document-model/schemas.ts
@@ -14,7 +14,6 @@ import type {
   DeleteOperationExampleInput,
   DeleteOperationInput,
   DeleteStateExampleInput,
-  DocumentFile,
   DocumentModelGlobalState,
   DocumentSpecification,
   LoadStateActionInput,
@@ -97,16 +96,6 @@ export function DocumentActionSchema() {
     SetPreferredEditorActionSchema(),
     UndoActionSchema(),
   ]);
-}
-
-export function DocumentFileSchema(): z.ZodObject<Properties<DocumentFile>> {
-  return z.object({
-    __typename: z.literal("DocumentFile").optional(),
-    data: z.string(),
-    extension: z.string().nullable(),
-    fileName: z.string().nullable(),
-    mimeType: z.string(),
-  });
 }
 
 export function LoadStateActionSchema(): z.ZodObject<

--- a/packages/shared/document-model/types.ts
+++ b/packages/shared/document-model/types.ts
@@ -2,7 +2,7 @@ import type { Draft } from "mutative";
 import type { ProcessorFactoryBuilder } from "processors";
 import type { FC, ReactNode } from "react";
 import type { z } from "zod";
-import type { Action, Attachment, AttachmentRef } from "./actions.js";
+import type { Action } from "./actions.js";
 import type { PHDocument } from "./documents.js";
 import type { Operation } from "./operations.js";
 import type {
@@ -1031,7 +1031,10 @@ export type Scalars = {
     input: `${string}:0x${string}`;
     output: `${string}:0x${string}`;
   };
-  Attachment: { input: string; output: string };
+  AttachmentRef: {
+    input: `attachment://v${number}:${string}`;
+    output: `attachment://v${number}:${string}`;
+  };
   DateTime: { input: string; output: string };
   Unknown: { input: unknown; output: unknown };
 };
@@ -1043,14 +1046,6 @@ export type OperationsByScope = Partial<Record<string, Operation[]>>;
 export type SkipHeaderOperationIndex = Partial<Pick<OperationIndex, "index">> &
   Pick<OperationIndex, "skip">;
 export type UndoRedoAction = SchemaRedoAction | SchemaUndoAction;
-
-export type DocumentFile = {
-  __typename?: "DocumentFile";
-  data: Scalars["String"]["output"];
-  extension: Maybe<Scalars["String"]["output"]>;
-  fileName: Maybe<Scalars["String"]["output"]>;
-  mimeType: Scalars["String"]["output"];
-};
 
 export type IAction = {
   type: Scalars["String"]["output"];
@@ -1461,16 +1456,6 @@ export type StateReducer<TState extends PHBaseState = PHBaseState> = (
   action: Action,
   dispatch?: SignalDispatch,
 ) => TState | undefined;
-
-/**
- * Object that indexes attachments of a Document.
- *
- * @remarks
- * This is used to reduce memory usage to avoid
- * multiple instances of the binary data of the attachments.
- *
- */
-export type FileRegistry = Record<AttachmentRef, Attachment>;
 
 export type MappedOperation = {
   ignore: boolean;

--- a/packages/vetra/document-models/app-module/v1/gen/reducer.ts
+++ b/packages/vetra/document-models/app-module/v1/gen/reducer.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import type { Reducer, StateReducer } from "document-model";
 import { createReducer, isDocumentAction } from "document-model";
 import type { AppModulePHState } from "document-models/app-module/v1";

--- a/packages/vetra/document-models/app-module/v1/gen/schema/types.ts
+++ b/packages/vetra/document-models/app-module/v1/gen/schema/types.ts
@@ -45,7 +45,10 @@ export type Scalars = {
   Amount_Money: { input: number; output: number };
   Amount_Percentage: { input: number; output: number };
   Amount_Tokens: { input: number; output: number };
-  Attachment: { input: string; output: string };
+  AttachmentRef: {
+    input: `attachment://v${number}:${string}`;
+    output: `attachment://v${number}:${string}`;
+  };
   Currency: { input: string; output: string };
   Date: { input: string; output: string };
   DateTime: { input: string; output: string };

--- a/packages/vetra/document-models/app-module/v1/schema.graphql
+++ b/packages/vetra/document-models/app-module/v1/schema.graphql
@@ -1,7 +1,7 @@
 scalar Unknown
 scalar DateTime
-scalar Attachment
 scalar Address
+scalar AttachmentRef
 scalar Amount_Tokens
 scalar EthereumAddress
 scalar EmailAddress

--- a/packages/vetra/document-models/document-editor/v1/gen/reducer.ts
+++ b/packages/vetra/document-models/document-editor/v1/gen/reducer.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import type { Reducer, StateReducer } from "document-model";
 import { createReducer, isDocumentAction } from "document-model";
 import type { DocumentEditorPHState } from "document-models/document-editor/v1";

--- a/packages/vetra/document-models/document-editor/v1/gen/schema/types.ts
+++ b/packages/vetra/document-models/document-editor/v1/gen/schema/types.ts
@@ -45,7 +45,10 @@ export type Scalars = {
   Amount_Money: { input: number; output: number };
   Amount_Percentage: { input: number; output: number };
   Amount_Tokens: { input: number; output: number };
-  Attachment: { input: string; output: string };
+  AttachmentRef: {
+    input: `attachment://v${number}:${string}`;
+    output: `attachment://v${number}:${string}`;
+  };
   Currency: { input: string; output: string };
   Date: { input: string; output: string };
   DateTime: { input: string; output: string };

--- a/packages/vetra/document-models/document-editor/v1/schema.graphql
+++ b/packages/vetra/document-models/document-editor/v1/schema.graphql
@@ -1,7 +1,7 @@
 scalar Unknown
 scalar DateTime
-scalar Attachment
 scalar Address
+scalar AttachmentRef
 scalar Amount_Tokens
 scalar EthereumAddress
 scalar EmailAddress

--- a/packages/vetra/document-models/processor-module/v1/gen/reducer.ts
+++ b/packages/vetra/document-models/processor-module/v1/gen/reducer.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import type { Reducer, StateReducer } from "document-model";
 import { createReducer, isDocumentAction } from "document-model";
 import type { ProcessorModulePHState } from "document-models/processor-module/v1";

--- a/packages/vetra/document-models/processor-module/v1/gen/schema/types.ts
+++ b/packages/vetra/document-models/processor-module/v1/gen/schema/types.ts
@@ -45,7 +45,10 @@ export type Scalars = {
   Amount_Money: { input: number; output: number };
   Amount_Percentage: { input: number; output: number };
   Amount_Tokens: { input: number; output: number };
-  Attachment: { input: string; output: string };
+  AttachmentRef: {
+    input: `attachment://v${number}:${string}`;
+    output: `attachment://v${number}:${string}`;
+  };
   Currency: { input: string; output: string };
   Date: { input: string; output: string };
   DateTime: { input: string; output: string };

--- a/packages/vetra/document-models/processor-module/v1/schema.graphql
+++ b/packages/vetra/document-models/processor-module/v1/schema.graphql
@@ -1,7 +1,7 @@
 scalar Unknown
 scalar DateTime
-scalar Attachment
 scalar Address
+scalar AttachmentRef
 scalar Amount_Tokens
 scalar EthereumAddress
 scalar EmailAddress

--- a/packages/vetra/document-models/subgraph-module/v1/gen/reducer.ts
+++ b/packages/vetra/document-models/subgraph-module/v1/gen/reducer.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import type { Reducer, StateReducer } from "document-model";
 import { createReducer, isDocumentAction } from "document-model";
 import type { SubgraphModulePHState } from "document-models/subgraph-module/v1";

--- a/packages/vetra/document-models/subgraph-module/v1/gen/schema/types.ts
+++ b/packages/vetra/document-models/subgraph-module/v1/gen/schema/types.ts
@@ -45,7 +45,10 @@ export type Scalars = {
   Amount_Money: { input: number; output: number };
   Amount_Percentage: { input: number; output: number };
   Amount_Tokens: { input: number; output: number };
-  Attachment: { input: string; output: string };
+  AttachmentRef: {
+    input: `attachment://v${number}:${string}`;
+    output: `attachment://v${number}:${string}`;
+  };
   Currency: { input: string; output: string };
   Date: { input: string; output: string };
   DateTime: { input: string; output: string };

--- a/packages/vetra/document-models/subgraph-module/v1/schema.graphql
+++ b/packages/vetra/document-models/subgraph-module/v1/schema.graphql
@@ -1,7 +1,7 @@
 scalar Unknown
 scalar DateTime
-scalar Attachment
 scalar Address
+scalar AttachmentRef
 scalar Amount_Tokens
 scalar EthereumAddress
 scalar EmailAddress

--- a/packages/vetra/document-models/vetra-package/v1/gen/reducer.ts
+++ b/packages/vetra/document-models/vetra-package/v1/gen/reducer.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import type { Reducer, StateReducer } from "document-model";
 import { createReducer, isDocumentAction } from "document-model";
 import type { VetraPackagePHState } from "document-models/vetra-package/v1";

--- a/packages/vetra/document-models/vetra-package/v1/gen/schema/types.ts
+++ b/packages/vetra/document-models/vetra-package/v1/gen/schema/types.ts
@@ -45,7 +45,10 @@ export type Scalars = {
   Amount_Money: { input: number; output: number };
   Amount_Percentage: { input: number; output: number };
   Amount_Tokens: { input: number; output: number };
-  Attachment: { input: string; output: string };
+  AttachmentRef: {
+    input: `attachment://v${number}:${string}`;
+    output: `attachment://v${number}:${string}`;
+  };
   Currency: { input: string; output: string };
   Date: { input: string; output: string };
   DateTime: { input: string; output: string };

--- a/packages/vetra/document-models/vetra-package/v1/gen/schema/zod.ts
+++ b/packages/vetra/document-models/vetra-package/v1/gen/schema/zod.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as z from "zod";
 import type {
   AddPackageKeywordInput,

--- a/packages/vetra/document-models/vetra-package/v1/schema.graphql
+++ b/packages/vetra/document-models/vetra-package/v1/schema.graphql
@@ -1,7 +1,7 @@
 scalar Unknown
 scalar DateTime
-scalar Attachment
 scalar Address
+scalar AttachmentRef
 scalar Amount_Tokens
 scalar EthereumAddress
 scalar EmailAddress

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1543,9 +1543,6 @@ importers:
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
-      mime:
-        specifier: ^4.0.4
-        version: 4.1.0
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14

--- a/test/codegen/tests/ReducerGenerator.test.ts
+++ b/test/codegen/tests/ReducerGenerator.test.ts
@@ -82,7 +82,6 @@ describe("ReducerGenerator Integration", () => {
           template: null,
           scope: "global",
           hasInput: true,
-          hasAttachment: false,
           state: "",
         },
         {
@@ -96,7 +95,6 @@ describe("ReducerGenerator Integration", () => {
           template: null,
           scope: "global",
           hasInput: false,
-          hasAttachment: false,
           state: "",
         },
       ];
@@ -166,7 +164,6 @@ describe("ReducerGenerator Integration", () => {
           template: null,
           scope: "global",
           hasInput: true,
-          hasAttachment: false,
           state: "",
         },
       ];
@@ -197,7 +194,6 @@ describe("ReducerGenerator Integration", () => {
           template: null,
           scope: "global",
           hasInput: false,
-          hasAttachment: false,
           state: "",
         },
       ];
@@ -249,7 +245,6 @@ describe("ReducerGenerator Integration", () => {
             template: null,
             scope: "global",
             hasInput: true,
-            hasAttachment: false,
             state: "",
           },
         ],
@@ -326,7 +321,6 @@ describe("ReducerGenerator Integration", () => {
           template: null,
           scope: "global",
           hasInput: true,
-          hasAttachment: false,
           state: "",
         },
       ];
@@ -374,7 +368,6 @@ describe("ReducerGenerator Integration", () => {
           template: null,
           scope: "global",
           hasInput: true,
-          hasAttachment: false,
           state: "",
         },
         {
@@ -388,7 +381,6 @@ describe("ReducerGenerator Integration", () => {
           template: null,
           scope: "global",
           hasInput: false,
-          hasAttachment: false,
           state: "",
         },
         {
@@ -402,7 +394,6 @@ describe("ReducerGenerator Integration", () => {
           template: null,
           scope: "global",
           hasInput: false,
-          hasAttachment: false,
           state: "",
         },
       ];
@@ -445,7 +436,6 @@ describe("ReducerGenerator Integration", () => {
           template: null,
           scope: "global",
           hasInput: true,
-          hasAttachment: false,
           state: "",
         },
       ];
@@ -490,7 +480,6 @@ describe("ReducerGenerator Integration", () => {
           template: null,
           scope: "global",
           hasInput: true,
-          hasAttachment: false,
           state: "",
         },
       ];
@@ -530,7 +519,6 @@ describe("ReducerGenerator Integration", () => {
           template: null,
           scope: "global",
           hasInput: true,
-          hasAttachment: false,
           state: "",
         },
       ];
@@ -567,7 +555,6 @@ describe("ReducerGenerator Integration", () => {
           template: null,
           scope: "global",
           hasInput: true,
-          hasAttachment: false,
           state: "",
         },
       ];
@@ -597,7 +584,6 @@ describe("ReducerGenerator Integration", () => {
           template: null,
           scope: "global",
           hasInput: true,
-          hasAttachment: false,
           state: "",
         },
       ];

--- a/test/codegen/tests/ReducerGenerator.test.ts
+++ b/test/codegen/tests/ReducerGenerator.test.ts
@@ -30,6 +30,8 @@ class TestDirectoryManager extends DirectoryManager {
   }
 
   async createSourceFile(project: Project, filePath: string) {
+    // Mirror the base manager (a no-op override here) so this stays genuinely async.
+    await this.ensureExists(filePath);
     // Check if file already exists and return it, otherwise create new one
     const existing = project.getSourceFile(filePath);
     if (existing) {

--- a/test/test-connect/src/orchestrator.ts
+++ b/test/test-connect/src/orchestrator.ts
@@ -149,19 +149,23 @@ async function waitForSwitchboard(
   url: string,
   timeoutMs: number,
 ): Promise<void> {
+  const readyUrl = new URL("/ready", url).toString();
   const start = Date.now();
-  const client = new GraphQLClient(url);
 
   while (Date.now() - start < timeoutMs) {
-    const connected = await client.testConnection();
-    if (connected) {
-      return;
+    try {
+      const res = await fetch(readyUrl);
+      if (res.ok) {
+        return;
+      }
+    } catch {
+      // server not accepting connections yet
     }
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
 
   throw new Error(
-    `Switchboard did not become ready at ${url} within ${timeoutMs}ms`,
+    `Switchboard did not become ready at ${readyUrl} within ${timeoutMs}ms`,
   );
 }
 

--- a/test/test-connect/src/run-integration.ts
+++ b/test/test-connect/src/run-integration.ts
@@ -147,19 +147,23 @@ async function waitForSwitchboard(
   url: string,
   timeoutMs: number,
 ): Promise<void> {
+  const readyUrl = new URL("/ready", url).toString();
   const start = Date.now();
-  const client = new GraphQLClient(url);
 
   while (Date.now() - start < timeoutMs) {
-    const connected = await client.testConnection();
-    if (connected) {
-      return;
+    try {
+      const res = await fetch(readyUrl);
+      if (res.ok) {
+        return;
+      }
+    } catch {
+      // server not accepting connections yet
     }
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
 
   throw new Error(
-    `Switchboard did not become ready at ${url} within ${timeoutMs}ms`,
+    `Switchboard did not become ready at ${readyUrl} within ${timeoutMs}ms`,
   );
 }
 

--- a/test/versioned-documents/document-models/todo/v1/gen/document-model.ts
+++ b/test/versioned-documents/document-models/todo/v1/gen/document-model.ts
@@ -1,153 +1,153 @@
 import type { DocumentModelGlobalState } from "document-model";
 
 export const documentModel: DocumentModelGlobalState = {
+  id: "test/todo",
+  name: "Todo",
   author: {
     name: "Powerhouse",
     website: "https://powerhouse.inc",
   },
-  description: "A versioned todo document model for testing codegen",
   extension: "todo",
-  id: "test/todo",
-  name: "Todo",
+  description: "A versioned todo document model for testing codegen",
   specifications: [
     {
-      changeLog: [],
-      modules: [
-        {
-          description: "",
-          id: "42454fe7-a04b-4e25-8d2b-428df928dcd6",
-          name: "todo_operations",
-          operations: [
-            {
-              description: "",
-              errors: [],
-              examples: [],
-              id: "c0285a3b-6641-4899-8d40-73327a4fd4c5",
-              name: "ADD_TODO",
-              reducer:
-                "state.todos.push({\n  id: action.input.id,\n  title: action.input.title,\n  completed: action.input.completed,\n});",
-              schema:
-                "input AddTodoInput {\n  id: String!\n  title: String!\n  completed: Boolean!\n}",
-              template: "",
-              scope: "global",
-            },
-            {
-              description: "",
-              errors: [],
-              examples: [],
-              id: "890bddb3-aaff-49be-b981-57a5c79302e1",
-              name: "REMOVE_TODO",
-              reducer:
-                "const index = state.todos.findIndex(t => t.id === action.input.id);\nif (index !== -1) {\n  state.todos.splice(index, 1);\n}",
-              schema: "input RemoveTodoInput {\n  id: String!\n}",
-              template: "",
-              scope: "global",
-            },
-            {
-              description: "",
-              errors: [],
-              examples: [],
-              id: "22b59393-17c6-4afa-8f4d-0138e34f2832",
-              name: "UPDATE_TODO",
-              reducer:
-                "const todo = state.todos.find(t => t.id === action.input.id);\nif (todo) {\n  if (action.input.title !== undefined) todo.title = action.input.title;\n  if (action.input.completed !== undefined) todo.completed = action.input.completed;\n}",
-              schema:
-                "input UpdateTodoInput {\n  id: String!\n  title: String\n  completed: Boolean\n}",
-              template: "",
-              scope: "global",
-            },
-          ],
-        },
-      ],
       state: {
-        global: {
+        local: {
+          schema: "",
           examples: [],
-          initialValue: '{"todos":[]}',
+          initialValue: "",
+        },
+        global: {
           schema:
             "type TodoState {\n  todos: [TodoItem!]!\n}\n\ntype TodoItem {\n  id: String!\n  title: String!\n  completed: Boolean!\n}",
-        },
-        local: {
           examples: [],
-          initialValue: "",
-          schema: "",
+          initialValue: '{"todos":[]}',
         },
       },
-      version: 1,
-    },
-    {
-      changeLog: [],
       modules: [
         {
-          description: "",
           id: "42454fe7-a04b-4e25-8d2b-428df928dcd6",
           name: "todo_operations",
+          description: "",
           operations: [
             {
-              description: "",
-              errors: [],
-              examples: [],
               id: "c0285a3b-6641-4899-8d40-73327a4fd4c5",
               name: "ADD_TODO",
-              reducer:
-                "state.todos.push({\n  id: action.input.id,\n  title: action.input.title,\n  completed: action.input.completed,\n});",
+              description: "",
               schema:
                 "input AddTodoInput {\n  id: String!\n  title: String!\n  completed: Boolean!\n}",
               template: "",
+              reducer:
+                "state.todos.push({\n  id: action.input.id,\n  title: action.input.title,\n  completed: action.input.completed,\n});",
+              errors: [],
+              examples: [],
               scope: "global",
             },
             {
-              description: "",
-              errors: [],
-              examples: [],
               id: "890bddb3-aaff-49be-b981-57a5c79302e1",
               name: "REMOVE_TODO",
-              reducer:
-                "const index = state.todos.findIndex(t => t.id === action.input.id);\nif (index !== -1) {\n  state.todos.splice(index, 1);\n}",
+              description: "",
               schema: "input RemoveTodoInput {\n  id: String!\n}",
               template: "",
+              reducer:
+                "const index = state.todos.findIndex(t => t.id === action.input.id);\nif (index !== -1) {\n  state.todos.splice(index, 1);\n}",
+              errors: [],
+              examples: [],
               scope: "global",
             },
             {
-              description: "",
-              errors: [],
-              examples: [],
               id: "22b59393-17c6-4afa-8f4d-0138e34f2832",
               name: "UPDATE_TODO",
-              reducer:
-                "const todo = state.todos.find(t => t.id === action.input.id);\nif (todo) {\n  if (action.input.title !== undefined) todo.title = action.input.title;\n  if (action.input.completed !== undefined) todo.completed = action.input.completed;\n}",
+              description: "",
               schema:
                 "input UpdateTodoInput {\n  id: String!\n  title: String\n  completed: Boolean\n}",
               template: "",
-              scope: "global",
-            },
-            {
-              description: "",
+              reducer:
+                "const todo = state.todos.find(t => t.id === action.input.id);\nif (todo) {\n  if (action.input.title !== undefined) todo.title = action.input.title;\n  if (action.input.completed !== undefined) todo.completed = action.input.completed;\n}",
               errors: [],
               examples: [],
-              id: "896ca10b-6598-4d03-a73c-22fa706ca4fe",
-              name: "EDIT_TITLE",
-              reducer: "state.title = action.input.title || null;",
-              schema: "input EditTitleInput {\n  title: String\n}",
-              template: "",
               scope: "global",
             },
           ],
         },
       ],
+      version: 1,
+      changeLog: [],
+    },
+    {
       state: {
-        global: {
-          examples: [],
-          initialValue: '{"todos":[],"title":""}',
-          schema:
-            "type TodoState {\n  title: String\n  todos: [TodoItem!]!\n}\n\ntype TodoItem {\n  id: String!\n  title: String!\n  completed: Boolean!\n}",
-        },
         local: {
+          schema: "",
           examples: [],
           initialValue: "",
-          schema: "",
+        },
+        global: {
+          schema:
+            "type TodoState {\n  title: String\n  todos: [TodoItem!]!\n}\n\ntype TodoItem {\n  id: String!\n  title: String!\n  completed: Boolean!\n}",
+          examples: [],
+          initialValue: '{"todos":[],"title":""}',
         },
       },
+      modules: [
+        {
+          id: "42454fe7-a04b-4e25-8d2b-428df928dcd6",
+          name: "todo_operations",
+          description: "",
+          operations: [
+            {
+              id: "c0285a3b-6641-4899-8d40-73327a4fd4c5",
+              name: "ADD_TODO",
+              description: "",
+              schema:
+                "input AddTodoInput {\n  id: String!\n  title: String!\n  completed: Boolean!\n}",
+              template: "",
+              reducer:
+                "state.todos.push({\n  id: action.input.id,\n  title: action.input.title,\n  completed: action.input.completed,\n});",
+              errors: [],
+              examples: [],
+              scope: "global",
+            },
+            {
+              id: "890bddb3-aaff-49be-b981-57a5c79302e1",
+              name: "REMOVE_TODO",
+              description: "",
+              schema: "input RemoveTodoInput {\n  id: String!\n}",
+              template: "",
+              reducer:
+                "const index = state.todos.findIndex(t => t.id === action.input.id);\nif (index !== -1) {\n  state.todos.splice(index, 1);\n}",
+              errors: [],
+              examples: [],
+              scope: "global",
+            },
+            {
+              id: "22b59393-17c6-4afa-8f4d-0138e34f2832",
+              name: "UPDATE_TODO",
+              description: "",
+              schema:
+                "input UpdateTodoInput {\n  id: String!\n  title: String\n  completed: Boolean\n}",
+              template: "",
+              reducer:
+                "const todo = state.todos.find(t => t.id === action.input.id);\nif (todo) {\n  if (action.input.title !== undefined) todo.title = action.input.title;\n  if (action.input.completed !== undefined) todo.completed = action.input.completed;\n}",
+              errors: [],
+              examples: [],
+              scope: "global",
+            },
+            {
+              id: "896ca10b-6598-4d03-a73c-22fa706ca4fe",
+              name: "EDIT_TITLE",
+              description: "",
+              schema: "input EditTitleInput {\n  title: String\n}",
+              template: "",
+              reducer: "state.title = action.input.title || null;",
+              errors: [],
+              examples: [],
+              scope: "global",
+            },
+          ],
+        },
+      ],
       version: 2,
+      changeLog: [],
     },
   ],
 };

--- a/test/versioned-documents/document-models/todo/v1/gen/reducer.ts
+++ b/test/versioned-documents/document-models/todo/v1/gen/reducer.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import type { Reducer, StateReducer } from "document-model";
 import { createReducer, isDocumentAction } from "document-model";
 import type { TodoPHState } from "document-models/todo/v1";

--- a/test/versioned-documents/document-models/todo/v1/gen/schema/types.ts
+++ b/test/versioned-documents/document-models/todo/v1/gen/schema/types.ts
@@ -45,7 +45,10 @@ export type Scalars = {
   Amount_Money: { input: number; output: number };
   Amount_Percentage: { input: number; output: number };
   Amount_Tokens: { input: number; output: number };
-  Attachment: { input: string; output: string };
+  AttachmentRef: {
+    input: `attachment://v${number}:${string}`;
+    output: `attachment://v${number}:${string}`;
+  };
   Currency: { input: string; output: string };
   Date: { input: string; output: string };
   DateTime: { input: string; output: string };

--- a/test/versioned-documents/document-models/todo/v1/gen/schema/zod.ts
+++ b/test/versioned-documents/document-models/todo/v1/gen/schema/zod.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as z from "zod";
 import type {
   AddTodoInput,

--- a/test/versioned-documents/document-models/todo/v1/schema.graphql
+++ b/test/versioned-documents/document-models/todo/v1/schema.graphql
@@ -1,7 +1,7 @@
 scalar Unknown
 scalar DateTime
-scalar Attachment
 scalar Address
+scalar AttachmentRef
 scalar Amount_Tokens
 scalar EthereumAddress
 scalar EmailAddress

--- a/test/versioned-documents/document-models/todo/v2/gen/document-model.ts
+++ b/test/versioned-documents/document-models/todo/v2/gen/document-model.ts
@@ -1,153 +1,153 @@
 import type { DocumentModelGlobalState } from "document-model";
 
 export const documentModel: DocumentModelGlobalState = {
+  id: "test/todo",
+  name: "Todo",
   author: {
     name: "Powerhouse",
     website: "https://powerhouse.inc",
   },
-  description: "A versioned todo document model for testing codegen",
   extension: "todo",
-  id: "test/todo",
-  name: "Todo",
+  description: "A versioned todo document model for testing codegen",
   specifications: [
     {
-      changeLog: [],
-      modules: [
-        {
-          description: "",
-          id: "42454fe7-a04b-4e25-8d2b-428df928dcd6",
-          name: "todo_operations",
-          operations: [
-            {
-              description: "",
-              errors: [],
-              examples: [],
-              id: "c0285a3b-6641-4899-8d40-73327a4fd4c5",
-              name: "ADD_TODO",
-              reducer:
-                "state.todos.push({\n  id: action.input.id,\n  title: action.input.title,\n  completed: action.input.completed,\n});",
-              schema:
-                "input AddTodoInput {\n  id: String!\n  title: String!\n  completed: Boolean!\n}",
-              template: "",
-              scope: "global",
-            },
-            {
-              description: "",
-              errors: [],
-              examples: [],
-              id: "890bddb3-aaff-49be-b981-57a5c79302e1",
-              name: "REMOVE_TODO",
-              reducer:
-                "const index = state.todos.findIndex(t => t.id === action.input.id);\nif (index !== -1) {\n  state.todos.splice(index, 1);\n}",
-              schema: "input RemoveTodoInput {\n  id: String!\n}",
-              template: "",
-              scope: "global",
-            },
-            {
-              description: "",
-              errors: [],
-              examples: [],
-              id: "22b59393-17c6-4afa-8f4d-0138e34f2832",
-              name: "UPDATE_TODO",
-              reducer:
-                "const todo = state.todos.find(t => t.id === action.input.id);\nif (todo) {\n  if (action.input.title !== undefined) todo.title = action.input.title;\n  if (action.input.completed !== undefined) todo.completed = action.input.completed;\n}",
-              schema:
-                "input UpdateTodoInput {\n  id: String!\n  title: String\n  completed: Boolean\n}",
-              template: "",
-              scope: "global",
-            },
-          ],
-        },
-      ],
       state: {
-        global: {
+        local: {
+          schema: "",
           examples: [],
-          initialValue: '{"todos":[]}',
+          initialValue: "",
+        },
+        global: {
           schema:
             "type TodoState {\n  todos: [TodoItem!]!\n}\n\ntype TodoItem {\n  id: String!\n  title: String!\n  completed: Boolean!\n}",
-        },
-        local: {
           examples: [],
-          initialValue: "",
-          schema: "",
+          initialValue: '{"todos":[]}',
         },
       },
-      version: 1,
-    },
-    {
-      changeLog: [],
       modules: [
         {
-          description: "",
           id: "42454fe7-a04b-4e25-8d2b-428df928dcd6",
           name: "todo_operations",
+          description: "",
           operations: [
             {
-              description: "",
-              errors: [],
-              examples: [],
               id: "c0285a3b-6641-4899-8d40-73327a4fd4c5",
               name: "ADD_TODO",
-              reducer:
-                "state.todos.push({\n  id: action.input.id,\n  title: action.input.title,\n  completed: action.input.completed,\n});",
+              description: "",
               schema:
                 "input AddTodoInput {\n  id: String!\n  title: String!\n  completed: Boolean!\n}",
               template: "",
+              reducer:
+                "state.todos.push({\n  id: action.input.id,\n  title: action.input.title,\n  completed: action.input.completed,\n});",
+              errors: [],
+              examples: [],
               scope: "global",
             },
             {
-              description: "",
-              errors: [],
-              examples: [],
               id: "890bddb3-aaff-49be-b981-57a5c79302e1",
               name: "REMOVE_TODO",
-              reducer:
-                "const index = state.todos.findIndex(t => t.id === action.input.id);\nif (index !== -1) {\n  state.todos.splice(index, 1);\n}",
+              description: "",
               schema: "input RemoveTodoInput {\n  id: String!\n}",
               template: "",
+              reducer:
+                "const index = state.todos.findIndex(t => t.id === action.input.id);\nif (index !== -1) {\n  state.todos.splice(index, 1);\n}",
+              errors: [],
+              examples: [],
               scope: "global",
             },
             {
-              description: "",
-              errors: [],
-              examples: [],
               id: "22b59393-17c6-4afa-8f4d-0138e34f2832",
               name: "UPDATE_TODO",
-              reducer:
-                "const todo = state.todos.find(t => t.id === action.input.id);\nif (todo) {\n  if (action.input.title !== undefined) todo.title = action.input.title;\n  if (action.input.completed !== undefined) todo.completed = action.input.completed;\n}",
+              description: "",
               schema:
                 "input UpdateTodoInput {\n  id: String!\n  title: String\n  completed: Boolean\n}",
               template: "",
-              scope: "global",
-            },
-            {
-              description: "",
+              reducer:
+                "const todo = state.todos.find(t => t.id === action.input.id);\nif (todo) {\n  if (action.input.title !== undefined) todo.title = action.input.title;\n  if (action.input.completed !== undefined) todo.completed = action.input.completed;\n}",
               errors: [],
               examples: [],
-              id: "896ca10b-6598-4d03-a73c-22fa706ca4fe",
-              name: "EDIT_TITLE",
-              reducer: "state.title = action.input.title || null;",
-              schema: "input EditTitleInput {\n  title: String\n}",
-              template: "",
               scope: "global",
             },
           ],
         },
       ],
+      version: 1,
+      changeLog: [],
+    },
+    {
       state: {
-        global: {
-          examples: [],
-          initialValue: '{"todos":[],"title":""}',
-          schema:
-            "type TodoState {\n  title: String\n  todos: [TodoItem!]!\n}\n\ntype TodoItem {\n  id: String!\n  title: String!\n  completed: Boolean!\n}",
-        },
         local: {
+          schema: "",
           examples: [],
           initialValue: "",
-          schema: "",
+        },
+        global: {
+          schema:
+            "type TodoState {\n  title: String\n  todos: [TodoItem!]!\n}\n\ntype TodoItem {\n  id: String!\n  title: String!\n  completed: Boolean!\n}",
+          examples: [],
+          initialValue: '{"todos":[],"title":""}',
         },
       },
+      modules: [
+        {
+          id: "42454fe7-a04b-4e25-8d2b-428df928dcd6",
+          name: "todo_operations",
+          description: "",
+          operations: [
+            {
+              id: "c0285a3b-6641-4899-8d40-73327a4fd4c5",
+              name: "ADD_TODO",
+              description: "",
+              schema:
+                "input AddTodoInput {\n  id: String!\n  title: String!\n  completed: Boolean!\n}",
+              template: "",
+              reducer:
+                "state.todos.push({\n  id: action.input.id,\n  title: action.input.title,\n  completed: action.input.completed,\n});",
+              errors: [],
+              examples: [],
+              scope: "global",
+            },
+            {
+              id: "890bddb3-aaff-49be-b981-57a5c79302e1",
+              name: "REMOVE_TODO",
+              description: "",
+              schema: "input RemoveTodoInput {\n  id: String!\n}",
+              template: "",
+              reducer:
+                "const index = state.todos.findIndex(t => t.id === action.input.id);\nif (index !== -1) {\n  state.todos.splice(index, 1);\n}",
+              errors: [],
+              examples: [],
+              scope: "global",
+            },
+            {
+              id: "22b59393-17c6-4afa-8f4d-0138e34f2832",
+              name: "UPDATE_TODO",
+              description: "",
+              schema:
+                "input UpdateTodoInput {\n  id: String!\n  title: String\n  completed: Boolean\n}",
+              template: "",
+              reducer:
+                "const todo = state.todos.find(t => t.id === action.input.id);\nif (todo) {\n  if (action.input.title !== undefined) todo.title = action.input.title;\n  if (action.input.completed !== undefined) todo.completed = action.input.completed;\n}",
+              errors: [],
+              examples: [],
+              scope: "global",
+            },
+            {
+              id: "896ca10b-6598-4d03-a73c-22fa706ca4fe",
+              name: "EDIT_TITLE",
+              description: "",
+              schema: "input EditTitleInput {\n  title: String\n}",
+              template: "",
+              reducer: "state.title = action.input.title || null;",
+              errors: [],
+              examples: [],
+              scope: "global",
+            },
+          ],
+        },
+      ],
       version: 2,
+      changeLog: [],
     },
   ],
 };

--- a/test/versioned-documents/document-models/todo/v2/gen/reducer.ts
+++ b/test/versioned-documents/document-models/todo/v2/gen/reducer.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import type { Reducer, StateReducer } from "document-model";
 import { createReducer, isDocumentAction } from "document-model";
 import type { TodoPHState } from "document-models/todo/v2";

--- a/test/versioned-documents/document-models/todo/v2/gen/schema/types.ts
+++ b/test/versioned-documents/document-models/todo/v2/gen/schema/types.ts
@@ -45,7 +45,10 @@ export type Scalars = {
   Amount_Money: { input: number; output: number };
   Amount_Percentage: { input: number; output: number };
   Amount_Tokens: { input: number; output: number };
-  Attachment: { input: string; output: string };
+  AttachmentRef: {
+    input: `attachment://v${number}:${string}`;
+    output: `attachment://v${number}:${string}`;
+  };
   Currency: { input: string; output: string };
   Date: { input: string; output: string };
   DateTime: { input: string; output: string };

--- a/test/versioned-documents/document-models/todo/v2/gen/schema/zod.ts
+++ b/test/versioned-documents/document-models/todo/v2/gen/schema/zod.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as z from "zod";
 import type {
   AddTodoInput,

--- a/test/versioned-documents/document-models/todo/v2/schema.graphql
+++ b/test/versioned-documents/document-models/todo/v2/schema.graphql
@@ -1,7 +1,7 @@
 scalar Unknown
 scalar DateTime
-scalar Attachment
 scalar Address
+scalar AttachmentRef
 scalar Amount_Tokens
 scalar EthereumAddress
 scalar EmailAddress

--- a/tools/registry-audit/README.md
+++ b/tools/registry-audit/README.md
@@ -129,6 +129,40 @@ pnpm audit:load [--package <name>] [--from-report] [--filter <substr>] [--limit 
 > models whose SDL still declares `scalar Attachment` boot fine — the undeclared
 > scalar degrades to a passthrough rather than throwing.
 
+### 6. create-query — `pnpm audit:create-query` (runtime API test)
+
+The deepest check in the suite. Where `load` only proves a model **boots and
+registers**, this proves its generated GraphQL API actually **works** against the
+current core: for every document model a package contributes, it hits that model's
+own generated subgraph endpoint (`/graphql/<kebab-name>`), creates an empty document
+of that type, then queries it back by id.
+
+```
+pnpm audit:create-query [--package <name>] [--from-report] [--filter <substr>] [--limit <n>] [--timeout <ms>] [--reinstall]
+```
+
+- Boots the same in-process Switchboard as `load` (in-memory PGlite) with the single
+  package loaded, then for each **own** model (core/baseline models excluded) runs,
+  over HTTP against the per-model subgraph:
+  - `mutation { <Name> { createEmptyDocument { id … } } }`, then
+  - `query { <Name> { document(identifier: <id>) { document { id documentType } } } }`.
+
+  `<Name>` is the model's GraphQL namespace (`pascalCase(name)`) and the endpoint
+  segment is `kebabCase(name)` — mirroring how `reactor-api` names subgraphs.
+- `createEmptyDocument` needs no drive and no input, so the check is uniform across
+  models. The query verifies the round-tripped `id` and `documentType` match.
+- **Reuses the `load` scaffolds** under `.cache/registry-audit/load/<pkg>/` — if a
+  package is already installed there (e.g. after `audit:load`), no reinstall happens.
+  Use `--reinstall` to force a fresh install.
+- Each package runs in its **own subprocess** (`create-query-worker.ts`) with a
+  per-package `--timeout` (default 120s).
+- Status per package: `ok` (every model created **and** queried), `partial` (some
+  models failed), `failed` (none succeeded), `no-models` (booted, contributed
+  nothing), `boot-failed`, `install-failed`, `timeout`. A per-model entry that 404s
+  on its subgraph is flagged `endpointMissing` (usually a name-derivation drift).
+- Writes `create-query-report.json` + a console summary. **Requires the local
+  Switchboard to be built**: `pnpm --filter=@powerhousedao/switchboard build`.
+
 ## Typical run
 
 ```
@@ -139,4 +173,6 @@ pnpm audit:analyze --rules tools/registry-audit/rules/legacy-attachments.json
 pnpm audit:typecheck --from-report --limit 5
 # runtime proof: boot a switchboard and import each model:
 pnpm audit:load
+# deepest proof: create + query a document per model via its generated endpoint:
+pnpm audit:create-query
 ```

--- a/tools/registry-audit/README.md
+++ b/tools/registry-audit/README.md
@@ -67,19 +67,67 @@ Options: `--rules <file>` (repeatable), `--pattern <regex>` (repeatable),
 ### 3b. typecheck — `pnpm audit:typecheck` (optional, best-effort)
 
 For each target package, scaffolds a standalone consumer project that installs the
-published tarball with selected dependencies **overridden to the local workspace
-builds**, then runs `tsc --noEmit`. Answers "do these published packages still
-typecheck against the current local build?".
+published tarball (`pnpm install --ignore-workspace --ignore-scripts`), then runs
+`tsc --noEmit` over an entry that imports it — with local workspace packages
+redirected via TypeScript `compilerOptions.paths`. tsc honours `paths` for every
+import in the program, including those inside the published package's own `.d.ts`,
+so the package is effectively type-checked against the **current local build**.
+Answers "do these published packages still typecheck against the current local code?".
 
 ```
 pnpm audit:typecheck [--from-report] [--package <name>] [--override <pkg>=<dir>] [--limit <n>] [--skip-install]
 ```
 
-Defaults to packages flagged in `report.json`. Local workspace packages
-(`packages/*`, `clis/*`) are overridden by default; the local builds must already be
-built. This installs a full dependency tree per package, so it is slow. Note that
-packages which bundle/inline their dependency types won't surface breakage here — the
-pattern scan is the better detector for that.
+- **Defaults to all extracted packages.** Use `--from-report` to limit to the
+  packages flagged by `analyze.ts`, or `--package <name>` for specific ones.
+- Local workspace packages under `packages/*` and `clis/*` that have built types are
+  redirected by default (the local builds must already be built). Add or change
+  redirects with `--override <pkg>=<dir>`.
+- Reported errors are **scoped to the target package's own files**; unrelated
+  transitive-dependency `.d.ts` noise is written to each scaffold's `tsc-errors.txt`
+  but not counted.
+- Installs a full dependency tree per package (the pnpm store is shared, so repeat
+  installs are faster), so it is slow.
+
+> Why `paths` and not pnpm `overrides`? pnpm does not apply `overrides` in an
+> `--ignore-workspace` standalone project, so the redirect would be silently ignored.
+
+**Important — limited signal for this audit.** Published models *bundle/inline* the
+removed types (e.g. their own copy of `AttachmentInput`), and import only surviving
+symbols (`Action`, …) from `document-model`. The inlined copies don't reference the
+local package, so tsc sees nothing wrong and these packages report `ok`. This phase
+only catches a package that *imports a now-removed named export*. For the
+attachment removal, **`analyze.ts` is the authoritative detector**, and the harness
+has been verified to flag removed exports (importing `AttachmentInput` from the local
+`document-model` correctly errors `TS2305`).
+
+### 5. load — `pnpm audit:load` (runtime integration test)
+
+Boots a **real Switchboard** server in-process (in-memory PGlite — no Postgres, no
+external services) and imports each extracted model package into it, building its
+GraphQL subgraph schema. This answers what the static phases can't: *does the
+published model actually load and build against the current core code?*
+
+```
+pnpm audit:load [--package <name>] [--from-report] [--filter <substr>] [--limit <n>] [--timeout <ms>]
+```
+
+- Each package is loaded in its **own subprocess** (`load-worker.ts`), so a
+  hang or hard crash is isolated; a per-package `--timeout` (default 120s) guards hangs.
+- Only packages that export `./document-models` are loaded; others are skipped.
+- The loaded package's runtime `import "document-model"` resolves (via node's
+  module walk-up to the repo's `node_modules`) to the **local** build — so this tests
+  the published model against the *current* core, not the version it was built with.
+- A baseline boot (no package) establishes the core model ids; each package's
+  contribution is the delta. Status per package: `loaded` (registered models +
+  schema built), `no-models` (booted but registered nothing), `boot-failed`
+  (threw — captured), `timeout`.
+- Writes `load-report.json` + a console summary. **Requires the local Switchboard to
+  be built**: `pnpm --filter=@powerhousedao/switchboard build`.
+
+> This is the phase that actually proves the attachment removal's runtime impact:
+> models whose SDL still declares `scalar Attachment` boot fine — the undeclared
+> scalar degrades to a passthrough rather than throwing.
 
 ## Typical run
 
@@ -87,6 +135,8 @@ pattern scan is the better detector for that.
 pnpm audit:download
 pnpm audit:extract
 pnpm audit:analyze --rules tools/registry-audit/rules/legacy-attachments.json
-# then optionally, on just the flagged packages:
+# optional static cross-reference check, on just the flagged packages:
 pnpm audit:typecheck --from-report --limit 5
+# runtime proof: boot a switchboard and import each model:
+pnpm audit:load
 ```

--- a/tools/registry-audit/README.md
+++ b/tools/registry-audit/README.md
@@ -1,0 +1,92 @@
+# registry-audit
+
+A phased pipeline of small, explicit tools that audit every package published to a
+Verdaccio/npm registry. Each phase is independently runnable and idempotent, and
+threads state through a single `manifest.json`.
+
+The tools are **generic** — what to look for is supplied as data (rules / patterns /
+override targets), not baked in. The first use case is checking which published
+document models reference the legacy attachment system removed in `163a5f6f1`, but the
+same pipeline works for any future change.
+
+All state lives under the repo-root `.cache/registry-audit/` (gitignored):
+
+```
+.cache/registry-audit/
+  manifest.json     # threads the phases together
+  report.json       # analyze.ts output
+  tarballs/         # download.ts output
+  extracted/        # extract.ts output
+  typecheck/        # typecheck.ts scaffolds
+```
+
+## Phases
+
+### 1. download — `pnpm audit:download`
+
+Enumerates every package (`/-/verdaccio/data/packages`), resolves each to its
+`dist-tags.latest`, and downloads the tarball.
+
+```
+pnpm audit:download [--registry <url>] [--filter <substr>] [--concurrency <n>] [--force]
+```
+
+### 2. extract — `pnpm audit:extract`
+
+Unpacks each tarball into `extracted/<name>/` (strips the leading `package/`).
+
+```
+pnpm audit:extract [--filter <substr>] [--force]
+```
+
+### 3a. analyze — `pnpm audit:analyze`
+
+Configurable pattern scan over the extracted files. Rules come from a JSON file
+and/or ad-hoc `--pattern` flags. Writes `report.json` and prints a per-package summary.
+
+```
+pnpm audit:analyze --rules tools/registry-audit/rules/legacy-attachments.json
+pnpm audit:analyze --pattern "\\bsomeRemovedSymbol\\b" --rule removed-scalar-attachment
+```
+
+Rule shape (see `rules/legacy-attachments.json`):
+
+```jsonc
+{
+  "id": "removed-scalar-attachment",
+  "severity": "high",
+  "pattern": "\\bAttachment:\\s*\\{",   // JS RegExp source
+  "include": ["gen/schema/"],            // optional path substring filters
+  "exclude": []
+}
+```
+
+Options: `--rules <file>` (repeatable), `--pattern <regex>` (repeatable),
+`--rule <id>` (filter), `--filter <substr>`, `--ext d.ts,js,mjs`, `--json`.
+
+### 3b. typecheck — `pnpm audit:typecheck` (optional, best-effort)
+
+For each target package, scaffolds a standalone consumer project that installs the
+published tarball with selected dependencies **overridden to the local workspace
+builds**, then runs `tsc --noEmit`. Answers "do these published packages still
+typecheck against the current local build?".
+
+```
+pnpm audit:typecheck [--from-report] [--package <name>] [--override <pkg>=<dir>] [--limit <n>] [--skip-install]
+```
+
+Defaults to packages flagged in `report.json`. Local workspace packages
+(`packages/*`, `clis/*`) are overridden by default; the local builds must already be
+built. This installs a full dependency tree per package, so it is slow. Note that
+packages which bundle/inline their dependency types won't surface breakage here — the
+pattern scan is the better detector for that.
+
+## Typical run
+
+```
+pnpm audit:download
+pnpm audit:extract
+pnpm audit:analyze --rules tools/registry-audit/rules/legacy-attachments.json
+# then optionally, on just the flagged packages:
+pnpm audit:typecheck --from-report --limit 5
+```

--- a/tools/registry-audit/analyze.ts
+++ b/tools/registry-audit/analyze.ts
@@ -1,0 +1,239 @@
+/**
+ * Phase 3a: configurable pattern scan over the extracted packages.
+ *
+ * The search is supplied as data - nothing here is specific to any one audit.
+ *
+ * Usage:
+ *   tsx tools/registry-audit/analyze.ts --rules <file.json> [options]
+ *   tsx tools/registry-audit/analyze.ts --pattern "<regex>" [--pattern ...]
+ *
+ * Options:
+ *   --rules <file>       JSON rules file (repeatable). See rules/legacy-attachments.json.
+ *   --pattern <regex>    Ad-hoc rule (repeatable); id is derived from the regex.
+ *   --rule <id>          Only run the rule(s) with this id (repeatable).
+ *   --filter <substr>    Only scan packages whose name includes <substr> (repeatable).
+ *   --ext <list>         Comma-separated file extensions to scan
+ *                        (default: d.ts,js,mjs,d.mts,cjs).
+ *   --json               Print the full report JSON to stdout instead of a summary.
+ *
+ * Reads extractedPath from the manifest, writes findings to
+ * .cache/registry-audit/report.json.
+ */
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { opt, parseArgs, REPORT_PATH, requireManifest } from "./lib.js";
+
+/** Conventionally "high" | "medium" | "low", but any string is allowed. */
+type Severity = string;
+
+type Rule = {
+  id: string;
+  description?: string;
+  severity?: Severity;
+  pattern: string;
+  flags?: string;
+  /** Only apply to files whose relative path includes one of these substrings. */
+  include?: string[];
+  /** Skip files whose relative path includes one of these substrings. */
+  exclude?: string[];
+};
+
+type RulesFile = { name?: string; description?: string; rules: Rule[] };
+
+type CompiledRule = Rule & { regex: RegExp };
+
+type Finding = {
+  package: string;
+  version: string;
+  file: string;
+  line: number;
+  rule: string;
+  severity: Severity;
+  snippet: string;
+};
+
+async function loadRules(args: ReturnType<typeof parseArgs>): Promise<Rule[]> {
+  const rules: Rule[] = [];
+
+  for (const file of args.options.rules ?? []) {
+    const parsed = JSON.parse(await readFile(file, "utf8")) as RulesFile;
+    rules.push(...parsed.rules);
+  }
+
+  for (const pattern of args.options.pattern ?? []) {
+    rules.push({
+      id: `pattern:${pattern}`,
+      severity: "medium",
+      pattern,
+    });
+  }
+
+  const onlyIds = new Set(args.options.rule ?? []);
+  return onlyIds.size ? rules.filter((r) => onlyIds.has(r.id)) : rules;
+}
+
+function compile(rules: Rule[]): CompiledRule[] {
+  return rules.map((r) => ({
+    ...r,
+    severity: r.severity ?? "medium",
+    // Force global+multiline so we can iterate all matches with line numbers.
+    regex: new RegExp(r.pattern, `${r.flags ?? ""}g`.replace(/g+/, "g")),
+  }));
+}
+
+async function* walk(dir: string): AsyncGenerator<string> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name === "node_modules") continue;
+      yield* walk(full);
+    } else if (e.isFile()) {
+      yield full;
+    }
+  }
+}
+
+function matchesExt(file: string, exts: string[]): boolean {
+  return exts.some((ext) => file.endsWith(`.${ext}`));
+}
+
+function lineNumberAt(text: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index && i < text.length; i++) {
+    if (text[i] === "\n") line++;
+  }
+  return line;
+}
+
+async function scanFile(
+  absFile: string,
+  relFile: string,
+  pkgName: string,
+  version: string,
+  rules: CompiledRule[],
+): Promise<Finding[]> {
+  const findings: Finding[] = [];
+  let text: string;
+  try {
+    text = await readFile(absFile, "utf8");
+  } catch {
+    return findings;
+  }
+  const lines = text.split("\n");
+
+  for (const rule of rules) {
+    if (rule.include && !rule.include.some((s) => relFile.includes(s)))
+      continue;
+    if (rule.exclude && rule.exclude.some((s) => relFile.includes(s))) continue;
+
+    rule.regex.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = rule.regex.exec(text)) !== null) {
+      const line = lineNumberAt(text, m.index);
+      findings.push({
+        package: pkgName,
+        version,
+        file: relFile,
+        line,
+        rule: rule.id,
+        severity: rule.severity!,
+        snippet: (lines[line - 1] ?? m[0]).trim().slice(0, 200),
+      });
+      if (m.index === rule.regex.lastIndex) rule.regex.lastIndex++; // guard zero-width
+    }
+  }
+  return findings;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2), ["json"]);
+  const filters = args.options.filter ?? [];
+  const exts = (opt(args, "ext", "d.ts,js,mjs,d.mts,cjs") as string)
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const rules = compile(await loadRules(args));
+  if (!rules.length) {
+    console.error(
+      "No rules supplied. Pass --rules <file.json> and/or --pattern <regex>.",
+    );
+    process.exit(1);
+  }
+
+  const manifest = await requireManifest("tsx tools/registry-audit/extract.ts");
+  let entries = Object.values(manifest.packages).filter((e) => e.extractedPath);
+  if (filters.length) {
+    entries = entries.filter((e) => filters.some((f) => e.name.includes(f)));
+  }
+
+  console.log(
+    `Scanning ${entries.length} package(s) with ${rules.length} rule(s) ` +
+      `over .${exts.join(", .")} files...\n`,
+  );
+
+  const allFindings: Finding[] = [];
+  for (const entry of entries) {
+    const root = entry.extractedPath!;
+    for await (const absFile of walk(root)) {
+      if (!matchesExt(absFile, exts)) continue;
+      const relFile = relative(root, absFile);
+      allFindings.push(
+        ...(await scanFile(absFile, relFile, entry.name, entry.version, rules)),
+      );
+    }
+  }
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    registry: manifest.registry,
+    rules: rules.map((r) => ({
+      id: r.id,
+      severity: r.severity,
+      description: r.description,
+    })),
+    packagesScanned: entries.length,
+    findings: allFindings,
+  };
+  await writeFile(REPORT_PATH, JSON.stringify(report, null, 2));
+
+  if (args.flags.json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  // Summary: per package, count by rule.
+  const byPackage = new Map<string, Map<string, number>>();
+  for (const f of allFindings) {
+    const m = byPackage.get(f.package) ?? new Map<string, number>();
+    m.set(f.rule, (m.get(f.rule) ?? 0) + 1);
+    byPackage.set(f.package, m);
+  }
+
+  const flagged = [...byPackage.keys()].sort();
+  if (!flagged.length) {
+    console.log("No findings. 🎉");
+  } else {
+    console.log(`Flagged ${flagged.length}/${entries.length} package(s):\n`);
+    for (const pkg of flagged) {
+      const counts = byPackage.get(pkg)!;
+      const total = [...counts.values()].reduce((a, b) => a + b, 0);
+      console.log(`  ${pkg}  (${total} finding(s))`);
+      for (const [ruleId, count] of [...counts.entries()].sort()) {
+        console.log(`      ${count.toString().padStart(4)}  ${ruleId}`);
+      }
+    }
+  }
+  console.log(`\nFull report: ${REPORT_PATH}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/registry-audit/create-query-worker.ts
+++ b/tools/registry-audit/create-query-worker.ts
@@ -43,38 +43,27 @@ type StartSwitchboard = (
 ) => Promise<SwitchboardHandle>;
 
 type ModelResult = {
-  /** Model id == document type, e.g. "powerhouse/builder-profile". */
   id: string;
-  /** Model global name (source of the subgraph/namespace names). */
   name: string;
-  /** Per-model subgraph URL segment, e.g. "powerhouse-builder-profile". */
   subgraph: string;
   created: boolean;
   queried: boolean;
-  /** Set when the subgraph endpoint itself is missing (404) - likely name drift. */
   endpointMissing?: boolean;
   createError?: string;
   queryError?: string;
 };
 
-/**
- * A fixed port to bind the Switchboard on. Unlike `load`, this phase must address
- * the HTTP server, and `startSwitchboard` does not report back an OS-assigned
- * (`port: 0`) port. Workers run one at a time and fully exit between packages, so a
- * fixed port is reusable; `strictPort` makes a lingering listener a hard error
- * rather than a silent rebind we couldn't find.
- */
+// startSwitchboard does not report back an OS-assigned (port: 0) port, and this
+// phase must address the HTTP server. Workers run sequentially so a fixed port is
+// reusable; strictPort surfaces a lingering listener instead of silently rebinding.
 const PORT = 47100;
 
 function emit(obj: unknown): void {
   console.log(`__SBCQ__ ${JSON.stringify(obj)}`);
 }
 
-/**
- * Splits an identifier into words on separators (/ space - _ .) and camel/acronym
- * boundaries - the basis for kebab/pascal casing that mirrors `change-case`, which
- * is what reactor-api uses to name each model's subgraph and GraphQL namespace.
- */
+// kebab/pascal below mirror `change-case`, which reactor-api uses to name each
+// model's subgraph (kebab) and GraphQL namespace (pascal).
 function toWords(input: string): string[] {
   return input
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
@@ -83,14 +72,12 @@ function toWords(input: string): string[] {
     .filter(Boolean);
 }
 
-/** kebabCase(name) - the subgraph URL segment (mirrors document-model-subgraph.ts). */
 function kebabCase(name: string): string {
   return toWords(name)
     .map((w) => w.toLowerCase())
     .join("-");
 }
 
-/** pascalCase(name) - the GraphQL namespace type (mirrors getDocumentModelSchemaName). */
 function pascalCase(name: string): string {
   return toWords(name)
     .map((w) => w[0].toUpperCase() + w.slice(1).toLowerCase())
@@ -131,7 +118,6 @@ async function gqlFetch(
   };
 }
 
-/** Joins GraphQL error messages into a single short string. */
 function errText(res: GqlResponse): string {
   if (!res.httpOk && !res.errors?.length) return `HTTP ${res.status}`;
   return (res.errors ?? [])
@@ -147,8 +133,7 @@ async function exerciseModel(
 ): Promise<ModelResult> {
   const subgraph = kebabCase(name);
   const namespace = pascalCase(name);
-  // 127.0.0.1, not "localhost": on macOS localhost can resolve to ::1 first and
-  // miss an IPv4-only listener.
+  // 127.0.0.1, not localhost: localhost can resolve to ::1 and miss an IPv4 listener.
   const endpoint = `http://127.0.0.1:${port}/graphql/${subgraph}`;
   const result: ModelResult = {
     id,
@@ -158,7 +143,6 @@ async function exerciseModel(
     queried: false,
   };
 
-  // 1. Create an empty document of this type via the model's generated subgraph.
   const createRes = await gqlFetch(
     endpoint,
     `mutation { ${namespace} { createEmptyDocument { id name documentType } } }`,
@@ -180,7 +164,6 @@ async function exerciseModel(
   result.created = true;
   const docId = created.id;
 
-  // 2. Query it back by id via the same generated subgraph.
   const queryRes = await gqlFetch(
     endpoint,
     `query($id: String!) { ${namespace} { document(identifier: $id) { document { id documentType } childIds } } }`,
@@ -246,8 +229,6 @@ async function main(): Promise<void> {
     try {
       models.push(await exerciseModel(PORT, m.id, m.name));
     } catch (e) {
-      // A transport-level failure (e.g. fetch failed) is the model's result, not
-      // a worker crash - record it so the other models still run.
       const msg = e instanceof Error ? e.message : String(e);
       models.push({
         id: m.id,

--- a/tools/registry-audit/create-query-worker.ts
+++ b/tools/registry-audit/create-query-worker.ts
@@ -1,0 +1,268 @@
+/**
+ * Worker process for create-query.ts. Not a phase entry point - it is spawned by
+ * create-query.ts (one per package) so a hang or hard crash is isolated to a
+ * single child process. Argv[1] is the package name to exercise.
+ *
+ * Boots a Switchboard (in-process, in-memory PGlite) with the single named
+ * package loaded, then for every document model that package CONTRIBUTES (i.e.
+ * not a core/baseline model), it hits that model's own generated GraphQL
+ * subgraph endpoint and:
+ *   1. creates an empty document of that type (createEmptyDocument), then
+ *   2. queries it back by id (document(identifier:)).
+ *
+ * The baseline core model ids arrive via PH_BASELINE_MODEL_IDS (JSON array) so we
+ * only exercise the package's own models. The worker prints exactly one
+ * machine-readable line for the parent to parse:
+ *
+ *   __SBCQ__ {"ok":true,"ms":1234,"models":[{...}]}
+ *
+ * and exits 0 on success / 1 on a boot failure.
+ *
+ * The Switchboard build is imported by absolute path; create-query.ts runs this
+ * worker with cwd set to the package's install scaffold so the Switchboard's
+ * package loader resolves the named package (and its deps) from that scaffold.
+ */
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { REPO_ROOT, SWITCHBOARD_SERVER } from "./lib.js";
+
+type DocModule = {
+  documentModel?: { global?: { id?: string; name?: string } };
+};
+type SwitchboardHandle = {
+  port: number;
+  reactor: {
+    getDocumentModelModules: () => Promise<
+      { results?: DocModule[] } | DocModule[]
+    >;
+  };
+  shutdown: () => Promise<void>;
+};
+type StartSwitchboard = (
+  opts: Record<string, unknown>,
+) => Promise<SwitchboardHandle>;
+
+type ModelResult = {
+  /** Model id == document type, e.g. "powerhouse/builder-profile". */
+  id: string;
+  /** Model global name (source of the subgraph/namespace names). */
+  name: string;
+  /** Per-model subgraph URL segment, e.g. "powerhouse-builder-profile". */
+  subgraph: string;
+  created: boolean;
+  queried: boolean;
+  /** Set when the subgraph endpoint itself is missing (404) - likely name drift. */
+  endpointMissing?: boolean;
+  createError?: string;
+  queryError?: string;
+};
+
+/**
+ * A fixed port to bind the Switchboard on. Unlike `load`, this phase must address
+ * the HTTP server, and `startSwitchboard` does not report back an OS-assigned
+ * (`port: 0`) port. Workers run one at a time and fully exit between packages, so a
+ * fixed port is reusable; `strictPort` makes a lingering listener a hard error
+ * rather than a silent rebind we couldn't find.
+ */
+const PORT = 47100;
+
+function emit(obj: unknown): void {
+  console.log(`__SBCQ__ ${JSON.stringify(obj)}`);
+}
+
+/**
+ * Splits an identifier into words on separators (/ space - _ .) and camel/acronym
+ * boundaries - the basis for kebab/pascal casing that mirrors `change-case`, which
+ * is what reactor-api uses to name each model's subgraph and GraphQL namespace.
+ */
+function toWords(input: string): string[] {
+  return input
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean);
+}
+
+/** kebabCase(name) - the subgraph URL segment (mirrors document-model-subgraph.ts). */
+function kebabCase(name: string): string {
+  return toWords(name)
+    .map((w) => w.toLowerCase())
+    .join("-");
+}
+
+/** pascalCase(name) - the GraphQL namespace type (mirrors getDocumentModelSchemaName). */
+function pascalCase(name: string): string {
+  return toWords(name)
+    .map((w) => w[0].toUpperCase() + w.slice(1).toLowerCase())
+    .join("");
+}
+
+type GqlResponse = {
+  httpOk: boolean;
+  status: number;
+  data?: Record<string, unknown>;
+  errors?: { message?: string }[];
+};
+
+async function gqlFetch(
+  endpoint: string,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<GqlResponse> {
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+  let body: { data?: Record<string, unknown>; errors?: { message?: string }[] } =
+    {};
+  try {
+    body = (await res.json()) as typeof body;
+  } catch {
+    /* non-JSON (e.g. a 404 page) - leave body empty */
+  }
+  return {
+    httpOk: res.ok,
+    status: res.status,
+    data: body.data,
+    errors: body.errors,
+  };
+}
+
+/** Joins GraphQL error messages into a single short string. */
+function errText(res: GqlResponse): string {
+  if (!res.httpOk && !res.errors?.length) return `HTTP ${res.status}`;
+  return (res.errors ?? []).map((e) => e.message ?? "").join("; ").slice(0, 500);
+}
+
+async function exerciseModel(
+  port: number,
+  id: string,
+  name: string,
+): Promise<ModelResult> {
+  const subgraph = kebabCase(name);
+  const namespace = pascalCase(name);
+  // 127.0.0.1, not "localhost": on macOS localhost can resolve to ::1 first and
+  // miss an IPv4-only listener.
+  const endpoint = `http://127.0.0.1:${port}/graphql/${subgraph}`;
+  const result: ModelResult = {
+    id,
+    name,
+    subgraph,
+    created: false,
+    queried: false,
+  };
+
+  // 1. Create an empty document of this type via the model's generated subgraph.
+  const createRes = await gqlFetch(
+    endpoint,
+    `mutation { ${namespace} { createEmptyDocument { id name documentType } } }`,
+  );
+  if (createRes.status === 404) {
+    result.endpointMissing = true;
+    result.createError = `no subgraph at /graphql/${subgraph}`;
+    return result;
+  }
+  const created = (
+    createRes.data?.[namespace] as
+      | { createEmptyDocument?: { id?: string; documentType?: string } }
+      | undefined
+  )?.createEmptyDocument;
+  if (!created?.id) {
+    result.createError = errText(createRes) || "no document id returned";
+    return result;
+  }
+  result.created = true;
+  const docId = created.id;
+
+  // 2. Query it back by id via the same generated subgraph.
+  const queryRes = await gqlFetch(
+    endpoint,
+    `query($id: String!) { ${namespace} { document(identifier: $id) { document { id documentType } childIds } } }`,
+    { id: docId },
+  );
+  const fetched = (
+    queryRes.data?.[namespace] as
+      | { document?: { document?: { id?: string; documentType?: string } } }
+      | undefined
+  )?.document?.document;
+  if (!fetched?.id) {
+    result.queryError = errText(queryRes) || "document not found";
+    return result;
+  }
+  if (fetched.id !== docId) {
+    result.queryError = `queried id ${fetched.id} != created id ${docId}`;
+    return result;
+  }
+  if (fetched.documentType && fetched.documentType !== id) {
+    result.queryError = `documentType ${fetched.documentType} != ${id}`;
+    return result;
+  }
+  result.queried = true;
+  return result;
+}
+
+async function main(): Promise<void> {
+  const ext = process.argv[2];
+  if (!ext || ext === "none") {
+    emit({ ok: false, models: [], error: "no package name given" });
+    process.exit(1);
+  }
+  const baseline = new Set<string>(
+    JSON.parse(process.env.PH_BASELINE_MODEL_IDS ?? "[]") as string[],
+  );
+  const t0 = Date.now();
+
+  const serverUrl = pathToFileURL(SWITCHBOARD_SERVER).href;
+  const mod = (await import(serverUrl)) as {
+    startSwitchboard: StartSwitchboard;
+  };
+
+  const sb = await mod.startSwitchboard({
+    port: PORT,
+    strictPort: true,
+    packages: [ext],
+    disableLocalPackages: true,
+    mcp: false,
+    enableDocumentModelSubgraphs: true,
+  });
+
+  const res = await sb.reactor.getDocumentModelModules();
+  const arr = Array.isArray(res) ? res : (res.results ?? []);
+  const targets = arr
+    .map((m) => ({
+      id: m?.documentModel?.global?.id ?? "",
+      name: m?.documentModel?.global?.name ?? "",
+    }))
+    .filter((m) => m.id && m.name && !baseline.has(m.id));
+
+  const models: ModelResult[] = [];
+  for (const m of targets) {
+    try {
+      models.push(await exerciseModel(PORT, m.id, m.name));
+    } catch (e) {
+      // A transport-level failure (e.g. fetch failed) is the model's result, not
+      // a worker crash - record it so the other models still run.
+      const msg = e instanceof Error ? e.message : String(e);
+      models.push({
+        id: m.id,
+        name: m.name,
+        subgraph: kebabCase(m.name),
+        created: false,
+        queried: false,
+        createError: msg.slice(0, 500),
+      });
+    }
+  }
+
+  await sb.shutdown();
+  emit({ ok: true, ms: Date.now() - t0, models });
+  // Force exit: the reactor/GraphQL stack can leave timers/handles open.
+  process.exit(0);
+}
+
+main().catch((e: unknown) => {
+  const error = e instanceof Error ? (e.stack ?? e.message) : String(e);
+  emit({ ok: false, models: [], error: error.slice(0, 2000) });
+  process.exit(1);
+});

--- a/tools/registry-audit/create-query-worker.ts
+++ b/tools/registry-audit/create-query-worker.ts
@@ -114,8 +114,10 @@ async function gqlFetch(
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ query, variables }),
   });
-  let body: { data?: Record<string, unknown>; errors?: { message?: string }[] } =
-    {};
+  let body: {
+    data?: Record<string, unknown>;
+    errors?: { message?: string }[];
+  } = {};
   try {
     body = (await res.json()) as typeof body;
   } catch {
@@ -132,7 +134,10 @@ async function gqlFetch(
 /** Joins GraphQL error messages into a single short string. */
 function errText(res: GqlResponse): string {
   if (!res.httpOk && !res.errors?.length) return `HTTP ${res.status}`;
-  return (res.errors ?? []).map((e) => e.message ?? "").join("; ").slice(0, 500);
+  return (res.errors ?? [])
+    .map((e) => e.message ?? "")
+    .join("; ")
+    .slice(0, 500);
 }
 
 async function exerciseModel(

--- a/tools/registry-audit/create-query.ts
+++ b/tools/registry-audit/create-query.ts
@@ -1,0 +1,287 @@
+/**
+ * Phase 6: boot a Switchboard, then for every document model a published package
+ * contributes, create a document of that type and query it back - through the
+ * model's OWN generated GraphQL subgraph endpoint (/graphql/<kebab-name>).
+ *
+ * This is the deepest runtime check in the suite. Where `load` only proves a
+ * model boots and registers, this proves its generated schema + resolvers
+ * actually function against the current core: an empty document can be created
+ * and read back via the per-model API.
+ *
+ * For each target package this:
+ *   1. reuses (or creates) the install scaffold under .cache/registry-audit/load/
+ *      <pkg>/ that the `load` phase also uses - so a single install serves both
+ *      phases, and
+ *   2. spawns an isolated worker (create-query-worker.ts) with cwd set to that
+ *      scaffold, which boots a Switchboard in-process (in-memory PGlite), loads
+ *      that one package, and exercises each contributed model over HTTP.
+ *
+ * Usage:
+ *   tsx tools/registry-audit/create-query.ts [options]
+ *
+ * Options:
+ *   --package <name>   Only run this package (repeatable).
+ *   --from-report      Only run packages flagged in report.json.
+ *   --filter <substr>  Only run packages whose name includes <substr> (repeatable).
+ *   --limit <n>        Process at most n packages.
+ *   --timeout <ms>     Per-package boot+exercise timeout (default 120000).
+ *   --reinstall        Force a fresh install even if a scaffold already exists.
+ *
+ * Writes .cache/registry-audit/create-query-report.json and a console summary.
+ * Requires the local Switchboard to be built (apps/switchboard/dist/server.mjs).
+ */
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  CREATE_QUERY_REPORT_PATH,
+  hasDocumentModelsExport,
+  installScaffold,
+  LOAD_DIR,
+  opt,
+  parseArgs,
+  REPO_ROOT,
+  REPORT_PATH,
+  requireManifest,
+  requireSwitchboardBuild,
+  spawnWorker,
+} from "./lib.js";
+
+const CQ_RUNNER = join(
+  REPO_ROOT,
+  "tools",
+  "registry-audit",
+  "create-query-worker.ts",
+);
+const LOAD_RUNNER = join(
+  REPO_ROOT,
+  "tools",
+  "registry-audit",
+  "load-worker.ts",
+);
+
+type ModelResult = {
+  id: string;
+  name: string;
+  subgraph: string;
+  created: boolean;
+  queried: boolean;
+  endpointMissing?: boolean;
+  createError?: string;
+  queryError?: string;
+};
+type CqResult = {
+  ok: boolean;
+  models: ModelResult[];
+  ms?: number;
+  error?: string;
+};
+type LoadResult = { ok: boolean; ids: string[]; error?: string };
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2), ["from-report", "reinstall"]);
+  const filters = args.options.filter ?? [];
+  const wantPackages = new Set(args.options.package ?? []);
+  const timeoutMs = Number(opt(args, "timeout", "120000"));
+  // Reuse the load phase's installs by default; the tarball is immutable per version.
+  const skipInstall = !args.flags["reinstall"];
+
+  await requireSwitchboardBuild();
+
+  const manifest = await requireManifest("tsx tools/registry-audit/extract.ts");
+  let entries = Object.values(manifest.packages).filter(
+    (e) => e.extractedPath && e.tarballPath,
+  );
+
+  if (wantPackages.size) {
+    entries = entries.filter((e) => wantPackages.has(e.name));
+  } else if (args.flags["from-report"]) {
+    try {
+      const report = JSON.parse(await readFile(REPORT_PATH, "utf8")) as {
+        findings: { package: string }[];
+      };
+      const flagged = new Set(report.findings.map((f) => f.package));
+      entries = entries.filter((e) => flagged.has(e.name));
+    } catch {
+      console.error(
+        "--from-report given but no report.json found. Run analyze.ts first.",
+      );
+      process.exit(1);
+    }
+  }
+  if (filters.length) {
+    entries = entries.filter((e) => filters.some((f) => e.name.includes(f)));
+  }
+
+  // Only packages that actually expose document models are exercisable.
+  const targets: typeof entries = [];
+  for (const e of entries) {
+    if (await hasDocumentModelsExport(e.extractedPath!)) targets.push(e);
+  }
+  const limit = args.options.limit ? Number(opt(args, "limit")) : undefined;
+  const finalTargets = limit !== undefined ? targets.slice(0, limit) : targets;
+
+  console.log(
+    `Create+query for ${finalTargets.length} model package(s) ` +
+      `(per-model generated subgraph endpoints)...\n`,
+  );
+
+  // Baseline: the core model ids present with no external package loaded, so we
+  // exercise only each package's OWN models. Reuses the load worker.
+  console.log("  baseline (no package) ...");
+  const baseline = await spawnWorker<LoadResult>({
+    runner: LOAD_RUNNER,
+    arg: "none",
+    cwd: REPO_ROOT,
+    timeoutMs,
+    sentinel: "__SBLOAD__",
+  });
+  const baselineIds = baseline.result?.ids ?? [];
+  console.log(`  baseline: ${baselineIds.length} core model(s)\n`);
+
+  type Outcome = {
+    package: string;
+    version: string;
+    status:
+      | "ok"
+      | "partial"
+      | "failed"
+      | "no-models"
+      | "boot-failed"
+      | "install-failed"
+      | "timeout";
+    models: ModelResult[];
+    ms?: number;
+    error?: string;
+  };
+  const results: Outcome[] = [];
+
+  for (const entry of finalTargets) {
+    const scaffold = await installScaffold({
+      name: entry.name,
+      tarballPath: entry.tarballPath!,
+      baseDir: LOAD_DIR,
+      namePrefix: "audit-load",
+      skipInstall,
+    });
+    if ("error" in scaffold) {
+      results.push({
+        package: entry.name,
+        version: entry.version,
+        status: "install-failed",
+        models: [],
+        error: scaffold.error,
+      });
+      console.log(
+        `  INSTALL-FAIL ${entry.name}: ${scaffold.error.slice(0, 120)}`,
+      );
+      continue;
+    }
+
+    const run = await spawnWorker<CqResult>({
+      runner: CQ_RUNNER,
+      arg: entry.name,
+      cwd: scaffold.dir,
+      timeoutMs,
+      sentinel: "__SBCQ__",
+      env: { PH_BASELINE_MODEL_IDS: JSON.stringify(baselineIds) },
+    });
+
+    let status: Outcome["status"];
+    let models: ModelResult[] = [];
+    let error: string | undefined;
+
+    if (run.timedOut) {
+      status = "timeout";
+      error = `killed after ${timeoutMs}ms`;
+    } else if (run.result?.ok) {
+      models = run.result.models;
+      const full = models.filter((m) => m.created && m.queried).length;
+      if (models.length === 0) status = "no-models";
+      else if (full === models.length) status = "ok";
+      else if (full === 0) status = "failed";
+      else status = "partial";
+    } else {
+      status = "boot-failed";
+      error = run.result?.error ?? `exit ${run.exitCode}\n${run.rawTail}`;
+    }
+
+    results.push({
+      package: entry.name,
+      version: entry.version,
+      status,
+      models,
+      ms: run.result?.ms,
+      error,
+    });
+
+    const ok = models.filter((m) => m.created && m.queried).length;
+    const label =
+      status === "ok"
+        ? `ok      ${entry.name}  (${ok}/${models.length} models)`
+        : status === "partial"
+          ? `PARTIAL ${entry.name}  (${ok}/${models.length} models)`
+          : status === "failed"
+            ? `FAILED  ${entry.name}  (0/${models.length} models)`
+            : status === "no-models"
+              ? `WARN    ${entry.name}  (booted, no own models)`
+              : status === "timeout"
+                ? `TIMEOUT ${entry.name}`
+                : `BOOT-FAIL ${entry.name}`;
+    console.log(`  ${label}`);
+    for (const m of models.filter((m) => !(m.created && m.queried))) {
+      const why = m.createError ?? m.queryError ?? "unknown";
+      console.log(`            ${m.id}: ${why.split("\n")[0].slice(0, 160)}`);
+    }
+    if (status === "boot-failed" && error) {
+      console.log(`            ${error.split("\n")[0].slice(0, 200)}`);
+    }
+  }
+
+  await writeFile(
+    CREATE_QUERY_REPORT_PATH,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        registry: manifest.registry,
+        baselineModels: [...baselineIds].sort(),
+        results: results.sort((a, b) => a.package.localeCompare(b.package)),
+      },
+      null,
+      2,
+    ),
+  );
+
+  const okCount = results.filter((r) => r.status === "ok").length;
+  const partial = results.filter((r) => r.status === "partial");
+  const failed = results.filter((r) => r.status === "failed");
+  const noModels = results.filter((r) => r.status === "no-models");
+  const bootFailed = results.filter(
+    (r) => r.status === "boot-failed" || r.status === "timeout",
+  );
+  const installFailed = results.filter((r) => r.status === "install-failed");
+
+  console.log(
+    `\nDone. ok=${okCount} partial=${partial.length} failed=${failed.length} ` +
+      `noModels=${noModels.length} bootFailed=${bootFailed.length} ` +
+      `installFailed=${installFailed.length}`,
+  );
+  const problems = [...partial, ...failed, ...bootFailed];
+  if (problems.length) {
+    console.log(`\nModels that did not create+query cleanly:`);
+    for (const r of problems) {
+      console.log(`  ${r.package}@${r.version}  [${r.status}]`);
+      if (r.error) console.log(`      ${r.error.split("\n")[0].slice(0, 200)}`);
+      for (const m of r.models.filter((m) => !(m.created && m.queried))) {
+        const why = m.createError ?? m.queryError ?? "unknown";
+        console.log(`      ${m.id}: ${why.split("\n")[0].slice(0, 160)}`);
+      }
+    }
+  }
+  console.log(`\nFull report: ${CREATE_QUERY_REPORT_PATH}`);
+  if (problems.length) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/registry-audit/download.ts
+++ b/tools/registry-audit/download.ts
@@ -1,0 +1,127 @@
+/**
+ * Phase 1: download the latest published tarball of every package in the registry.
+ *
+ * Usage:
+ *   tsx tools/registry-audit/download.ts [options]
+ *
+ * Options:
+ *   --registry <url>     Registry base URL (default: $PH_REGISTRY or the dev registry)
+ *   --filter <substr>    Only download packages whose name includes <substr> (repeatable)
+ *   --concurrency <n>    Parallel downloads (default: 8)
+ *   --force              Re-download even if the tarball already exists
+ *
+ * Writes tarballs to .cache/registry-audit/tarballs/ and records each package in
+ * .cache/registry-audit/manifest.json.
+ */
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
+import type { PackageEntry } from "./lib.js";
+import {
+  CACHE_DIR,
+  download,
+  emptyManifest,
+  getPackument,
+  listPackageNames,
+  mapLimit,
+  opt,
+  parseArgs,
+  readManifest,
+  resolveLatest,
+  resolveRegistry,
+  sanitize,
+  TARBALLS_DIR,
+  writeManifest,
+} from "./lib.js";
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2), ["force"]);
+  const registry = resolveRegistry(args);
+  const force = args.flags.force ?? false;
+  const filters = args.options.filter ?? [];
+  const concurrency = Number(opt(args, "concurrency", "8"));
+
+  console.log(`Registry: ${registry}`);
+  console.log(`Cache:    ${CACHE_DIR}`);
+
+  let names = await listPackageNames(registry);
+  if (filters.length) {
+    names = names.filter((n) => filters.some((f) => n.includes(f)));
+  }
+  console.log(`Found ${names.length} package(s) to process.\n`);
+
+  // Start from the existing manifest so re-runs preserve prior state.
+  const existing = await readManifest();
+  const manifest =
+    existing && existing.registry === registry
+      ? existing
+      : emptyManifest(registry);
+
+  let downloaded = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  await mapLimit(names, concurrency, async (name) => {
+    const entry: PackageEntry = manifest.packages[name] ?? {
+      name,
+      version: "",
+      tarballUrl: "",
+    };
+    try {
+      const packument = await getPackument(registry, name);
+      const { version, tarballUrl } = resolveLatest(packument);
+      const tarballPath = join(
+        TARBALLS_DIR,
+        `${sanitize(name)}-${version}.tgz`,
+      );
+
+      entry.version = version;
+      entry.tarballUrl = tarballUrl;
+      entry.error = undefined;
+
+      if (
+        !force &&
+        entry.tarballPath === tarballPath &&
+        (await exists(tarballPath))
+      ) {
+        skipped++;
+        console.log(`  skip   ${name}@${version}`);
+      } else {
+        await download(tarballUrl, tarballPath);
+        entry.tarballPath = tarballPath;
+        entry.downloadedAt = new Date().toISOString();
+        // A newer version invalidates any prior extraction.
+        entry.extractedPath = undefined;
+        entry.extractedAt = undefined;
+        downloaded++;
+        console.log(`  ok     ${name}@${version}`);
+      }
+    } catch (err) {
+      failed++;
+      entry.error = err instanceof Error ? err.message : String(err);
+      console.log(`  FAIL   ${name}: ${entry.error}`);
+    }
+    manifest.packages[name] = entry;
+  });
+
+  manifest.generatedAt = new Date().toISOString();
+  await writeManifest(manifest);
+
+  console.log(
+    `\nDone. downloaded=${downloaded} skipped=${skipped} failed=${failed}`,
+  );
+  if (failed) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/registry-audit/extract.ts
+++ b/tools/registry-audit/extract.ts
@@ -1,0 +1,94 @@
+/**
+ * Phase 2: extract the downloaded tarballs.
+ *
+ * Usage:
+ *   tsx tools/registry-audit/extract.ts [options]
+ *
+ * Options:
+ *   --filter <substr>   Only extract packages whose name includes <substr> (repeatable)
+ *   --force             Re-extract even if already extracted
+ *
+ * Reads .cache/registry-audit/manifest.json, unpacks each tarball into
+ * .cache/registry-audit/extracted/<sanitized-name>/, and records extractedPath.
+ */
+import { mkdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  EXTRACTED_DIR,
+  parseArgs,
+  requireManifest,
+  run,
+  sanitize,
+  writeManifest,
+} from "./lib.js";
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2), ["force"]);
+  const force = args.flags.force ?? false;
+  const filters = args.options.filter ?? [];
+
+  const manifest = await requireManifest(
+    "tsx tools/registry-audit/download.ts",
+  );
+
+  let entries = Object.values(manifest.packages).filter((e) => e.tarballPath);
+  if (filters.length) {
+    entries = entries.filter((e) => filters.some((f) => e.name.includes(f)));
+  }
+  console.log(`Extracting ${entries.length} package(s).\n`);
+
+  let extracted = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const entry of entries) {
+    const dest = join(EXTRACTED_DIR, sanitize(entry.name));
+    try {
+      if (!force && entry.extractedPath === dest && (await exists(dest))) {
+        skipped++;
+        console.log(`  skip   ${entry.name}@${entry.version}`);
+        continue;
+      }
+
+      await rm(dest, { recursive: true, force: true });
+      await mkdir(dest, { recursive: true });
+      // npm tarballs nest everything under a top-level "package/" dir.
+      const code = await run(
+        "tar",
+        ["-xzf", entry.tarballPath!, "-C", dest, "--strip-components=1"],
+        { quiet: true },
+      );
+      if (code !== 0) throw new Error(`tar exited with code ${code}`);
+
+      entry.extractedPath = dest;
+      entry.extractedAt = new Date().toISOString();
+      entry.error = undefined;
+      extracted++;
+      console.log(`  ok     ${entry.name}@${entry.version}`);
+    } catch (err) {
+      failed++;
+      entry.error = err instanceof Error ? err.message : String(err);
+      console.log(`  FAIL   ${entry.name}: ${entry.error}`);
+    }
+  }
+
+  await writeManifest(manifest);
+  console.log(
+    `\nDone. extracted=${extracted} skipped=${skipped} failed=${failed}`,
+  );
+  if (failed) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/registry-audit/lib.ts
+++ b/tools/registry-audit/lib.ts
@@ -16,7 +16,7 @@
  */
 import { spawn } from "node:child_process";
 import { createWriteStream } from "node:fs";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline as streamPipeline } from "node:stream/promises";
@@ -35,9 +35,25 @@ export const CACHE_DIR = join(REPO_ROOT, ".cache", "registry-audit");
 export const TARBALLS_DIR = join(CACHE_DIR, "tarballs");
 export const EXTRACTED_DIR = join(CACHE_DIR, "extracted");
 export const TYPECHECK_DIR = join(CACHE_DIR, "typecheck");
+/** Install scaffolds for the in-process boot phases (load, create-query). Shared so a single install is reused across both. */
+export const LOAD_DIR = join(CACHE_DIR, "load");
 export const MANIFEST_PATH = join(CACHE_DIR, "manifest.json");
 export const REPORT_PATH = join(CACHE_DIR, "report.json");
 export const TYPECHECK_REPORT_PATH = join(CACHE_DIR, "typecheck-report.json");
+export const LOAD_REPORT_PATH = join(CACHE_DIR, "load-report.json");
+export const CREATE_QUERY_REPORT_PATH = join(
+  CACHE_DIR,
+  "create-query-report.json",
+);
+
+/** The local Switchboard server build the boot phases import by absolute path. */
+export const SWITCHBOARD_SERVER = join(
+  REPO_ROOT,
+  "apps",
+  "switchboard",
+  "dist",
+  "server.mjs",
+);
 
 // ---------------------------------------------------------------------------
 // Manifest
@@ -234,6 +250,160 @@ export function runCapture(
     child.on("close", (code) =>
       resolvePromise({ code: code ?? 0, stdout, stderr }),
     );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Switchboard boot harness (shared by load.ts and create-query.ts)
+// ---------------------------------------------------------------------------
+
+/** True if `path` exists. */
+export async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** True if the extracted package declares a `./document-models` export. */
+export async function hasDocumentModelsExport(
+  extractedPath: string,
+): Promise<boolean> {
+  try {
+    const pkg = JSON.parse(
+      await readFile(join(extractedPath, "package.json"), "utf8"),
+    ) as { exports?: Record<string, unknown> };
+    return Boolean(pkg.exports?.["./document-models"]);
+  } catch {
+    return false;
+  }
+}
+
+/** Exits with a build hint if the local Switchboard server build is missing. */
+export async function requireSwitchboardBuild(): Promise<void> {
+  if (!(await exists(SWITCHBOARD_SERVER))) {
+    console.error(
+      `Switchboard build not found at ${SWITCHBOARD_SERVER}.\n` +
+        `Build it first:  pnpm --filter=@powerhousedao/switchboard build`,
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * Installs a published tarball into a clean scaffold under `baseDir/<sanitized>`
+ * so its full dependency graph resolves the way it would in a real deployment.
+ * Returns the scaffold dir, or an error string. When `skipInstall` is set and the
+ * package is already installed there, the existing install is reused (the
+ * published tarball is immutable for a given version, so reuse is always safe).
+ */
+export async function installScaffold(opts: {
+  name: string;
+  tarballPath: string;
+  baseDir: string;
+  /** package.json name prefix, e.g. "audit-load" / "audit-cq". */
+  namePrefix: string;
+  skipInstall: boolean;
+}): Promise<{ dir: string } | { error: string }> {
+  const dir = join(opts.baseDir, sanitize(opts.name));
+  await mkdir(dir, { recursive: true });
+  // Deliberately no tsconfig.json here: a tsconfig with `paths` would make tsx
+  // mis-resolve the Switchboard's own deps when running with cwd=scaffold.
+  await writeFile(
+    join(dir, "package.json"),
+    JSON.stringify(
+      {
+        name: `${opts.namePrefix}-${sanitize(opts.name).replace(/[@/]/g, "")}`,
+        private: true,
+        type: "module",
+        dependencies: { [opts.name]: `file:${opts.tarballPath}` },
+      },
+      null,
+      2,
+    ),
+  );
+  if (opts.skipInstall && (await exists(join(dir, "node_modules", opts.name)))) {
+    return { dir };
+  }
+  const install = await runCapture(
+    "pnpm",
+    ["install", "--ignore-workspace", "--no-frozen-lockfile", "--ignore-scripts"],
+    { cwd: dir },
+  );
+  if (install.code !== 0) {
+    await writeFile(
+      join(dir, "install-error.txt"),
+      install.stdout + install.stderr,
+    );
+    return {
+      error:
+        (install.stderr || install.stdout).trim().split("\n").pop() ??
+        `pnpm install exited ${install.code}`,
+    };
+  }
+  return { dir };
+}
+
+export type WorkerOutcome<T> = {
+  exitCode: number | null;
+  /** Parsed sentinel-line payload, or null if absent/unparseable. */
+  result: T | null;
+  /** Last 25 lines of combined stdout+stderr (for diagnosing failures). */
+  rawTail: string;
+  timedOut: boolean;
+};
+
+/**
+ * Spawns a worker (`tsx <runner> <arg>`) with cwd set to its scaffold, in-memory
+ * PGlite forced on, and a SIGKILL timeout. The worker prints exactly one machine
+ * line `"<sentinel> <json>"`; that JSON is parsed into `result`.
+ */
+export function spawnWorker<T>(opts: {
+  runner: string;
+  /** Worker argv[2]: a package name, or "none" for the baseline. */
+  arg: string;
+  cwd: string;
+  timeoutMs: number;
+  sentinel: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<WorkerOutcome<T>> {
+  const tsx = join(REPO_ROOT, "node_modules", ".bin", "tsx");
+  const prefix = `${opts.sentinel} `;
+  return new Promise((resolvePromise) => {
+    const child = spawn(tsx, [opts.runner, opts.arg], {
+      cwd: opts.cwd,
+      env: { ...process.env, PH_PGLITE_IN_MEMORY: "1", ...opts.env },
+    });
+    let out = "";
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, opts.timeoutMs);
+
+    const collect = (d: Buffer) => (out += d.toString());
+    child.stdout.on("data", collect);
+    child.stderr.on("data", collect);
+    child.on("close", (exitCode) => {
+      clearTimeout(timer);
+      const line = out.split("\n").find((l) => l.startsWith(prefix));
+      let result: T | null = null;
+      if (line) {
+        try {
+          result = JSON.parse(line.slice(prefix.length)) as T;
+        } catch {
+          /* leave null */
+        }
+      }
+      resolvePromise({
+        exitCode,
+        result,
+        rawTail: out.split("\n").slice(-25).join("\n"),
+        timedOut,
+      });
+    });
   });
 }
 

--- a/tools/registry-audit/lib.ts
+++ b/tools/registry-audit/lib.ts
@@ -1,0 +1,306 @@
+/**
+ * Shared utilities for the registry-audit pipeline.
+ *
+ * The pipeline is a set of small, explicit, independently-runnable tools that
+ * audit every published package in a Verdaccio/npm registry:
+ *
+ *   1. download.ts   - download the latest tarball of every package
+ *   2. extract.ts    - unpack the tarballs
+ *   3. analyze.ts    - run a configurable pattern scan over the unpacked files
+ *   4. typecheck.ts  - (optional) typecheck packages against local workspace builds
+ *
+ * Nothing in here is specific to any particular audit (e.g. attachments) - the
+ * search rules are supplied as data to analyze.ts.
+ *
+ * State is threaded between phases through a single manifest.json under CACHE_DIR.
+ */
+import { spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline as streamPipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Repo root, derived from this file's location (tools/registry-audit/lib.ts). */
+export const REPO_ROOT = resolve(__dirname, "..", "..");
+
+/** Default registry. Override with --registry or PH_REGISTRY. */
+export const DEFAULT_REGISTRY = "https://registry.dev.vetra.io";
+
+/** All audit state lives here (gitignored via .cache/). */
+export const CACHE_DIR = join(REPO_ROOT, ".cache", "registry-audit");
+export const TARBALLS_DIR = join(CACHE_DIR, "tarballs");
+export const EXTRACTED_DIR = join(CACHE_DIR, "extracted");
+export const TYPECHECK_DIR = join(CACHE_DIR, "typecheck");
+export const MANIFEST_PATH = join(CACHE_DIR, "manifest.json");
+export const REPORT_PATH = join(CACHE_DIR, "report.json");
+
+// ---------------------------------------------------------------------------
+// Manifest
+// ---------------------------------------------------------------------------
+
+export type PackageEntry = {
+  /** npm package name, e.g. "@test/issue-tracker". */
+  name: string;
+  /** Resolved dist-tags.latest version. */
+  version: string;
+  /** Tarball URL from the packument. */
+  tarballUrl: string;
+  /** Absolute path to the downloaded .tgz, once downloaded. */
+  tarballPath?: string;
+  /** ISO timestamp of the download. */
+  downloadedAt?: string;
+  /** Absolute path to the extracted package dir, once extracted. */
+  extractedPath?: string;
+  /** ISO timestamp of the extraction. */
+  extractedAt?: string;
+  /** Non-fatal error encountered while processing this package. */
+  error?: string;
+};
+
+export type Manifest = {
+  registry: string;
+  /** ISO timestamp of the last download run. */
+  generatedAt?: string;
+  packages: Record<string, PackageEntry>;
+};
+
+export function emptyManifest(registry: string): Manifest {
+  return { registry, packages: {} };
+}
+
+export async function readManifest(): Promise<Manifest | null> {
+  try {
+    const raw = await readFile(MANIFEST_PATH, "utf8");
+    return JSON.parse(raw) as Manifest;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+/** Reads the manifest or exits with a helpful message if it's missing. */
+export async function requireManifest(prevTool: string): Promise<Manifest> {
+  const manifest = await readManifest();
+  if (!manifest) {
+    console.error(
+      `No manifest found at ${MANIFEST_PATH}.\nRun \`${prevTool}\` first.`,
+    );
+    process.exit(1);
+  }
+  return manifest;
+}
+
+/** Atomic write: write to a temp file then rename into place. */
+export async function writeManifest(manifest: Manifest): Promise<void> {
+  await mkdir(CACHE_DIR, { recursive: true });
+  const tmp = `${MANIFEST_PATH}.tmp`;
+  await writeFile(tmp, JSON.stringify(manifest, null, 2));
+  await rename(tmp, MANIFEST_PATH);
+}
+
+// ---------------------------------------------------------------------------
+// Registry client (standard npm/Verdaccio API)
+// ---------------------------------------------------------------------------
+
+type VerdaccioPackageSummary = { name: string };
+
+type Packument = {
+  name: string;
+  "dist-tags"?: Record<string, string>;
+  versions?: Record<string, { dist?: { tarball?: string } }>;
+};
+
+export async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (!res.ok) {
+    throw new Error(`GET ${url} -> ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+/** Lists every package name known to the registry. */
+export async function listPackageNames(registry: string): Promise<string[]> {
+  const url = `${registry.replace(/\/$/, "")}/-/verdaccio/data/packages`;
+  const summaries = await fetchJson<VerdaccioPackageSummary[]>(url);
+  return summaries.map((p) => p.name).sort();
+}
+
+/** URL-encodes a (possibly scoped) package name for the packument path. */
+export function encodePackageName(name: string): string {
+  return name.replace("/", "%2F");
+}
+
+export async function getPackument(
+  registry: string,
+  name: string,
+): Promise<Packument> {
+  const url = `${registry.replace(/\/$/, "")}/${encodePackageName(name)}`;
+  return fetchJson<Packument>(url);
+}
+
+export type ResolvedLatest = { version: string; tarballUrl: string };
+
+/** Resolves dist-tags.latest -> { version, tarballUrl }. */
+export function resolveLatest(packument: Packument): ResolvedLatest {
+  const version = packument["dist-tags"]?.latest;
+  if (!version) {
+    throw new Error(`no dist-tags.latest for ${packument.name}`);
+  }
+  const tarballUrl = packument.versions?.[version]?.dist?.tarball;
+  if (!tarballUrl) {
+    throw new Error(`no tarball for ${packument.name}@${version}`);
+  }
+  return { version, tarballUrl };
+}
+
+/** Streams a URL to a destination file. */
+export async function download(url: string, dest: string): Promise<void> {
+  const res = await fetch(url);
+  if (!res.ok || !res.body) {
+    throw new Error(`GET ${url} -> ${res.status} ${res.statusText}`);
+  }
+  await mkdir(dirname(dest), { recursive: true });
+  await streamPipeline(
+    Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]),
+    createWriteStream(dest),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Misc helpers
+// ---------------------------------------------------------------------------
+
+/** Filesystem-safe id for a package name: "@test/issue-tracker" -> "@test__issue-tracker". */
+export function sanitize(name: string): string {
+  return name.replace(/\//g, "__");
+}
+
+/**
+ * Runs N async tasks with bounded concurrency, preserving input order in the
+ * returned results. Never rejects on individual task failure - callers decide.
+ */
+export async function mapLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.max(1, limit) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+/** Promisified spawn that inherits stdio and resolves with the exit code. */
+export function run(
+  cmd: string,
+  args: string[],
+  opts: { cwd?: string; quiet?: boolean } = {},
+): Promise<number> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(cmd, args, {
+      cwd: opts.cwd,
+      stdio: opts.quiet ? ["ignore", "pipe", "pipe"] : "inherit",
+    });
+    child.on("error", rejectPromise);
+    child.on("close", (code) => resolvePromise(code ?? 0));
+  });
+}
+
+/** Captures stdout/stderr of a command instead of inheriting. */
+export function runCapture(
+  cmd: string,
+  args: string[],
+  opts: { cwd?: string } = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(cmd, args, { cwd: opts.cwd });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
+    child.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
+    child.on("error", rejectPromise);
+    child.on("close", (code) =>
+      resolvePromise({ code: code ?? 0, stdout, stderr }),
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tiny arg parser
+// ---------------------------------------------------------------------------
+
+export type ParsedArgs = {
+  /** Boolean flags, e.g. { force: true }. */
+  flags: Record<string, boolean>;
+  /** Repeatable string options, e.g. { pattern: ["a", "b"] }. */
+  options: Record<string, string[]>;
+  /** Positional args. */
+  positionals: string[];
+};
+
+/**
+ * Minimal parser supporting:
+ *   --flag                 -> flags.flag = true
+ *   --key value            -> options.key = [..., "value"]
+ *   --key=value            -> options.key = [..., "value"]
+ * `booleanFlags` lists keys that take no value.
+ */
+export function parseArgs(
+  argv: string[],
+  booleanFlags: string[] = [],
+): ParsedArgs {
+  const flags: Record<string, boolean> = {};
+  const options: Record<string, string[]> = {};
+  const positionals: string[] = [];
+  const boolSet = new Set(booleanFlags);
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith("--")) {
+      const body = arg.slice(2);
+      const eq = body.indexOf("=");
+      if (eq !== -1) {
+        const key = body.slice(0, eq);
+        (options[key] ??= []).push(body.slice(eq + 1));
+      } else if (boolSet.has(body)) {
+        flags[body] = true;
+      } else {
+        const nextArg = argv[i + 1];
+        if (nextArg !== undefined && !nextArg.startsWith("--")) {
+          (options[body] ??= []).push(nextArg);
+          i++;
+        } else {
+          flags[body] = true;
+        }
+      }
+    } else {
+      positionals.push(arg);
+    }
+  }
+  return { flags, options, positionals };
+}
+
+/** First value of a repeatable option, with a fallback. */
+export function opt(
+  parsed: ParsedArgs,
+  key: string,
+  fallback?: string,
+): string | undefined {
+  return parsed.options[key]?.[0] ?? fallback;
+}
+
+/** Resolves the registry from --registry, PH_REGISTRY, or the default. */
+export function resolveRegistry(parsed: ParsedArgs): string {
+  return opt(parsed, "registry") ?? process.env.PH_REGISTRY ?? DEFAULT_REGISTRY;
+}

--- a/tools/registry-audit/lib.ts
+++ b/tools/registry-audit/lib.ts
@@ -324,12 +324,20 @@ export async function installScaffold(opts: {
       2,
     ),
   );
-  if (opts.skipInstall && (await exists(join(dir, "node_modules", opts.name)))) {
+  if (
+    opts.skipInstall &&
+    (await exists(join(dir, "node_modules", opts.name)))
+  ) {
     return { dir };
   }
   const install = await runCapture(
     "pnpm",
-    ["install", "--ignore-workspace", "--no-frozen-lockfile", "--ignore-scripts"],
+    [
+      "install",
+      "--ignore-workspace",
+      "--no-frozen-lockfile",
+      "--ignore-scripts",
+    ],
     { cwd: dir },
   );
   if (install.code !== 0) {

--- a/tools/registry-audit/lib.ts
+++ b/tools/registry-audit/lib.ts
@@ -37,6 +37,7 @@ export const EXTRACTED_DIR = join(CACHE_DIR, "extracted");
 export const TYPECHECK_DIR = join(CACHE_DIR, "typecheck");
 export const MANIFEST_PATH = join(CACHE_DIR, "manifest.json");
 export const REPORT_PATH = join(CACHE_DIR, "report.json");
+export const TYPECHECK_REPORT_PATH = join(CACHE_DIR, "typecheck-report.json");
 
 // ---------------------------------------------------------------------------
 // Manifest

--- a/tools/registry-audit/load-worker.ts
+++ b/tools/registry-audit/load-worker.ts
@@ -1,0 +1,78 @@
+/**
+ * Worker process for load.ts (Phase 5). Not a phase entry point - it is spawned
+ * by load.ts (one per package) so a hang or hard crash is isolated to a single
+ * child process. Argv[1] is the package name to load ("none" = baseline).
+ *
+ * Boots a Switchboard (in-process, in-memory PGlite) with the single named
+ * package loaded, lists the registered document-model ids, then shuts down. It
+ * prints exactly one machine-readable line for the parent to parse:
+ *
+ *   __SBLOAD__ {"ok":true,"ids":[...],"ms":1234}
+ *
+ * and exits 0 on success / 1 on any failure.
+ *
+ * The local Switchboard build is imported by absolute path (it is an app, not
+ * hoisted into the root node_modules). load.ts runs this worker with its cwd set
+ * to the package's install scaffold, so the Switchboard's package loader resolves
+ * the named package (and its dependencies) from that scaffold's node_modules.
+ */
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { REPO_ROOT } from "./lib.js";
+
+type DocModule = { documentModel?: { global?: { id?: string } } };
+type SwitchboardHandle = {
+  port: number;
+  reactor: {
+    getDocumentModelModules: () => Promise<
+      { results?: DocModule[] } | DocModule[]
+    >;
+  };
+  shutdown: () => Promise<void>;
+};
+type StartSwitchboard = (
+  opts: Record<string, unknown>,
+) => Promise<SwitchboardHandle>;
+
+function emit(obj: unknown): void {
+  console.log(`__SBLOAD__ ${JSON.stringify(obj)}`);
+}
+
+async function main(): Promise<void> {
+  const arg = process.argv[2];
+  const ext = arg && arg !== "none" ? arg : undefined;
+  const t0 = Date.now();
+
+  const serverUrl = pathToFileURL(
+    join(REPO_ROOT, "apps", "switchboard", "dist", "server.mjs"),
+  ).href;
+  const mod = (await import(serverUrl)) as {
+    startSwitchboard: StartSwitchboard;
+  };
+
+  const sb = await mod.startSwitchboard({
+    port: 0,
+    strictPort: false,
+    packages: ext ? [ext] : [],
+    disableLocalPackages: true,
+    mcp: false,
+    enableDocumentModelSubgraphs: true,
+  });
+
+  const res = await sb.reactor.getDocumentModelModules();
+  const arr = Array.isArray(res) ? res : (res.results ?? []);
+  const ids = arr
+    .map((m) => m?.documentModel?.global?.id ?? "")
+    .filter((id): id is string => id.length > 0);
+
+  await sb.shutdown();
+  emit({ ok: true, ids, ms: Date.now() - t0 });
+  // Force exit: the reactor/GraphQL stack can leave timers/handles open.
+  process.exit(0);
+}
+
+main().catch((e: unknown) => {
+  const error = e instanceof Error ? (e.stack ?? e.message) : String(e);
+  emit({ ok: false, ids: [], error: error.slice(0, 2000) });
+  process.exit(1);
+});

--- a/tools/registry-audit/load.ts
+++ b/tools/registry-audit/load.ts
@@ -1,0 +1,373 @@
+/**
+ * Phase 5: actually boot a Switchboard and import each published model.
+ *
+ * For every extracted package that exports `./document-models`, this:
+ *   1. installs the published tarball into a clean scaffold under
+ *      .cache/registry-audit/load/<pkg>/ (pnpm, --ignore-scripts), so the
+ *      package's full dependency graph resolves the way it would in a real
+ *      deployment, and
+ *   2. spawns an isolated worker (load-worker.ts) with cwd set to that
+ *      scaffold, which starts a real Switchboard in-process (in-memory PGlite,
+ *      no external services), loads that one package, and builds its GraphQL
+ *      subgraph schema.
+ *
+ * This answers what the static phases cannot: *does the current Switchboard
+ * successfully import this published package and build its schema?* The
+ * Switchboard / reactor-api doing the schema assembly is the LOCAL build, so a
+ * stale SDL (e.g. `scalar Attachment`) is exercised against the current core.
+ *
+ * (The package is imported as-published, with its own pinned deps — we install
+ * rather than load from the cache dir because published build outputs vary
+ * wildly: some bundle their deps, some externalise `document-model`, some even
+ * pull in test-only imports. A real install is the only uniformly reliable way
+ * to resolve them.)
+ *
+ * Usage:
+ *   tsx tools/registry-audit/load.ts [options]
+ *
+ * Options:
+ *   --package <name>   Only load this package (repeatable).
+ *   --from-report      Only load packages flagged in report.json.
+ *   --filter <substr>  Only load packages whose name includes <substr> (repeatable).
+ *   --limit <n>        Process at most n packages.
+ *   --timeout <ms>     Per-package boot timeout (default 120000).
+ *   --skip-install     Reuse a prior install in each scaffold.
+ *
+ * Writes .cache/registry-audit/load-report.json and a console summary.
+ * Requires the local Switchboard to be built (apps/switchboard/dist/server.mjs).
+ */
+import { spawn } from "node:child_process";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  CACHE_DIR,
+  opt,
+  parseArgs,
+  REPO_ROOT,
+  REPORT_PATH,
+  requireManifest,
+  runCapture,
+  sanitize,
+} from "./lib.js";
+
+const LOAD_DIR = join(CACHE_DIR, "load");
+const LOAD_REPORT_PATH = join(CACHE_DIR, "load-report.json");
+const RUNNER = join(REPO_ROOT, "tools", "registry-audit", "load-worker.ts");
+const TSX = join(REPO_ROOT, "node_modules", ".bin", "tsx");
+const SWITCHBOARD = join(
+  REPO_ROOT,
+  "apps",
+  "switchboard",
+  "dist",
+  "server.mjs",
+);
+
+type RunnerResult = { ok: boolean; ids: string[]; error?: string; ms?: number };
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** True if the extracted package declares a `./document-models` export. */
+async function hasDocumentModelsExport(
+  extractedPath: string,
+): Promise<boolean> {
+  try {
+    const pkg = JSON.parse(
+      await readFile(join(extractedPath, "package.json"), "utf8"),
+    ) as { exports?: Record<string, unknown> };
+    return Boolean(pkg.exports?.["./document-models"]);
+  } catch {
+    return false;
+  }
+}
+
+type RunOutcome = {
+  exitCode: number | null;
+  result: RunnerResult | null;
+  rawTail: string;
+  timedOut: boolean;
+};
+
+/**
+ * Spawns the runner subprocess. `pkgName` undefined = baseline (no package);
+ * `cwd` defaults to the repo root (used for the baseline).
+ */
+function runOnce(
+  pkgName: string | undefined,
+  cwd: string,
+  timeoutMs: number,
+): Promise<RunOutcome> {
+  return new Promise((resolvePromise) => {
+    const child = spawn(TSX, [RUNNER, pkgName ?? "none"], {
+      cwd,
+      env: { ...process.env, PH_PGLITE_IN_MEMORY: "1" },
+    });
+    let out = "";
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+
+    const collect = (d: Buffer) => (out += d.toString());
+    child.stdout.on("data", collect);
+    child.stderr.on("data", collect);
+    child.on("close", (exitCode) => {
+      clearTimeout(timer);
+      const line = out.split("\n").find((l) => l.startsWith("__SBLOAD__ "));
+      let result: RunnerResult | null = null;
+      if (line) {
+        try {
+          result = JSON.parse(line.slice("__SBLOAD__ ".length)) as RunnerResult;
+        } catch {
+          /* leave null */
+        }
+      }
+      resolvePromise({
+        exitCode,
+        result,
+        rawTail: out.split("\n").slice(-25).join("\n"),
+        timedOut,
+      });
+    });
+  });
+}
+
+/** Installs the published tarball into a clean scaffold; returns its dir or null. */
+async function installScaffold(
+  name: string,
+  tarballPath: string,
+  skipInstall: boolean,
+): Promise<{ dir: string } | { error: string }> {
+  const dir = join(LOAD_DIR, sanitize(name));
+  await mkdir(dir, { recursive: true });
+  // Deliberately no tsconfig.json here: a tsconfig with `paths` would make tsx
+  // mis-resolve the Switchboard's own deps when running with cwd=scaffold.
+  await writeFile(
+    join(dir, "package.json"),
+    JSON.stringify(
+      {
+        name: `audit-load-${sanitize(name).replace(/[@/]/g, "")}`,
+        private: true,
+        type: "module",
+        dependencies: { [name]: `file:${tarballPath}` },
+      },
+      null,
+      2,
+    ),
+  );
+  if (skipInstall && (await exists(join(dir, "node_modules", name)))) {
+    return { dir };
+  }
+  const install = await runCapture(
+    "pnpm",
+    [
+      "install",
+      "--ignore-workspace",
+      "--no-frozen-lockfile",
+      "--ignore-scripts",
+    ],
+    { cwd: dir },
+  );
+  if (install.code !== 0) {
+    await writeFile(
+      join(dir, "install-error.txt"),
+      install.stdout + install.stderr,
+    );
+    return {
+      error:
+        (install.stderr || install.stdout).trim().split("\n").pop() ??
+        `pnpm install exited ${install.code}`,
+    };
+  }
+  return { dir };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2), [
+    "from-report",
+    "skip-install",
+  ]);
+  const filters = args.options.filter ?? [];
+  const wantPackages = new Set(args.options.package ?? []);
+  const timeoutMs = Number(opt(args, "timeout", "120000"));
+  const skipInstall = args.flags["skip-install"] ?? false;
+
+  if (!(await exists(SWITCHBOARD))) {
+    console.error(
+      `Switchboard build not found at ${SWITCHBOARD}.\n` +
+        `Build it first:  pnpm --filter=@powerhousedao/switchboard build`,
+    );
+    process.exit(1);
+  }
+
+  const manifest = await requireManifest("tsx tools/registry-audit/extract.ts");
+  let entries = Object.values(manifest.packages).filter(
+    (e) => e.extractedPath && e.tarballPath,
+  );
+
+  if (wantPackages.size) {
+    entries = entries.filter((e) => wantPackages.has(e.name));
+  } else if (args.flags["from-report"]) {
+    try {
+      const report = JSON.parse(await readFile(REPORT_PATH, "utf8")) as {
+        findings: { package: string }[];
+      };
+      const flagged = new Set(report.findings.map((f) => f.package));
+      entries = entries.filter((e) => flagged.has(e.name));
+    } catch {
+      console.error(
+        "--from-report given but no report.json found. Run analyze.ts first.",
+      );
+      process.exit(1);
+    }
+  }
+  if (filters.length) {
+    entries = entries.filter((e) => filters.some((f) => e.name.includes(f)));
+  }
+
+  // Only packages that actually expose document models are loadable.
+  const targets: typeof entries = [];
+  for (const e of entries) {
+    if (await hasDocumentModelsExport(e.extractedPath!)) targets.push(e);
+  }
+  const limit = args.options.limit ? Number(opt(args, "limit")) : undefined;
+  const finalTargets = limit !== undefined ? targets.slice(0, limit) : targets;
+
+  console.log(
+    `Booting Switchboard for ${finalTargets.length} model package(s) ` +
+      `(install + in-memory boot, schema build on)...\n`,
+  );
+
+  // Baseline: which document-model ids exist with no external package loaded.
+  console.log("  baseline (no package) ...");
+  const baseline = await runOnce(undefined, REPO_ROOT, timeoutMs);
+  const baselineIds = new Set(baseline.result?.ids ?? []);
+  console.log(`  baseline: ${baselineIds.size} core model(s)\n`);
+
+  type Outcome = {
+    package: string;
+    version: string;
+    status:
+      | "loaded"
+      | "no-models"
+      | "boot-failed"
+      | "install-failed"
+      | "timeout";
+    loadedModels: string[];
+    ms?: number;
+    error?: string;
+  };
+  const results: Outcome[] = [];
+
+  for (const entry of finalTargets) {
+    const scaffold = await installScaffold(
+      entry.name,
+      entry.tarballPath!,
+      skipInstall,
+    );
+    if ("error" in scaffold) {
+      results.push({
+        package: entry.name,
+        version: entry.version,
+        status: "install-failed",
+        loadedModels: [],
+        error: scaffold.error,
+      });
+      console.log(
+        `  INSTALL-FAIL ${entry.name}: ${scaffold.error.slice(0, 120)}`,
+      );
+      continue;
+    }
+
+    const run = await runOnce(entry.name, scaffold.dir, timeoutMs);
+    let status: Outcome["status"];
+    let loadedModels: string[] = [];
+    let error: string | undefined;
+
+    if (run.timedOut) {
+      status = "timeout";
+      error = `killed after ${timeoutMs}ms`;
+    } else if (run.result?.ok) {
+      loadedModels = run.result.ids.filter((id) => !baselineIds.has(id));
+      status = loadedModels.length ? "loaded" : "no-models";
+    } else {
+      status = "boot-failed";
+      error = run.result?.error ?? `exit ${run.exitCode}\n${run.rawTail}`;
+    }
+
+    results.push({
+      package: entry.name,
+      version: entry.version,
+      status,
+      loadedModels,
+      ms: run.result?.ms,
+      error,
+    });
+
+    const label =
+      status === "loaded"
+        ? `ok      ${entry.name}  → ${loadedModels.join(", ")}`
+        : status === "no-models"
+          ? `WARN    ${entry.name}  (booted, registered no models)`
+          : status === "timeout"
+            ? `TIMEOUT ${entry.name}`
+            : `FAILED  ${entry.name}`;
+    console.log(`  ${label}`);
+    if (status === "boot-failed" && error) {
+      console.log(`            ${error.split("\n")[0].slice(0, 200)}`);
+    }
+  }
+
+  await writeFile(
+    LOAD_REPORT_PATH,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        registry: manifest.registry,
+        baselineModels: [...baselineIds].sort(),
+        results: results.sort((a, b) => a.package.localeCompare(b.package)),
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loaded = results.filter((r) => r.status === "loaded");
+  const noModels = results.filter((r) => r.status === "no-models");
+  const failed = results.filter(
+    (r) => r.status === "boot-failed" || r.status === "timeout",
+  );
+  const installFailed = results.filter((r) => r.status === "install-failed");
+
+  console.log(
+    `\nDone. loaded=${loaded.length} noModels=${noModels.length} ` +
+      `bootFailed=${failed.length} installFailed=${installFailed.length}`,
+  );
+  if (failed.length) {
+    console.log(`\nBooted the Switchboard but failed (worth investigating):`);
+    for (const r of failed) {
+      console.log(`  ${r.package}@${r.version}  [${r.status}]`);
+      if (r.error) console.log(`      ${r.error.split("\n")[0].slice(0, 200)}`);
+    }
+  }
+  if (noModels.length) {
+    console.log(
+      `\nBooted but registered no models (often unrelated packaging issues):`,
+    );
+    for (const r of noModels) console.log(`  ${r.package}@${r.version}`);
+  }
+  console.log(`\nFull report: ${LOAD_REPORT_PATH}`);
+  if (failed.length) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/registry-audit/load.ts
+++ b/tools/registry-audit/load.ts
@@ -36,157 +36,38 @@
  * Writes .cache/registry-audit/load-report.json and a console summary.
  * Requires the local Switchboard to be built (apps/switchboard/dist/server.mjs).
  */
-import { spawn } from "node:child_process";
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
-  CACHE_DIR,
+  hasDocumentModelsExport,
+  installScaffold,
+  LOAD_DIR,
+  LOAD_REPORT_PATH,
   opt,
   parseArgs,
   REPO_ROOT,
   REPORT_PATH,
   requireManifest,
-  runCapture,
-  sanitize,
+  requireSwitchboardBuild,
+  spawnWorker,
 } from "./lib.js";
 
-const LOAD_DIR = join(CACHE_DIR, "load");
-const LOAD_REPORT_PATH = join(CACHE_DIR, "load-report.json");
 const RUNNER = join(REPO_ROOT, "tools", "registry-audit", "load-worker.ts");
-const TSX = join(REPO_ROOT, "node_modules", ".bin", "tsx");
-const SWITCHBOARD = join(
-  REPO_ROOT,
-  "apps",
-  "switchboard",
-  "dist",
-  "server.mjs",
-);
 
 type RunnerResult = { ok: boolean; ids: string[]; error?: string; ms?: number };
-
-async function exists(path: string): Promise<boolean> {
-  try {
-    await stat(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/** True if the extracted package declares a `./document-models` export. */
-async function hasDocumentModelsExport(
-  extractedPath: string,
-): Promise<boolean> {
-  try {
-    const pkg = JSON.parse(
-      await readFile(join(extractedPath, "package.json"), "utf8"),
-    ) as { exports?: Record<string, unknown> };
-    return Boolean(pkg.exports?.["./document-models"]);
-  } catch {
-    return false;
-  }
-}
-
-type RunOutcome = {
-  exitCode: number | null;
-  result: RunnerResult | null;
-  rawTail: string;
-  timedOut: boolean;
-};
 
 /**
  * Spawns the runner subprocess. `pkgName` undefined = baseline (no package);
  * `cwd` defaults to the repo root (used for the baseline).
  */
-function runOnce(
-  pkgName: string | undefined,
-  cwd: string,
-  timeoutMs: number,
-): Promise<RunOutcome> {
-  return new Promise((resolvePromise) => {
-    const child = spawn(TSX, [RUNNER, pkgName ?? "none"], {
-      cwd,
-      env: { ...process.env, PH_PGLITE_IN_MEMORY: "1" },
-    });
-    let out = "";
-    let timedOut = false;
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGKILL");
-    }, timeoutMs);
-
-    const collect = (d: Buffer) => (out += d.toString());
-    child.stdout.on("data", collect);
-    child.stderr.on("data", collect);
-    child.on("close", (exitCode) => {
-      clearTimeout(timer);
-      const line = out.split("\n").find((l) => l.startsWith("__SBLOAD__ "));
-      let result: RunnerResult | null = null;
-      if (line) {
-        try {
-          result = JSON.parse(line.slice("__SBLOAD__ ".length)) as RunnerResult;
-        } catch {
-          /* leave null */
-        }
-      }
-      resolvePromise({
-        exitCode,
-        result,
-        rawTail: out.split("\n").slice(-25).join("\n"),
-        timedOut,
-      });
-    });
+function runOnce(pkgName: string | undefined, cwd: string, timeoutMs: number) {
+  return spawnWorker<RunnerResult>({
+    runner: RUNNER,
+    arg: pkgName ?? "none",
+    cwd,
+    timeoutMs,
+    sentinel: "__SBLOAD__",
   });
-}
-
-/** Installs the published tarball into a clean scaffold; returns its dir or null. */
-async function installScaffold(
-  name: string,
-  tarballPath: string,
-  skipInstall: boolean,
-): Promise<{ dir: string } | { error: string }> {
-  const dir = join(LOAD_DIR, sanitize(name));
-  await mkdir(dir, { recursive: true });
-  // Deliberately no tsconfig.json here: a tsconfig with `paths` would make tsx
-  // mis-resolve the Switchboard's own deps when running with cwd=scaffold.
-  await writeFile(
-    join(dir, "package.json"),
-    JSON.stringify(
-      {
-        name: `audit-load-${sanitize(name).replace(/[@/]/g, "")}`,
-        private: true,
-        type: "module",
-        dependencies: { [name]: `file:${tarballPath}` },
-      },
-      null,
-      2,
-    ),
-  );
-  if (skipInstall && (await exists(join(dir, "node_modules", name)))) {
-    return { dir };
-  }
-  const install = await runCapture(
-    "pnpm",
-    [
-      "install",
-      "--ignore-workspace",
-      "--no-frozen-lockfile",
-      "--ignore-scripts",
-    ],
-    { cwd: dir },
-  );
-  if (install.code !== 0) {
-    await writeFile(
-      join(dir, "install-error.txt"),
-      install.stdout + install.stderr,
-    );
-    return {
-      error:
-        (install.stderr || install.stdout).trim().split("\n").pop() ??
-        `pnpm install exited ${install.code}`,
-    };
-  }
-  return { dir };
 }
 
 async function main() {
@@ -199,13 +80,7 @@ async function main() {
   const timeoutMs = Number(opt(args, "timeout", "120000"));
   const skipInstall = args.flags["skip-install"] ?? false;
 
-  if (!(await exists(SWITCHBOARD))) {
-    console.error(
-      `Switchboard build not found at ${SWITCHBOARD}.\n` +
-        `Build it first:  pnpm --filter=@powerhousedao/switchboard build`,
-    );
-    process.exit(1);
-  }
+  await requireSwitchboardBuild();
 
   const manifest = await requireManifest("tsx tools/registry-audit/extract.ts");
   let entries = Object.values(manifest.packages).filter(
@@ -267,11 +142,13 @@ async function main() {
   const results: Outcome[] = [];
 
   for (const entry of finalTargets) {
-    const scaffold = await installScaffold(
-      entry.name,
-      entry.tarballPath!,
+    const scaffold = await installScaffold({
+      name: entry.name,
+      tarballPath: entry.tarballPath!,
+      baseDir: LOAD_DIR,
+      namePrefix: "audit-load",
       skipInstall,
-    );
+    });
     if ("error" in scaffold) {
       results.push({
         package: entry.name,

--- a/tools/registry-audit/rules/legacy-attachments.json
+++ b/tools/registry-audit/rules/legacy-attachments.json
@@ -1,0 +1,43 @@
+{
+  "name": "legacy-attachments",
+  "description": "Detects references to the legacy attachment system removed in 163a5f6f1. Published models authored against the old system bundle these now-removed symbols and may be incompatible with the current document-model.",
+  "rules": [
+    {
+      "id": "removed-scalar-attachment",
+      "description": "Old `Attachment` GraphQL scalar (renamed to AttachmentRef). Appears as a Scalars key in generated schema types.",
+      "severity": "high",
+      "pattern": "\\bAttachment:\\s*\\{",
+      "include": ["gen/schema/", "types"]
+    },
+    {
+      "id": "removed-type-documentfile",
+      "description": "Removed `DocumentFile` type.",
+      "severity": "high",
+      "pattern": "\\bDocumentFile\\b"
+    },
+    {
+      "id": "removed-type-attachmentinput",
+      "description": "Removed `AttachmentInput` type.",
+      "severity": "high",
+      "pattern": "\\bAttachmentInput\\b"
+    },
+    {
+      "id": "removed-type-actionwithattachment",
+      "description": "Removed `ActionWithAttachment` type.",
+      "severity": "high",
+      "pattern": "\\bActionWithAttachment\\b"
+    },
+    {
+      "id": "removed-type-fileregistry",
+      "description": "Removed `FileRegistry` type.",
+      "severity": "medium",
+      "pattern": "\\bFileRegistry\\b"
+    },
+    {
+      "id": "removed-field-attachments",
+      "description": "Removed `attachments` field on Action: the typed declaration (`attachments?: AttachmentInput[]`) or the legacy createAction code that read/wrote `action.attachments`. Deliberately scoped to `action.attachments` to avoid matching unrelated `.attachments` members (e.g. UI controllers).",
+      "severity": "medium",
+      "pattern": "attachments\\??\\s*:\\s*(?:Maybe<)?\\s*AttachmentInput|\\baction\\.attachments\\b"
+    }
+  ]
+}

--- a/tools/registry-audit/tsconfig.json
+++ b/tools/registry-audit/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2022",
+    "lib": ["es2023"],
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["*.ts"]
+}

--- a/tools/registry-audit/typecheck.ts
+++ b/tools/registry-audit/typecheck.ts
@@ -3,16 +3,23 @@
  * LOCAL workspace builds.
  *
  * For each target package this scaffolds a tiny standalone consumer project that
- * installs the published tarball, but with chosen dependencies overridden to the
- * local workspace packages (via pnpm `overrides` + `--ignore-workspace`), then
- * runs `tsc --noEmit` and reports the resulting type errors.
+ * installs the published tarball, then runs `tsc --noEmit` over an entry that
+ * imports the package - but with selected dependencies redirected to the LOCAL
+ * workspace builds via TypeScript `compilerOptions.paths`. tsc honours `paths`
+ * for every import in the program, including the ones inside the published
+ * package's own `.d.ts`, so the package is effectively type-checked against the
+ * current local code.
+ *
+ * (We use tsc `paths` rather than pnpm `overrides` because pnpm does not apply
+ * overrides in an `--ignore-workspace` standalone project.)
  *
  * This is generic - it knows nothing about any specific audit. It answers:
  * "do these published packages still typecheck against the current local build?"
  *
  * Caveats:
  *  - Packages that bundle/inline their dependency types won't surface breakage
- *    here (the pattern scan in analyze.ts is the better detector for that).
+ *    here (the pattern scan in analyze.ts is the better detector for that): the
+ *    inlined copies don't reference the local package, so tsc sees nothing wrong.
  *  - The local workspace packages must already be built (their dist/ present).
  *  - This installs a full dependency tree per package; it is slow.
  *
@@ -20,32 +27,65 @@
  *   tsx tools/registry-audit/typecheck.ts [options]
  *
  * Options:
- *   --from-report           Only check packages flagged in report.json (default
- *                           if report.json exists; otherwise all extracted).
+ *   --from-report           Only check packages flagged in report.json.
  *   --package <name>        Only check this package (repeatable).
- *   --override <pkg>=<dir>  Override <pkg> to a local dir (repeatable). Defaults
+ *   --override <pkg>=<dir>  Redirect <pkg> to a local dir (repeatable). Defaults
  *                           to every discovered workspace package under
- *                           packages/* and clis/*.
+ *                           packages/* and clis/* that has built types.
  *   --skip-install          Reuse a prior install in the scaffold dir.
  *   --limit <n>             Process at most n packages.
+ *
+ * By default every extracted package is checked. Errors are scoped to the target
+ * package's own files; the full tsc output is written to tsc-errors.txt.
  */
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
-import { join, relative } from "node:path";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
 import {
   opt,
   parseArgs,
   REPO_ROOT,
   REPORT_PATH,
   requireManifest,
-  run,
   runCapture,
   sanitize,
   TYPECHECK_DIR,
+  TYPECHECK_REPORT_PATH,
 } from "./lib.js";
 
-/** Discovers local workspace package name -> absolute dir under packages/* and clis/*. */
-async function discoverWorkspacePackages(): Promise<Map<string, string>> {
-  const map = new Map<string, string>();
+type PkgJson = {
+  name?: string;
+  types?: string;
+  typings?: string;
+  exports?: Record<string, unknown>;
+};
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The "." types entry of a package.json, if declared. */
+function typesEntry(pkg: PkgJson): string | undefined {
+  const dot = pkg.exports?.["."];
+  if (dot && typeof dot === "object") {
+    const t = (dot as Record<string, unknown>).types;
+    if (typeof t === "string") return t;
+  }
+  return pkg.types ?? pkg.typings;
+}
+
+type LocalPackage = { name: string; dir: string; types: string };
+
+/**
+ * Discovers local workspace packages under packages/* and clis/* that have a
+ * declared, on-disk types entry (i.e. are built).
+ */
+async function discoverWorkspacePackages(): Promise<LocalPackage[]> {
+  const out: LocalPackage[] = [];
   for (const group of ["packages", "clis"]) {
     const groupDir = join(REPO_ROOT, group);
     let dirs: string[];
@@ -61,14 +101,17 @@ async function discoverWorkspacePackages(): Promise<Map<string, string>> {
       try {
         const pkg = JSON.parse(
           await readFile(join(pkgDir, "package.json"), "utf8"),
-        ) as { name?: string };
-        if (pkg.name) map.set(pkg.name, pkgDir);
+        ) as PkgJson;
+        const types = typesEntry(pkg);
+        if (pkg.name && types && (await exists(join(pkgDir, types)))) {
+          out.push({ name: pkg.name, dir: pkgDir, types });
+        }
       } catch {
-        /* no package.json */
+        /* no/invalid package.json */
       }
     }
   }
-  return map;
+  return out;
 }
 
 async function loadReportFlagged(): Promise<Set<string> | null> {
@@ -82,19 +125,16 @@ async function loadReportFlagged(): Promise<Set<string> | null> {
   }
 }
 
-const TSCONFIG = {
-  compilerOptions: {
-    module: "nodenext",
-    moduleResolution: "nodenext",
-    target: "es2022",
-    strict: true,
-    noEmit: true,
-    skipLibCheck: false,
-    types: [],
-    jsx: "react-jsx",
-  },
-  include: ["index.ts"],
-};
+/** Builds the tsconfig `paths` map that redirects local packages to their build. */
+function buildPaths(locals: LocalPackage[]): Record<string, string[]> {
+  const paths: Record<string, string[]> = {};
+  for (const p of locals) {
+    const distDir = join(p.dir, dirname(p.types));
+    paths[p.name] = [join(p.dir, p.types)];
+    paths[`${p.name}/*`] = [`${distDir}/*`];
+  }
+  return paths;
+}
 
 async function main() {
   const args = parseArgs(process.argv.slice(2), [
@@ -103,59 +143,93 @@ async function main() {
   ]);
 
   const manifest = await requireManifest("tsx tools/registry-audit/extract.ts");
-  const workspace = await discoverWorkspacePackages();
+  let locals = await discoverWorkspacePackages();
 
-  // Build the override map: workspace defaults, then explicit --override wins.
-  const overrides = new Map<string, string>();
-  for (const [name, dir] of workspace) overrides.set(name, `link:${dir}`);
+  // Optional explicit redirects: --override <pkg>=<dir> (dir relative to repo root).
   for (const o of args.options.override ?? []) {
     const eq = o.indexOf("=");
     if (eq === -1) continue;
-    overrides.set(o.slice(0, eq), `link:${join(REPO_ROOT, o.slice(eq + 1))}`);
+    const name = o.slice(0, eq);
+    const dir = join(REPO_ROOT, o.slice(eq + 1));
+    const pkg = JSON.parse(
+      await readFile(join(dir, "package.json"), "utf8"),
+    ) as PkgJson;
+    const types = typesEntry(pkg) ?? "dist/index.d.ts";
+    locals = locals.filter((l) => l.name !== name);
+    locals.push({ name, dir, types });
   }
+  const paths = buildPaths(locals);
 
-  // Determine targets.
+  // Determine targets. Default: all extracted packages.
   let entries = Object.values(manifest.packages).filter((e) => e.tarballPath);
   const wantPackages = new Set(args.options.package ?? []);
   if (wantPackages.size) {
     entries = entries.filter((e) => wantPackages.has(e.name));
-  } else {
-    const useReport = args.flags["from-report"] ?? true;
-    if (useReport) {
-      const flagged = await loadReportFlagged();
-      if (flagged) entries = entries.filter((e) => flagged.has(e.name));
+  } else if (args.flags["from-report"]) {
+    const flagged = await loadReportFlagged();
+    if (flagged) {
+      entries = entries.filter((e) => flagged.has(e.name));
+    } else {
+      console.error(
+        "--from-report given but no report.json found. Run analyze.ts first.",
+      );
+      process.exit(1);
     }
   }
   const limit = args.options.limit ? Number(opt(args, "limit")) : undefined;
   if (limit !== undefined) entries = entries.slice(0, limit);
 
   console.log(
-    `Typechecking ${entries.length} package(s) against local builds.\n`,
+    `Typechecking ${entries.length} package(s) against local builds ` +
+      `(${locals.length} local redirect(s)).\n`,
   );
 
-  const results: { package: string; errors: number; ok: boolean }[] = [];
+  const tsconfig = {
+    compilerOptions: {
+      module: "nodenext",
+      moduleResolution: "nodenext",
+      target: "es2022",
+      strict: false,
+      noEmit: true,
+      skipLibCheck: false,
+      types: [] as string[],
+      jsx: "react-jsx",
+      paths,
+    },
+    include: ["index.ts"],
+  };
+
+  type Result = {
+    package: string;
+    version: string;
+    status: "ok" | "errors" | "install-failed";
+    targetErrors: number;
+    totalErrors: number;
+    errorsFile?: string;
+    sample: string[];
+  };
+  const results: Result[] = [];
 
   for (const entry of entries) {
     const dir = join(TYPECHECK_DIR, sanitize(entry.name));
     await mkdir(dir, { recursive: true });
 
-    const overridesObj = Object.fromEntries(overrides);
-    const consumerPkg = {
-      name: `audit-consumer-${sanitize(entry.name).replace(/[@/]/g, "")}`,
-      private: true,
-      type: "module",
-      dependencies: {
-        [entry.name]: `file:${entry.tarballPath}`,
-      },
-      pnpm: { overrides: overridesObj },
-    };
     await writeFile(
       join(dir, "package.json"),
-      JSON.stringify(consumerPkg, null, 2),
+      JSON.stringify(
+        {
+          name: `audit-consumer-${sanitize(entry.name).replace(/[@/]/g, "")}`,
+          private: true,
+          type: "module",
+          dependencies: { [entry.name]: `file:${entry.tarballPath}` },
+        },
+        null,
+        2,
+      ),
     );
     await writeFile(
       join(dir, "tsconfig.json"),
-      JSON.stringify(TSCONFIG, null, 2),
+      JSON.stringify(tsconfig, null, 2),
     );
     await writeFile(
       join(dir, "index.ts"),
@@ -164,16 +238,56 @@ async function main() {
 
     if (!args.flags["skip-install"]) {
       console.log(`  install ${entry.name}@${entry.version} ...`);
-      const code = await run(
+      // --ignore-scripts avoids pnpm's unapproved-build-scripts gate (we only
+      // need type declarations on disk, not native builds).
+      const install = await runCapture(
         "pnpm",
-        ["install", "--ignore-workspace", "--no-frozen-lockfile", "--silent"],
-        { cwd: dir, quiet: true },
+        [
+          "install",
+          "--ignore-workspace",
+          "--no-frozen-lockfile",
+          "--ignore-scripts",
+        ],
+        { cwd: dir },
       );
-      if (code !== 0) {
-        console.log(`  FAIL    ${entry.name}: pnpm install exited ${code}`);
-        results.push({ package: entry.name, errors: -1, ok: false });
+      if (install.code !== 0) {
+        await writeFile(
+          join(dir, "install-error.txt"),
+          install.stdout + install.stderr,
+        );
+        console.log(
+          `  FAIL    ${entry.name}: pnpm install exited ${install.code}`,
+        );
+        results.push({
+          package: entry.name,
+          version: entry.version,
+          status: "install-failed",
+          targetErrors: 0,
+          totalErrors: 0,
+          errorsFile: relative(REPO_ROOT, join(dir, "install-error.txt")),
+          sample: [
+            (install.stderr || install.stdout).trim().split("\n").pop() ?? "",
+          ],
+        });
         continue;
       }
+    }
+
+    // The target must actually be installed for the typecheck to be meaningful
+    // (relevant with --skip-install, or when a prior install failed).
+    if (!(await exists(join(dir, "node_modules", entry.name)))) {
+      console.log(
+        `  FAIL    ${entry.name}: not installed (run without --skip-install)`,
+      );
+      results.push({
+        package: entry.name,
+        version: entry.version,
+        status: "install-failed",
+        targetErrors: 0,
+        totalErrors: 0,
+        sample: ["package not installed"],
+      });
+      continue;
     }
 
     const tsc = await runCapture(
@@ -181,34 +295,85 @@ async function main() {
       ["--noEmit", "-p", "tsconfig.json"],
       { cwd: dir },
     );
-    const errorLines = (tsc.stdout + tsc.stderr)
+    const allErrors = (tsc.stdout + tsc.stderr)
       .split("\n")
       .filter((l) => /error TS\d+/.test(l));
-    const ok = tsc.code === 0;
-    results.push({ package: entry.name, errors: errorLines.length, ok });
+    // Scope to the target package's own files; unrelated transitive-dependency
+    // .d.ts noise (pglite, etc.) is recorded in tsc-errors.txt but not counted.
+    const marker = `/node_modules/${entry.name}/`;
+    const targetErrors = allErrors.filter((l) => l.includes(marker));
+    const ok = targetErrors.length === 0;
+    const errorsFile = relative(REPO_ROOT, join(dir, "tsc-errors.txt"));
+    results.push({
+      package: entry.name,
+      version: entry.version,
+      status: ok ? "ok" : "errors",
+      targetErrors: targetErrors.length,
+      totalErrors: allErrors.length,
+      errorsFile,
+      sample: targetErrors.slice(0, 5).map((l) => l.trim()),
+    });
+
+    await writeFile(
+      join(dir, "tsc-errors.txt"),
+      `# target errors: ${targetErrors.length}, total errors (incl. deps): ${allErrors.length}\n\n` +
+        tsc.stdout +
+        tsc.stderr,
+    );
 
     if (ok) {
       console.log(`  ok      ${entry.name}`);
     } else {
-      console.log(`  ERRORS  ${entry.name} (${errorLines.length})`);
-      // Persist the full tsc output for inspection.
-      await writeFile(join(dir, "tsc-errors.txt"), tsc.stdout + tsc.stderr);
-      for (const l of errorLines.slice(0, 5)) {
+      console.log(`  ERRORS  ${entry.name} (${targetErrors.length})`);
+      for (const l of targetErrors.slice(0, 5)) {
         console.log(`            ${l.trim()}`);
       }
-      if (errorLines.length > 5) {
-        console.log(
-          `            ... see ${relative(REPO_ROOT, join(dir, "tsc-errors.txt"))}`,
-        );
+      if (targetErrors.length > 5) {
+        console.log(`            ... see ${errorsFile}`);
       }
     }
   }
 
-  const failed = results.filter((r) => !r.ok);
-  console.log(
-    `\nDone. ok=${results.length - failed.length} withErrors=${failed.length}`,
+  // Consolidated report so "which packages are broken" lives in one place.
+  await writeFile(
+    TYPECHECK_REPORT_PATH,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        registry: manifest.registry,
+        localRedirects: locals.map((l) => l.name).sort(),
+        results: results.sort((a, b) => a.package.localeCompare(b.package)),
+      },
+      null,
+      2,
+    ),
   );
-  if (failed.length) process.exitCode = 1;
+
+  const broken = results.filter((r) => r.status === "errors");
+  const installFailed = results.filter((r) => r.status === "install-failed");
+  const okCount = results.filter((r) => r.status === "ok").length;
+
+  console.log(
+    `\nDone. ok=${okCount} withErrors=${broken.length} installFailed=${installFailed.length}`,
+  );
+  if (broken.length) {
+    console.log(`\nType errors in (target package's own files):`);
+    for (const r of broken) {
+      console.log(
+        `  ${r.package}@${r.version}  (${r.targetErrors})  ${r.errorsFile}`,
+      );
+    }
+  }
+  if (installFailed.length) {
+    console.log(`\nInstall failed (not type-checked):`);
+    for (const r of installFailed) {
+      console.log(
+        `  ${r.package}@${r.version}  ${r.errorsFile ?? r.sample[0] ?? ""}`,
+      );
+    }
+  }
+  console.log(`\nFull report: ${relative(REPO_ROOT, TYPECHECK_REPORT_PATH)}`);
+  if (broken.length || installFailed.length) process.exitCode = 1;
 }
 
 main().catch((err) => {

--- a/tools/registry-audit/typecheck.ts
+++ b/tools/registry-audit/typecheck.ts
@@ -1,0 +1,217 @@
+/**
+ * Phase 3b (optional, best-effort): typecheck published packages against the
+ * LOCAL workspace builds.
+ *
+ * For each target package this scaffolds a tiny standalone consumer project that
+ * installs the published tarball, but with chosen dependencies overridden to the
+ * local workspace packages (via pnpm `overrides` + `--ignore-workspace`), then
+ * runs `tsc --noEmit` and reports the resulting type errors.
+ *
+ * This is generic - it knows nothing about any specific audit. It answers:
+ * "do these published packages still typecheck against the current local build?"
+ *
+ * Caveats:
+ *  - Packages that bundle/inline their dependency types won't surface breakage
+ *    here (the pattern scan in analyze.ts is the better detector for that).
+ *  - The local workspace packages must already be built (their dist/ present).
+ *  - This installs a full dependency tree per package; it is slow.
+ *
+ * Usage:
+ *   tsx tools/registry-audit/typecheck.ts [options]
+ *
+ * Options:
+ *   --from-report           Only check packages flagged in report.json (default
+ *                           if report.json exists; otherwise all extracted).
+ *   --package <name>        Only check this package (repeatable).
+ *   --override <pkg>=<dir>  Override <pkg> to a local dir (repeatable). Defaults
+ *                           to every discovered workspace package under
+ *                           packages/* and clis/*.
+ *   --skip-install          Reuse a prior install in the scaffold dir.
+ *   --limit <n>             Process at most n packages.
+ */
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import {
+  opt,
+  parseArgs,
+  REPO_ROOT,
+  REPORT_PATH,
+  requireManifest,
+  run,
+  runCapture,
+  sanitize,
+  TYPECHECK_DIR,
+} from "./lib.js";
+
+/** Discovers local workspace package name -> absolute dir under packages/* and clis/*. */
+async function discoverWorkspacePackages(): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  for (const group of ["packages", "clis"]) {
+    const groupDir = join(REPO_ROOT, group);
+    let dirs: string[];
+    try {
+      dirs = (await readdir(groupDir, { withFileTypes: true }))
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name);
+    } catch {
+      continue;
+    }
+    for (const d of dirs) {
+      const pkgDir = join(groupDir, d);
+      try {
+        const pkg = JSON.parse(
+          await readFile(join(pkgDir, "package.json"), "utf8"),
+        ) as { name?: string };
+        if (pkg.name) map.set(pkg.name, pkgDir);
+      } catch {
+        /* no package.json */
+      }
+    }
+  }
+  return map;
+}
+
+async function loadReportFlagged(): Promise<Set<string> | null> {
+  try {
+    const report = JSON.parse(await readFile(REPORT_PATH, "utf8")) as {
+      findings: { package: string }[];
+    };
+    return new Set(report.findings.map((f) => f.package));
+  } catch {
+    return null;
+  }
+}
+
+const TSCONFIG = {
+  compilerOptions: {
+    module: "nodenext",
+    moduleResolution: "nodenext",
+    target: "es2022",
+    strict: true,
+    noEmit: true,
+    skipLibCheck: false,
+    types: [],
+    jsx: "react-jsx",
+  },
+  include: ["index.ts"],
+};
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2), [
+    "from-report",
+    "skip-install",
+  ]);
+
+  const manifest = await requireManifest("tsx tools/registry-audit/extract.ts");
+  const workspace = await discoverWorkspacePackages();
+
+  // Build the override map: workspace defaults, then explicit --override wins.
+  const overrides = new Map<string, string>();
+  for (const [name, dir] of workspace) overrides.set(name, `link:${dir}`);
+  for (const o of args.options.override ?? []) {
+    const eq = o.indexOf("=");
+    if (eq === -1) continue;
+    overrides.set(o.slice(0, eq), `link:${join(REPO_ROOT, o.slice(eq + 1))}`);
+  }
+
+  // Determine targets.
+  let entries = Object.values(manifest.packages).filter((e) => e.tarballPath);
+  const wantPackages = new Set(args.options.package ?? []);
+  if (wantPackages.size) {
+    entries = entries.filter((e) => wantPackages.has(e.name));
+  } else {
+    const useReport = args.flags["from-report"] ?? true;
+    if (useReport) {
+      const flagged = await loadReportFlagged();
+      if (flagged) entries = entries.filter((e) => flagged.has(e.name));
+    }
+  }
+  const limit = args.options.limit ? Number(opt(args, "limit")) : undefined;
+  if (limit !== undefined) entries = entries.slice(0, limit);
+
+  console.log(
+    `Typechecking ${entries.length} package(s) against local builds.\n`,
+  );
+
+  const results: { package: string; errors: number; ok: boolean }[] = [];
+
+  for (const entry of entries) {
+    const dir = join(TYPECHECK_DIR, sanitize(entry.name));
+    await mkdir(dir, { recursive: true });
+
+    const overridesObj = Object.fromEntries(overrides);
+    const consumerPkg = {
+      name: `audit-consumer-${sanitize(entry.name).replace(/[@/]/g, "")}`,
+      private: true,
+      type: "module",
+      dependencies: {
+        [entry.name]: `file:${entry.tarballPath}`,
+      },
+      pnpm: { overrides: overridesObj },
+    };
+    await writeFile(
+      join(dir, "package.json"),
+      JSON.stringify(consumerPkg, null, 2),
+    );
+    await writeFile(
+      join(dir, "tsconfig.json"),
+      JSON.stringify(TSCONFIG, null, 2),
+    );
+    await writeFile(
+      join(dir, "index.ts"),
+      `import * as pkg from "${entry.name}";\nvoid (pkg as unknown);\n`,
+    );
+
+    if (!args.flags["skip-install"]) {
+      console.log(`  install ${entry.name}@${entry.version} ...`);
+      const code = await run(
+        "pnpm",
+        ["install", "--ignore-workspace", "--no-frozen-lockfile", "--silent"],
+        { cwd: dir, quiet: true },
+      );
+      if (code !== 0) {
+        console.log(`  FAIL    ${entry.name}: pnpm install exited ${code}`);
+        results.push({ package: entry.name, errors: -1, ok: false });
+        continue;
+      }
+    }
+
+    const tsc = await runCapture(
+      join(REPO_ROOT, "node_modules", ".bin", "tsc"),
+      ["--noEmit", "-p", "tsconfig.json"],
+      { cwd: dir },
+    );
+    const errorLines = (tsc.stdout + tsc.stderr)
+      .split("\n")
+      .filter((l) => /error TS\d+/.test(l));
+    const ok = tsc.code === 0;
+    results.push({ package: entry.name, errors: errorLines.length, ok });
+
+    if (ok) {
+      console.log(`  ok      ${entry.name}`);
+    } else {
+      console.log(`  ERRORS  ${entry.name} (${errorLines.length})`);
+      // Persist the full tsc output for inspection.
+      await writeFile(join(dir, "tsc-errors.txt"), tsc.stdout + tsc.stderr);
+      for (const l of errorLines.slice(0, 5)) {
+        console.log(`            ${l.trim()}`);
+      }
+      if (errorLines.length > 5) {
+        console.log(
+          `            ... see ${relative(REPO_ROOT, join(dir, "tsc-errors.txt"))}`,
+        );
+      }
+    }
+  }
+
+  const failed = results.filter((r) => !r.ok);
+  console.log(
+    `\nDone. ok=${results.length - failed.length} withErrors=${failed.length}`,
+  );
+  if (failed.length) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/registry-audit/typecheck.ts
+++ b/tools/registry-audit/typecheck.ts
@@ -231,6 +231,14 @@ async function main() {
       join(dir, "tsconfig.json"),
       JSON.stringify(tsconfig, null, 2),
     );
+    // Scope the install's registry to this scaffold only (a project-local
+    // .npmrc, read because pnpm runs with cwd: dir). The audit registry is a
+    // Verdaccio proxy, so both the published internal packages (e.g. vetra-app)
+    // and public deps resolve through it - without touching global npm config.
+    await writeFile(
+      join(dir, ".npmrc"),
+      `registry=${manifest.registry.replace(/\/$/, "")}/\n`,
+    );
     await writeFile(
       join(dir, "index.ts"),
       `import * as pkg from "${entry.name}";\nvoid (pkg as unknown);\n`,


### PR DESCRIPTION
- Removed legacy attachment system.
- Added `registry-audit` tools. These:

1. Download all the latest packages from the registry
2. Extract them
3. Do text searches on them to file reports
4. Tries to compile them all against _current_ monorepo sources and reports issues
5. Tries to load each one in switchboard and report issues