### PR TITLE
Auth Refactor Part I

### DIFF
--- a/apps/switchboard/src/server.mts
+++ b/apps/switchboard/src/server.mts
@@ -564,6 +564,7 @@ async function initServer(
       graphqlManager,
       syncManager: api.syncManager,
       path: graphqlManager.getBasePath(),
+      authorizationService: graphqlManager.getAuthorizationService(),
       packageManagementService,
     });
 

--- a/packages/reactor-api/src/graphql/auth/resolvers.ts
+++ b/packages/reactor-api/src/graphql/auth/resolvers.ts
@@ -1,5 +1,5 @@
 import { GraphQLError } from "graphql";
-import type { AuthorizationService } from "../../services/authorization.service.js";
+import type { IAuthorizationService } from "../../services/authorization.service.js";
 import type {
   DocumentPermissionService,
   GetParentIdsFn,
@@ -65,13 +65,13 @@ export async function userDocumentPermissions(
 
 export async function grantDocumentPermission(
   service: DocumentPermissionService,
+  authorizationService: IAuthorizationService,
   args: {
     documentId: string;
     userAddress: string;
     permission: DocumentPermissionLevel;
   },
   grantedByAddress: string | undefined,
-  isGlobalAdmin: boolean,
 ): Promise<{
   documentId: string;
   userAddress: string;
@@ -80,21 +80,18 @@ export async function grantDocumentPermission(
   createdAt: Date;
   updatedAt: Date;
 }> {
-  // Check authorization: must be global admin or document admin
   if (!grantedByAddress) {
     throw new GraphQLError("Authentication required");
   }
 
-  if (!isGlobalAdmin) {
-    const canManage = await service.canManageDocument(
-      args.documentId,
-      grantedByAddress,
+  const canManage = await authorizationService.canManage(
+    args.documentId,
+    grantedByAddress,
+  );
+  if (!canManage) {
+    throw new GraphQLError(
+      "Forbidden: You must be an admin of this document to grant permissions",
     );
-    if (!canManage) {
-      throw new GraphQLError(
-        "Forbidden: You must be an admin of this document to grant permissions",
-      );
-    }
   }
 
   return service.grantPermission(
@@ -107,25 +104,22 @@ export async function grantDocumentPermission(
 
 export async function revokeDocumentPermission(
   service: DocumentPermissionService,
+  authorizationService: IAuthorizationService,
   args: { documentId: string; userAddress: string },
   revokedByAddress: string | undefined,
-  isGlobalAdmin: boolean,
 ): Promise<boolean> {
-  // Check authorization: must be global admin or document admin
   if (!revokedByAddress) {
     throw new GraphQLError("Authentication required");
   }
 
-  if (!isGlobalAdmin) {
-    const canManage = await service.canManageDocument(
-      args.documentId,
-      revokedByAddress,
+  const canManage = await authorizationService.canManage(
+    args.documentId,
+    revokedByAddress,
+  );
+  if (!canManage) {
+    throw new GraphQLError(
+      "Forbidden: You must be an admin of this document to revoke permissions",
     );
-    if (!canManage) {
-      throw new GraphQLError(
-        "Forbidden: You must be an admin of this document to revoke permissions",
-      );
-    }
   }
 
   await service.revokePermission(args.documentId, args.userAddress);
@@ -236,29 +230,26 @@ export type DocumentGroupPermission = {
 
 export async function grantGroupPermission(
   service: DocumentPermissionService,
+  authorizationService: IAuthorizationService,
   args: {
     documentId: string;
     groupId: number;
     permission: DocumentPermissionLevel;
   },
   grantedByAddress: string | undefined,
-  isGlobalAdmin: boolean,
 ): Promise<DocumentGroupPermission> {
-  // Check authorization: must be global admin or document admin
   if (!grantedByAddress) {
     throw new GraphQLError("Authentication required");
   }
 
-  if (!isGlobalAdmin) {
-    const canManage = await service.canManageDocument(
-      args.documentId,
-      grantedByAddress,
+  const canManage = await authorizationService.canManage(
+    args.documentId,
+    grantedByAddress,
+  );
+  if (!canManage) {
+    throw new GraphQLError(
+      "Forbidden: You must be an admin of this document to grant permissions",
     );
-    if (!canManage) {
-      throw new GraphQLError(
-        "Forbidden: You must be an admin of this document to grant permissions",
-      );
-    }
   }
 
   return service.grantGroupPermission(
@@ -271,25 +262,22 @@ export async function grantGroupPermission(
 
 export async function revokeGroupPermission(
   service: DocumentPermissionService,
+  authorizationService: IAuthorizationService,
   args: { documentId: string; groupId: number },
   revokedByAddress: string | undefined,
-  isGlobalAdmin: boolean,
 ): Promise<boolean> {
-  // Check authorization: must be global admin or document admin
   if (!revokedByAddress) {
     throw new GraphQLError("Authentication required");
   }
 
-  if (!isGlobalAdmin) {
-    const canManage = await service.canManageDocument(
-      args.documentId,
-      revokedByAddress,
+  const canManage = await authorizationService.canManage(
+    args.documentId,
+    revokedByAddress,
+  );
+  if (!canManage) {
+    throw new GraphQLError(
+      "Forbidden: You must be an admin of this document to revoke permissions",
     );
-    if (!canManage) {
-      throw new GraphQLError(
-        "Forbidden: You must be an admin of this document to revoke permissions",
-      );
-    }
   }
 
   await service.revokeGroupPermission(args.documentId, args.groupId);
@@ -358,24 +346,22 @@ export async function canExecuteOperation(
 
 export async function grantOperationPermission(
   service: DocumentPermissionService,
+  authorizationService: IAuthorizationService,
   args: { documentId: string; operationType: string; userAddress: string },
   grantedByAddress: string | undefined,
-  isGlobalAdmin: boolean,
 ): Promise<OperationUserPermission> {
   if (!grantedByAddress) {
     throw new GraphQLError("Authentication required");
   }
 
-  if (!isGlobalAdmin) {
-    const canManage = await service.canManageDocument(
-      args.documentId,
-      grantedByAddress,
+  const canManage = await authorizationService.canManage(
+    args.documentId,
+    grantedByAddress,
+  );
+  if (!canManage) {
+    throw new GraphQLError(
+      "Forbidden: You must be an admin of this document to grant operation permissions",
     );
-    if (!canManage) {
-      throw new GraphQLError(
-        "Forbidden: You must be an admin of this document to grant operation permissions",
-      );
-    }
   }
 
   return service.grantOperationPermission(
@@ -388,24 +374,22 @@ export async function grantOperationPermission(
 
 export async function revokeOperationPermission(
   service: DocumentPermissionService,
+  authorizationService: IAuthorizationService,
   args: { documentId: string; operationType: string; userAddress: string },
   revokedByAddress: string | undefined,
-  isGlobalAdmin: boolean,
 ): Promise<boolean> {
   if (!revokedByAddress) {
     throw new GraphQLError("Authentication required");
   }
 
-  if (!isGlobalAdmin) {
-    const canManage = await service.canManageDocument(
-      args.documentId,
-      revokedByAddress,
+  const canManage = await authorizationService.canManage(
+    args.documentId,
+    revokedByAddress,
+  );
+  if (!canManage) {
+    throw new GraphQLError(
+      "Forbidden: You must be an admin of this document to revoke operation permissions",
     );
-    if (!canManage) {
-      throw new GraphQLError(
-        "Forbidden: You must be an admin of this document to revoke operation permissions",
-      );
-    }
   }
 
   await service.revokeOperationPermission(
@@ -418,24 +402,22 @@ export async function revokeOperationPermission(
 
 export async function grantGroupOperationPermission(
   service: DocumentPermissionService,
+  authorizationService: IAuthorizationService,
   args: { documentId: string; operationType: string; groupId: number },
   grantedByAddress: string | undefined,
-  isGlobalAdmin: boolean,
 ): Promise<OperationGroupPermission> {
   if (!grantedByAddress) {
     throw new GraphQLError("Authentication required");
   }
 
-  if (!isGlobalAdmin) {
-    const canManage = await service.canManageDocument(
-      args.documentId,
-      grantedByAddress,
+  const canManage = await authorizationService.canManage(
+    args.documentId,
+    grantedByAddress,
+  );
+  if (!canManage) {
+    throw new GraphQLError(
+      "Forbidden: You must be an admin of this document to grant operation permissions",
     );
-    if (!canManage) {
-      throw new GraphQLError(
-        "Forbidden: You must be an admin of this document to grant operation permissions",
-      );
-    }
   }
 
   return service.grantGroupOperationPermission(
@@ -448,24 +430,22 @@ export async function grantGroupOperationPermission(
 
 export async function revokeGroupOperationPermission(
   service: DocumentPermissionService,
+  authorizationService: IAuthorizationService,
   args: { documentId: string; operationType: string; groupId: number },
   revokedByAddress: string | undefined,
-  isGlobalAdmin: boolean,
 ): Promise<boolean> {
   if (!revokedByAddress) {
     throw new GraphQLError("Authentication required");
   }
 
-  if (!isGlobalAdmin) {
-    const canManage = await service.canManageDocument(
-      args.documentId,
-      revokedByAddress,
+  const canManage = await authorizationService.canManage(
+    args.documentId,
+    revokedByAddress,
+  );
+  if (!canManage) {
+    throw new GraphQLError(
+      "Forbidden: You must be an admin of this document to revoke operation permissions",
     );
-    if (!canManage) {
-      throw new GraphQLError(
-        "Forbidden: You must be an admin of this document to revoke operation permissions",
-      );
-    }
   }
 
   await service.revokeGroupOperationPermission(
@@ -495,38 +475,22 @@ export async function documentProtection(
 
 export async function setDocumentProtection(
   service: DocumentPermissionService,
-  authorizationService: AuthorizationService | undefined,
+  authorizationService: IAuthorizationService,
   args: { documentId: string; protected: boolean },
   userAddress: string | undefined,
-  isGlobalAdmin: boolean,
 ): Promise<DocumentProtectionInfo> {
   if (!userAddress) {
     throw new GraphQLError("Authentication required");
   }
 
-  // Check manage permission
-  if (!isGlobalAdmin) {
-    if (authorizationService) {
-      const canManage = await authorizationService.canManage(
-        args.documentId,
-        userAddress,
-      );
-      if (!canManage) {
-        throw new GraphQLError(
-          "Forbidden: You must be an admin of this document to change protection",
-        );
-      }
-    } else {
-      const canManage = await service.canManageDocument(
-        args.documentId,
-        userAddress,
-      );
-      if (!canManage) {
-        throw new GraphQLError(
-          "Forbidden: You must be an admin of this document to change protection",
-        );
-      }
-    }
+  const canManage = await authorizationService.canManage(
+    args.documentId,
+    userAddress,
+  );
+  if (!canManage) {
+    throw new GraphQLError(
+      "Forbidden: You must be an admin of this document to change protection",
+    );
   }
 
   await service.setDocumentProtection(args.documentId, args.protected);
@@ -535,38 +499,22 @@ export async function setDocumentProtection(
 
 export async function transferDocumentOwnership(
   service: DocumentPermissionService,
-  authorizationService: AuthorizationService | undefined,
+  authorizationService: IAuthorizationService,
   args: { documentId: string; newOwnerAddress: string },
   userAddress: string | undefined,
-  isGlobalAdmin: boolean,
 ): Promise<DocumentProtectionInfo> {
   if (!userAddress) {
     throw new GraphQLError("Authentication required");
   }
 
-  // Check manage permission
-  if (!isGlobalAdmin) {
-    if (authorizationService) {
-      const canManage = await authorizationService.canManage(
-        args.documentId,
-        userAddress,
-      );
-      if (!canManage) {
-        throw new GraphQLError(
-          "Forbidden: You must be an admin of this document to transfer ownership",
-        );
-      }
-    } else {
-      const canManage = await service.canManageDocument(
-        args.documentId,
-        userAddress,
-      );
-      if (!canManage) {
-        throw new GraphQLError(
-          "Forbidden: You must be an admin of this document to transfer ownership",
-        );
-      }
-    }
+  const canManage = await authorizationService.canManage(
+    args.documentId,
+    userAddress,
+  );
+  if (!canManage) {
+    throw new GraphQLError(
+      "Forbidden: You must be an admin of this document to transfer ownership",
+    );
   }
 
   // Revoke old owner's explicit ADMIN grant before transferring

--- a/packages/reactor-api/src/graphql/auth/subgraph.ts
+++ b/packages/reactor-api/src/graphql/auth/subgraph.ts
@@ -199,13 +199,11 @@ export class AuthSubgraph extends BaseSubgraph {
           throw new GraphQLError("DocumentPermissionService not available");
         }
         try {
-          const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "") ?? false;
           return await resolvers.setDocumentProtection(
             this.documentPermissionService,
             this.authorizationService,
             args,
             ctx.user?.address,
-            isGlobalAdmin,
           );
         } catch (error) {
           this.logger.error("Error in setDocumentProtection: @error", error);
@@ -226,13 +224,11 @@ export class AuthSubgraph extends BaseSubgraph {
           throw new GraphQLError("DocumentPermissionService not available");
         }
         try {
-          const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "") ?? false;
           return await resolvers.transferDocumentOwnership(
             this.documentPermissionService,
             this.authorizationService,
             args,
             ctx.user?.address,
-            isGlobalAdmin,
           );
         } catch (error) {
           this.logger.error(
@@ -256,16 +252,15 @@ export class AuthSubgraph extends BaseSubgraph {
           throw new GraphQLError("DocumentPermissionService not available");
         }
         try {
-          const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "") ?? false;
           return await resolvers.grantDocumentPermission(
             this.documentPermissionService,
+            this.authorizationService,
             args as {
               documentId: string;
               userAddress: string;
               permission: "READ" | "WRITE" | "ADMIN";
             },
             ctx.user?.address,
-            isGlobalAdmin,
           );
         } catch (error) {
           this.logger.error("Error in grantDocumentPermission: @error", error);
@@ -286,12 +281,11 @@ export class AuthSubgraph extends BaseSubgraph {
           throw new GraphQLError("DocumentPermissionService not available");
         }
         try {
-          const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "") ?? false;
           return await resolvers.revokeDocumentPermission(
             this.documentPermissionService,
+            this.authorizationService,
             args,
             ctx.user?.address,
-            isGlobalAdmin,
           );
         } catch (error) {
           this.logger.error("Error in revokeDocumentPermission: @error", error);
@@ -387,16 +381,15 @@ export class AuthSubgraph extends BaseSubgraph {
           throw new GraphQLError("DocumentPermissionService not available");
         }
         try {
-          const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "") ?? false;
           return await resolvers.grantGroupPermission(
             this.documentPermissionService,
+            this.authorizationService,
             args as {
               documentId: string;
               groupId: number;
               permission: "READ" | "WRITE" | "ADMIN";
             },
             ctx.user?.address,
-            isGlobalAdmin,
           );
         } catch (error) {
           this.logger.error("Error in grantGroupPermission: @error", error);
@@ -417,12 +410,11 @@ export class AuthSubgraph extends BaseSubgraph {
           throw new GraphQLError("DocumentPermissionService not available");
         }
         try {
-          const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "") ?? false;
           return await resolvers.revokeGroupPermission(
             this.documentPermissionService,
+            this.authorizationService,
             args,
             ctx.user?.address,
-            isGlobalAdmin,
           );
         } catch (error) {
           this.logger.error("Error in revokeGroupPermission: @error", error);
@@ -448,12 +440,11 @@ export class AuthSubgraph extends BaseSubgraph {
           throw new GraphQLError("DocumentPermissionService not available");
         }
         try {
-          const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "") ?? false;
           return await resolvers.grantOperationPermission(
             this.documentPermissionService,
+            this.authorizationService,
             args,
             ctx.user?.address,
-            isGlobalAdmin,
           );
         } catch (error) {
           this.logger.error("Error in grantOperationPermission: @error", error);
@@ -478,12 +469,11 @@ export class AuthSubgraph extends BaseSubgraph {
           throw new GraphQLError("DocumentPermissionService not available");
         }
         try {
-          const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "") ?? false;
           return await resolvers.revokeOperationPermission(
             this.documentPermissionService,
+            this.authorizationService,
             args,
             ctx.user?.address,
-            isGlobalAdmin,
           );
         } catch (error) {
           this.logger.error(
@@ -507,12 +497,11 @@ export class AuthSubgraph extends BaseSubgraph {
           throw new GraphQLError("DocumentPermissionService not available");
         }
         try {
-          const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "") ?? false;
           return await resolvers.grantGroupOperationPermission(
             this.documentPermissionService,
+            this.authorizationService,
             args,
             ctx.user?.address,
-            isGlobalAdmin,
           );
         } catch (error) {
           this.logger.error(
@@ -536,12 +525,11 @@ export class AuthSubgraph extends BaseSubgraph {
           throw new GraphQLError("DocumentPermissionService not available");
         }
         try {
-          const isGlobalAdmin = ctx.isAdmin?.(ctx.user?.address ?? "") ?? false;
           return await resolvers.revokeGroupOperationPermission(
             this.documentPermissionService,
+            this.authorizationService,
             args,
             ctx.user?.address,
-            isGlobalAdmin,
           );
         } catch (error) {
           this.logger.error(

--- a/packages/reactor-api/src/graphql/auth/subgraph.ts
+++ b/packages/reactor-api/src/graphql/auth/subgraph.ts
@@ -190,7 +190,8 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; protected: boolean },
         ctx: {
-          user?: { address: string };        },
+          user?: { address: string };
+        },
       ) => {
         this.logger.debug("setDocumentProtection(@args)", args);
         if (!this.documentPermissionService) {
@@ -213,7 +214,8 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; newOwnerAddress: string },
         ctx: {
-          user?: { address: string };        },
+          user?: { address: string };
+        },
       ) => {
         this.logger.debug("transferDocumentOwnership(@args)", args);
         if (!this.documentPermissionService) {
@@ -239,7 +241,8 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; userAddress: string; permission: string },
         ctx: {
-          user?: { address: string };        },
+          user?: { address: string };
+        },
       ) => {
         this.logger.debug("grantDocumentPermission(@args)", args);
         if (!this.documentPermissionService) {
@@ -266,7 +269,8 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; userAddress: string },
         ctx: {
-          user?: { address: string };        },
+          user?: { address: string };
+        },
       ) => {
         this.logger.debug("revokeDocumentPermission(@args)", args);
         if (!this.documentPermissionService) {
@@ -364,7 +368,8 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; groupId: number; permission: string },
         ctx: {
-          user?: { address: string };        },
+          user?: { address: string };
+        },
       ) => {
         this.logger.debug("grantGroupPermission(@args)", args);
         if (!this.documentPermissionService) {
@@ -391,7 +396,8 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; groupId: number },
         ctx: {
-          user?: { address: string };        },
+          user?: { address: string };
+        },
       ) => {
         this.logger.debug("revokeGroupPermission(@args)", args);
         if (!this.documentPermissionService) {
@@ -419,7 +425,8 @@ export class AuthSubgraph extends BaseSubgraph {
           userAddress: string;
         },
         ctx: {
-          user?: { address: string };        },
+          user?: { address: string };
+        },
       ) => {
         this.logger.debug("grantOperationPermission(@args)", args);
         if (!this.documentPermissionService) {
@@ -446,7 +453,8 @@ export class AuthSubgraph extends BaseSubgraph {
           userAddress: string;
         },
         ctx: {
-          user?: { address: string };        },
+          user?: { address: string };
+        },
       ) => {
         this.logger.debug("revokeOperationPermission(@args)", args);
         if (!this.documentPermissionService) {
@@ -472,7 +480,8 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; operationType: string; groupId: number },
         ctx: {
-          user?: { address: string };        },
+          user?: { address: string };
+        },
       ) => {
         this.logger.debug("grantGroupOperationPermission(@args)", args);
         if (!this.documentPermissionService) {
@@ -498,7 +507,8 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; operationType: string; groupId: number },
         ctx: {
-          user?: { address: string };        },
+          user?: { address: string };
+        },
       ) => {
         this.logger.debug("revokeGroupOperationPermission(@args)", args);
         if (!this.documentPermissionService) {

--- a/packages/reactor-api/src/graphql/auth/subgraph.ts
+++ b/packages/reactor-api/src/graphql/auth/subgraph.ts
@@ -190,9 +190,7 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; protected: boolean },
         ctx: {
-          user?: { address: string };
-          isAdmin?: (address: string) => boolean;
-        },
+          user?: { address: string };        },
       ) => {
         this.logger.debug("setDocumentProtection(@args)", args);
         if (!this.documentPermissionService) {
@@ -215,9 +213,7 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; newOwnerAddress: string },
         ctx: {
-          user?: { address: string };
-          isAdmin?: (address: string) => boolean;
-        },
+          user?: { address: string };        },
       ) => {
         this.logger.debug("transferDocumentOwnership(@args)", args);
         if (!this.documentPermissionService) {
@@ -243,9 +239,7 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; userAddress: string; permission: string },
         ctx: {
-          user?: { address: string };
-          isAdmin?: (address: string) => boolean;
-        },
+          user?: { address: string };        },
       ) => {
         this.logger.debug("grantDocumentPermission(@args)", args);
         if (!this.documentPermissionService) {
@@ -272,9 +266,7 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; userAddress: string },
         ctx: {
-          user?: { address: string };
-          isAdmin?: (address: string) => boolean;
-        },
+          user?: { address: string };        },
       ) => {
         this.logger.debug("revokeDocumentPermission(@args)", args);
         if (!this.documentPermissionService) {
@@ -372,9 +364,7 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; groupId: number; permission: string },
         ctx: {
-          user?: { address: string };
-          isAdmin?: (address: string) => boolean;
-        },
+          user?: { address: string };        },
       ) => {
         this.logger.debug("grantGroupPermission(@args)", args);
         if (!this.documentPermissionService) {
@@ -401,9 +391,7 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; groupId: number },
         ctx: {
-          user?: { address: string };
-          isAdmin?: (address: string) => boolean;
-        },
+          user?: { address: string };        },
       ) => {
         this.logger.debug("revokeGroupPermission(@args)", args);
         if (!this.documentPermissionService) {
@@ -431,9 +419,7 @@ export class AuthSubgraph extends BaseSubgraph {
           userAddress: string;
         },
         ctx: {
-          user?: { address: string };
-          isAdmin?: (address: string) => boolean;
-        },
+          user?: { address: string };        },
       ) => {
         this.logger.debug("grantOperationPermission(@args)", args);
         if (!this.documentPermissionService) {
@@ -460,9 +446,7 @@ export class AuthSubgraph extends BaseSubgraph {
           userAddress: string;
         },
         ctx: {
-          user?: { address: string };
-          isAdmin?: (address: string) => boolean;
-        },
+          user?: { address: string };        },
       ) => {
         this.logger.debug("revokeOperationPermission(@args)", args);
         if (!this.documentPermissionService) {
@@ -488,9 +472,7 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; operationType: string; groupId: number },
         ctx: {
-          user?: { address: string };
-          isAdmin?: (address: string) => boolean;
-        },
+          user?: { address: string };        },
       ) => {
         this.logger.debug("grantGroupOperationPermission(@args)", args);
         if (!this.documentPermissionService) {
@@ -516,9 +498,7 @@ export class AuthSubgraph extends BaseSubgraph {
         _parent: unknown,
         args: { documentId: string; operationType: string; groupId: number },
         ctx: {
-          user?: { address: string };
-          isAdmin?: (address: string) => boolean;
-        },
+          user?: { address: string };        },
       ) => {
         this.logger.debug("revokeGroupOperationPermission(@args)", args);
         if (!this.documentPermissionService) {

--- a/packages/reactor-api/src/graphql/base-subgraph.ts
+++ b/packages/reactor-api/src/graphql/base-subgraph.ts
@@ -11,7 +11,10 @@ import type {
 import type { DocumentNode } from "graphql";
 import { GraphQLError } from "graphql";
 import { gql } from "graphql-tag";
-import type { AuthorizationService } from "../services/authorization.service.js";
+import {
+  AuthorizationPolicy,
+  type IAuthorizationService,
+} from "../services/authorization.service.js";
 import type {
   DocumentPermissionService,
   GetParentIdsFn,
@@ -36,7 +39,7 @@ export class BaseSubgraph implements ISubgraph {
   relationalDb: IRelationalDb;
   syncManager: ISyncManager;
   documentPermissionService?: DocumentPermissionService;
-  authorizationService?: AuthorizationService;
+  authorizationService: IAuthorizationService;
 
   constructor(args: SubgraphArgs) {
     this.reactorClient = args.reactorClient;
@@ -70,67 +73,30 @@ export class BaseSubgraph implements ISubgraph {
     };
   }
 
-  protected hasGlobalAdminAccess(ctx: Context): boolean {
-    return !!ctx.isAdmin?.(ctx.user?.address ?? "");
-  }
-
   protected async canReadDocument(
     documentId: string,
     ctx: Context,
   ): Promise<boolean> {
-    if (this.authorizationService) {
-      return this.authorizationService.canRead(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-    }
-    if (this.hasGlobalAdminAccess(ctx)) return true;
-    if (this.documentPermissionService) {
-      return this.documentPermissionService.canRead(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
-      );
-    }
-    return false;
+    return this.authorizationService.canRead(
+      documentId,
+      ctx.user?.address,
+      this.getParentIdsFn(),
+    );
   }
 
   protected async assertCanRead(
     documentId: string,
     ctx: Context,
   ): Promise<void> {
-    if (this.authorizationService) {
-      const canRead = await this.authorizationService.canRead(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
+    const canRead = await this.authorizationService.canRead(
+      documentId,
+      ctx.user?.address,
+      this.getParentIdsFn(),
+    );
+    if (!canRead) {
+      throw new GraphQLError(
+        "Forbidden: insufficient permissions to read this document",
       );
-      if (!canRead) {
-        throw new GraphQLError(
-          "Forbidden: insufficient permissions to read this document",
-        );
-      }
-      return;
-    }
-    // Legacy fallback
-    if (!this.hasGlobalAdminAccess(ctx)) {
-      if (this.documentPermissionService) {
-        const canRead = await this.documentPermissionService.canRead(
-          documentId,
-          ctx.user?.address,
-          this.getParentIdsFn(),
-        );
-        if (!canRead) {
-          throw new GraphQLError(
-            "Forbidden: insufficient permissions to read this document",
-          );
-        }
-      } else {
-        throw new GraphQLError(
-          "Forbidden: insufficient permissions to read this document",
-        );
-      }
     }
   }
 
@@ -138,37 +104,15 @@ export class BaseSubgraph implements ISubgraph {
     documentId: string,
     ctx: Context,
   ): Promise<void> {
-    if (this.authorizationService) {
-      const canWrite = await this.authorizationService.canWrite(
-        documentId,
-        ctx.user?.address,
-        this.getParentIdsFn(),
+    const canWrite = await this.authorizationService.canWrite(
+      documentId,
+      ctx.user?.address,
+      this.getParentIdsFn(),
+    );
+    if (!canWrite) {
+      throw new GraphQLError(
+        "Forbidden: insufficient permissions to write to this document",
       );
-      if (!canWrite) {
-        throw new GraphQLError(
-          "Forbidden: insufficient permissions to write to this document",
-        );
-      }
-      return;
-    }
-    // Legacy fallback
-    if (!this.hasGlobalAdminAccess(ctx)) {
-      if (this.documentPermissionService) {
-        const canWrite = await this.documentPermissionService.canWrite(
-          documentId,
-          ctx.user?.address,
-          this.getParentIdsFn(),
-        );
-        if (!canWrite) {
-          throw new GraphQLError(
-            "Forbidden: insufficient permissions to write to this document",
-          );
-        }
-      } else {
-        throw new GraphQLError(
-          "Forbidden: insufficient permissions to write to this document",
-        );
-      }
     }
   }
 
@@ -177,40 +121,32 @@ export class BaseSubgraph implements ISubgraph {
     operationType: string,
     ctx: Context,
   ): Promise<void> {
-    if (this.authorizationService) {
-      const canMutate = await this.authorizationService.canMutate(
-        documentId,
-        operationType,
-        ctx.user?.address,
-        this.getParentIdsFn(),
+    const canMutate = await this.authorizationService.canMutate(
+      documentId,
+      operationType,
+      ctx.user?.address,
+      this.getParentIdsFn(),
+    );
+    if (!canMutate) {
+      throw new GraphQLError(
+        `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
       );
-      if (!canMutate) {
-        throw new GraphQLError(
-          `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
-        );
-      }
-      return;
     }
-    // Legacy fallback
-    if (!this.documentPermissionService) return;
-    if (ctx.isAdmin?.(ctx.user?.address ?? "")) return;
-    const isRestricted =
-      await this.documentPermissionService.isOperationRestricted(
-        documentId,
-        operationType,
+  }
+
+  protected assertCanCreate(ctx: Context): void {
+    const policy = this.authorizationService.config.policy;
+    if (policy === AuthorizationPolicy.OPEN) return;
+    if (this.authorizationService.isSupremeAdmin(ctx.user?.address)) return;
+    if (policy === AuthorizationPolicy.ADMIN_ONLY) {
+      throw new GraphQLError(
+        "Forbidden: insufficient permissions to create documents",
       );
-    if (isRestricted) {
-      const canExecute =
-        await this.documentPermissionService.canExecuteOperation(
-          documentId,
-          operationType,
-          ctx.user?.address,
-        );
-      if (!canExecute) {
-        throw new GraphQLError(
-          `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
-        );
-      }
+    }
+    if (!ctx.user?.address) {
+      throw new GraphQLError(
+        "Forbidden: authentication required to create documents",
+      );
     }
   }
 }

--- a/packages/reactor-api/src/graphql/document-model-subgraph.ts
+++ b/packages/reactor-api/src/graphql/document-model-subgraph.ts
@@ -313,10 +313,7 @@ export class DocumentModelSubgraph extends BaseSubgraph {
           });
 
           // Filter by permission if needed
-          if (
-            !this.hasGlobalAdminAccess(ctx) &&
-            this.documentPermissionService
-          ) {
+          if (!this.authorizationService.isSupremeAdmin(ctx.user?.address)) {
             const filteredItems = [];
             for (const item of result.items) {
               const canRead = await this.canReadDocument(item.id, ctx);
@@ -355,10 +352,7 @@ export class DocumentModelSubgraph extends BaseSubgraph {
             paging,
           });
 
-          if (
-            !this.hasGlobalAdminAccess(ctx) &&
-            this.documentPermissionService
-          ) {
+          if (!this.authorizationService.isSupremeAdmin(ctx.user?.address)) {
             const filteredItems = [];
             for (const item of result.items) {
               const canRead = await this.canReadDocument(item.id, ctx);
@@ -459,16 +453,8 @@ export class DocumentModelSubgraph extends BaseSubgraph {
 
           if (parentIdentifier) {
             await this.assertCanWrite(parentIdentifier, ctx);
-          } else if (this.authorizationService) {
-            if (!ctx.user?.address) {
-              throw new GraphQLError(
-                "Forbidden: authentication required to create documents",
-              );
-            }
-          } else if (!this.hasGlobalAdminAccess(ctx)) {
-            throw new GraphQLError(
-              "Forbidden: insufficient permissions to create documents",
-            );
+          } else {
+            this.assertCanCreate(ctx);
           }
 
           let createdDoc;
@@ -498,11 +484,7 @@ export class DocumentModelSubgraph extends BaseSubgraph {
           }
 
           // Auto-ownership: set creator as document owner
-          if (
-            this.authorizationService &&
-            ctx.user?.address &&
-            createdDoc?.id
-          ) {
+          if (ctx.user?.address && createdDoc?.id) {
             await this.documentPermissionService?.initializeDocumentProtection(
               createdDoc.id,
               ctx.user.address,
@@ -537,16 +519,8 @@ export class DocumentModelSubgraph extends BaseSubgraph {
 
           if (parentIdentifier) {
             await this.assertCanWrite(parentIdentifier, ctx);
-          } else if (this.authorizationService) {
-            if (!ctx.user?.address) {
-              throw new GraphQLError(
-                "Forbidden: authentication required to create documents",
-              );
-            }
-          } else if (!this.hasGlobalAdminAccess(ctx)) {
-            throw new GraphQLError(
-              "Forbidden: insufficient permissions to create documents",
-            );
+          } else {
+            this.assertCanCreate(ctx);
           }
 
           const result = await createEmptyDocumentResolver(
@@ -559,7 +533,7 @@ export class DocumentModelSubgraph extends BaseSubgraph {
           );
 
           // Auto-ownership: set creator as document owner
-          if (this.authorizationService && ctx.user?.address && result?.id) {
+          if (ctx.user?.address && result?.id) {
             await this.documentPermissionService?.initializeDocumentProtection(
               result.id,
               ctx.user.address,
@@ -579,9 +553,6 @@ export class DocumentModelSubgraph extends BaseSubgraph {
           ) => {
             const { docId, input } = args;
 
-            if (!this.authorizationService) {
-              await this.assertCanWrite(docId, ctx);
-            }
             await this.assertCanExecuteOperation(docId, op.name!, ctx);
 
             const doc = await this.reactorClient.get(docId);
@@ -618,9 +589,6 @@ export class DocumentModelSubgraph extends BaseSubgraph {
           ) => {
             const { docId, input } = args;
 
-            if (!this.authorizationService) {
-              await this.assertCanWrite(docId, ctx);
-            }
             await this.assertCanExecuteOperation(docId, op.name!, ctx);
 
             const doc = await this.reactorClient.get(docId);

--- a/packages/reactor-api/src/graphql/graphql-manager.ts
+++ b/packages/reactor-api/src/graphql/graphql-manager.ts
@@ -22,7 +22,7 @@ import type { WebSocketServer } from "ws";
 import { debounce } from "../packages/util.js";
 import type { AuthConfig } from "../services/auth.service.js";
 import { AuthService } from "../services/auth.service.js";
-import type { AuthorizationService } from "../services/authorization.service.js";
+import type { IAuthorizationService } from "../services/authorization.service.js";
 import type { DocumentPermissionService } from "../services/document-permission.service.js";
 import {
   buildSubgraphSchemaModule,
@@ -128,6 +128,7 @@ export class GraphQLManager {
    * it for reactor-drive parents.
    */
   readonly reactorDriveClient?: IDriveClient;
+  private readonly authorizationService: IAuthorizationService;
 
   constructor(
     private readonly path: string,
@@ -144,9 +145,13 @@ export class GraphQLManager {
     private readonly documentPermissionService?: DocumentPermissionService,
     private readonly featureFlags: GraphqlManagerFeatureFlags = DefaultFeatureFlags,
     private readonly port: number = 4001,
-    private readonly authorizationService?: AuthorizationService,
+    authorizationService?: IAuthorizationService,
     reactorDriveClient?: IDriveClient,
   ) {
+    if (!authorizationService) {
+      throw new Error("GraphQLManager requires an authorizationService");
+    }
+    this.authorizationService = authorizationService;
     this.reactorDriveClient = reactorDriveClient;
     if (this.authConfig) {
       this.authService = new AuthService(this.authConfig);
@@ -471,11 +476,15 @@ export class GraphQLManager {
         );
     }
 
+    const authEnabled = this.authConfig?.enabled ?? false;
+    const admins = this.authConfig?.admins ?? [];
     const context: Context = {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       headers: connectionParams as any,
       db: this.relationalDb,
       ...this.getAdditionalContextFields(),
+      isAdmin: (address: string) =>
+        !authEnabled ? true : admins.includes(address.toLowerCase()),
     };
 
     if (user) {

--- a/packages/reactor-api/src/graphql/graphql-manager.ts
+++ b/packages/reactor-api/src/graphql/graphql-manager.ts
@@ -476,15 +476,11 @@ export class GraphQLManager {
         );
     }
 
-    const authEnabled = this.authConfig?.enabled ?? false;
-    const admins = this.authConfig?.admins ?? [];
     const context: Context = {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       headers: connectionParams as any,
       db: this.relationalDb,
       ...this.getAdditionalContextFields(),
-      isAdmin: (address: string) =>
-        !authEnabled ? true : admins.includes(address.toLowerCase()),
     };
 
     if (user) {
@@ -508,12 +504,6 @@ export class GraphQLManager {
         ...this.getAdditionalContextFields(),
         driveId,
         user: authCtx?.user,
-        isAdmin: authCtx
-          ? (addr) =>
-              !authCtx.auth_enabled
-                ? true
-                : authCtx.admins.includes(addr.toLowerCase())
-          : () => true,
       });
     };
   }

--- a/packages/reactor-api/src/graphql/graphql-manager.ts
+++ b/packages/reactor-api/src/graphql/graphql-manager.ts
@@ -414,6 +414,15 @@ export class GraphQLManager {
     return this.path;
   }
 
+  /**
+   * Get the authorization service shared with subgraphs. Use this when
+   * constructing a subgraph instance externally for
+   * {@link registerSubgraphInstance}.
+   */
+  getAuthorizationService(): IAuthorizationService {
+    return this.authorizationService;
+  }
+
   async registerSubgraph(
     subgraph: SubgraphClass,
     supergraph = "",

--- a/packages/reactor-api/src/graphql/packages/resolvers.ts
+++ b/packages/reactor-api/src/graphql/packages/resolvers.ts
@@ -1,11 +1,14 @@
 import { GraphQLError } from "graphql";
+import type { IAuthorizationService } from "../../services/authorization.service.js";
 import type { PackageManagementService } from "../../services/package-management.service.js";
 import type { InstalledPackageInfo } from "../../services/package-storage.js";
 import type { Context } from "../types.js";
 
-function requireAdmin(ctx: Context): void {
-  const isAdmin = ctx.isAdmin?.(ctx.user?.address ?? "") ?? false;
-  if (!isAdmin) {
+function requireAdmin(
+  authorizationService: IAuthorizationService,
+  ctx: Context,
+): void {
+  if (!authorizationService.isSupremeAdmin(ctx.user?.address)) {
     throw new GraphQLError("Admin access required");
   }
 }
@@ -37,13 +40,14 @@ export async function installedPackage(
 
 export async function installPackage(
   service: PackageManagementService,
+  authorizationService: IAuthorizationService,
   args: { name: string; registryUrl?: string | null },
   ctx: Context,
 ): Promise<{
   package: ReturnType<typeof formatPackageInfo>;
   documentModelsLoaded: number;
 }> {
-  requireAdmin(ctx);
+  requireAdmin(authorizationService, ctx);
 
   const result = await service.installPackage(
     args.name,
@@ -58,10 +62,11 @@ export async function installPackage(
 
 export async function uninstallPackage(
   service: PackageManagementService,
+  authorizationService: IAuthorizationService,
   args: { name: string },
   ctx: Context,
 ): Promise<boolean> {
-  requireAdmin(ctx);
+  requireAdmin(authorizationService, ctx);
 
   return service.uninstallPackage(args.name);
 }

--- a/packages/reactor-api/src/graphql/packages/subgraph.ts
+++ b/packages/reactor-api/src/graphql/packages/subgraph.ts
@@ -70,6 +70,7 @@ export class PackagesSubgraph extends BaseSubgraph {
         try {
           return await resolvers.installPackage(
             this.packageManagementService,
+            this.authorizationService,
             args,
             ctx,
           );
@@ -88,6 +89,7 @@ export class PackagesSubgraph extends BaseSubgraph {
         try {
           return await resolvers.uninstallPackage(
             this.packageManagementService,
+            this.authorizationService,
             args,
             ctx,
           );

--- a/packages/reactor-api/src/graphql/reactor/subgraph.ts
+++ b/packages/reactor-api/src/graphql/reactor/subgraph.ts
@@ -1,5 +1,4 @@
 import { ConsoleLogger } from "document-model";
-import { GraphQLError } from "graphql";
 import { withFilter } from "graphql-subscriptions";
 import { gql } from "graphql-tag";
 import schemaSource from "./schema.graphql";
@@ -155,10 +154,7 @@ export class ReactorSubgraph extends BaseSubgraph {
             this.reactorClient,
             args,
           );
-          if (
-            !this.hasGlobalAdminAccess(ctx) &&
-            this.documentPermissionService
-          ) {
+          if (!this.authorizationService.isSupremeAdmin(ctx.user?.address)) {
             const filteredItems = [];
             for (const item of result.items) {
               const canRead = await this.canReadDocument(item.id, ctx);
@@ -191,10 +187,7 @@ export class ReactorSubgraph extends BaseSubgraph {
           });
 
           // Filter results to only include documents the user can read
-          if (
-            !this.hasGlobalAdminAccess(ctx) &&
-            this.documentPermissionService
-          ) {
+          if (!this.authorizationService.isSupremeAdmin(ctx.user?.address)) {
             const filteredItems = [];
             for (const item of result.items) {
               const canRead = await this.canReadDocument(item.id, ctx);
@@ -273,16 +266,8 @@ export class ReactorSubgraph extends BaseSubgraph {
             });
 
             await this.assertCanWrite(parent.document.id, ctx);
-          } else if (this.authorizationService) {
-            if (!ctx.user?.address) {
-              throw new GraphQLError(
-                "Forbidden: authentication required to create documents",
-              );
-            }
-          } else if (!this.hasGlobalAdminAccess(ctx)) {
-            throw new GraphQLError(
-              "Forbidden: insufficient permissions to create documents",
-            );
+          } else {
+            this.assertCanCreate(ctx);
           }
           const result = await resolvers.createDocument(
             this.reactorClient,
@@ -295,7 +280,7 @@ export class ReactorSubgraph extends BaseSubgraph {
           }
 
           // Auto-ownership: set creator as document owner
-          if (this.authorizationService && ctx.user?.address && result?.id) {
+          if (ctx.user?.address && result?.id) {
             await this.documentPermissionService?.initializeDocumentProtection(
               result.id,
               ctx.user.address,
@@ -324,16 +309,8 @@ export class ReactorSubgraph extends BaseSubgraph {
             });
 
             await this.assertCanWrite(parent.document.id, ctx);
-          } else if (this.authorizationService) {
-            if (!ctx.user?.address) {
-              throw new GraphQLError(
-                "Forbidden: authentication required to create documents",
-              );
-            }
-          } else if (!this.hasGlobalAdminAccess(ctx)) {
-            throw new GraphQLError(
-              "Forbidden: insufficient permissions to create documents",
-            );
+          } else {
+            this.assertCanCreate(ctx);
           }
           const result = await resolvers.createEmptyDocument(
             this.reactorClient,
@@ -346,7 +323,7 @@ export class ReactorSubgraph extends BaseSubgraph {
           }
 
           // Auto-ownership: set creator as document owner
-          if (this.authorizationService && ctx.user?.address && result?.id) {
+          if (ctx.user?.address && result?.id) {
             await this.documentPermissionService?.initializeDocumentProtection(
               result.id,
               ctx.user.address,
@@ -368,13 +345,7 @@ export class ReactorSubgraph extends BaseSubgraph {
       mutateDocument: async (_parent, args, ctx: Context) => {
         this.logger.debug("mutateDocument(@args)", args);
         try {
-          // assertCanExecuteOperations uses canMutate (which combines write + operation checks)
-          // when authorizationService is available. For legacy fallback, assertCanWrite is needed.
-          if (!this.authorizationService) {
-            await this.assertCanWrite(args.documentIdentifier, ctx);
-          }
-
-          // Check operation-level permissions for each action
+          // canMutate combines the write + operation checks per action.
           await this.assertCanExecuteOperations(
             args.documentIdentifier,
             args.actions,
@@ -395,11 +366,6 @@ export class ReactorSubgraph extends BaseSubgraph {
       mutateDocumentAsync: async (_parent, args, ctx: Context) => {
         this.logger.debug("mutateDocumentAsync(@args)", args);
         try {
-          if (!this.authorizationService) {
-            await this.assertCanWrite(args.documentIdentifier, ctx);
-          }
-
-          // Check operation-level permissions for each action
           await this.assertCanExecuteOperations(
             args.documentIdentifier,
             args.actions,

--- a/packages/reactor-api/src/graphql/types.ts
+++ b/packages/reactor-api/src/graphql/types.ts
@@ -9,7 +9,7 @@ import type { DocumentDriveGlobalState } from "@powerhousedao/shared/document-dr
 import type { PHDocument } from "@powerhousedao/shared/document-model";
 import type { DocumentNode } from "graphql";
 import type { IncomingHttpHeaders } from "http";
-import type { AuthorizationService } from "../services/authorization.service.js";
+import type { IAuthorizationService } from "../services/authorization.service.js";
 import type { DocumentPermissionService } from "../services/document-permission.service.js";
 import type { BaseSubgraph } from "./base-subgraph.js";
 
@@ -27,7 +27,7 @@ export type Context = {
     networkId: string;
   };
   documentPermissionService?: DocumentPermissionService;
-  authorizationService?: AuthorizationService;
+  authorizationService?: IAuthorizationService;
 };
 
 export type ISubgraph = {
@@ -48,7 +48,7 @@ export type SubgraphArgs = {
   graphqlManager: GraphQLManager;
   syncManager: ISyncManager;
   documentPermissionService?: DocumentPermissionService;
-  authorizationService?: AuthorizationService;
+  authorizationService: IAuthorizationService;
   path?: string;
 };
 

--- a/packages/reactor-api/src/graphql/types.ts
+++ b/packages/reactor-api/src/graphql/types.ts
@@ -20,14 +20,11 @@ export type Context = {
   document?: PHDocument;
   headers: IncomingHttpHeaders;
   db: unknown;
-  isAdmin?: (address: string) => boolean;
   user?: {
     address: string;
     chainId: number;
     networkId: string;
   };
-  documentPermissionService?: DocumentPermissionService;
-  authorizationService?: IAuthorizationService;
 };
 
 export type ISubgraph = {

--- a/packages/reactor-api/src/server.ts
+++ b/packages/reactor-api/src/server.ts
@@ -120,6 +120,25 @@ type ProcessorInitializer = ProcessorFactoryBuilder;
 
 const DEFAULT_PORT = 4000;
 
+/**
+ * Doc-perms require auth: with auth off no `user` is ever resolved, so every
+ * authorization check fails closed. Refuse to boot rather than run broken.
+ */
+export function assertAuthRequiredForDocumentPermissions(
+  authEnabled: boolean,
+  documentPermissionsRequested: boolean,
+): void {
+  if (!authEnabled && documentPermissionsRequested) {
+    throw new Error(
+      "Document permissions require authentication: AUTH_ENABLED is false but " +
+        "document permissions were requested (DOCUMENT_PERMISSIONS_ENABLED=true " +
+        "or a documentPermissionService was provided). Enable authentication " +
+        "(AUTH_ENABLED=true, or auth.enabled in the config file) or disable " +
+        "document permissions.",
+    );
+  }
+}
+
 function createReadinessGate(): ReadinessGate {
   let ready = false;
   return {
@@ -433,6 +452,14 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
   if (SKIP_CREDENTIAL_VERIFICATION !== undefined) {
     skipCredentialVerification = SKIP_CREDENTIAL_VERIFICATION === "true";
   }
+
+  const documentPermissionsRequested =
+    options.documentPermissionService !== undefined ||
+    DOCUMENT_PERMISSIONS_ENABLED === "true";
+  assertAuthRequiredForDocumentPermissions(
+    authEnabled,
+    documentPermissionsRequested,
+  );
 
   const logger = options.logger ?? defaultLogger;
 

--- a/packages/reactor-api/src/server.ts
+++ b/packages/reactor-api/src/server.ts
@@ -227,6 +227,7 @@ async function setupGraphQLManager(
     core: SubgraphClass[];
   },
   logger: ILogger,
+  authorizationService: AuthorizationService,
   auth?: {
     enabled: boolean;
     admins: string[];
@@ -234,7 +235,6 @@ async function setupGraphQLManager(
   documentPermissionService?: DocumentPermissionService,
   enableDocumentModelSubgraphs?: boolean,
   port?: number,
-  authorizationService?: AuthorizationService,
   reactorDriveClient?: IDriveClient,
 ): Promise<GraphQLManager> {
   const graphqlManager = new GraphQLManager(
@@ -624,7 +624,7 @@ async function _setupAPI(
   processorApp: ProcessorApp,
   readModels: IReadModel[],
   attachments: AttachmentBuildResult,
-  authorizationService?: AuthorizationService,
+  authorizationService: AuthorizationService,
   documentModelRegistry?: IDocumentModelRegistry,
   dbClosers: Array<() => Promise<void>> = [],
   reactorDriveClient?: IDriveClient,
@@ -754,11 +754,11 @@ async function _setupAPI(
       core: coreSubgraphs,
     },
     logger.child(["graphql-manager"]),
+    authorizationService,
     auth,
     documentPermissionService,
     options.enableDocumentModelSubgraphs,
     port,
-    authorizationService,
     reactorDriveClient,
   );
 

--- a/packages/reactor-api/src/server.ts
+++ b/packages/reactor-api/src/server.ts
@@ -50,9 +50,10 @@ import { runMigrations } from "./migrations/index.js";
 import { ImportPackageLoader } from "./packages/import-loader.js";
 import { PackageManager } from "./packages/package-manager.js";
 import { AuthService } from "./services/auth.service.js";
+import type { IAuthorizationService } from "./services/authorization.service.js";
 import {
   AuthorizationPolicy,
-  AuthorizationService,
+  createAuthorizationService,
 } from "./services/authorization.service.js";
 import { DocumentPermissionService } from "./services/document-permission.service.js";
 import type {
@@ -227,7 +228,7 @@ async function setupGraphQLManager(
     core: SubgraphClass[];
   },
   logger: ILogger,
-  authorizationService: AuthorizationService,
+  authorizationService: IAuthorizationService,
   auth?: {
     enabled: boolean;
     admins: string[];
@@ -412,7 +413,7 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
   relationalDb: IRelationalDb;
   analyticsStore: IAnalyticsStore;
   documentPermissionService: DocumentPermissionService | undefined;
-  authorizationService: AuthorizationService;
+  authorizationService: IAuthorizationService;
   attachments: AttachmentBuildResult;
   packages: PackageManager;
   dbClosers: Array<() => Promise<void>>;
@@ -541,9 +542,9 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
     : authEnabled
       ? AuthorizationPolicy.ADMIN_ONLY
       : AuthorizationPolicy.OPEN;
-  const authorizationService = new AuthorizationService(
-    documentPermissionService,
+  const authorizationService = createAuthorizationService(
     { admins, defaultProtection, policy },
+    documentPermissionService,
   );
   logger.info(`Authorization service initialized (policy: ${policy})`);
 
@@ -624,7 +625,7 @@ async function _setupAPI(
   processorApp: ProcessorApp,
   readModels: IReadModel[],
   attachments: AttachmentBuildResult,
-  authorizationService: AuthorizationService,
+  authorizationService: IAuthorizationService,
   documentModelRegistry?: IDocumentModelRegistry,
   dbClosers: Array<() => Promise<void>> = [],
   reactorDriveClient?: IDriveClient,

--- a/packages/reactor-api/src/server.ts
+++ b/packages/reactor-api/src/server.ts
@@ -50,7 +50,10 @@ import { runMigrations } from "./migrations/index.js";
 import { ImportPackageLoader } from "./packages/import-loader.js";
 import { PackageManager } from "./packages/package-manager.js";
 import { AuthService } from "./services/auth.service.js";
-import { AuthorizationService } from "./services/authorization.service.js";
+import {
+  AuthorizationPolicy,
+  AuthorizationService,
+} from "./services/authorization.service.js";
 import { DocumentPermissionService } from "./services/document-permission.service.js";
 import type {
   API,
@@ -409,7 +412,7 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
   relationalDb: IRelationalDb;
   analyticsStore: IAnalyticsStore;
   documentPermissionService: DocumentPermissionService | undefined;
-  authorizationService: AuthorizationService | undefined;
+  authorizationService: AuthorizationService;
   attachments: AttachmentBuildResult;
   packages: PackageManager;
   dbClosers: Array<() => Promise<void>>;
@@ -530,15 +533,19 @@ async function _setupCommonInfrastructure(options: Options): Promise<{
     logger.info("Document permission service initialized");
   }
 
-  // Create AuthorizationService when document permission service is available
-  let authorizationService: AuthorizationService | undefined;
-  if (documentPermissionService) {
-    authorizationService = new AuthorizationService(documentPermissionService, {
-      admins,
-      defaultProtection,
-    });
-    logger.info("Authorization service initialized");
-  }
+  // Authorization service is always present; the policy collapses the prior
+  // dual enforcement paths into one. Document permissions imply authentication
+  // (guaranteed by the boot gate above).
+  const policy = documentPermissionService
+    ? AuthorizationPolicy.DOCUMENT_PERMISSIONS
+    : authEnabled
+      ? AuthorizationPolicy.ADMIN_ONLY
+      : AuthorizationPolicy.OPEN;
+  const authorizationService = new AuthorizationService(
+    documentPermissionService,
+    { admins, defaultProtection, policy },
+  );
+  logger.info(`Authorization service initialized (policy: ${policy})`);
 
   // Initialize attachment service
   const attachmentStoragePath = resolveAttachmentStoragePath(options);

--- a/packages/reactor-api/src/services/auth.service.ts
+++ b/packages/reactor-api/src/services/auth.service.ts
@@ -179,38 +179,6 @@ export class AuthService {
   }
 
   /**
-   * Get additional context fields for GraphQL
-   */
-  getAdditionalContextFields() {
-    if (!this.config.enabled) {
-      return {
-        isAdmin: () => true,
-      };
-    }
-
-    return {
-      isAdmin: (address: string) =>
-        this.config.enabled &&
-        this.config.admins?.includes(address.toLowerCase()),
-    };
-  }
-
-  /**
-   * Get user context for GraphQL
-   */
-  getUserContext(user?: User) {
-    if (!user) return {};
-
-    return {
-      user: {
-        address: user.address.toLowerCase(),
-        chainId: user.chainId,
-        networkId: user.networkId,
-      },
-    };
-  }
-
-  /**
    * Verify that the credential still exists on the Renown API
    */
   private async verifyCredentialExists(

--- a/packages/reactor-api/src/services/authorization.service.ts
+++ b/packages/reactor-api/src/services/authorization.service.ts
@@ -22,7 +22,7 @@ export interface AuthorizationConfig {
  * Single source of truth for every permission decision. Always present (never
  * null) so callers branch on data, not on the existence of a service.
  *
- * The policy selects behavior once at boot:
+ * The policy selects an implementation once at boot:
  * - OPEN: authentication disabled — everyone (incl. anonymous) is allowed.
  * - ADMIN_ONLY: authentication on, document permissions off — only ADMINS.
  * - DOCUMENT_PERMISSIONS: the full per-document protection + grant model.
@@ -58,30 +58,94 @@ export interface IAuthorizationService {
   ): Promise<boolean>;
 }
 
-export class AuthorizationService implements IAuthorizationService {
-  readonly config: AuthorizationConfig;
-
-  constructor(
-    private readonly documentPermissionService:
-      | DocumentPermissionService
-      | undefined,
-    config: AuthorizationConfig,
-  ) {
-    if (
-      config.policy === AuthorizationPolicy.DOCUMENT_PERMISSIONS &&
-      !documentPermissionService
-    ) {
-      throw new Error(
-        "DocumentPermissionService is required for the DOCUMENT_PERMISSIONS policy",
-      );
-    }
-    this.config = config;
-  }
+/** Shared config holder and admin-list check for the policy strategies. */
+abstract class BaseAuthorizationService implements IAuthorizationService {
+  constructor(readonly config: AuthorizationConfig) {}
 
   isSupremeAdmin(userAddress?: string): boolean {
-    if (this.config.policy === AuthorizationPolicy.OPEN) return true;
     if (!userAddress) return false;
     return this.config.admins.includes(userAddress.toLowerCase());
+  }
+
+  abstract canRead(
+    documentId: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean>;
+
+  abstract canWrite(
+    documentId: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean>;
+
+  abstract canManage(
+    documentId: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean>;
+
+  abstract canMutate(
+    documentId: string,
+    operationType: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean>;
+}
+
+/** OPEN: authentication disabled — everyone (incl. anonymous) is allowed. */
+class OpenAuthorizationService extends BaseAuthorizationService {
+  isSupremeAdmin(): boolean {
+    return true;
+  }
+
+  canRead(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  canWrite(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  canManage(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  canMutate(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+}
+
+/** ADMIN_ONLY: authentication on, document permissions off — only ADMINS. */
+class AdminOnlyAuthorizationService extends BaseAuthorizationService {
+  canRead(_documentId: string, userAddress?: string): Promise<boolean> {
+    return Promise.resolve(this.isSupremeAdmin(userAddress));
+  }
+
+  canWrite(_documentId: string, userAddress?: string): Promise<boolean> {
+    return Promise.resolve(this.isSupremeAdmin(userAddress));
+  }
+
+  canManage(_documentId: string, userAddress?: string): Promise<boolean> {
+    return Promise.resolve(this.isSupremeAdmin(userAddress));
+  }
+
+  canMutate(
+    _documentId: string,
+    _operationType: string,
+    userAddress?: string,
+  ): Promise<boolean> {
+    return Promise.resolve(this.isSupremeAdmin(userAddress));
+  }
+}
+
+/** DOCUMENT_PERMISSIONS: the full per-document protection + grant model. */
+class DocumentPermissionsAuthorizationService extends BaseAuthorizationService {
+  constructor(
+    private readonly permissions: DocumentPermissionService,
+    config: AuthorizationConfig,
+  ) {
+    super(config);
   }
 
   async canRead(
@@ -89,10 +153,25 @@ export class AuthorizationService implements IAuthorizationService {
     userAddress?: string,
     getParentIds?: GetParentIdsFn,
   ): Promise<boolean> {
-    if (this.config.policy === AuthorizationPolicy.OPEN) return true;
     if (this.isSupremeAdmin(userAddress)) return true;
-    if (this.config.policy === AuthorizationPolicy.ADMIN_ONLY) return false;
-    return this.#permissionCanRead(documentId, userAddress, getParentIds);
+
+    const isProtected = getParentIds
+      ? await this.permissions.isProtectedWithAncestors(
+          documentId,
+          getParentIds,
+        )
+      : await this.permissions.isDocumentProtected(documentId);
+
+    if (!isProtected) return true;
+    if (!userAddress) return false;
+
+    const owner = await this.permissions.getDocumentOwner(documentId);
+    if (owner && owner === userAddress.toLowerCase()) return true;
+
+    if (getParentIds) {
+      return this.permissions.canRead(documentId, userAddress, getParentIds);
+    }
+    return this.permissions.canReadDocument(documentId, userAddress);
   }
 
   async canWrite(
@@ -100,21 +179,18 @@ export class AuthorizationService implements IAuthorizationService {
     userAddress?: string,
     getParentIds?: GetParentIdsFn,
   ): Promise<boolean> {
-    if (this.config.policy === AuthorizationPolicy.OPEN) return true;
     if (this.isSupremeAdmin(userAddress)) return true;
-    if (this.config.policy === AuthorizationPolicy.ADMIN_ONLY) return false;
     return this.#permissionCanWrite(documentId, userAddress, getParentIds);
   }
 
-  async canManage(
-    documentId: string,
-    userAddress?: string,
-    getParentIds?: GetParentIdsFn,
-  ): Promise<boolean> {
-    if (this.config.policy === AuthorizationPolicy.OPEN) return true;
+  async canManage(documentId: string, userAddress?: string): Promise<boolean> {
     if (this.isSupremeAdmin(userAddress)) return true;
-    if (this.config.policy === AuthorizationPolicy.ADMIN_ONLY) return false;
-    return this.#permissionCanManage(documentId, userAddress, getParentIds);
+    if (!userAddress) return false;
+
+    const owner = await this.permissions.getDocumentOwner(documentId);
+    if (owner && owner === userAddress.toLowerCase()) return true;
+
+    return this.permissions.canManageDocument(documentId, userAddress);
   }
 
   async canMutate(
@@ -123,96 +199,15 @@ export class AuthorizationService implements IAuthorizationService {
     userAddress?: string,
     getParentIds?: GetParentIdsFn,
   ): Promise<boolean> {
-    if (this.config.policy === AuthorizationPolicy.OPEN) return true;
     if (this.isSupremeAdmin(userAddress)) return true;
-    if (this.config.policy === AuthorizationPolicy.ADMIN_ONLY) return false;
-    return this.#permissionCanMutate(
-      documentId,
-      operationType,
-      userAddress,
-      getParentIds,
-    );
-  }
 
-  #permissions(): DocumentPermissionService {
-    if (!this.documentPermissionService) {
-      throw new Error("DocumentPermissionService is not available");
-    }
-    return this.documentPermissionService;
-  }
-
-  async #permissionCanRead(
-    documentId: string,
-    userAddress?: string,
-    getParentIds?: GetParentIdsFn,
-  ): Promise<boolean> {
-    const permissions = this.#permissions();
-    const isProtected = getParentIds
-      ? await permissions.isProtectedWithAncestors(documentId, getParentIds)
-      : await permissions.isDocumentProtected(documentId);
-
-    if (!isProtected) return true;
-    if (!userAddress) return false;
-
-    const owner = await permissions.getDocumentOwner(documentId);
-    if (owner && owner === userAddress.toLowerCase()) return true;
-
-    if (getParentIds) {
-      return permissions.canRead(documentId, userAddress, getParentIds);
-    }
-    return permissions.canReadDocument(documentId, userAddress);
-  }
-
-  async #permissionCanWrite(
-    documentId: string,
-    userAddress?: string,
-    getParentIds?: GetParentIdsFn,
-  ): Promise<boolean> {
-    const permissions = this.#permissions();
-    const isProtected = getParentIds
-      ? await permissions.isProtectedWithAncestors(documentId, getParentIds)
-      : await permissions.isDocumentProtected(documentId);
-
-    if (!isProtected) return true;
-    if (!userAddress) return false;
-
-    const owner = await permissions.getDocumentOwner(documentId);
-    if (owner && owner === userAddress.toLowerCase()) return true;
-
-    if (getParentIds) {
-      return permissions.canWrite(documentId, userAddress, getParentIds);
-    }
-    return permissions.canWriteDocument(documentId, userAddress);
-  }
-
-  async #permissionCanManage(
-    documentId: string,
-    userAddress?: string,
-    _getParentIds?: GetParentIdsFn,
-  ): Promise<boolean> {
-    if (!userAddress) return false;
-
-    const permissions = this.#permissions();
-    const owner = await permissions.getDocumentOwner(documentId);
-    if (owner && owner === userAddress.toLowerCase()) return true;
-
-    return permissions.canManageDocument(documentId, userAddress);
-  }
-
-  async #permissionCanMutate(
-    documentId: string,
-    operationType: string,
-    userAddress?: string,
-    getParentIds?: GetParentIdsFn,
-  ): Promise<boolean> {
-    const permissions = this.#permissions();
-    const isRestricted = await permissions.isOperationRestricted(
+    const isRestricted = await this.permissions.isOperationRestricted(
       documentId,
       operationType,
     );
 
     if (isRestricted) {
-      return permissions.canExecuteOperation(
+      return this.permissions.canExecuteOperation(
         documentId,
         operationType,
         userAddress?.toLowerCase(),
@@ -221,4 +216,53 @@ export class AuthorizationService implements IAuthorizationService {
 
     return this.#permissionCanWrite(documentId, userAddress, getParentIds);
   }
+
+  async #permissionCanWrite(
+    documentId: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean> {
+    const isProtected = getParentIds
+      ? await this.permissions.isProtectedWithAncestors(
+          documentId,
+          getParentIds,
+        )
+      : await this.permissions.isDocumentProtected(documentId);
+
+    if (!isProtected) return true;
+    if (!userAddress) return false;
+
+    const owner = await this.permissions.getDocumentOwner(documentId);
+    if (owner && owner === userAddress.toLowerCase()) return true;
+
+    if (getParentIds) {
+      return this.permissions.canWrite(documentId, userAddress, getParentIds);
+    }
+    return this.permissions.canWriteDocument(documentId, userAddress);
+  }
+}
+
+/**
+ * Selects the strategy for the configured policy. The strategy classes are
+ * not exported, so this guard is the only construction path.
+ */
+export function createAuthorizationService(
+  config: AuthorizationConfig,
+  documentPermissionService?: DocumentPermissionService,
+): IAuthorizationService {
+  if (config.policy === AuthorizationPolicy.OPEN) {
+    return new OpenAuthorizationService(config);
+  }
+  if (config.policy === AuthorizationPolicy.ADMIN_ONLY) {
+    return new AdminOnlyAuthorizationService(config);
+  }
+  if (!documentPermissionService) {
+    throw new Error(
+      "DocumentPermissionService is required for the DOCUMENT_PERMISSIONS policy",
+    );
+  }
+  return new DocumentPermissionsAuthorizationService(
+    documentPermissionService,
+    config,
+  );
 }

--- a/packages/reactor-api/src/services/authorization.service.ts
+++ b/packages/reactor-api/src/services/authorization.service.ts
@@ -3,239 +3,269 @@ import type {
   GetParentIdsFn,
 } from "./document-permission.service.js";
 
+export const AuthorizationPolicy = {
+  OPEN: "OPEN",
+  ADMIN_ONLY: "ADMIN_ONLY",
+  DOCUMENT_PERMISSIONS: "DOCUMENT_PERMISSIONS",
+} as const;
+
+export type AuthorizationPolicy =
+  (typeof AuthorizationPolicy)[keyof typeof AuthorizationPolicy];
+
 export interface AuthorizationConfig {
   admins: string[];
   defaultProtection: boolean;
+  policy: AuthorizationPolicy;
 }
 
 /**
- * Central authorization service — single source of truth for all permission checks.
+ * Single source of truth for every permission decision. Always present (never
+ * null) so callers branch on data, not on the existence of a service.
  *
- * Authorization model:
- * 1. Supreme admin (ADMINS env) → ALLOW ALL
- * 2. Is document protected?
- *    a. NOT protected:
- *       - READ: anyone (even anonymous) → ALLOW
- *       - WRITE: authenticated user → ALLOW
- *    b. PROTECTED:
- *       - READ: requires explicit READ/WRITE/ADMIN grant (direct or via group/parent)
- *       - WRITE: requires explicit WRITE/ADMIN grant (direct or via group/parent)
- * 3. Operation restricted? → Check OperationUserPermission
- * 4. Document owner = implicit ADMIN
- * 5. Drive protected = all children effectively protected
+ * The policy selects behavior once at boot:
+ * - OPEN: authentication disabled — everyone (incl. anonymous) is allowed.
+ * - ADMIN_ONLY: authentication on, document permissions off — only ADMINS.
+ * - DOCUMENT_PERMISSIONS: the full per-document protection + grant model.
  */
-export class AuthorizationService {
+export interface IAuthorizationService {
+  readonly config: AuthorizationConfig;
+
+  isSupremeAdmin(userAddress?: string): boolean;
+
+  canRead(
+    documentId: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean>;
+
+  canWrite(
+    documentId: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean>;
+
+  canManage(
+    documentId: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean>;
+
+  canExecuteOperation(
+    documentId: string,
+    operationType: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean>;
+
+  canMutate(
+    documentId: string,
+    operationType: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean>;
+}
+
+export class AuthorizationService implements IAuthorizationService {
   readonly config: AuthorizationConfig;
 
   constructor(
-    private readonly documentPermissionService: DocumentPermissionService,
+    private readonly documentPermissionService:
+      | DocumentPermissionService
+      | undefined,
     config: AuthorizationConfig,
   ) {
+    if (
+      config.policy === AuthorizationPolicy.DOCUMENT_PERMISSIONS &&
+      !documentPermissionService
+    ) {
+      throw new Error(
+        "DocumentPermissionService is required for the DOCUMENT_PERMISSIONS policy",
+      );
+    }
     this.config = config;
   }
 
-  /**
-   * Check if a user is a supreme admin (from ADMINS env var).
-   */
   isSupremeAdmin(userAddress?: string): boolean {
+    if (this.config.policy === AuthorizationPolicy.OPEN) return true;
     if (!userAddress) return false;
     return this.config.admins.includes(userAddress.toLowerCase());
   }
 
-  /**
-   * Check if a user can read a document.
-   *
-   * - Supreme admin → yes
-   * - Not protected → anyone can read (even anonymous)
-   * - Protected → requires READ/WRITE/ADMIN grant (direct, group, or parent inheritance)
-   * - Owner → yes (implicit ADMIN)
-   */
   async canRead(
     documentId: string,
     userAddress?: string,
     getParentIds?: GetParentIdsFn,
   ): Promise<boolean> {
-    // Supreme admin bypasses all
+    if (this.config.policy === AuthorizationPolicy.OPEN) return true;
     if (this.isSupremeAdmin(userAddress)) return true;
-
-    // Check protection status (walks parent chain if getParentIds provided)
-    const isProtected = getParentIds
-      ? await this.documentPermissionService.isProtectedWithAncestors(
-          documentId,
-          getParentIds,
-        )
-      : await this.documentPermissionService.isDocumentProtected(documentId);
-
-    // Unprotected documents are readable by anyone
-    if (!isProtected) return true;
-
-    // Protected document — requires authentication
-    if (!userAddress) return false;
-
-    // Owner has implicit ADMIN
-    const owner =
-      await this.documentPermissionService.getDocumentOwner(documentId);
-    if (owner && owner === userAddress.toLowerCase()) return true;
-
-    // Check grant (READ/WRITE/ADMIN all allow reading)
-    if (getParentIds) {
-      return this.documentPermissionService.canRead(
-        documentId,
-        userAddress,
-        getParentIds,
-      );
-    }
-    return this.documentPermissionService.canReadDocument(
-      documentId,
-      userAddress,
-    );
+    if (this.config.policy === AuthorizationPolicy.ADMIN_ONLY) return false;
+    return this.#permissionCanRead(documentId, userAddress, getParentIds);
   }
 
-  /**
-   * Check if a user can write to a document.
-   *
-   * - Supreme admin → yes
-   * - Not protected → anyone can write (even anonymous)
-   * - Protected → requires authentication + WRITE/ADMIN grant
-   * - Owner → yes (implicit ADMIN)
-   */
   async canWrite(
     documentId: string,
     userAddress?: string,
     getParentIds?: GetParentIdsFn,
   ): Promise<boolean> {
-    // Supreme admin bypasses all
+    if (this.config.policy === AuthorizationPolicy.OPEN) return true;
     if (this.isSupremeAdmin(userAddress)) return true;
-
-    // Check protection status
-    const isProtected = getParentIds
-      ? await this.documentPermissionService.isProtectedWithAncestors(
-          documentId,
-          getParentIds,
-        )
-      : await this.documentPermissionService.isDocumentProtected(documentId);
-
-    // Unprotected documents are writable by anyone (even anonymous)
-    if (!isProtected) return true;
-
-    // Protected document — requires authentication
-    if (!userAddress) return false;
-
-    // Owner has implicit ADMIN
-    const owner =
-      await this.documentPermissionService.getDocumentOwner(documentId);
-    if (owner && owner === userAddress.toLowerCase()) return true;
-
-    // Check grant (WRITE/ADMIN allow writing)
-    if (getParentIds) {
-      return this.documentPermissionService.canWrite(
-        documentId,
-        userAddress,
-        getParentIds,
-      );
-    }
-    return this.documentPermissionService.canWriteDocument(
-      documentId,
-      userAddress,
-    );
+    if (this.config.policy === AuthorizationPolicy.ADMIN_ONLY) return false;
+    return this.#permissionCanWrite(documentId, userAddress, getParentIds);
   }
 
-  /**
-   * Check if a user can manage a document (change permissions, protection, transfer ownership).
-   *
-   * - Supreme admin → yes
-   * - Owner → yes
-   * - Has ADMIN grant → yes
-   */
   async canManage(
     documentId: string,
     userAddress?: string,
-    _getParentIds?: GetParentIdsFn,
+    getParentIds?: GetParentIdsFn,
   ): Promise<boolean> {
-    // Supreme admin bypasses all
+    if (this.config.policy === AuthorizationPolicy.OPEN) return true;
     if (this.isSupremeAdmin(userAddress)) return true;
-
-    if (!userAddress) return false;
-
-    // Owner has implicit ADMIN
-    const owner =
-      await this.documentPermissionService.getDocumentOwner(documentId);
-    if (owner && owner === userAddress.toLowerCase()) return true;
-
-    // Check ADMIN grant
-    return this.documentPermissionService.canManageDocument(
-      documentId,
-      userAddress,
-    );
+    if (this.config.policy === AuthorizationPolicy.ADMIN_ONLY) return false;
+    return this.#permissionCanManage(documentId, userAddress, getParentIds);
   }
 
-  /**
-   * Check if a user can execute a specific operation.
-   * If the operation is not restricted, falls through to the standard write check.
-   * If the operation is restricted, requires an explicit OperationUserPermission grant.
-   */
   async canExecuteOperation(
     documentId: string,
     operationType: string,
     userAddress?: string,
     getParentIds?: GetParentIdsFn,
   ): Promise<boolean> {
-    // Supreme admin bypasses all
+    if (this.config.policy === AuthorizationPolicy.OPEN) return true;
     if (this.isSupremeAdmin(userAddress)) return true;
-
-    // Check if operation is restricted
-    const isRestricted =
-      await this.documentPermissionService.isOperationRestricted(
-        documentId,
-        operationType,
-      );
-
-    if (!isRestricted) {
-      // Operation not restricted — standard write check applies
-      return this.canWrite(documentId, userAddress, getParentIds);
-    }
-
-    // Operation is restricted — user needs explicit operation grant
-    return this.documentPermissionService.canExecuteOperation(
+    if (this.config.policy === AuthorizationPolicy.ADMIN_ONLY) return false;
+    return this.#permissionCanExecuteOperation(
       documentId,
       operationType,
-      userAddress?.toLowerCase(),
+      userAddress,
+      getParentIds,
     );
   }
 
-  /**
-   * Combined check for mutations: can the user write + execute the operation?
-   * This enables READ-only users with operation grants to execute specific operations.
-   * For restricted operations, only the operation grant is checked (bypasses write check),
-   * allowing READ-only users with an explicit operation grant to execute that operation.
-   */
   async canMutate(
     documentId: string,
     operationType: string,
     userAddress?: string,
     getParentIds?: GetParentIdsFn,
   ): Promise<boolean> {
-    // Supreme admin bypasses all
+    if (this.config.policy === AuthorizationPolicy.OPEN) return true;
     if (this.isSupremeAdmin(userAddress)) return true;
+    if (this.config.policy === AuthorizationPolicy.ADMIN_ONLY) return false;
+    return this.#permissionCanMutate(
+      documentId,
+      operationType,
+      userAddress,
+      getParentIds,
+    );
+  }
 
-    // Check if the operation is restricted
-    const isRestricted =
-      await this.documentPermissionService.isOperationRestricted(
-        documentId,
-        operationType,
-      );
+  #permissions(): DocumentPermissionService {
+    if (!this.documentPermissionService) {
+      throw new Error("DocumentPermissionService is not available");
+    }
+    return this.documentPermissionService;
+  }
+
+  async #permissionCanRead(
+    documentId: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean> {
+    const permissions = this.#permissions();
+    const isProtected = getParentIds
+      ? await permissions.isProtectedWithAncestors(documentId, getParentIds)
+      : await permissions.isDocumentProtected(documentId);
+
+    if (!isProtected) return true;
+    if (!userAddress) return false;
+
+    const owner = await permissions.getDocumentOwner(documentId);
+    if (owner && owner === userAddress.toLowerCase()) return true;
+
+    if (getParentIds) {
+      return permissions.canRead(documentId, userAddress, getParentIds);
+    }
+    return permissions.canReadDocument(documentId, userAddress);
+  }
+
+  async #permissionCanWrite(
+    documentId: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean> {
+    const permissions = this.#permissions();
+    const isProtected = getParentIds
+      ? await permissions.isProtectedWithAncestors(documentId, getParentIds)
+      : await permissions.isDocumentProtected(documentId);
+
+    if (!isProtected) return true;
+    if (!userAddress) return false;
+
+    const owner = await permissions.getDocumentOwner(documentId);
+    if (owner && owner === userAddress.toLowerCase()) return true;
+
+    if (getParentIds) {
+      return permissions.canWrite(documentId, userAddress, getParentIds);
+    }
+    return permissions.canWriteDocument(documentId, userAddress);
+  }
+
+  async #permissionCanManage(
+    documentId: string,
+    userAddress?: string,
+    _getParentIds?: GetParentIdsFn,
+  ): Promise<boolean> {
+    if (!userAddress) return false;
+
+    const permissions = this.#permissions();
+    const owner = await permissions.getDocumentOwner(documentId);
+    if (owner && owner === userAddress.toLowerCase()) return true;
+
+    return permissions.canManageDocument(documentId, userAddress);
+  }
+
+  async #permissionCanExecuteOperation(
+    documentId: string,
+    operationType: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean> {
+    const permissions = this.#permissions();
+    const isRestricted = await permissions.isOperationRestricted(
+      documentId,
+      operationType,
+    );
+
+    if (!isRestricted) {
+      return this.#permissionCanWrite(documentId, userAddress, getParentIds);
+    }
+
+    return permissions.canExecuteOperation(
+      documentId,
+      operationType,
+      userAddress?.toLowerCase(),
+    );
+  }
+
+  async #permissionCanMutate(
+    documentId: string,
+    operationType: string,
+    userAddress?: string,
+    getParentIds?: GetParentIdsFn,
+  ): Promise<boolean> {
+    const permissions = this.#permissions();
+    const isRestricted = await permissions.isOperationRestricted(
+      documentId,
+      operationType,
+    );
 
     if (isRestricted) {
-      // For restricted operations, only the operation grant matters
-      // This allows READ-only users with operation grants to execute
-      return this.documentPermissionService.canExecuteOperation(
+      return permissions.canExecuteOperation(
         documentId,
         operationType,
         userAddress?.toLowerCase(),
       );
     }
 
-    // For unrestricted operations, standard write check applies
-    return this.canWrite(documentId, userAddress, getParentIds);
+    return this.#permissionCanWrite(documentId, userAddress, getParentIds);
   }
 }

--- a/packages/reactor-api/src/services/authorization.service.ts
+++ b/packages/reactor-api/src/services/authorization.service.ts
@@ -50,13 +50,6 @@ export interface IAuthorizationService {
     getParentIds?: GetParentIdsFn,
   ): Promise<boolean>;
 
-  canExecuteOperation(
-    documentId: string,
-    operationType: string,
-    userAddress?: string,
-    getParentIds?: GetParentIdsFn,
-  ): Promise<boolean>;
-
   canMutate(
     documentId: string,
     operationType: string,
@@ -122,23 +115,6 @@ export class AuthorizationService implements IAuthorizationService {
     if (this.isSupremeAdmin(userAddress)) return true;
     if (this.config.policy === AuthorizationPolicy.ADMIN_ONLY) return false;
     return this.#permissionCanManage(documentId, userAddress, getParentIds);
-  }
-
-  async canExecuteOperation(
-    documentId: string,
-    operationType: string,
-    userAddress?: string,
-    getParentIds?: GetParentIdsFn,
-  ): Promise<boolean> {
-    if (this.config.policy === AuthorizationPolicy.OPEN) return true;
-    if (this.isSupremeAdmin(userAddress)) return true;
-    if (this.config.policy === AuthorizationPolicy.ADMIN_ONLY) return false;
-    return this.#permissionCanExecuteOperation(
-      documentId,
-      operationType,
-      userAddress,
-      getParentIds,
-    );
   }
 
   async canMutate(
@@ -221,29 +197,6 @@ export class AuthorizationService implements IAuthorizationService {
     if (owner && owner === userAddress.toLowerCase()) return true;
 
     return permissions.canManageDocument(documentId, userAddress);
-  }
-
-  async #permissionCanExecuteOperation(
-    documentId: string,
-    operationType: string,
-    userAddress?: string,
-    getParentIds?: GetParentIdsFn,
-  ): Promise<boolean> {
-    const permissions = this.#permissions();
-    const isRestricted = await permissions.isOperationRestricted(
-      documentId,
-      operationType,
-    );
-
-    if (!isRestricted) {
-      return this.#permissionCanWrite(documentId, userAddress, getParentIds);
-    }
-
-    return permissions.canExecuteOperation(
-      documentId,
-      operationType,
-      userAddress?.toLowerCase(),
-    );
   }
 
   async #permissionCanMutate(

--- a/packages/reactor-api/test/auth-resolvers-canmanage.test.ts
+++ b/packages/reactor-api/test/auth-resolvers-canmanage.test.ts
@@ -5,9 +5,10 @@ import {
   revokeDocumentPermission,
 } from "../src/graphql/auth/resolvers.js";
 import { runMigrations } from "../src/migrations/index.js";
+import type { IAuthorizationService } from "../src/services/authorization.service.js";
 import {
   AuthorizationPolicy,
-  AuthorizationService,
+  createAuthorizationService,
 } from "../src/services/authorization.service.js";
 import { DocumentPermissionService } from "../src/services/document-permission.service.js";
 import type { DocumentPermissionDatabase } from "../src/utils/db.js";
@@ -22,18 +23,21 @@ import { getDbClient } from "../src/utils/db.js";
 describe("grant/revoke resolvers route through canManage", () => {
   let db: Kysely<DocumentPermissionDatabase>;
   let permissions: DocumentPermissionService;
-  let authorization: AuthorizationService;
+  let authorization: IAuthorizationService;
 
   beforeEach(async () => {
     const { db: dbClient } = getDbClient();
     db = dbClient as Kysely<DocumentPermissionDatabase>;
     await runMigrations(db as Kysely<unknown>);
     permissions = new DocumentPermissionService(db);
-    authorization = new AuthorizationService(permissions, {
-      admins: ["0xadmin"],
-      defaultProtection: false,
-      policy: AuthorizationPolicy.DOCUMENT_PERMISSIONS,
-    });
+    authorization = createAuthorizationService(
+      {
+        admins: ["0xadmin"],
+        defaultProtection: false,
+        policy: AuthorizationPolicy.DOCUMENT_PERMISSIONS,
+      },
+      permissions,
+    );
     await permissions.setDocumentProtection("doc-1", true);
   });
 

--- a/packages/reactor-api/test/auth-resolvers-canmanage.test.ts
+++ b/packages/reactor-api/test/auth-resolvers-canmanage.test.ts
@@ -1,0 +1,91 @@
+import type { Kysely } from "kysely";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  grantDocumentPermission,
+  revokeDocumentPermission,
+} from "../src/graphql/auth/resolvers.js";
+import { runMigrations } from "../src/migrations/index.js";
+import {
+  AuthorizationPolicy,
+  AuthorizationService,
+} from "../src/services/authorization.service.js";
+import { DocumentPermissionService } from "../src/services/document-permission.service.js";
+import type { DocumentPermissionDatabase } from "../src/utils/db.js";
+import { getDbClient } from "../src/utils/db.js";
+
+/**
+ * Manage-permission gating for the grant/revoke resolvers after consolidation:
+ * they now route through AuthorizationService.canManage, which grants
+ * document owners (and supreme admins) management rights in addition to holders
+ * of an explicit ADMIN grant.
+ */
+describe("grant/revoke resolvers route through canManage", () => {
+  let db: Kysely<DocumentPermissionDatabase>;
+  let permissions: DocumentPermissionService;
+  let authorization: AuthorizationService;
+
+  beforeEach(async () => {
+    const { db: dbClient } = getDbClient();
+    db = dbClient as Kysely<DocumentPermissionDatabase>;
+    await runMigrations(db as Kysely<unknown>);
+    permissions = new DocumentPermissionService(db);
+    authorization = new AuthorizationService(permissions, {
+      admins: ["0xadmin"],
+      defaultProtection: false,
+      policy: AuthorizationPolicy.DOCUMENT_PERMISSIONS,
+    });
+    await permissions.setDocumentProtection("doc-1", true);
+  });
+
+  it("lets a document owner without an ADMIN grant manage permissions", async () => {
+    await permissions.setDocumentOwner("doc-1", "0xowner");
+
+    const result = await grantDocumentPermission(
+      permissions,
+      authorization,
+      { documentId: "doc-1", userAddress: "0xbob", permission: "READ" },
+      "0xowner",
+    );
+
+    expect(result.userAddress).toBe("0xbob");
+    expect(await permissions.canReadDocument("doc-1", "0xbob")).toBe(true);
+  });
+
+  it("lets a supreme admin manage permissions", async () => {
+    const result = await grantDocumentPermission(
+      permissions,
+      authorization,
+      { documentId: "doc-1", userAddress: "0xbob", permission: "READ" },
+      "0xadmin",
+    );
+    expect(result.userAddress).toBe("0xbob");
+  });
+
+  it("denies a caller who is neither owner, admin, nor ADMIN grantee", async () => {
+    await permissions.setDocumentOwner("doc-1", "0xowner");
+
+    await expect(
+      grantDocumentPermission(
+        permissions,
+        authorization,
+        { documentId: "doc-1", userAddress: "0xbob", permission: "READ" },
+        "0xstranger",
+      ),
+    ).rejects.toThrow("Forbidden");
+  });
+
+  it("lets an owner revoke permissions", async () => {
+    await permissions.setDocumentOwner("doc-1", "0xowner");
+    await permissions.grantPermission("doc-1", "0xbob", "READ", "0xowner");
+
+    const revoked = await revokeDocumentPermission(
+      permissions,
+      authorization,
+      { documentId: "doc-1", userAddress: "0xbob" },
+      "0xowner",
+    );
+
+    expect(revoked).toBe(true);
+    expect(await permissions.canReadDocument("doc-1", "0xbob")).toBe(false);
+  });
+});

--- a/packages/reactor-api/test/authorization.service.test.ts
+++ b/packages/reactor-api/test/authorization.service.test.ts
@@ -257,67 +257,6 @@ describe("AuthorizationService", () => {
     });
   });
 
-  describe("canExecuteOperation", () => {
-    it("should allow supreme admin", async () => {
-      const result = await service.canExecuteOperation(
-        "doc-1",
-        "SET_NAME",
-        "0xadmin",
-      );
-      expect(result).toBe(true);
-    });
-
-    it("should fall through to write check for unrestricted operations", async () => {
-      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
-        false,
-      );
-      vi.mocked(mockPermissionService.isDocumentProtected!).mockResolvedValue(
-        false,
-      );
-      const result = await service.canExecuteOperation(
-        "doc-1",
-        "SET_NAME",
-        "0xuser",
-      );
-      expect(result).toBe(true); // unprotected + authenticated = write allowed
-    });
-
-    it("should check operation grant for restricted operations", async () => {
-      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
-        true,
-      );
-      vi.mocked(mockPermissionService.canExecuteOperation!).mockResolvedValue(
-        true,
-      );
-      const result = await service.canExecuteOperation(
-        "doc-1",
-        "SPECIAL_OP",
-        "0xuser",
-      );
-      expect(result).toBe(true);
-      expect(mockPermissionService.canExecuteOperation).toHaveBeenCalledWith(
-        "doc-1",
-        "SPECIAL_OP",
-        "0xuser",
-      );
-    });
-
-    it("should deny when restricted and no operation grant", async () => {
-      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
-        true,
-      );
-      vi.mocked(mockPermissionService.canExecuteOperation!).mockResolvedValue(
-        false,
-      );
-      const result = await service.canExecuteOperation(
-        "doc-1",
-        "SPECIAL_OP",
-        "0xuser",
-      );
-      expect(result).toBe(false);
-    });
-  });
-
   describe("canMutate", () => {
     it("should allow supreme admin", async () => {
       const result = await service.canMutate("doc-1", "SET_NAME", "0xadmin");
@@ -386,21 +325,6 @@ describe("AuthorizationService", () => {
   });
 
   describe("Address normalization", () => {
-    it("should normalize address in canExecuteOperation for restricted ops", async () => {
-      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
-        true,
-      );
-      vi.mocked(mockPermissionService.canExecuteOperation!).mockResolvedValue(
-        true,
-      );
-      await service.canExecuteOperation("doc-1", "SPECIAL_OP", "0xMixedCase");
-      expect(mockPermissionService.canExecuteOperation).toHaveBeenCalledWith(
-        "doc-1",
-        "SPECIAL_OP",
-        "0xmixedcase",
-      );
-    });
-
     it("should normalize address in canMutate for restricted ops", async () => {
       vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
         true,
@@ -413,26 +337,6 @@ describe("AuthorizationService", () => {
         "doc-1",
         "SPECIAL_OP",
         "0xmixedcase",
-      );
-    });
-
-    it("should handle undefined address in canExecuteOperation", async () => {
-      vi.mocked(mockPermissionService.isOperationRestricted!).mockResolvedValue(
-        true,
-      );
-      vi.mocked(mockPermissionService.canExecuteOperation!).mockResolvedValue(
-        false,
-      );
-      const result = await service.canExecuteOperation(
-        "doc-1",
-        "SPECIAL_OP",
-        undefined,
-      );
-      expect(result).toBe(false);
-      expect(mockPermissionService.canExecuteOperation).toHaveBeenCalledWith(
-        "doc-1",
-        "SPECIAL_OP",
-        undefined,
       );
     });
   });
@@ -476,9 +380,6 @@ describe("AuthorizationService", () => {
       expect(await open.canRead("doc-1", undefined)).toBe(true);
       expect(await open.canWrite("doc-1", undefined)).toBe(true);
       expect(await open.canManage("doc-1", undefined)).toBe(true);
-      expect(await open.canExecuteOperation("doc-1", "OP", undefined)).toBe(
-        true,
-      );
       expect(await open.canMutate("doc-1", "OP", undefined)).toBe(true);
     });
   });

--- a/packages/reactor-api/test/authorization.service.test.ts
+++ b/packages/reactor-api/test/authorization.service.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IAuthorizationService } from "../src/services/authorization.service.js";
 import {
   AuthorizationPolicy,
-  AuthorizationService,
+  createAuthorizationService,
 } from "../src/services/authorization.service.js";
 import type { DocumentPermissionService } from "../src/services/document-permission.service.js";
 
-describe("AuthorizationService", () => {
-  let service: AuthorizationService;
+describe("createAuthorizationService", () => {
+  let service: IAuthorizationService;
   let mockPermissionService: Partial<DocumentPermissionService>;
   const getParentIds = vi.fn().mockResolvedValue([]);
 
@@ -24,13 +25,13 @@ describe("AuthorizationService", () => {
       isOperationRestricted: vi.fn().mockResolvedValue(false),
       canExecuteOperation: vi.fn().mockResolvedValue(false),
     };
-    service = new AuthorizationService(
-      mockPermissionService as DocumentPermissionService,
+    service = createAuthorizationService(
       {
         admins: ["0xadmin"],
         defaultProtection: false,
         policy: AuthorizationPolicy.DOCUMENT_PERMISSIONS,
       },
+      mockPermissionService as DocumentPermissionService,
     );
   });
 
@@ -361,10 +362,10 @@ describe("AuthorizationService", () => {
   });
 
   describe("OPEN policy", () => {
-    let open: AuthorizationService;
+    let open: IAuthorizationService;
 
     beforeEach(() => {
-      open = new AuthorizationService(undefined, {
+      open = createAuthorizationService({
         admins: [],
         defaultProtection: false,
         policy: AuthorizationPolicy.OPEN,
@@ -385,10 +386,10 @@ describe("AuthorizationService", () => {
   });
 
   describe("ADMIN_ONLY policy", () => {
-    let adminOnly: AuthorizationService;
+    let adminOnly: IAuthorizationService;
 
     beforeEach(() => {
-      adminOnly = new AuthorizationService(undefined, {
+      adminOnly = createAuthorizationService({
         admins: ["0xadmin"],
         defaultProtection: false,
         policy: AuthorizationPolicy.ADMIN_ONLY,
@@ -412,15 +413,14 @@ describe("AuthorizationService", () => {
     });
   });
 
-  describe("constructor invariant", () => {
+  describe("factory invariant", () => {
     it("throws for DOCUMENT_PERMISSIONS policy without a permission service", () => {
-      expect(
-        () =>
-          new AuthorizationService(undefined, {
-            admins: [],
-            defaultProtection: false,
-            policy: AuthorizationPolicy.DOCUMENT_PERMISSIONS,
-          }),
+      expect(() =>
+        createAuthorizationService({
+          admins: [],
+          defaultProtection: false,
+          policy: AuthorizationPolicy.DOCUMENT_PERMISSIONS,
+        }),
       ).toThrow(/DocumentPermissionService is required/);
     });
   });

--- a/packages/reactor-api/test/authorization.service.test.ts
+++ b/packages/reactor-api/test/authorization.service.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { AuthorizationService } from "../src/services/authorization.service.js";
+import {
+  AuthorizationPolicy,
+  AuthorizationService,
+} from "../src/services/authorization.service.js";
 import type { DocumentPermissionService } from "../src/services/document-permission.service.js";
 
 describe("AuthorizationService", () => {
@@ -23,7 +26,11 @@ describe("AuthorizationService", () => {
     };
     service = new AuthorizationService(
       mockPermissionService as DocumentPermissionService,
-      { admins: ["0xadmin"], defaultProtection: false },
+      {
+        admins: ["0xadmin"],
+        defaultProtection: false,
+        policy: AuthorizationPolicy.DOCUMENT_PERMISSIONS,
+      },
     );
   });
 
@@ -446,6 +453,74 @@ describe("AuthorizationService", () => {
       expect(
         mockPermissionService.isProtectedWithAncestors,
       ).toHaveBeenCalledWith("doc-1", getParentIds);
+    });
+  });
+
+  describe("OPEN policy", () => {
+    let open: AuthorizationService;
+
+    beforeEach(() => {
+      open = new AuthorizationService(undefined, {
+        admins: [],
+        defaultProtection: false,
+        policy: AuthorizationPolicy.OPEN,
+      });
+    });
+
+    it("treats everyone (incl. anonymous) as a supreme admin", () => {
+      expect(open.isSupremeAdmin(undefined)).toBe(true);
+      expect(open.isSupremeAdmin("0xanyone")).toBe(true);
+    });
+
+    it("allows every decision without touching a permission store", async () => {
+      expect(await open.canRead("doc-1", undefined)).toBe(true);
+      expect(await open.canWrite("doc-1", undefined)).toBe(true);
+      expect(await open.canManage("doc-1", undefined)).toBe(true);
+      expect(await open.canExecuteOperation("doc-1", "OP", undefined)).toBe(
+        true,
+      );
+      expect(await open.canMutate("doc-1", "OP", undefined)).toBe(true);
+    });
+  });
+
+  describe("ADMIN_ONLY policy", () => {
+    let adminOnly: AuthorizationService;
+
+    beforeEach(() => {
+      adminOnly = new AuthorizationService(undefined, {
+        admins: ["0xadmin"],
+        defaultProtection: false,
+        policy: AuthorizationPolicy.ADMIN_ONLY,
+      });
+    });
+
+    it("allows supreme admins everything", async () => {
+      expect(await adminOnly.canRead("doc-1", "0xadmin")).toBe(true);
+      expect(await adminOnly.canWrite("doc-1", "0xadmin")).toBe(true);
+      expect(await adminOnly.canManage("doc-1", "0xadmin")).toBe(true);
+      expect(await adminOnly.canMutate("doc-1", "OP", "0xadmin")).toBe(true);
+    });
+
+    it("denies non-admins and anonymous everything", async () => {
+      expect(await adminOnly.canRead("doc-1", "0xuser")).toBe(false);
+      expect(await adminOnly.canWrite("doc-1", "0xuser")).toBe(false);
+      expect(await adminOnly.canManage("doc-1", "0xuser")).toBe(false);
+      expect(await adminOnly.canMutate("doc-1", "OP", "0xuser")).toBe(false);
+      expect(await adminOnly.canRead("doc-1", undefined)).toBe(false);
+      expect(await adminOnly.canWrite("doc-1", undefined)).toBe(false);
+    });
+  });
+
+  describe("constructor invariant", () => {
+    it("throws for DOCUMENT_PERMISSIONS policy without a permission service", () => {
+      expect(
+        () =>
+          new AuthorizationService(undefined, {
+            admins: [],
+            defaultProtection: false,
+            policy: AuthorizationPolicy.DOCUMENT_PERMISSIONS,
+          }),
+      ).toThrow(/DocumentPermissionService is required/);
     });
   });
 });

--- a/packages/reactor-api/test/document-model-subgraph-permissions.test.ts
+++ b/packages/reactor-api/test/document-model-subgraph-permissions.test.ts
@@ -7,10 +7,13 @@ import { GraphQLError } from "graphql";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DocumentModelSubgraph } from "../src/graphql/document-model-subgraph.js";
 import type { Context, SubgraphArgs } from "../src/graphql/types.js";
-import type { DocumentPermissionService } from "../src/services/document-permission.service.js";
+import {
+  AuthorizationPolicy,
+  type IAuthorizationService,
+} from "../src/services/authorization.service.js";
 
 describe("DocumentModelSubgraph Permission Checks", () => {
-  let mockDocumentPermissionService: Partial<DocumentPermissionService>;
+  let mockAuthorizationService: Partial<IAuthorizationService>;
   let mockReactorClient: Partial<IReactorClient>;
   let subgraph: DocumentModelSubgraph;
 
@@ -77,25 +80,44 @@ describe("DocumentModelSubgraph Permission Checks", () => {
 
   const mockDocument = createMockDocument("doc-123", "Test Document");
 
-  const createContext = (options: {
-    isAdmin?: boolean;
-    userAddress?: string;
-  }): Context =>
+  const createContext = (options: { userAddress?: string }): Context =>
     ({
       user: options.userAddress ? { address: options.userAddress } : undefined,
-      isAdmin: vi.fn().mockReturnValue(options.isAdmin ?? false),
     }) as unknown as Context;
+
+  /**
+   * Build a SubgraphArgs-shaped object with the given authorizationService.
+   * We cast to unknown first so TypeScript doesn't complain about the stub fields.
+   */
+  const buildSubgraphArgs = (
+    authSvc: Partial<IAuthorizationService>,
+  ): SubgraphArgs =>
+    ({
+      reactorClient: mockReactorClient as IReactorClient,
+      authorizationService: authSvc as IAuthorizationService,
+      relationalDb: {} as SubgraphArgs["relationalDb"],
+      analyticsStore: {} as SubgraphArgs["analyticsStore"],
+      graphqlManager: {} as SubgraphArgs["graphqlManager"],
+      syncManager: {} as SubgraphArgs["syncManager"],
+    }) as unknown as SubgraphArgs;
 
   beforeEach(() => {
     vi.clearAllMocks();
 
-    mockDocumentPermissionService = {
+    // Default mock: DOCUMENT_PERMISSIONS policy, not a supreme admin, all
+    // decisions deny.
+    mockAuthorizationService = {
+      config: {
+        admins: [],
+        defaultProtection: false,
+        policy: AuthorizationPolicy.DOCUMENT_PERMISSIONS,
+      },
+      isSupremeAdmin: vi.fn().mockReturnValue(false),
       canRead: vi.fn().mockResolvedValue(false),
       canWrite: vi.fn().mockResolvedValue(false),
-      canReadDocument: vi.fn().mockResolvedValue(false),
-      canWriteDocument: vi.fn().mockResolvedValue(false),
-      isOperationRestricted: vi.fn().mockResolvedValue(false),
+      canManage: vi.fn().mockResolvedValue(false),
       canExecuteOperation: vi.fn().mockResolvedValue(false),
+      canMutate: vi.fn().mockResolvedValue(false),
     };
 
     mockReactorClient = {
@@ -119,16 +141,15 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       }),
     };
 
-    subgraph = new DocumentModelSubgraph(mockDocumentModel, {
-      reactorClient: mockReactorClient as IReactorClient,
-      documentPermissionService:
-        mockDocumentPermissionService as DocumentPermissionService,
-      relationalDb: {} as SubgraphArgs["relationalDb"],
-      analyticsStore: {} as SubgraphArgs["analyticsStore"],
-      graphqlManager: {} as SubgraphArgs["graphqlManager"],
-      syncManager: {} as SubgraphArgs["syncManager"],
-    } as SubgraphArgs);
+    subgraph = new DocumentModelSubgraph(
+      mockDocumentModel,
+      buildSubgraphArgs(mockAuthorizationService),
+    );
   });
+
+  // ---------------------------------------------------------------------------
+  // Query: document
+  // ---------------------------------------------------------------------------
 
   describe("Query: document", () => {
     const callGetDocument = async (ctx: Context, identifier: string) => {
@@ -137,38 +158,44 @@ describe("DocumentModelSubgraph Permission Checks", () => {
     };
 
     describe("Global Admin Access", () => {
-      it("should allow access when user is global admin", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+      it("should allow access when authorizationService.canRead resolves true (supreme admin path)", async () => {
+        vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(true);
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         const result = await callGetDocument(ctx, "doc-123");
 
         expect(result).toBeDefined();
         expect(result.document.id).toBe("doc-123");
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
+        expect(mockAuthorizationService.canRead).toHaveBeenCalled();
+      });
+
+      it("should deny access when canRead resolves false even for non-null user", async () => {
+        vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(false);
+        const ctx = createContext({ userAddress: "0xadmin" });
+
+        await expect(callGetDocument(ctx, "doc-123")).rejects.toThrow(
+          "Forbidden",
+        );
       });
     });
 
     describe("Document Permission Access", () => {
-      it("should check document permissions when no global access", async () => {
-        vi.mocked(mockDocumentPermissionService.canRead!).mockResolvedValue(
-          true,
-        );
+      it("should allow access when authorizationService.canRead resolves true", async () => {
+        vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(true);
         const ctx = createContext({ userAddress: "0xpermitted" });
 
         const result = await callGetDocument(ctx, "doc-123");
 
         expect(result).toBeDefined();
-        expect(mockDocumentPermissionService.canRead).toHaveBeenCalledWith(
+        expect(mockAuthorizationService.canRead).toHaveBeenCalledWith(
           "doc-123",
           "0xpermitted",
           expect.any(Function),
         );
       });
 
-      it("should deny access when user has no permissions", async () => {
-        vi.mocked(mockDocumentPermissionService.canRead!).mockResolvedValue(
-          false,
-        );
+      it("should deny access when authorizationService.canRead resolves false", async () => {
+        vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(false);
         const ctx = createContext({ userAddress: "0xunpermitted" });
 
         await expect(callGetDocument(ctx, "doc-123")).rejects.toThrow(
@@ -179,7 +206,8 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         );
       });
 
-      it("should deny access when user is not authenticated", async () => {
+      it("should deny access when user is not authenticated (canRead false for undefined address)", async () => {
+        vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(false);
         const ctx = createContext({});
 
         await expect(callGetDocument(ctx, "doc-123")).rejects.toThrow(
@@ -190,7 +218,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
 
     describe("Document validation", () => {
       it("should throw error when identifier is not provided", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         await expect(callGetDocument(ctx, "")).rejects.toThrow(
           "Document identifier is required",
@@ -203,7 +231,7 @@ describe("DocumentModelSubgraph Permission Checks", () => {
           header: { ...mockDocument.header, documentType: "other/type" },
         };
         mockReactorClient.get = vi.fn().mockResolvedValue(wrongTypeDoc);
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         await expect(callGetDocument(ctx, "doc-123")).rejects.toThrow(
           "is not of type",
@@ -227,9 +255,9 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         let capturedGetParentsFn:
           | ((docId: string) => Promise<string[]>)
           | null = null;
-        vi.mocked(mockDocumentPermissionService.canRead!).mockImplementation(
+        vi.mocked(mockAuthorizationService.canRead!).mockImplementation(
           (_docId, _user, getParentsFn) => {
-            capturedGetParentsFn = getParentsFn;
+            capturedGetParentsFn = getParentsFn ?? null;
             return Promise.resolve(true);
           },
         );
@@ -250,9 +278,9 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         let capturedGetParentsFn:
           | ((docId: string) => Promise<string[]>)
           | null = null;
-        vi.mocked(mockDocumentPermissionService.canRead!).mockImplementation(
+        vi.mocked(mockAuthorizationService.canRead!).mockImplementation(
           (_docId, _user, getParentsFn) => {
-            capturedGetParentsFn = getParentsFn;
+            capturedGetParentsFn = getParentsFn ?? null;
             return Promise.resolve(true);
           },
         );
@@ -267,7 +295,8 @@ describe("DocumentModelSubgraph Permission Checks", () => {
 
     describe("reactorClient integration", () => {
       it("should use reactorClient.get to fetch document", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+        vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(true);
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         await callGetDocument(ctx, "doc-123");
 
@@ -278,6 +307,10 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       });
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Query: findDocuments
+  // ---------------------------------------------------------------------------
 
   describe("Query: findDocuments", () => {
     const callFindDocuments = async (ctx: Context, parentId?: string) => {
@@ -290,14 +323,17 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       return result.items;
     };
 
-    describe("Global Role Access", () => {
-      it("should return all documents for admin", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+    describe("Supreme Admin Access (no per-item canRead call)", () => {
+      it("should return all documents and skip per-item canRead when isSupremeAdmin=true", async () => {
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
+          true,
+        );
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         const result = await callFindDocuments(ctx, "drive-1");
 
         expect(result).toHaveLength(1);
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
+        expect(mockAuthorizationService.canRead).not.toHaveBeenCalled();
       });
     });
 
@@ -314,12 +350,12 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         } as PagedResults<PHDocument>);
       });
 
-      it("should filter documents based on permissions when no global access", async () => {
-        vi.mocked(mockDocumentPermissionService.canRead!).mockImplementation(
-          (docId) =>
-            Promise.resolve(
-              docId === "drive-1" || docId === "doc-1" || docId === "doc-3",
-            ),
+      it("should filter documents based on canRead when not a supreme admin", async () => {
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
+          false,
+        );
+        vi.mocked(mockAuthorizationService.canRead!).mockImplementation(
+          (docId) => Promise.resolve(docId === "doc-1" || docId === "doc-3"),
         );
         const ctx = createContext({ userAddress: "0xpartial" });
 
@@ -332,10 +368,11 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         ]);
       });
 
-      it("should return empty array when user has no document permissions", async () => {
-        vi.mocked(mockDocumentPermissionService.canRead!).mockImplementation(
-          (docId) => Promise.resolve(docId === "drive-1"),
+      it("should return empty array when canRead always resolves false", async () => {
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
+          false,
         );
+        vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(false);
         const ctx = createContext({ userAddress: "0xnopermissions" });
 
         const result = await callFindDocuments(ctx, "drive-1");
@@ -344,12 +381,13 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       });
     });
 
-    describe("Permission filtering", () => {
-      it("should filter out all documents when user has no permissions", async () => {
-        vi.mocked(mockDocumentPermissionService.canRead!).mockResolvedValue(
+    describe("Permission filtering (no user)", () => {
+      it("should filter out all documents when user is not authenticated", async () => {
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
           false,
         );
-        const ctx = createContext({ userAddress: "0xunpermitted" });
+        vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(false);
+        const ctx = createContext({});
 
         const result = await callFindDocuments(ctx, "drive-1");
         expect(result).toHaveLength(0);
@@ -358,7 +396,10 @@ describe("DocumentModelSubgraph Permission Checks", () => {
 
     describe("reactorClient integration", () => {
       it("should use reactorClient.find with type filter", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
+          true,
+        );
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         await callFindDocuments(ctx, "drive-1");
 
@@ -376,6 +417,10 @@ describe("DocumentModelSubgraph Permission Checks", () => {
     });
   });
 
+  // ---------------------------------------------------------------------------
+  // Query: documents (get all)
+  // ---------------------------------------------------------------------------
+
   describe("Query: documents (get all)", () => {
     const callDocuments = async (
       ctx: Context,
@@ -386,14 +431,17 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       return result;
     };
 
-    describe("Global Role Access", () => {
-      it("should return all documents for admin", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+    describe("Supreme Admin Access", () => {
+      it("should return all documents and skip per-item canRead when isSupremeAdmin=true", async () => {
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
+          true,
+        );
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         const result = await callDocuments(ctx, { limit: 10 });
 
         expect(result.items).toHaveLength(1);
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
+        expect(mockAuthorizationService.canRead).not.toHaveBeenCalled();
       });
     });
 
@@ -410,8 +458,11 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         } as PagedResults<PHDocument>);
       });
 
-      it("should filter documents based on permissions when no global access", async () => {
-        vi.mocked(mockDocumentPermissionService.canRead!).mockImplementation(
+      it("should filter documents based on canRead when not a supreme admin", async () => {
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
+          false,
+        );
+        vi.mocked(mockAuthorizationService.canRead!).mockImplementation(
           (docId) => Promise.resolve(docId === "doc-1" || docId === "doc-3"),
         );
         const ctx = createContext({ userAddress: "0xpartial" });
@@ -425,10 +476,11 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         ]);
       });
 
-      it("should return empty array when user has no document permissions", async () => {
-        vi.mocked(mockDocumentPermissionService.canRead!).mockResolvedValue(
+      it("should return empty array when canRead always resolves false", async () => {
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
           false,
         );
+        vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(false);
         const ctx = createContext({ userAddress: "0xnopermissions" });
 
         const result = await callDocuments(ctx, { limit: 10 });
@@ -439,7 +491,10 @@ describe("DocumentModelSubgraph Permission Checks", () => {
 
     describe("reactorClient integration", () => {
       it("should use reactorClient.find with type filter and no parentId", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
+          true,
+        );
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         await callDocuments(ctx, { limit: 10 });
 
@@ -455,7 +510,10 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       });
 
       it("should work without paging argument", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
+          true,
+        );
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         const result = await callDocuments(ctx);
 
@@ -463,6 +521,10 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       });
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Mutation: createDocument
+  // ---------------------------------------------------------------------------
 
   describe("Mutation: createDocument", () => {
     const callCreateDocument = async (
@@ -474,38 +536,103 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       return mutation(null, { name, parentIdentifier }, ctx);
     };
 
-    describe("Global Admin Access", () => {
-      it("should allow creation when user is global admin", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+    describe("Without parentIdentifier — assertCanCreate path", () => {
+      it("should allow creation when policy=DOCUMENT_PERMISSIONS and user has an address", async () => {
+        // DOCUMENT_PERMISSIONS + non-admin + user address set → allowed
+        const ctx = createContext({ userAddress: "0xuser" });
 
         const result = await callCreateDocument(ctx, "New Doc");
 
         expect(result).toMatchObject({ id: "doc-123" });
-        expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
+        // canWrite should NOT be called (no parent)
+        expect(mockAuthorizationService.canWrite).not.toHaveBeenCalled();
+      });
+
+      it("should throw Forbidden when policy=DOCUMENT_PERMISSIONS and no user address", async () => {
+        const ctx = createContext({});
+
+        await expect(callCreateDocument(ctx, "New Doc")).rejects.toThrow(
+          "Forbidden",
+        );
+      });
+
+      it("should allow creation when isSupremeAdmin=true regardless of policy", async () => {
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
+          true,
+        );
+        const ctx = createContext({ userAddress: "0xadmin" });
+
+        const result = await callCreateDocument(ctx, "New Doc");
+
+        expect(result).toMatchObject({ id: "doc-123" });
+      });
+
+      it("should throw Forbidden when policy=ADMIN_ONLY and user is not a supreme admin", async () => {
+        const adminOnlyAuth: Partial<IAuthorizationService> = {
+          ...mockAuthorizationService,
+          config: {
+            admins: [],
+            defaultProtection: false,
+            policy: AuthorizationPolicy.ADMIN_ONLY,
+          },
+          isSupremeAdmin: vi.fn().mockReturnValue(false),
+        };
+        const sg = new DocumentModelSubgraph(
+          mockDocumentModel,
+          buildSubgraphArgs(adminOnlyAuth),
+        );
+
+        const ctx = createContext({ userAddress: "0xuser" });
+        await expect(
+          sg.mutationResolvers.createDocument(null, { name: "X" }, ctx),
+        ).rejects.toThrow(
+          "Forbidden: insufficient permissions to create documents",
+        );
+      });
+
+      it("should allow all when policy=OPEN (no user needed)", async () => {
+        const openAuth: Partial<IAuthorizationService> = {
+          ...mockAuthorizationService,
+          config: {
+            admins: [],
+            defaultProtection: false,
+            policy: AuthorizationPolicy.OPEN,
+          },
+          isSupremeAdmin: vi.fn().mockReturnValue(true),
+        };
+        const sg = new DocumentModelSubgraph(
+          mockDocumentModel,
+          buildSubgraphArgs(openAuth),
+        );
+
+        // No user at all
+        const ctx = createContext({});
+        const result = await sg.mutationResolvers.createDocument(
+          null,
+          { name: "OpenDoc" },
+          ctx,
+        );
+        expect(result).toMatchObject({ id: "doc-123" });
       });
     });
 
-    describe("With parentIdentifier", () => {
-      it("should check write permission on parent when parentIdentifier provided", async () => {
-        vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-          true,
-        );
+    describe("With parentIdentifier — assertCanWrite path", () => {
+      it("should allow creation when canWrite resolves true on parent", async () => {
+        vi.mocked(mockAuthorizationService.canWrite!).mockResolvedValue(true);
         const ctx = createContext({ userAddress: "0xpermitted" });
 
         const result = await callCreateDocument(ctx, "New Doc", "drive-1");
 
         expect(result).toMatchObject({ id: "doc-123" });
-        expect(mockDocumentPermissionService.canWrite).toHaveBeenCalledWith(
+        expect(mockAuthorizationService.canWrite).toHaveBeenCalledWith(
           "drive-1",
           "0xpermitted",
           expect.any(Function),
         );
       });
 
-      it("should deny creation when user cannot write to parent", async () => {
-        vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-          false,
-        );
+      it("should deny creation when canWrite resolves false on parent", async () => {
+        vi.mocked(mockAuthorizationService.canWrite!).mockResolvedValue(false);
         const ctx = createContext({ userAddress: "0xunpermitted" });
 
         await expect(
@@ -514,19 +641,10 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       });
     });
 
-    describe("Without parentIdentifier", () => {
-      it("should deny when user lacks global admin access", async () => {
-        const ctx = createContext({ userAddress: "0xnoglobal" });
-
-        await expect(callCreateDocument(ctx, "New Doc")).rejects.toThrow(
-          "Forbidden: insufficient permissions to create documents",
-        );
-      });
-    });
-
     describe("reactorClient integration", () => {
       it("should use reactorClient.createEmpty with parentIdentifier", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+        vi.mocked(mockAuthorizationService.canWrite!).mockResolvedValue(true);
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         await callCreateDocument(ctx, "New Doc", "drive-1");
 
@@ -536,8 +654,12 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         );
       });
 
-      it("should use reactorClient.execute to set name", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+      it("should use reactorClient.execute to set name when name differs from created doc", async () => {
+        // mockDocument.header.name = "Test Document"; passing "New Doc" triggers SET_NAME
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
+          true,
+        );
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         await callCreateDocument(ctx, "New Doc");
 
@@ -548,8 +670,26 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         );
       });
 
+      it("should not call execute if name matches created document name", async () => {
+        // Make createEmpty return a doc whose name already matches
+        const namedDoc = createMockDocument("doc-123", "Same Name");
+        mockReactorClient.createEmpty = vi.fn().mockResolvedValue(namedDoc);
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
+          true,
+        );
+        const ctx = createContext({ userAddress: "0xadmin" });
+
+        await callCreateDocument(ctx, "Same Name");
+
+        expect(mockReactorClient.createEmpty).toHaveBeenCalled();
+        expect(mockReactorClient.execute).not.toHaveBeenCalled();
+      });
+
       it("should not call execute if name is empty", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
+          true,
+        );
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         await callCreateDocument(ctx, "");
 
@@ -558,6 +698,11 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       });
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Mutation: operations (setName, setValue, restrictedOp, etc.)
+  // They all go through assertCanExecuteOperation → canMutate
+  // ---------------------------------------------------------------------------
 
   describe("Mutation: operations (setName, setValue, etc.)", () => {
     const callMutation = async (
@@ -570,101 +715,58 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       return await mutation(null, { docId, input }, ctx);
     };
 
-    describe("Write Permission Check", () => {
-      it("should check write permission before executing operation", async () => {
-        vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-          true,
-        );
+    describe("canMutate delegation", () => {
+      it("should delegate to canMutate and allow when it resolves true", async () => {
+        vi.mocked(mockAuthorizationService.canMutate!).mockResolvedValue(true);
         const ctx = createContext({ userAddress: "0xpermitted" });
 
-        await callMutation(ctx, "setName", "doc-123", { name: "New Name" });
+        const result = await callMutation(ctx, "setName", "doc-123", {
+          name: "New Name",
+        });
 
-        expect(mockDocumentPermissionService.canWrite).toHaveBeenCalledWith(
+        expect(result).toMatchObject({
+          id: "doc-123",
+          revisionsList: expect.arrayContaining([
+            expect.objectContaining({ scope: "global", revision: 2 }),
+          ]) as unknown[],
+        });
+        expect(mockAuthorizationService.canMutate).toHaveBeenCalledWith(
           "doc-123",
+          "SET_NAME",
           "0xpermitted",
           expect.any(Function),
         );
       });
 
-      it("should deny operation when user cannot write", async () => {
-        vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-          false,
-        );
+      it("should deny operation when canMutate resolves false", async () => {
+        vi.mocked(mockAuthorizationService.canMutate!).mockResolvedValue(false);
         const ctx = createContext({ userAddress: "0xunpermitted" });
 
         await expect(
           callMutation(ctx, "setName", "doc-123", { name: "New Name" }),
-        ).rejects.toThrow("Forbidden: insufficient permissions to write");
+        ).rejects.toThrow("Forbidden");
       });
 
-      it("should allow operation for global admin without permission check", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+      it("should deny operation for unauthenticated user when canMutate resolves false", async () => {
+        vi.mocked(mockAuthorizationService.canMutate!).mockResolvedValue(false);
+        const ctx = createContext({});
 
-        const result = await callMutation(ctx, "setName", "doc-123", {
-          name: "New Name",
-        });
-
-        expect(result).toMatchObject({
-          id: "doc-123",
-          revisionsList: expect.arrayContaining([
-            expect.objectContaining({ scope: "global", revision: 2 }),
-          ]) as unknown[],
-        });
-        expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
-      });
-    });
-
-    describe("Operation-Level Permission Check", () => {
-      it("should check operation restriction after write permission", async () => {
-        vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-          true,
-        );
-        vi.mocked(
-          mockDocumentPermissionService.isOperationRestricted!,
-        ).mockResolvedValue(false);
-        const ctx = createContext({ userAddress: "0xpermitted" });
-
-        await callMutation(ctx, "setName", "doc-123", { name: "New Name" });
-
-        expect(
-          mockDocumentPermissionService.isOperationRestricted,
-        ).toHaveBeenCalledWith("doc-123", "SET_NAME");
+        await expect(
+          callMutation(ctx, "setName", "doc-123", { name: "New Name" }),
+        ).rejects.toThrow("Forbidden");
       });
 
-      it("should allow operation when not restricted", async () => {
-        vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-          true,
-        );
-        vi.mocked(
-          mockDocumentPermissionService.isOperationRestricted!,
-        ).mockResolvedValue(false);
-        const ctx = createContext({ userAddress: "0xpermitted" });
+      it("should deny restricted operation when canMutate resolves false", async () => {
+        vi.mocked(mockAuthorizationService.canMutate!).mockResolvedValue(false);
+        const ctx = createContext({ userAddress: "0xunauthorized" });
 
-        const result = await callMutation(ctx, "setName", "doc-123", {
-          name: "New Name",
-        });
-
-        expect(result).toMatchObject({
-          id: "doc-123",
-          revisionsList: expect.arrayContaining([
-            expect.objectContaining({ scope: "global", revision: 2 }),
-          ]) as unknown[],
-        });
-        expect(
-          mockDocumentPermissionService.canExecuteOperation,
-        ).not.toHaveBeenCalled();
+        await expect(
+          callMutation(ctx, "restrictedOp", "doc-123", { value: 42 }),
+        ).rejects.toThrow("Forbidden");
       });
 
-      it("should check operation permission when operation is restricted", async () => {
-        vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-          true,
-        );
-        vi.mocked(
-          mockDocumentPermissionService.isOperationRestricted!,
-        ).mockResolvedValue(true);
-        vi.mocked(
-          mockDocumentPermissionService.canExecuteOperation!,
-        ).mockResolvedValue(true);
+      it("should allow restricted operation when canMutate resolves true", async () => {
+        vi.mocked(mockAuthorizationService.canMutate!).mockResolvedValue(true);
         const ctx = createContext({ userAddress: "0xauthorized" });
 
         const result = await callMutation(ctx, "restrictedOp", "doc-123", {
@@ -677,49 +779,32 @@ describe("DocumentModelSubgraph Permission Checks", () => {
             expect.objectContaining({ scope: "global", revision: 2 }),
           ]) as unknown[],
         });
-        expect(
-          mockDocumentPermissionService.canExecuteOperation,
-        ).toHaveBeenCalledWith("doc-123", "RESTRICTED_OP", "0xauthorized");
-      });
-
-      it("should deny operation when user lacks operation permission", async () => {
-        vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-          true,
-        );
-        vi.mocked(
-          mockDocumentPermissionService.isOperationRestricted!,
-        ).mockResolvedValue(true);
-        vi.mocked(
-          mockDocumentPermissionService.canExecuteOperation!,
-        ).mockResolvedValue(false);
-        const ctx = createContext({ userAddress: "0xunauthorized" });
-
-        await expect(
-          callMutation(ctx, "restrictedOp", "doc-123", { value: 42 }),
-        ).rejects.toThrow(
-          'Forbidden: insufficient permissions to execute operation "RESTRICTED_OP"',
+        expect(mockAuthorizationService.canMutate).toHaveBeenCalledWith(
+          "doc-123",
+          "RESTRICTED_OP",
+          "0xauthorized",
+          expect.any(Function),
         );
       });
 
-      it("should skip operation restriction check for global admin", async () => {
-        vi.mocked(
-          mockDocumentPermissionService.isOperationRestricted!,
-        ).mockResolvedValue(true);
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+      it("should pass correct operation type name to canMutate", async () => {
+        vi.mocked(mockAuthorizationService.canMutate!).mockResolvedValue(true);
+        const ctx = createContext({ userAddress: "0xuser" });
 
-        await callMutation(ctx, "restrictedOp", "doc-123", { value: 42 });
+        await callMutation(ctx, "setValue", "doc-123", { value: 42 });
 
-        expect(
-          mockDocumentPermissionService.isOperationRestricted,
-        ).not.toHaveBeenCalled();
+        expect(mockAuthorizationService.canMutate).toHaveBeenCalledWith(
+          "doc-123",
+          "SET_VALUE",
+          "0xuser",
+          expect.any(Function),
+        );
       });
     });
 
     describe("Document type validation", () => {
       it("should throw error when document type does not match", async () => {
-        vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-          true,
-        );
+        vi.mocked(mockAuthorizationService.canMutate!).mockResolvedValue(true);
         const wrongTypeDoc = {
           ...mockDocument,
           header: { ...mockDocument.header, documentType: "other/type" },
@@ -735,7 +820,8 @@ describe("DocumentModelSubgraph Permission Checks", () => {
 
     describe("reactorClient integration", () => {
       it("should use reactorClient.get to verify document", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+        vi.mocked(mockAuthorizationService.canMutate!).mockResolvedValue(true);
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         await callMutation(ctx, "setName", "doc-123", { name: "New Name" });
 
@@ -743,7 +829,8 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       });
 
       it("should use reactorClient.execute to apply action", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+        vi.mocked(mockAuthorizationService.canMutate!).mockResolvedValue(true);
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         await callMutation(ctx, "setName", "doc-123", { name: "New Name" });
 
@@ -759,7 +846,8 @@ describe("DocumentModelSubgraph Permission Checks", () => {
           ...mockDocument,
           header: { ...mockDocument.header, revision: { global: 42 } },
         });
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+        vi.mocked(mockAuthorizationService.canMutate!).mockResolvedValue(true);
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         const result = await callMutation(ctx, "setName", "doc-123", {
           name: "New Name",
@@ -777,7 +865,8 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         mockReactorClient.execute = vi
           .fn()
           .mockRejectedValue(new Error("Execute failed"));
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+        vi.mocked(mockAuthorizationService.canMutate!).mockResolvedValue(true);
+        const ctx = createContext({ userAddress: "0xadmin" });
 
         await expect(
           callMutation(ctx, "setName", "doc-123", { name: "New Name" }),
@@ -786,87 +875,58 @@ describe("DocumentModelSubgraph Permission Checks", () => {
     });
   });
 
-  describe("AUTH_ENABLED=false behavior", () => {
-    it("should allow all read access when admin role returns true", async () => {
-      const ctx = createContext({ isAdmin: true, userAddress: "0xanyone" });
+  // ---------------------------------------------------------------------------
+  // OPEN policy — replaces deleted "AUTH_ENABLED=false" and "No Permission
+  // Service" describe blocks. With OPEN policy isSupremeAdmin always returns
+  // true and all canX return true, so everyone (incl. unauthenticated) can
+  // read, write, and mutate.
+  // ---------------------------------------------------------------------------
 
-      const queryResolver = subgraph.queryResolvers.document;
-      const result = await queryResolver(null, { identifier: "doc-123" }, ctx);
-
-      expect(result).toBeDefined();
-      expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-    });
-
-    it("should allow all write access when admin role returns true", async () => {
-      const ctx = createContext({ isAdmin: true, userAddress: "0xanyone" });
-
-      const result = await subgraph.mutationResolvers.setName(
-        null,
-        { docId: "doc-123", input: { name: "New" } },
-        ctx,
-      );
-
-      expect(result).toMatchObject({
-        id: "doc-123",
-        revisionsList: expect.arrayContaining([
-          expect.objectContaining({ scope: "global", revision: 2 }),
-        ]) as unknown[],
-      });
-      expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("No Permission Service", () => {
-    let subgraphWithoutPermService: DocumentModelSubgraph;
+  describe("OPEN policy behavior (auth disabled equivalent)", () => {
+    let openSubgraph: DocumentModelSubgraph;
 
     beforeEach(() => {
-      subgraphWithoutPermService = new DocumentModelSubgraph(
+      const openAuth: Partial<IAuthorizationService> = {
+        config: {
+          admins: [],
+          defaultProtection: false,
+          policy: AuthorizationPolicy.OPEN,
+        },
+        isSupremeAdmin: vi.fn().mockReturnValue(true),
+        canRead: vi.fn().mockResolvedValue(true),
+        canWrite: vi.fn().mockResolvedValue(true),
+        canManage: vi.fn().mockResolvedValue(true),
+        canExecuteOperation: vi.fn().mockResolvedValue(true),
+        canMutate: vi.fn().mockResolvedValue(true),
+      };
+      openSubgraph = new DocumentModelSubgraph(
         mockDocumentModel,
-        {
-          reactorClient: mockReactorClient as IReactorClient,
-          documentPermissionService: undefined,
-          relationalDb: {} as SubgraphArgs["relationalDb"],
-          analyticsStore: {} as SubgraphArgs["analyticsStore"],
-          graphqlManager: {} as SubgraphArgs["graphqlManager"],
-          syncManager: {} as SubgraphArgs["syncManager"],
-        } as SubgraphArgs,
+        buildSubgraphArgs(openAuth),
       );
     });
 
-    it("should deny read access when no permission service and no global access", async () => {
-      const ctx = createContext({ userAddress: "0xuser" });
-      const queryResolver = subgraphWithoutPermService.queryResolvers.document;
+    it("should allow read access for any user (incl. unauthenticated)", async () => {
+      const ctx = createContext({});
 
-      await expect(
-        queryResolver(null, { identifier: "doc-123" }, ctx),
-      ).rejects.toThrow("Forbidden");
-    });
-
-    it("should deny write access when no permission service and no global access", async () => {
-      const ctx = createContext({ userAddress: "0xuser" });
-
-      await expect(
-        subgraphWithoutPermService.mutationResolvers.setName(
-          null,
-          { docId: "doc-123", input: { name: "New" } },
-          ctx,
-        ),
-      ).rejects.toThrow("Forbidden");
-    });
-
-    it("should allow access with global roles even without permission service", async () => {
-      const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
-      const queryResolver = subgraphWithoutPermService.queryResolvers.document;
-
+      const queryResolver = openSubgraph.queryResolvers.document;
       const result = await queryResolver(null, { identifier: "doc-123" }, ctx);
 
       expect(result).toBeDefined();
     });
 
-    it("should skip operation restriction check when no permission service", async () => {
-      const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+    it("should allow read access for authenticated user", async () => {
+      const ctx = createContext({ userAddress: "0xanyone" });
 
-      const result = await subgraphWithoutPermService.mutationResolvers.setName(
+      const queryResolver = openSubgraph.queryResolvers.document;
+      const result = await queryResolver(null, { identifier: "doc-123" }, ctx);
+
+      expect(result).toBeDefined();
+    });
+
+    it("should allow write/mutation for any user (incl. unauthenticated)", async () => {
+      const ctx = createContext({});
+
+      const result = await openSubgraph.mutationResolvers.setName(
         null,
         { docId: "doc-123", input: { name: "New" } },
         ctx,
@@ -879,14 +939,40 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         ]) as unknown[],
       });
     });
+
+    it("should return all documents without per-item filtering (isSupremeAdmin=true)", async () => {
+      const ctx = createContext({});
+
+      const queryResolver = openSubgraph.queryResolvers.documents;
+      const result = await queryResolver(null, { paging: { limit: 10 } }, ctx);
+
+      expect(result.items).toHaveLength(1);
+    });
+
+    it("should allow createDocument without user (OPEN policy)", async () => {
+      const ctx = createContext({});
+
+      const result = await openSubgraph.mutationResolvers.createDocument(
+        null,
+        { name: "OpenDoc" },
+        ctx,
+      );
+
+      expect(result).toMatchObject({ id: "doc-123" });
+    });
   });
 
+  // ---------------------------------------------------------------------------
+  // Edge Cases
+  // ---------------------------------------------------------------------------
+
   describe("Edge Cases", () => {
-    it("should handle empty user address in context", async () => {
+    it("should handle empty user address in context (canRead called with empty string)", async () => {
       const ctx = {
         user: { address: "" },
-        isAdmin: vi.fn().mockReturnValue(false),
       } as unknown as Context;
+
+      vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(false);
 
       const queryResolver = subgraph.queryResolvers.document;
 
@@ -894,30 +980,11 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         queryResolver(null, { identifier: "doc-123" }, ctx),
       ).rejects.toThrow("Forbidden");
 
-      expect(ctx.isAdmin).toHaveBeenCalledWith("");
-    });
-
-    it("should pass correct operation type name to permission check", async () => {
-      vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-        true,
+      expect(mockAuthorizationService.canRead).toHaveBeenCalledWith(
+        "doc-123",
+        "",
+        expect.any(Function),
       );
-      vi.mocked(
-        mockDocumentPermissionService.isOperationRestricted!,
-      ).mockResolvedValue(true);
-      vi.mocked(
-        mockDocumentPermissionService.canExecuteOperation!,
-      ).mockResolvedValue(true);
-      const ctx = createContext({ userAddress: "0xuser" });
-
-      await subgraph.mutationResolvers.setValue(
-        null,
-        { docId: "doc-123", input: { value: 42 } },
-        ctx,
-      );
-
-      expect(
-        mockDocumentPermissionService.isOperationRestricted,
-      ).toHaveBeenCalledWith("doc-123", "SET_VALUE");
     });
   });
 });

--- a/packages/reactor-api/test/document-model-subgraph-permissions.test.ts
+++ b/packages/reactor-api/test/document-model-subgraph-permissions.test.ts
@@ -116,7 +116,6 @@ describe("DocumentModelSubgraph Permission Checks", () => {
       canRead: vi.fn().mockResolvedValue(false),
       canWrite: vi.fn().mockResolvedValue(false),
       canManage: vi.fn().mockResolvedValue(false),
-      canExecuteOperation: vi.fn().mockResolvedValue(false),
       canMutate: vi.fn().mockResolvedValue(false),
     };
 
@@ -896,7 +895,6 @@ describe("DocumentModelSubgraph Permission Checks", () => {
         canRead: vi.fn().mockResolvedValue(true),
         canWrite: vi.fn().mockResolvedValue(true),
         canManage: vi.fn().mockResolvedValue(true),
-        canExecuteOperation: vi.fn().mockResolvedValue(true),
         canMutate: vi.fn().mockResolvedValue(true),
       };
       openSubgraph = new DocumentModelSubgraph(

--- a/packages/reactor-api/test/graphql-manager.test.ts
+++ b/packages/reactor-api/test/graphql-manager.test.ts
@@ -30,7 +30,7 @@ import type {
 import { GraphQLManager } from "../src/graphql/graphql-manager.js";
 import {
   AuthorizationPolicy,
-  AuthorizationService,
+  createAuthorizationService,
 } from "../src/services/authorization.service.js";
 import type { Context } from "../src/graphql/types.js";
 import type { AuthContext, AuthService } from "../src/services/auth.service.js";
@@ -167,7 +167,7 @@ function makeHarness(options: HarnessOptions = {}) {
         options.enableDocumentModelSubgraphs ?? false,
     },
     4001,
-    new AuthorizationService(undefined, {
+    createAuthorizationService({
       admins: [],
       defaultProtection: false,
       policy: AuthorizationPolicy.OPEN,

--- a/packages/reactor-api/test/graphql-manager.test.ts
+++ b/packages/reactor-api/test/graphql-manager.test.ts
@@ -28,6 +28,10 @@ import type {
   WsDisposer,
 } from "../src/graphql/gateway/types.js";
 import { GraphQLManager } from "../src/graphql/graphql-manager.js";
+import {
+  AuthorizationPolicy,
+  AuthorizationService,
+} from "../src/services/authorization.service.js";
 import type { Context } from "../src/graphql/types.js";
 import type { AuthContext, AuthService } from "../src/services/auth.service.js";
 
@@ -163,7 +167,11 @@ function makeHarness(options: HarnessOptions = {}) {
         options.enableDocumentModelSubgraphs ?? false,
     },
     4001,
-    undefined, // authorizationService
+    new AuthorizationService(undefined, {
+      admins: [],
+      defaultProtection: false,
+      policy: AuthorizationPolicy.OPEN,
+    }),
   );
 
   return {

--- a/packages/reactor-api/test/graphql-manager.test.ts
+++ b/packages/reactor-api/test/graphql-manager.test.ts
@@ -423,17 +423,6 @@ describe("GraphQLManager", () => {
       expect(ctx["customField"]).toBe("custom-value");
     });
 
-    it("isAdmin always returns true when no AuthContext is present (auth disabled)", async () => {
-      const { manager, gatewayAdapter } = makeHarness();
-      await initAndFlush(manager);
-
-      const [, , contextFactory] =
-        gatewayAdapter.createSupergraphHandler.mock.calls[0];
-      const ctx = await contextFactory(new Request("http://localhost/graphql"));
-
-      expect(ctx.isAdmin("0xanyone")).toBe(true);
-    });
-
     it("populates user from the WeakMap AuthContext when present", async () => {
       const { manager, gatewayAdapter } = makeHarness();
       await initAndFlush(manager);
@@ -462,61 +451,11 @@ describe("GraphQLManager", () => {
       });
     });
 
-    it("isAdmin checks the admins list from the AuthContext when auth_enabled=true", async () => {
-      const { manager, gatewayAdapter } = makeHarness();
-      await initAndFlush(manager);
-
-      const [, , contextFactory] =
-        gatewayAdapter.createSupergraphHandler.mock.calls[0];
-
-      const req = new Request("http://localhost/graphql");
-      const mockService = {
-        authenticateRequest: vi.fn().mockResolvedValue({
-          user: undefined,
-          admins: ["0xadmin"],
-          auth_enabled: true,
-        } satisfies AuthContext),
-      } as unknown as AuthService;
-      await createAuthFetchMiddleware(mockService)(() =>
-        Promise.resolve(new Response("ok")),
-      )(req);
-
-      const ctx = await contextFactory(req);
-
-      expect(ctx.isAdmin("0xadmin")).toBe(true);
-      expect(ctx.isAdmin("0xnotadmin")).toBe(false);
-    });
-
-    it("isAdmin always returns true when auth_enabled=false in the AuthContext", async () => {
-      const { manager, gatewayAdapter } = makeHarness();
-      await initAndFlush(manager);
-
-      const [, , contextFactory] =
-        gatewayAdapter.createSupergraphHandler.mock.calls[0];
-
-      const req = new Request("http://localhost/graphql");
-      const mockService = {
-        authenticateRequest: vi.fn().mockResolvedValue({
-          user: undefined,
-          admins: [],
-          auth_enabled: false,
-        } satisfies AuthContext),
-      } as unknown as AuthService;
-      await createAuthFetchMiddleware(mockService)(() =>
-        Promise.resolve(new Response("ok")),
-      )(req);
-
-      const ctx = await contextFactory(req);
-
-      expect(ctx.isAdmin("0xanyone")).toBe(true);
-    });
-
-    it("auth fields (user, isAdmin) win over additionalContextFields with the same key", async () => {
+    it("auth-derived user wins over additionalContextFields with the same key", async () => {
       const { manager, gatewayAdapter } = makeHarness();
       // Deliberately set conflicting keys via setAdditionalContextFields
       manager.setAdditionalContextFields({
         user: { address: "0xoverridden" },
-        isAdmin: () => false,
       });
       await initAndFlush(manager);
 
@@ -544,8 +483,6 @@ describe("GraphQLManager", () => {
 
       // The auth-derived user should win over the one set via setAdditionalContextFields
       expect(ctx.user).toEqual(expectedUser);
-      // The auth-derived isAdmin should win too
-      expect(ctx.isAdmin("0xadmin")).toBe(true);
     });
   });
 

--- a/packages/reactor-api/test/permissions-integration.test.ts
+++ b/packages/reactor-api/test/permissions-integration.test.ts
@@ -7,7 +7,7 @@ import type { SubgraphArgs } from "../src/graphql/types.js";
 import { runMigrations } from "../src/migrations/index.js";
 import {
   AuthorizationPolicy,
-  AuthorizationService,
+  createAuthorizationService,
 } from "../src/services/authorization.service.js";
 import { DocumentPermissionService } from "../src/services/document-permission.service.js";
 import type { DocumentPermissionDatabase } from "../src/utils/db.js";
@@ -70,13 +70,13 @@ describe("Permissions Integration Tests", () => {
     db = dbClient as Kysely<DocumentPermissionDatabase>;
     await runMigrations(db as Kysely<unknown>);
     documentPermissionService = new DocumentPermissionService(db);
-    const authorizationService = new AuthorizationService(
-      documentPermissionService,
+    const authorizationService = createAuthorizationService(
       {
         admins: ["0xadmin"],
         defaultProtection: false,
         policy: AuthorizationPolicy.DOCUMENT_PERMISSIONS,
       },
+      documentPermissionService,
     );
     // These tests exercise grant enforcement, which only applies to protected
     // documents; unprotected documents are open under the authorization model.

--- a/packages/reactor-api/test/permissions-integration.test.ts
+++ b/packages/reactor-api/test/permissions-integration.test.ts
@@ -5,6 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ReactorSubgraph } from "../src/graphql/reactor/subgraph.js";
 import type { SubgraphArgs } from "../src/graphql/types.js";
 import { runMigrations } from "../src/migrations/index.js";
+import {
+  AuthorizationPolicy,
+  AuthorizationService,
+} from "../src/services/authorization.service.js";
 import { DocumentPermissionService } from "../src/services/document-permission.service.js";
 import type { DocumentPermissionDatabase } from "../src/utils/db.js";
 import { getDbClient } from "../src/utils/db.js";
@@ -70,6 +74,19 @@ describe("Permissions Integration Tests", () => {
     db = dbClient as Kysely<DocumentPermissionDatabase>;
     await runMigrations(db as Kysely<unknown>);
     documentPermissionService = new DocumentPermissionService(db);
+    const authorizationService = new AuthorizationService(
+      documentPermissionService,
+      {
+        admins: ["0xadmin"],
+        defaultProtection: false,
+        policy: AuthorizationPolicy.DOCUMENT_PERMISSIONS,
+      },
+    );
+    // These tests exercise grant enforcement, which only applies to protected
+    // documents; unprotected documents are open under the authorization model.
+    await documentPermissionService.setDocumentProtection("doc-123", true);
+    await documentPermissionService.setDocumentProtection("child-doc", true);
+    await documentPermissionService.setDocumentProtection("parent-doc", true);
 
     // Create mock ReactorClient with parent hierarchy
     mockReactorClient = {
@@ -124,6 +141,7 @@ describe("Permissions Integration Tests", () => {
     reactorSubgraph = new ReactorSubgraph({
       reactorClient: mockReactorClient as IReactorClient,
       documentPermissionService,
+      authorizationService,
       relationalDb: {} as any,
       analyticsStore: {} as any,
       graphqlManager: {
@@ -462,7 +480,7 @@ describe("Permissions Integration Tests", () => {
       );
     };
 
-    beforeEach(() => {
+    beforeEach(async () => {
       // Setup find to return multiple documents
       const doc1 = createMockDocument("doc-1", "Doc 1");
       const doc2 = createMockDocument("doc-2", "Doc 2");
@@ -472,6 +490,10 @@ describe("Permissions Integration Tests", () => {
         results: [doc1, doc2, doc3],
         options: { limit: 10 },
       } as PagedResults<PHDocument>);
+
+      await documentPermissionService.setDocumentProtection("doc-1", true);
+      await documentPermissionService.setDocumentProtection("doc-2", true);
+      await documentPermissionService.setDocumentProtection("doc-3", true);
     });
 
     it("should filter results based on user permissions", async () => {

--- a/packages/reactor-api/test/permissions-integration.test.ts
+++ b/packages/reactor-api/test/permissions-integration.test.ts
@@ -58,12 +58,8 @@ describe("Permissions Integration Tests", () => {
   );
 
   // Context factory
-  const createContext = (options: {
-    isAdmin?: boolean;
-    userAddress?: string;
-  }) => ({
+  const createContext = (options: { userAddress?: string }) => ({
     user: options.userAddress ? { address: options.userAddress } : undefined,
-    isAdmin: () => options.isAdmin ?? false,
   });
 
   beforeEach(async () => {
@@ -554,7 +550,7 @@ describe("Permissions Integration Tests", () => {
 
     it("should allow admin access without document permission", async () => {
       // No document permission granted
-      const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+      const ctx = createContext({ userAddress: "0xadmin" });
 
       const result = await callDocument(ctx);
 
@@ -571,7 +567,7 @@ describe("Permissions Integration Tests", () => {
       );
 
       // This user has global admin but no document permission
-      const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+      const ctx = createContext({ userAddress: "0xadmin" });
 
       const result = await callDocument(ctx);
 

--- a/packages/reactor-api/test/reactor-subgraph-permissions.test.ts
+++ b/packages/reactor-api/test/reactor-subgraph-permissions.test.ts
@@ -3,10 +3,13 @@ import type { PHDocument } from "@powerhousedao/shared/document-model";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ReactorSubgraph } from "../src/graphql/reactor/subgraph.js";
 import type { SubgraphArgs } from "../src/graphql/types.js";
-import type { DocumentPermissionService } from "../src/services/document-permission.service.js";
+import {
+  AuthorizationPolicy,
+  type IAuthorizationService,
+} from "../src/services/authorization.service.js";
 
 describe("ReactorSubgraph Permission Checks", () => {
-  let mockDocumentPermissionService: Partial<DocumentPermissionService>;
+  let mockAuthorizationService: Partial<IAuthorizationService>;
   let mockReactorClient: Partial<IReactorClient>;
   let reactorSubgraph: ReactorSubgraph;
 
@@ -43,28 +46,51 @@ describe("ReactorSubgraph Permission Checks", () => {
     "Parent Document",
   );
 
-  // Helper to create context with different permission levels
-  const createContext = (options: {
-    isAdmin?: boolean;
-    userAddress?: string;
-  }) => ({
+  // Helper to create context with different user states
+  const createContext = (options: { userAddress?: string }) => ({
     user: options.userAddress ? { address: options.userAddress } : undefined,
-    isAdmin: () => options.isAdmin ?? false,
+    headers: {},
+    db: {},
   });
+
+  const buildSubgraph = (
+    authSvc: Partial<IAuthorizationService>,
+  ): ReactorSubgraph =>
+    new ReactorSubgraph({
+      reactorClient: mockReactorClient as IReactorClient,
+      authorizationService: authSvc as IAuthorizationService,
+      relationalDb: {} as any,
+      analyticsStore: {} as any,
+      graphqlManager: {
+        driveOwnershipCache: {
+          has: () => false,
+          add: () => undefined,
+          remove: () => undefined,
+          size: () => 0,
+        },
+      } as any,
+      syncManager: {} as any,
+    } as SubgraphArgs);
 
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Create mock DocumentPermissionService
-    mockDocumentPermissionService = {
-      canReadDocument: vi.fn().mockResolvedValue(false),
-      canWriteDocument: vi.fn().mockResolvedValue(false),
+    // Default mock: DOCUMENT_PERMISSIONS policy, non-admin, all decisions false
+    mockAuthorizationService = {
+      config: {
+        admins: [],
+        defaultProtection: false,
+        policy: AuthorizationPolicy.DOCUMENT_PERMISSIONS,
+      },
+      isSupremeAdmin: vi.fn().mockReturnValue(false),
       canRead: vi.fn().mockResolvedValue(false),
       canWrite: vi.fn().mockResolvedValue(false),
+      canManage: vi.fn().mockResolvedValue(false),
+      canMutate: vi.fn().mockResolvedValue(false),
+      canExecuteOperation: vi.fn().mockResolvedValue(false),
     };
 
     // Create mock ReactorClient
-    // Note: get() returns PHDocument directly
     mockReactorClient = {
       get: vi.fn().mockResolvedValue(mockDocument),
       getOutgoingRelationships: vi.fn().mockResolvedValue({
@@ -100,65 +126,45 @@ describe("ReactorSubgraph Permission Checks", () => {
       subscribe: vi.fn(),
     };
 
-    reactorSubgraph = new ReactorSubgraph({
-      reactorClient: mockReactorClient as IReactorClient,
-      documentPermissionService:
-        mockDocumentPermissionService as DocumentPermissionService,
-      relationalDb: {} as any,
-      analyticsStore: {} as any,
-      graphqlManager: {
-        driveOwnershipCache: {
-          has: () => false,
-          add: () => undefined,
-          remove: () => undefined,
-          size: () => 0,
-        },
-      } as any,
-      syncManager: {} as any,
-    } as SubgraphArgs);
+    reactorSubgraph = buildSubgraph(mockAuthorizationService);
   });
 
+  // ============================================================
+  // Query: document
+  // ============================================================
   describe("Query: document", () => {
     const callDocument = (ctx: any) => {
       const query = (reactorSubgraph.resolvers.Query as any)?.document;
       return query(null, { identifier: "doc-123" }, ctx);
     };
 
-    describe("Global Role Access", () => {
-      it("should allow access when user is global admin", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+    it("should allow access when authorizationService.canRead resolves true", async () => {
+      vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(true);
+      const ctx = createContext({ userAddress: "0xpermitted" });
 
-        const result = await callDocument(ctx);
+      const result = await callDocument(ctx);
 
-        expect(result).toBeDefined();
-        expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-      });
+      expect(result).toBeDefined();
+      expect(mockAuthorizationService.canRead).toHaveBeenCalled();
     });
 
-    describe("Document Permission Access", () => {
-      it("should allow access when user has document read permission", async () => {
-        vi.mocked(mockDocumentPermissionService.canRead!).mockResolvedValue(
-          true,
-        );
-        const ctx = createContext({ userAddress: "0xpermitted" });
+    it("should deny access when authorizationService.canRead resolves false", async () => {
+      vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(false);
+      const ctx = createContext({ userAddress: "0xunpermitted" });
 
-        const result = await callDocument(ctx);
+      await expect(callDocument(ctx)).rejects.toThrow("Forbidden");
+    });
 
-        expect(result).toBeDefined();
-        expect(mockDocumentPermissionService.canRead).toHaveBeenCalled();
-      });
+    it("should deny access when no user is set (unauthenticated)", async () => {
+      const ctx = createContext({});
 
-      it("should deny access when user has no permissions", async () => {
-        vi.mocked(mockDocumentPermissionService.canRead!).mockResolvedValue(
-          false,
-        );
-        const ctx = createContext({ userAddress: "0xunpermitted" });
-
-        await expect(callDocument(ctx)).rejects.toThrow("Forbidden");
-      });
+      await expect(callDocument(ctx)).rejects.toThrow("Forbidden");
     });
   });
 
+  // ============================================================
+  // Query: documentOutgoingRelationships
+  // ============================================================
   describe("Query: documentOutgoingRelationships", () => {
     const callDocumentOutgoingRelationships = (ctx: any) => {
       const query = (reactorSubgraph.resolvers.Query as any)
@@ -170,27 +176,18 @@ describe("ReactorSubgraph Permission Checks", () => {
       );
     };
 
-    it("should allow access when user is global admin", async () => {
-      const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+    it("should allow access when canRead resolves true", async () => {
+      vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(true);
+      const ctx = createContext({ userAddress: "0xpermitted" });
 
       const result = await callDocumentOutgoingRelationships(ctx);
 
       expect(result).toBeDefined();
+      expect(mockAuthorizationService.canRead).toHaveBeenCalled();
     });
 
-    it("should check permission on source document", async () => {
-      vi.mocked(mockDocumentPermissionService.canRead!).mockResolvedValue(true);
-      const ctx = createContext({ userAddress: "0xpermitted" });
-
-      await callDocumentOutgoingRelationships(ctx);
-
-      expect(mockDocumentPermissionService.canRead).toHaveBeenCalled();
-    });
-
-    it("should deny access when user cannot read source", async () => {
-      vi.mocked(mockDocumentPermissionService.canRead!).mockResolvedValue(
-        false,
-      );
+    it("should deny access when canRead resolves false", async () => {
+      vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(false);
       const ctx = createContext({ userAddress: "0xunpermitted" });
 
       await expect(callDocumentOutgoingRelationships(ctx)).rejects.toThrow(
@@ -199,45 +196,55 @@ describe("ReactorSubgraph Permission Checks", () => {
     });
   });
 
+  // ============================================================
+  // Query: findDocuments — list-filter behavior
+  // ============================================================
   describe("Query: findDocuments", () => {
     const callFindDocuments = (ctx: any) => {
       const query = (reactorSubgraph.resolvers.Query as any)?.findDocuments;
       return query(null, { search: { type: "test/document" } }, ctx);
     };
 
-    it("should return all results for global admin", async () => {
-      const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+    it("should return all results without calling canRead when isSupremeAdmin is true", async () => {
+      vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(true);
+      const ctx = createContext({ userAddress: "0xadmin" });
 
       const result = await callFindDocuments(ctx);
 
       expect(result.items).toHaveLength(1);
-      expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
+      expect(mockAuthorizationService.canRead).not.toHaveBeenCalled();
     });
 
-    it("should filter results based on permissions when no global access", async () => {
-      // First document: user has permission
-      // Setup: canRead returns true for first call
-      vi.mocked(mockDocumentPermissionService.canRead!).mockResolvedValue(true);
+    it("should filter results through canRead when isSupremeAdmin is false and canRead resolves true", async () => {
+      vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
+        false,
+      );
+      vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(true);
       const ctx = createContext({ userAddress: "0xpermitted" });
 
       const result = await callFindDocuments(ctx);
 
       expect(result.items).toHaveLength(1);
-      expect(mockDocumentPermissionService.canRead).toHaveBeenCalled();
+      expect(mockAuthorizationService.canRead).toHaveBeenCalled();
     });
 
-    it("should return empty results when user has no permissions", async () => {
-      vi.mocked(mockDocumentPermissionService.canRead!).mockResolvedValue(
+    it("should return empty results when isSupremeAdmin is false and canRead resolves false", async () => {
+      vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
         false,
       );
+      vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(false);
       const ctx = createContext({ userAddress: "0xunpermitted" });
 
       const result = await callFindDocuments(ctx);
 
       expect(result.items).toHaveLength(0);
+      expect(mockAuthorizationService.canRead).toHaveBeenCalled();
     });
   });
 
+  // ============================================================
+  // Mutation: createDocument
+  // ============================================================
   describe("Mutation: createDocument", () => {
     const callCreateDocument = (ctx: any, parentIdentifier?: string) => {
       const mutation = (reactorSubgraph.resolvers.Mutation as any)
@@ -252,48 +259,95 @@ describe("ReactorSubgraph Permission Checks", () => {
       );
     };
 
-    // Helper to verify permission passed (may fail later validation, but NOT due to "Forbidden")
+    // Helper: permission passed when the error (if any) is NOT "Forbidden"
     const expectPermissionPassed = async (promise: Promise<any>) => {
       try {
         await promise;
       } catch (error: any) {
-        // If we get here, make sure it's NOT a permission error
         expect(error.message).not.toContain("Forbidden");
       }
     };
 
-    describe("Without Parent", () => {
-      it("should allow when user is global admin", async () => {
-        const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+    describe("Without Parent (assertCanCreate path)", () => {
+      it("should allow when user address is set and policy is DOCUMENT_PERMISSIONS", async () => {
+        const ctx = createContext({ userAddress: "0xpermitted" });
 
-        // Permission check passes, may fail later validation
+        // policy=DOCUMENT_PERMISSIONS + address set → assertCanCreate passes
         await expectPermissionPassed(callCreateDocument(ctx));
-        expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
       });
 
-      it("should deny when no global access", async () => {
-        const ctx = createContext({ userAddress: "0xunpermitted" });
+      it("should deny when no user address and policy is DOCUMENT_PERMISSIONS", async () => {
+        const ctx = createContext({});
 
         await expect(callCreateDocument(ctx)).rejects.toThrow("Forbidden");
       });
-    });
 
-    describe("With Parent", () => {
-      it("should check write permission on parent", async () => {
-        vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-          true,
+      it("should allow for any user when policy is OPEN", async () => {
+        const openSubgraph = buildSubgraph({
+          ...mockAuthorizationService,
+          config: {
+            admins: [],
+            defaultProtection: false,
+            policy: AuthorizationPolicy.OPEN,
+          },
+        });
+        const mutation = (openSubgraph.resolvers.Mutation as any)
+          ?.createDocument;
+        const ctx = createContext({});
+
+        await expectPermissionPassed(
+          mutation(
+            null,
+            { document: { documentType: "test/document", state: {} } },
+            ctx,
+          ),
         );
-        const ctx = createContext({ userAddress: "0xpermitted" });
-
-        // Permission check passes, may fail later validation
-        await expectPermissionPassed(callCreateDocument(ctx, "parent-123"));
-        expect(mockDocumentPermissionService.canWrite).toHaveBeenCalled();
       });
 
-      it("should deny when user cannot write to parent", async () => {
-        vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-          false,
+      it("should allow when isSupremeAdmin is true (DOCUMENT_PERMISSIONS policy)", async () => {
+        vi.mocked(mockAuthorizationService.isSupremeAdmin!).mockReturnValue(
+          true,
         );
+        const ctx = createContext({});
+
+        await expectPermissionPassed(callCreateDocument(ctx));
+      });
+
+      it("should deny for non-admin when policy is ADMIN_ONLY", async () => {
+        const adminOnlySubgraph = buildSubgraph({
+          ...mockAuthorizationService,
+          config: {
+            admins: [],
+            defaultProtection: false,
+            policy: AuthorizationPolicy.ADMIN_ONLY,
+          },
+          isSupremeAdmin: vi.fn().mockReturnValue(false),
+        });
+        const mutation = (adminOnlySubgraph.resolvers.Mutation as any)
+          ?.createDocument;
+        const ctx = createContext({ userAddress: "0xunpermitted" });
+
+        await expect(
+          mutation(
+            null,
+            { document: { documentType: "test/document", state: {} } },
+            ctx,
+          ),
+        ).rejects.toThrow("Forbidden");
+      });
+    });
+
+    describe("With Parent (assertCanWrite path)", () => {
+      it("should allow when canWrite resolves true on parent", async () => {
+        vi.mocked(mockAuthorizationService.canWrite!).mockResolvedValue(true);
+        const ctx = createContext({ userAddress: "0xpermitted" });
+
+        await expectPermissionPassed(callCreateDocument(ctx, "parent-123"));
+        expect(mockAuthorizationService.canWrite).toHaveBeenCalled();
+      });
+
+      it("should deny when canWrite resolves false on parent", async () => {
+        vi.mocked(mockAuthorizationService.canWrite!).mockResolvedValue(false);
         const ctx = createContext({ userAddress: "0xunpermitted" });
 
         await expect(callCreateDocument(ctx, "parent-123")).rejects.toThrow(
@@ -303,56 +357,55 @@ describe("ReactorSubgraph Permission Checks", () => {
     });
   });
 
+  // ============================================================
+  // Mutation: mutateDocument — drives via canMutate
+  // ============================================================
   describe("Mutation: mutateDocument", () => {
-    const callMutateDocument = (ctx: any) => {
+    const callMutateDocument = (ctx: any, actions: any[] = []) => {
       const mutation = (reactorSubgraph.resolvers.Mutation as any)
         ?.mutateDocument;
-      return mutation(
-        null,
-        { documentIdentifier: "doc-123", actions: [] },
-        ctx,
-      );
+      return mutation(null, { documentIdentifier: "doc-123", actions }, ctx);
     };
 
-    // Helper to verify permission passed (may fail later validation, but NOT due to "Forbidden")
     const expectPermissionPassed = async (promise: Promise<any>) => {
       try {
         await promise;
       } catch (error: any) {
-        // If we get here, make sure it's NOT a permission error
         expect(error.message).not.toContain("Forbidden");
       }
     };
 
-    it("should allow when user is global admin", async () => {
-      const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
-
-      // Permission check passes, may fail later validation (document model not found)
-      await expectPermissionPassed(callMutateDocument(ctx));
-      expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
-    });
-
-    it("should allow when user has write permission", async () => {
-      vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-        true,
-      );
+    it("should pass through when actions is empty (no canMutate calls)", async () => {
       const ctx = createContext({ userAddress: "0xpermitted" });
 
-      // Permission check passes, may fail later validation
-      await expectPermissionPassed(callMutateDocument(ctx));
-      expect(mockDocumentPermissionService.canWrite).toHaveBeenCalled();
+      // No actions → assertCanExecuteOperations never calls canMutate → no throw
+      await expectPermissionPassed(callMutateDocument(ctx, []));
+      expect(mockAuthorizationService.canMutate).not.toHaveBeenCalled();
     });
 
-    it("should deny when user has no write permission", async () => {
-      vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-        false,
+    it("should allow when canMutate resolves true for each action", async () => {
+      vi.mocked(mockAuthorizationService.canMutate!).mockResolvedValue(true);
+      const ctx = createContext({ userAddress: "0xpermitted" });
+
+      await expectPermissionPassed(
+        callMutateDocument(ctx, [{ type: "SET_NAME", input: {} }]),
       );
+      expect(mockAuthorizationService.canMutate).toHaveBeenCalled();
+    });
+
+    it("should deny when canMutate resolves false for an action", async () => {
+      vi.mocked(mockAuthorizationService.canMutate!).mockResolvedValue(false);
       const ctx = createContext({ userAddress: "0xunpermitted" });
 
-      await expect(callMutateDocument(ctx)).rejects.toThrow("Forbidden");
+      await expect(
+        callMutateDocument(ctx, [{ type: "SET_NAME", input: {} }]),
+      ).rejects.toThrow("Forbidden");
     });
   });
 
+  // ============================================================
+  // Mutation: deleteDocument — drives via canWrite
+  // ============================================================
   describe("Mutation: deleteDocument", () => {
     const callDeleteDocument = (ctx: any) => {
       const mutation = (reactorSubgraph.resolvers.Mutation as any)
@@ -360,35 +413,27 @@ describe("ReactorSubgraph Permission Checks", () => {
       return mutation(null, { identifier: "doc-123" }, ctx);
     };
 
-    it("should allow when user is global admin", async () => {
-      const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
-
-      const result = await callDeleteDocument(ctx);
-
-      expect(result).toBe(true);
-    });
-
-    it("should allow when user has write permission", async () => {
-      vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-        true,
-      );
+    it("should allow when canWrite resolves true", async () => {
+      vi.mocked(mockAuthorizationService.canWrite!).mockResolvedValue(true);
       const ctx = createContext({ userAddress: "0xpermitted" });
 
       const result = await callDeleteDocument(ctx);
 
       expect(result).toBe(true);
+      expect(mockAuthorizationService.canWrite).toHaveBeenCalled();
     });
 
-    it("should deny when user has no write permission", async () => {
-      vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-        false,
-      );
+    it("should deny when canWrite resolves false", async () => {
+      vi.mocked(mockAuthorizationService.canWrite!).mockResolvedValue(false);
       const ctx = createContext({ userAddress: "0xunpermitted" });
 
       await expect(callDeleteDocument(ctx)).rejects.toThrow("Forbidden");
     });
   });
 
+  // ============================================================
+  // Mutation: moveRelationship — assertCanWrite on both parents
+  // ============================================================
   describe("Mutation: moveRelationship", () => {
     const callMoveRelationship = (ctx: any) => {
       const mutation = (reactorSubgraph.resolvers.Mutation as any)
@@ -405,28 +450,19 @@ describe("ReactorSubgraph Permission Checks", () => {
       );
     };
 
-    it("should allow when user is global admin", async () => {
-      const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+    it("should allow when canWrite resolves true for both parents", async () => {
+      vi.mocked(mockAuthorizationService.canWrite!).mockResolvedValue(true);
+      const ctx = createContext({ userAddress: "0xpermitted" });
 
       const result = await callMoveRelationship(ctx);
 
       expect(result).toBeDefined();
+      // Called twice: once per parent
+      expect(mockAuthorizationService.canWrite).toHaveBeenCalledTimes(2);
     });
 
-    it("should check write permission on both parents", async () => {
-      vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValue(
-        true,
-      );
-      const ctx = createContext({ userAddress: "0xpermitted" });
-
-      await callMoveRelationship(ctx);
-
-      // Should be called twice - once for source, once for target
-      expect(mockDocumentPermissionService.canWrite).toHaveBeenCalledTimes(2);
-    });
-
-    it("should deny when user cannot write to source parent", async () => {
-      vi.mocked(mockDocumentPermissionService.canWrite!).mockResolvedValueOnce(
+    it("should deny when canWrite resolves false on source parent", async () => {
+      vi.mocked(mockAuthorizationService.canWrite!).mockResolvedValueOnce(
         false,
       );
       const ctx = createContext({ userAddress: "0xunpermitted" });
@@ -434,8 +470,8 @@ describe("ReactorSubgraph Permission Checks", () => {
       await expect(callMoveRelationship(ctx)).rejects.toThrow("Forbidden");
     });
 
-    it("should deny when user cannot write to target parent", async () => {
-      vi.mocked(mockDocumentPermissionService.canWrite!)
+    it("should deny when canWrite resolves false on target parent", async () => {
+      vi.mocked(mockAuthorizationService.canWrite!)
         .mockResolvedValueOnce(true) // source parent
         .mockResolvedValueOnce(false); // target parent
       const ctx = createContext({ userAddress: "0xunpermitted" });
@@ -444,59 +480,81 @@ describe("ReactorSubgraph Permission Checks", () => {
     });
   });
 
+  // ============================================================
+  // OPEN policy — all access allowed for anyone
+  // ============================================================
+  describe("OPEN policy behavior", () => {
+    let openSubgraph: ReactorSubgraph;
+
+    beforeEach(() => {
+      const openAuthSvc: Partial<IAuthorizationService> = {
+        config: {
+          admins: [],
+          defaultProtection: false,
+          policy: AuthorizationPolicy.OPEN,
+        },
+        isSupremeAdmin: vi.fn().mockReturnValue(true),
+        canRead: vi.fn().mockResolvedValue(true),
+        canWrite: vi.fn().mockResolvedValue(true),
+        canManage: vi.fn().mockResolvedValue(true),
+        canMutate: vi.fn().mockResolvedValue(true),
+        canExecuteOperation: vi.fn().mockResolvedValue(true),
+      };
+      openSubgraph = buildSubgraph(openAuthSvc);
+    });
+
+    it("should allow document reads for any user (including anonymous)", async () => {
+      const ctx = createContext({});
+      const query = (openSubgraph.resolvers.Query as any)?.document;
+
+      const result = await query(null, { identifier: "doc-123" }, ctx);
+
+      expect(result).toBeDefined();
+    });
+
+    it("should allow mutations for any user (including anonymous)", async () => {
+      const ctx = createContext({});
+      const mutation = (openSubgraph.resolvers.Mutation as any)?.deleteDocument;
+
+      const result = await mutation(null, { identifier: "doc-123" }, ctx);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return all findDocuments items without per-item filtering", async () => {
+      const ctx = createContext({});
+      const query = (openSubgraph.resolvers.Query as any)?.findDocuments;
+
+      const result = await query(null, { search: {} }, ctx);
+
+      expect(result.items).toHaveLength(1);
+    });
+  });
+
+  // ============================================================
+  // Permission Inheritance
+  // ============================================================
   describe("Permission Inheritance", () => {
-    it("should allow access to child when user has permission on parent", async () => {
-      // Setup: canRead checks parent hierarchy and finds permission on parent
-      vi.mocked(mockDocumentPermissionService.canRead!).mockResolvedValue(true);
+    it("should allow access to child when canRead resolves true (hierarchy check)", async () => {
+      vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(true);
       const ctx = createContext({ userAddress: "0xpermitted" });
 
       const query = (reactorSubgraph.resolvers.Query as any)?.document;
       const result = await query(null, { identifier: "child-doc" }, ctx);
 
       expect(result).toBeDefined();
-      // The canRead should be called with getParentIdsFn which handles hierarchy
-      expect(mockDocumentPermissionService.canRead).toHaveBeenCalled();
+      expect(mockAuthorizationService.canRead).toHaveBeenCalled();
     });
   });
 
-  describe("AUTH_ENABLED=false behavior", () => {
-    it("should allow all access when isAdmin returns true", async () => {
-      // When AUTH_ENABLED=false, isAdmin returns true
-      const ctx = createContext({
-        isAdmin: true,
-        userAddress: "0xanyone",
-      });
-
-      // Test document query - permission check passes
-      const docResult = await (
-        reactorSubgraph.resolvers.Query as any
-      )?.document(null, { identifier: "doc-123" }, ctx);
-      expect(docResult).toBeDefined();
-
-      // Test mutation - permission check passes, may fail later validation
-      // but should NOT throw "Forbidden"
-      try {
-        await (reactorSubgraph.resolvers.Mutation as any)?.mutateDocument(
-          null,
-          { documentIdentifier: "doc-123", actions: [] },
-          ctx,
-        );
-      } catch (error: any) {
-        // Ensure it's not a permission error
-        expect(error.message).not.toContain("Forbidden");
-      }
-
-      // Permission service should never be called (global roles bypass)
-      expect(mockDocumentPermissionService.canRead).not.toHaveBeenCalled();
-      expect(mockDocumentPermissionService.canWrite).not.toHaveBeenCalled();
-    });
-  });
-
+  // ============================================================
+  // Edge Cases
+  // ============================================================
   describe("Edge Cases", () => {
     it("should handle document not found gracefully", async () => {
-      // When get() returns null, the resolver throws an error
       vi.mocked(mockReactorClient.get!).mockResolvedValue(null as any);
-      const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+      vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(true);
+      const ctx = createContext({ userAddress: "0xadmin" });
 
       const query = (reactorSubgraph.resolvers.Query as any)?.document;
 
@@ -507,12 +565,11 @@ describe("ReactorSubgraph Permission Checks", () => {
     });
 
     it("should throw error when document is null in result", async () => {
-      // When get() returns null, resolver throws
-      // because it tries to access document.header
       vi.mocked(mockReactorClient.get!).mockResolvedValue(
         null as unknown as PHDocument,
       );
-      const ctx = createContext({ isAdmin: true, userAddress: "0xadmin" });
+      vi.mocked(mockAuthorizationService.canRead!).mockResolvedValue(true);
+      const ctx = createContext({ userAddress: "0xadmin" });
 
       const query = (reactorSubgraph.resolvers.Query as any)?.document;
 
@@ -522,7 +579,7 @@ describe("ReactorSubgraph Permission Checks", () => {
       ).rejects.toThrow();
     });
 
-    it("should handle unauthenticated user (no user address)", async () => {
+    it("should handle unauthenticated user (no user address) — canRead false → Forbidden", async () => {
       const ctx = createContext({});
 
       const query = (reactorSubgraph.resolvers.Query as any)?.document;

--- a/packages/reactor-api/test/reactor-subgraph-permissions.test.ts
+++ b/packages/reactor-api/test/reactor-subgraph-permissions.test.ts
@@ -87,7 +87,6 @@ describe("ReactorSubgraph Permission Checks", () => {
       canWrite: vi.fn().mockResolvedValue(false),
       canManage: vi.fn().mockResolvedValue(false),
       canMutate: vi.fn().mockResolvedValue(false),
-      canExecuteOperation: vi.fn().mockResolvedValue(false),
     };
 
     // Create mock ReactorClient
@@ -498,7 +497,6 @@ describe("ReactorSubgraph Permission Checks", () => {
         canWrite: vi.fn().mockResolvedValue(true),
         canManage: vi.fn().mockResolvedValue(true),
         canMutate: vi.fn().mockResolvedValue(true),
-        canExecuteOperation: vi.fn().mockResolvedValue(true),
       };
       openSubgraph = buildSubgraph(openAuthSvc);
     });

--- a/tools/registry-audit/rules/auth-context-consumers.json
+++ b/tools/registry-audit/rules/auth-context-consumers.json
@@ -1,0 +1,36 @@
+{
+  "name": "auth-context-consumers",
+  "description": "Detects published packages that consume the reactor-api authorization surface proposed for removal in feat/auth-refactor cleanup: the Context.isAdmin function, the Context.authorizationService / Context.documentPermissionService fields, and IAuthorizationService.canExecuteOperation. Scans published build output (.d.ts/.js/.mjs). Note: findings inside @powerhousedao/reactor-api itself are the source of these symbols, not consumers.",
+  "rules": [
+    {
+      "id": "ctx-isAdmin-member",
+      "description": "Member access on a Context-shaped value named isAdmin: ctx.isAdmin(...), context.isAdmin?.(...), e.isAdmin (minified). Strong signal a subgraph resolver consumes Context.isAdmin.",
+      "severity": "high",
+      "pattern": "\\.isAdmin\\b"
+    },
+    {
+      "id": "isAdmin-any-token",
+      "description": "Any bare isAdmin token (wide net; also catches minified receivers and unrelated domain fields named isAdmin). For manual triage.",
+      "severity": "low",
+      "pattern": "\\bisAdmin\\b"
+    },
+    {
+      "id": "ctx-authorizationService",
+      "description": "Reference to authorizationService (reactor-api Context field / injected service name).",
+      "severity": "high",
+      "pattern": "\\bauthorizationService\\b"
+    },
+    {
+      "id": "ctx-documentPermissionService",
+      "description": "Reference to documentPermissionService (reactor-api Context field / injected service name).",
+      "severity": "high",
+      "pattern": "\\bdocumentPermissionService\\b"
+    },
+    {
+      "id": "authorizationService-canExecuteOperation",
+      "description": "Call to .canExecuteOperation — the IAuthorizationService method proposed for removal (note: DocumentPermissionService also defines this name).",
+      "severity": "medium",
+      "pattern": "\\.canExecuteOperation\\b"
+    }
+  ]
+}


### PR DESCRIPTION
- Removed unused auth primitives.
- Consolidated all authorization inside of `AuthorizationService`.
- Authservice now ALWAYS exists, and keeps track, itself, of what features are enabled / disabled