### PR TITLE
fix(connect): don't block startup on default drive sync

### DIFF
--- a/apps/connect/src/store/reactor.ts
+++ b/apps/connect/src/store/reactor.ts
@@ -384,36 +384,22 @@ export async function createReactor(localPackage?: DocumentModelLib) {
   setDrives(drives);
   setFeatures(features);
 
-  // When the URL pins a drive slug, default drives and any URL-supplied
-  // remote drive must be materialized before setSelectedDrive runs —
-  // otherwise the slug is unknown and the URL gets rewritten to "/".
-  const driveResolutionRequired = Boolean(driveSlug);
-
-  // Add default drives for new reactor (after window.ph is set up)
+  // Add default drives and any URL-supplied remote drive in the background so
+  // the app renders immediately. setSelectedDrive defers selection until the
+  // drive matching the URL slug syncs in (see deferDriveSelection), so we only
+  // ever wait for the selected drive, never for unrelated default drives.
   const defaultDrivesConfig = getDefaultDrives(runtimeConfig);
   if (defaultDrivesConfig.length > 0) {
-    await addDefaultDrivesForNewReactor(
-      defaultDrivesConfig,
-      driveResolutionRequired
-        ? { awaitInitialSync: true, initialSyncTimeoutMs: 15_000 }
-        : undefined,
+    void addDefaultDrivesForNewReactor(defaultDrivesConfig).catch((error) =>
+      console.error("Failed to add default drives:", error),
     );
   }
 
   const remoteUrl = getDriveUrl();
   if (remoteUrl) {
-    try {
-      await addRemoteDrive(remoteUrl, undefined, {
-        awaitInitialSync: driveResolutionRequired,
-        initialSyncTimeoutMs: 15_000,
-      });
-    } catch (error) {
-      console.error(`Failed to add remote drive from ${remoteUrl}:`, error);
-    }
-  }
-
-  if (driveResolutionRequired) {
-    await refreshReactorDataClient(reactorClientModule.client);
+    void addRemoteDrive(remoteUrl, undefined).catch((error) =>
+      console.error(`Failed to add remote drive from ${remoteUrl}:`, error),
+    );
   }
 
   setSelectedDrive(driveSlug);

--- a/apps/connect/src/utils/reactor.ts
+++ b/apps/connect/src/utils/reactor.ts
@@ -4,6 +4,7 @@ import {
   ReactorBuilder,
   ReactorClientBuilder,
   setDriveMetadata,
+  waitForDocumentReady,
   type BrowserReactorClientModule,
   type Database,
   type IDocumentModelLoader,
@@ -97,54 +98,64 @@ export function getDefaultDrives(
 /**
  * Add default drives for the new reactor via sync manager.
  *
- * Retries with linear backoff to handle the common race where Connect's
- * dev server is ready before the switchboard has finished binding its port.
+ * Drives register concurrently so a slow or unreachable drive can't delay the
+ * others — in particular the one the URL slug resolves to. Retries with linear
+ * backoff to handle the common race where Connect's dev server is ready before
+ * the switchboard has finished binding its port.
  *
  * @param drives - Array of drive objects with url, optional name and icon
- * @param options - Forwarded to addRemoteDrive. Pass `awaitInitialSync: true`
- *   when the URL pins a drive slug that must resolve before selection.
  */
 export async function addDefaultDrivesForNewReactor(
   drives: PHConnectDefaultDrive[],
-  options?: { awaitInitialSync?: boolean; initialSyncTimeoutMs?: number },
 ): Promise<void> {
   const MAX_ATTEMPTS = 3;
   const BACKOFF_MS = 2000;
 
-  for (const drive of drives) {
-    let driveId: string | undefined;
-    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      try {
-        driveId = await addRemoteDrive(drive.url, undefined, options);
-        break;
-      } catch (error) {
-        if (attempt === MAX_ATTEMPTS) {
-          console.error(
-            `Failed to add default drive ${drive.url} after ${MAX_ATTEMPTS} attempts:`,
-            error,
-          );
-        } else {
-          const delay = BACKOFF_MS * attempt;
-          console.warn(
-            `Default drive ${drive.url} not reachable (attempt ${attempt}/${MAX_ATTEMPTS}), retrying in ${delay}ms...`,
-          );
-          await new Promise((resolve) => setTimeout(resolve, delay));
+  await Promise.all(
+    drives.map(async (drive) => {
+      let driveId: string | undefined;
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+          driveId = await addRemoteDrive(drive.url);
+          break;
+        } catch (error) {
+          if (attempt === MAX_ATTEMPTS) {
+            console.error(
+              `Failed to add default drive ${drive.url} after ${MAX_ATTEMPTS} attempts:`,
+              error,
+            );
+          } else {
+            const delay = BACKOFF_MS * attempt;
+            console.warn(
+              `Default drive ${drive.url} not reachable (attempt ${attempt}/${MAX_ATTEMPTS}), retrying in ${delay}ms...`,
+            );
+            await new Promise((resolve) => setTimeout(resolve, delay));
+          }
         }
       }
-    }
 
-    if (driveId && (drive.name || drive.icon)) {
-      try {
-        await setDriveMetadata(driveId, {
-          name: drive.name,
-          icon: drive.icon,
-        });
-      } catch (error) {
-        console.warn(
-          `Default drive ${drive.url} was added but metadata update failed:`,
-          error,
-        );
+      if (driveId && (drive.name || drive.icon)) {
+        try {
+          // setDriveMetadata dispatches against the local drive document, which
+          // only exists once initial backfill delivers it — wait for it first
+          // so the name/icon override isn't lost to a sync race.
+          const reactorClient = window.ph?.reactorClient;
+          if (reactorClient) {
+            await waitForDocumentReady(reactorClient, driveId, {
+              timeoutMs: 15_000,
+            });
+          }
+          await setDriveMetadata(driveId, {
+            name: drive.name,
+            icon: drive.icon,
+          });
+        } catch (error) {
+          console.warn(
+            `Default drive ${drive.url} was added but metadata update failed:`,
+            error,
+          );
+        }
       }
-    }
-  }
+    }),
+  );
 }

--- a/packages/reactor-browser/src/actions/drive.ts
+++ b/packages/reactor-browser/src/actions/drive.ts
@@ -20,6 +20,12 @@ import { getUserPermissions } from "../utils/user.js";
 
 const DEFAULT_INITIAL_SYNC_TIMEOUT_MS = 30_000;
 
+// In-flight remote registrations keyed by collectionId. sync.list()/sync.add()
+// is not atomic, so concurrent addRemoteDrive calls for the same drive would
+// both miss the existing remote and register duplicates. Concurrent callers
+// share the first registration instead.
+const inFlightRemoteRegistrations = new Map<string, Promise<unknown>>();
+
 export type AddRemoteDriveOptions = {
   pollBehavior?: PollBehavior;
   /**
@@ -161,26 +167,35 @@ export async function addRemoteDrive(
   const resolvedDriveId = driveId ?? driveInfo.id;
   const collectionId = driveCollectionId("main", resolvedDriveId);
 
-  const existingRemote = sync
-    .list()
-    .find((remote) => remote.collectionId === collectionId);
+  const inFlight = inFlightRemoteRegistrations.get(collectionId);
+  if (inFlight) {
+    await inFlight;
+  } else {
+    const existingRemote = sync
+      .list()
+      .find((remote) => remote.collectionId === collectionId);
 
-  if (!existingRemote) {
-    const remoteName = crypto.randomUUID();
-    await sync.add(
-      remoteName,
-      collectionId,
-      {
-        type: "gql",
-        parameters: {
-          url: driveInfo.graphqlEndpoint,
-        },
-      },
-      undefined,
-      options?.pollBehavior
-        ? { pollBehavior: options.pollBehavior }
-        : undefined,
-    );
+    if (!existingRemote) {
+      const remoteName = crypto.randomUUID();
+      const registration = sync
+        .add(
+          remoteName,
+          collectionId,
+          {
+            type: "gql",
+            parameters: {
+              url: driveInfo.graphqlEndpoint,
+            },
+          },
+          undefined,
+          options?.pollBehavior
+            ? { pollBehavior: options.pollBehavior }
+            : undefined,
+        )
+        .finally(() => inFlightRemoteRegistrations.delete(collectionId));
+      inFlightRemoteRegistrations.set(collectionId, registration);
+      await registration;
+    }
   }
 
   if (options?.awaitInitialSync) {


### PR DESCRIPTION
## Problem

Connect waited for **all** configured default drives to load before becoming interactive, even when none was selected or pinned in the URL.

`createReactor()` `await`ed `addDefaultDrivesForNewReactor(...)`, and that call sits in the boot critical path (`loadComponent` → `createReactor`, behind the Suspense skeleton). Adding each default drive does a blocking REST fetch + sync-register, **sequentially**, with linear retry backoff (2s + 4s + 6s = up to ~12s per unreachable drive). So the app blocked on every default drive before rendering the home screen.

## Fix

- **`apps/connect/src/store/reactor.ts`** — load default drives and the `?driveUrl=` remote in the background (`void ...`) instead of awaiting them in the boot path. Removed the `driveResolutionRequired` blocking branch and the redundant pre-selection refresh. `setSelectedDrive(driveSlug)` runs immediately; its existing `deferDriveSelection` waits for **only** the drive whose `header.slug` matches the URL slug (keyed on `ph:drivesUpdated`, 15s cap).
- **`apps/connect/src/utils/reactor.ts`** — `addDefaultDrivesForNewReactor` now registers drives **concurrently** (`Promise.all`) instead of sequentially, so a slow/unreachable default drive can't delay the selected one's registration (which would otherwise eat into the deferral budget). Dropped the now-unused `options` param.

Net effect: the app renders immediately and only ever waits for the selected drive, never for unrelated default drives — whether or not a drive is pinned in the URL.

## Testing

- `tsc --noEmit` passes for `apps/connect`.
- Lint clean on the changed files (pre-existing warnings only).