### PR TITLE
feat(connect): runtime-dynamic deploy base for Connect builds

### DIFF
--- a/apps/connect/index.html
+++ b/apps/connect/index.html
@@ -8,7 +8,7 @@
       content="Connect is a hub for your most important documents and processes, translated into software. Easily capture data in a structured way with dedicated business process packages. Collaborate on shared documents with ease while using your preferred storage solution (decentralized, centralized, or local)."
     />
     <title>Powerhouse Connect</title>
-    <link rel="icon" href="/icon.ico" />
+    <link rel="icon" href="%BASE_URL%icon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/apps/connect/src/connect.config.ts
+++ b/apps/connect/src/connect.config.ts
@@ -33,6 +33,22 @@ function getRouterBasenameFromBasePath(basePath: string) {
   return basePath.endsWith("/") ? basePath : basePath + "/";
 }
 
+// Runtime deploy base. In dynamic-base builds the plugin rewrites
+// import.meta.env.BASE_URL to (globalThis.__PH_DYNAMIC_BASE__||"/"), the same
+// base assets resolve against; it takes precedence so router basename and
+// path stripping match the served subpath. A baked runtime base path
+// (runtime.app.basePath) only applies to concrete-base builds, where the
+// dynamic global is unset.
+function getDeployBasePath() {
+  if (
+    typeof globalThis !== "undefined" &&
+    (globalThis as { __PH_DYNAMIC_BASE__?: string }).__PH_DYNAMIC_BASE__
+  ) {
+    return import.meta.env.BASE_URL;
+  }
+  return runtime.app?.basePath || import.meta.env.BASE_URL;
+}
+
 // Hardcoded literal defaults for `PHGlobalConfig` fields whose env-var
 // source was removed. The fields stay on the type so wired-but-dead SW /
 // hook consumers keep typechecking; values mirror the previous Zod
@@ -120,9 +136,10 @@ export function buildPHGlobalConfig(
 }
 
 function getPHGlobalConfigFromRuntime(): PHGlobalConfig {
-  // ConfigLoader merges DEFAULT_CONNECT_CONFIG at boot, so basePath is
-  // always defined; the `?? "/"` is a defensive guard for typecheck.
-  const basePath = runtime.app?.basePath ?? "/";
+  // Deploy base wins via getDeployBasePath: the dynamic-base global when set,
+  // else runtime.app.basePath (DEFAULT_CONNECT_CONFIG guarantees it defined),
+  // with a "/" fallback as a defensive guard for typecheck.
+  const basePath = getDeployBasePath() ?? "/";
   const routerBasename = getRouterBasenameFromBasePath(basePath);
   return buildPHGlobalConfig(basePath, routerBasename, runtime);
 }
@@ -148,7 +165,7 @@ logger.debug("Setting log level to @level.", RESOLVED_LOG_LEVEL);
 
 // Normalize the base path to ensure it starts and ends with a forward slash.
 export const PH_CONNECT_BASE_PATH = normalizeBasePath(
-  runtime.app?.basePath ?? "/",
+  getDeployBasePath() ?? "/",
 );
 
 // Analytics database name — derived deterministically from the base path so

--- a/clis/ph-cli/src/help.ts
+++ b/clis/ph-cli/src/help.ts
@@ -67,6 +67,9 @@ Options:
 
   --base <base>               Base path for the app. Default is "/".
 
+  --dynamic-base              Build one bundle that serves under any subpath; base
+                              resolved at serve time from a runtime global. Overrides --base.
+
   --mode <mode>               Vite mode to use (e.g., development, production).
 
   --config-file <configFile>  Path to the powerhouse.config.js file.

--- a/clis/ph-cli/src/services/connect-build.ts
+++ b/clis/ph-cli/src/services/connect-build.ts
@@ -9,7 +9,7 @@ import { buildCliConnectOverride } from "../utils/cli-connect-override.js";
 import { runBuild } from "./build.js";
 
 export async function runConnectBuild(args: ConnectBuildArgs) {
-  const { outDir, debug } = args;
+  const { outDir, debug, dynamicBase } = args;
 
   const mode = "production";
   const dirname = process.cwd();
@@ -44,6 +44,7 @@ export async function runConnectBuild(args: ConnectBuildArgs) {
     dirname,
     cliConnectOverride: connectOverride,
     cliPackageRegistryUrl: packageRegistryUrl,
+    dynamicBase,
   });
 
   const buildConfig: InlineConfig = {

--- a/packages/builder-tools/connect-utils/index.ts
+++ b/packages/builder-tools/connect-utils/index.ts
@@ -3,4 +3,5 @@ export * from "./helpers.js";
 export * from "./runtime-config-schema.js";
 export * from "./types.js";
 export * from "./vite-config.js";
+export * from "./vite-plugins/dynamic-base.js";
 export * from "./vite-plugins/ph-config.js";

--- a/packages/builder-tools/connect-utils/types.ts
+++ b/packages/builder-tools/connect-utils/types.ts
@@ -24,6 +24,9 @@ export type IConnectOptions = {
    * value in the emitted runtime config.
    */
   cliPackageRegistryUrl?: string;
+  /* Build one bundle that serves under any subpath; base resolved at serve
+   * time from a runtime global instead of baked in. Overrides the deploy base. */
+  dynamicBase?: boolean;
 };
 
 export type ConnectCommonOptions = {

--- a/packages/builder-tools/connect-utils/vite-config.ts
+++ b/packages/builder-tools/connect-utils/vite-config.ts
@@ -21,6 +21,10 @@ import {
 import { createHtmlPlugin } from "vite-plugin-html";
 import type { IConnectOptions } from "./types.js";
 import { devReactImportmapPlugin } from "./vite-plugins/dev-external-react.js";
+import {
+  connectDynamicBasePlugin,
+  DYNAMIC_BASE_PLACEHOLDER,
+} from "./vite-plugins/dynamic-base.js";
 import { connectFaviconPlugin } from "./vite-plugins/favicon.js";
 import { phBundledPackagesPlugin } from "./vite-plugins/ph-bundled-packages.js";
 import { phConfigPlugin } from "./vite-plugins/ph-config.js";
@@ -344,7 +348,16 @@ export function getConnectBaseViteConfig(options: IConnectOptions) {
     // Prefix served/built asset URLs so Connect can run under a path prefix
     // (reverse proxy). Mirrors the client router basename; normalize so a bare
     // `app` or `/app` becomes `/app/` and matches the router.
-    base: connectBasePath ? normalizeBasePath(connectBasePath) : undefined,
+    //
+    // Dynamic-base mode: set a placeholder token instead of a concrete base.
+    // connectDynamicBasePlugin (below) rewrites it in the emitted JS to a
+    // runtime expression so one bundle serves under any subpath; the proxy
+    // substitutes it in the HTML and sets the runtime global at serve time.
+    base: options.dynamicBase
+      ? DYNAMIC_BASE_PLACEHOLDER
+      : connectBasePath
+        ? normalizeBasePath(connectBasePath)
+        : undefined,
     server: {
       watch: {
         ignored: ["**/backup-documents/**", "**/.ph/**"],
@@ -407,9 +420,20 @@ export function getConnectBaseViteConfig(options: IConnectOptions) {
       // entries prevent the plugin from transforming require() calls.
       esmExternalRequirePlugin({ external: reactExternal }),
       connectFaviconPlugin(),
+      // enforce: "post" — rewrites the placeholder base after all other
+      // transforms have emitted their asset/chunk URLs.
+      ...(options.dynamicBase ? [connectDynamicBasePlugin()] : []),
     ],
     worker: {
       format: "es",
+      // Worker chunks are emitted by a separate Rolldown build, so the main
+      // bundle's generateBundle never sees them. The worker instance both
+      // rewrites the placeholder and prepends a prelude that resolves the base
+      // in worker scope (forWorker) — the proxy only sets the global on the
+      // main thread.
+      ...(options.dynamicBase
+        ? { plugins: () => [connectDynamicBasePlugin({ forWorker: true })] }
+        : {}),
     },
     build: {
       sourcemap: true,

--- a/packages/builder-tools/connect-utils/vite-plugins/dynamic-base.test.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/dynamic-base.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  connectDynamicBasePlugin,
+  DYNAMIC_BASE_PLACEHOLDER,
+} from "./dynamic-base.js";
+
+const BASE_EXPR = `(globalThis.__PH_DYNAMIC_BASE__||"/")`;
+
+type RenderChunkResult = {
+  code: string;
+  map: { version: number; mappings: string };
+} | null;
+
+/** Drives the plugin's renderChunk hook with a minimal mock context. */
+function runRenderChunk(
+  code: string,
+  options: { forWorker?: boolean } = {},
+): RenderChunkResult {
+  const ctx = { info: vi.fn() };
+  const plugin = connectDynamicBasePlugin(options);
+  const renderChunk = plugin.renderChunk as unknown as (
+    this: typeof ctx,
+    code: string,
+    chunk: { fileName: string },
+  ) => RenderChunkResult;
+  return renderChunk.call(ctx, code, { fileName: "assets/index.js" });
+}
+
+/** Drives the plugin's generateBundle hook with a minimal mock context. */
+function runGenerateBundle(bundle: Record<string, unknown>) {
+  const error = vi.fn((msg: string) => {
+    throw new Error(msg);
+  });
+  const ctx = { error, info: vi.fn() };
+  const plugin = connectDynamicBasePlugin();
+  const generateBundle = plugin.generateBundle as unknown as (
+    this: typeof ctx,
+    options: unknown,
+    bundle: Record<string, unknown>,
+  ) => void;
+  generateBundle.call(ctx, {}, bundle);
+  return { error };
+}
+
+describe("connectDynamicBasePlugin renderChunk rewrite", () => {
+  it("rewrites a double-quoted literal", () => {
+    expect(
+      runRenderChunk(
+        `new URL("${DYNAMIC_BASE_PLACEHOLDER}assets/x.png", import.meta.url)`,
+      )?.code,
+    ).toBe(`new URL((${BASE_EXPR}+"assets/x.png"), import.meta.url)`);
+  });
+
+  it("rewrites a single-quoted literal", () => {
+    expect(
+      runRenderChunk(`fetch('${DYNAMIC_BASE_PLACEHOLDER}ph-packages.json')`)
+        ?.code,
+    ).toBe(`fetch((${BASE_EXPR}+"ph-packages.json"))`);
+  });
+
+  it("rewrites a backtick literal without interpolation", () => {
+    expect(
+      runRenderChunk("load(`" + DYNAMIC_BASE_PLACEHOLDER + "assets/chunk.js`)")
+        ?.code,
+    ).toBe(`load((${BASE_EXPR}+"assets/chunk.js"))`);
+  });
+
+  it("rewrites a double-quoted literal containing an apostrophe without corruption", () => {
+    expect(
+      runRenderChunk(`u("${DYNAMIC_BASE_PLACEHOLDER}it's.png")`)?.code,
+    ).toBe(`u((${BASE_EXPR}+"it's.png"))`);
+  });
+
+  it("rewrites the bare placeholder (inlined BASE_URL) to the bare expression", () => {
+    expect(
+      runRenderChunk(`const base = "${DYNAMIC_BASE_PLACEHOLDER}";`)?.code,
+    ).toBe(`const base = ${BASE_EXPR};`);
+  });
+
+  it("leaves an interpolated template literal unrewritten", () => {
+    const code = "import(`" + DYNAMIC_BASE_PLACEHOLDER + "assets/${name}.js`)";
+    expect(runRenderChunk(code)).toBeNull();
+  });
+
+  it("returns null for a chunk without the placeholder", () => {
+    expect(runRenderChunk(`const x = "/static/";`)).toBeNull();
+  });
+});
+
+describe("connectDynamicBasePlugin renderChunk sourcemaps", () => {
+  it("returns a v3 hires map for a rewritten chunk", () => {
+    const result = runRenderChunk(
+      `const base = "${DYNAMIC_BASE_PLACEHOLDER}";\nfetch("${DYNAMIC_BASE_PLACEHOLDER}ph-packages.json");`,
+    );
+    expect(result).not.toBeNull();
+    expect(result?.map.version).toBe(3);
+    expect(result?.map.mappings.length).toBeGreaterThan(0);
+    // No prelude: generated line 1 maps back to source line 1.
+    expect(result?.map.mappings.startsWith(";")).toBe(false);
+  });
+
+  it("prepends the worker prelude and shifts the map by one line", () => {
+    const result = runRenderChunk(
+      `const base = "${DYNAMIC_BASE_PLACEHOLDER}";`,
+      { forWorker: true },
+    );
+    expect(result?.code).toBe(
+      `globalThis.__PH_DYNAMIC_BASE__=self.location.pathname.replace(/assets\\/[^/]*$/,"");\n` +
+        `const base = ${BASE_EXPR};`,
+    );
+    // Prelude occupies generated line 1 with no source mapping, so the
+    // mappings string starts with an empty line (leading ";").
+    expect(result?.map.version).toBe(3);
+    expect(result?.map.mappings.startsWith(";")).toBe(true);
+  });
+});
+
+describe("connectDynamicBasePlugin generateBundle assertion", () => {
+  it("leaves HTML assets untouched and passes a clean bundle", () => {
+    const chunk = {
+      type: "chunk",
+      fileName: "assets/index.js",
+      code: `const base = ${BASE_EXPR};`,
+    };
+    const html = {
+      type: "asset",
+      fileName: "index.html",
+      source: `<script src="${DYNAMIC_BASE_PLACEHOLDER}assets/index.js"></script>`,
+    };
+    const { error } = runGenerateBundle({
+      "assets/index.js": chunk,
+      "index.html": html,
+    });
+    expect(html.source).toContain(DYNAMIC_BASE_PLACEHOLDER);
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("fails the build when a chunk retains the token (interpolated template)", () => {
+    const chunk = {
+      type: "chunk",
+      fileName: "assets/index.js",
+      code: "import(`" + DYNAMIC_BASE_PLACEHOLDER + "assets/${name}.js`)",
+    };
+    expect(() => runGenerateBundle({ "assets/index.js": chunk })).toThrow(
+      /unrewritten placeholder.*assets\/index\.js/,
+    );
+  });
+
+  it("fails the build when a CSS asset carries the token", () => {
+    const css = {
+      type: "asset",
+      fileName: "assets/index.css",
+      source: `body{background:url(${DYNAMIC_BASE_PLACEHOLDER}bg.png)}`,
+    };
+    expect(() => runGenerateBundle({ "assets/index.css": css })).toThrow(
+      /unrewritten placeholder.*assets\/index\.css/,
+    );
+  });
+});

--- a/packages/builder-tools/connect-utils/vite-plugins/dynamic-base.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/dynamic-base.ts
@@ -1,0 +1,141 @@
+import MagicString from "magic-string";
+import type { Plugin } from "vite";
+
+/**
+ * Placeholder base used when Connect is built in dynamic-base mode. The Vite
+ * `base` option is set to this token; this plugin rewrites it in the emitted
+ * output so the effective base is resolved at serve time from a global instead
+ * of being baked at build time.
+ *
+ * Trailing slash matches `normalizeBasePath` output, so the token sits in the
+ * same syntactic position as a concrete base would.
+ */
+export const DYNAMIC_BASE_PLACEHOLDER = "/__PH_DYNAMIC_BASE__/";
+
+/**
+ * Global the runtime (ph-clint proxy) must set before the entry bundle loads.
+ * Value is the normalized deploy base, e.g. "/myagent/" or "/". The JS rewrite
+ * below resolves all asset / lazy-chunk / BASE_URL references against it.
+ */
+const RUNTIME_GLOBAL = "globalThis.__PH_DYNAMIC_BASE__";
+
+// `(globalThis.__PH_DYNAMIC_BASE__||"/")` — used everywhere the placeholder
+// base prefix appears in emitted JS.
+const BASE_EXPR = `(${RUNTIME_GLOBAL}||"/")`;
+
+/**
+ * Worker scope has its own global object; the proxy injects the runtime global
+ * into the main-thread `<head>` only, so a worker chunk's rewritten references
+ * would fall back to "/" and fetch siblings (pglite .data/.wasm) without the
+ * deploy prefix. Prepended to worker chunks, this defines the global in worker
+ * scope from the worker's own script URL: the worker loads from
+ * `<base>assets/<name>-<hash>.js`, so stripping `assets/<file>` off
+ * `self.location.pathname` yields the same trailing-slash base the main thread
+ * holds ("/myagent/" or "/").
+ */
+const WORKER_PRELUDE = `${RUNTIME_GLOBAL}=self.location.pathname.replace(/assets\\/[^/]*$/,"");\n`;
+
+// Match a string literal whose content STARTS with the placeholder, in any of
+// the three JS quote styles Rolldown emits (double, single, backtick). Group 1
+// captures the opening quote; the closing quote must be the same character
+// (backreference), so a double-quoted literal may contain ' or ` and vice
+// versa. Group 2 captures the literal text after the placeholder up to the
+// closing quote. Rolldown emits the base both as a bare literal (the inlined
+// BASE_URL) and as a `<base>`+suffix (preload/asset URL prefix); both start at
+// the placeholder. The content stops at `$`, so a template literal that
+// interpolates after the token (`` `<token>...${expr}` ``) is NOT rewritten —
+// the residual-token assertion in `generateBundle` fails the build instead of
+// shipping the raw placeholder.
+const PLACEHOLDER_LITERAL = new RegExp(
+  `(["'\`])${escapeForRegExp(DYNAMIC_BASE_PLACEHOLDER)}((?:(?!\\1)[^$])*)\\1`,
+  "g",
+);
+
+/**
+ * Rewrites the placeholder base in emitted JS chunks to a runtime expression so
+ * one built `dist/connect` serves under any subpath. Rolldown-native: per-match
+ * MagicString edits in `renderChunk`, no AST splicing (the SWC byte-offset
+ * splicing in vite-plugin-dynamic-base corrupts Rolldown chunks). Each edited
+ * chunk returns a hires sourcemap that the bundler composes into the chunk's
+ * map chain, so the emitted `.map` files track the rewrite (and the worker
+ * prelude's line shift).
+ *
+ * What gets rewritten in JS, all of which emit the base as a quoted string
+ * literal beginning with the placeholder:
+ *   - asset URLs (`new URL("/__PH_DYNAMIC_BASE__/assets/x.png", ...)`)
+ *   - dynamic-import / lazy-chunk preload URLs
+ *   - the inlined `import.meta.env.BASE_URL` (drives Connect's router basename
+ *     and BASE_URL-relative fetches such as `${BASE_URL}ph-packages.json`)
+ *
+ * A literal `"/__PH_DYNAMIC_BASE__/foo"` becomes `((globalThis.__PH_DYNAMIC_BASE__||"/")+"foo")`;
+ * a bare `"/__PH_DYNAMIC_BASE__/"` (the BASE_URL value) becomes `(globalThis.__PH_DYNAMIC_BASE__||"/")`.
+ *
+ * HTML is left untouched: the entry `<script>`/`<link>` tags keep the literal
+ * placeholder so the proxy substitutes it with the concrete base at serve time
+ * (the same proxy also sets the runtime global for the JS rewrite). See the
+ * plugin's module doc / report for the exact serve-time contract.
+ *
+ * CSS `url(...)` references resolve relative to the stylesheet's own URL, so
+ * they need no rewrite once the stylesheet itself is loaded from the right
+ * prefix (which the HTML substitution handles).
+ */
+export function connectDynamicBasePlugin(
+  options: { forWorker?: boolean } = {},
+): Plugin {
+  return {
+    name: "ph-connect-dynamic-base",
+    enforce: "post",
+    renderChunk(code, chunk) {
+      if (!code.includes(DYNAMIC_BASE_PLACEHOLDER)) return null;
+
+      const s = new MagicString(code);
+      for (const match of code.matchAll(PLACEHOLDER_LITERAL)) {
+        const rest = match[2];
+        s.overwrite(
+          match.index,
+          match.index + match[0].length,
+          rest.length === 0
+            ? BASE_EXPR
+            : `(${BASE_EXPR}+${JSON.stringify(rest)})`,
+        );
+      }
+
+      // Worker chunks run in their own global scope where the proxy never
+      // sets the runtime global; derive it from the worker's script URL so
+      // the rewritten references above resolve against the deploy base.
+      if (options.forWorker) {
+        s.prepend(WORKER_PRELUDE);
+        this.info(
+          `dynamic-base: worker prelude prepended to ${chunk.fileName}`,
+        );
+      }
+
+      if (!s.hasChanged()) return null;
+      return { code: s.toString(), map: s.generateMap({ hires: true }) };
+    },
+    generateBundle(_options, bundle) {
+      // A residual token in JS (a literal the regex couldn't rewrite, e.g. a
+      // template interpolating after the token) or CSS (url() must stay
+      // stylesheet-relative; the placeholder would ship verbatim and 404)
+      // would fail silently at runtime — fail the build instead. HTML keeps
+      // the token by design: the proxy substitutes it at serve time.
+      for (const file of Object.values(bundle)) {
+        const content =
+          file.type === "chunk"
+            ? file.code
+            : file.fileName.endsWith(".css") && typeof file.source === "string"
+              ? file.source
+              : undefined;
+        if (content?.includes(DYNAMIC_BASE_PLACEHOLDER)) {
+          this.error(
+            `dynamic-base: unrewritten placeholder ${DYNAMIC_BASE_PLACEHOLDER} remains in ${file.fileName}`,
+          );
+        }
+      }
+    },
+  };
+}
+
+function escapeForRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/builder-tools/package.json
+++ b/packages/builder-tools/package.json
@@ -33,6 +33,7 @@
     "@tailwindcss/vite": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "document-model": "workspace:*",
+    "magic-string": "^0.30.21",
     "vite": "catalog:",
     "vite-plugin-html": "catalog:"
   },

--- a/packages/shared/clis/args/connect.ts
+++ b/packages/shared/clis/args/connect.ts
@@ -1,5 +1,13 @@
 import type { Type } from "cmd-ts";
-import { number, option, optional, positional, string } from "cmd-ts";
+import {
+  boolean,
+  flag,
+  number,
+  option,
+  optional,
+  positional,
+  string,
+} from "cmd-ts";
 import {
   DEFAULT_CONNECT_OUTDIR,
   DEFAULT_CONNECT_PREVIEW_PORT,
@@ -187,6 +195,12 @@ export const connectBuildArgs = {
   }),
   ...connectRuntimeOverrideArgs,
   ...connectPositionalArgs,
+  dynamicBase: flag({
+    type: optional(boolean),
+    long: "dynamic-base",
+    description:
+      "Build one bundle that serves under any subpath; base resolved at serve time from a runtime global. Overrides --base.",
+  }),
   ...commonArgs,
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,7 +603,7 @@ importers:
         version: 4.2.2
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@5.9.3)
+        version: 0.21.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@5.9.3)
       vite:
         specifier: 'catalog:'
         version: 8.0.8(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -1163,6 +1163,9 @@ importers:
       document-model:
         specifier: workspace:*
         version: link:../document-model
+      magic-string:
+        specifier: ^0.30.21
+        version: 0.30.21
       vite:
         specifier: 'catalog:'
         version: 8.0.8(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -1175,7 +1178,7 @@ importers:
         version: 4.9.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@5.9.3)
+        version: 0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@5.9.3)
       tsx:
         specifier: 'catalog:'
         version: 4.21.0


### PR DESCRIPTION
## What

Makes one Connect bundle servable under any subpath, resolved at serve time instead of build time.

- `ph connect build --dynamic-base` (new flag in `packages/shared/clis/args/connect.ts`, wired through `clis/ph-cli/src/services/connect-build.ts`) sets the Vite `base` to the placeholder token `/__PH_DYNAMIC_BASE__/`.
- New `connectDynamicBasePlugin` (`packages/builder-tools/connect-utils/vite-plugins/dynamic-base.ts`) rewrites every placeholder-prefixed string literal in emitted JS chunks to a runtime expression reading `globalThis.__PH_DYNAMIC_BASE__` (falling back to `/`). The rewrite runs in `renderChunk` as per-match MagicString edits — no AST byte-offset splicing, which corrupts Rolldown chunks — and returns a hires sourcemap per edited chunk, which the bundler composes into the chunk's map chain so the emitted `.map` files stay aligned (including the worker prelude's line shift).
- HTML keeps the literal token: the serving runtime substitutes it per-request.
- Worker chunks get a prelude that derives the global in worker scope from the worker's own script URL (`self.location.pathname` minus `assets/<file>`), since the runtime only injects the global into the main-thread document.
- `getDeployBasePath()` (`apps/connect/src/connect.config.ts`) resolves the effective base at runtime; the router base and favicon now participate in the deploy base.

## Hardening from review

- The rewrite regex anchors the opening/closing quote via a backreference, so a literal containing the other quote character (e.g. an apostrophe inside a double-quoted string) is no longer truncated/corrupted.
- `generateBundle` asserts no residual placeholder remains in JS chunks or CSS assets — the build fails loudly rather than shipping the raw token. HTML is exempt by design (serve-time substitution).
- Rewrites carry sourcemaps: each edited chunk returns a MagicString-generated hires map from `renderChunk`, so column shifts from the placeholder rewrite and the worker prelude's prepended line are reflected in the emitted maps (Sentry uploads them when configured).
- Unit tests for the plugin added (`packages/builder-tools/connect-utils/vite-plugins/dynamic-base.test.ts`), including sourcemap assertions.

## Serve-time contract

The token `/__PH_DYNAMIC_BASE__/` (in HTML) and the global `globalThis.__PH_DYNAMIC_BASE__` (set before the entry bundle loads) are consumed by ph-clint's connect-server in a companion PR. Token name and global name are the cross-repo contract.

## Merge order

This is 1 of 3 integration PRs (monorepo → ph-clint → vetra-cli). Merge this one first.

## Commits

- f1a5df342 feat(connect): runtime-dynamic deploy base for Connect builds

## Test status

- packages/builder-tools: `vitest --run` 27/27 passed (includes the dynamic-base plugin tests with sourcemap coverage); `tsc` clean.
- apps/connect: `tsc` clean.
- packages/shared: `vitest --run` 124/124 passed (no `tsc` script in that package).
- clis/ph-cli: `tsc` clean.

No pre-existing failures encountered.
