### PR TITLE
feat(ph-cli): add --drives-public-base to ph vetra

### DIFF
--- a/apps/academy/docs/academy/04-APIReferences/00-PowerhouseCLI.md
+++ b/apps/academy/docs/academy/04-APIReferences/00-PowerhouseCLI.md
@@ -428,6 +428,8 @@ and real-time processing with a "Vetra" drive or connection to remote drives.
 **Default:** `3001`
 **Remote Drive** - URL of remote drive to connect to (skips switchboard initialization) - Usage: `--remote-drive \<str\>`
 
+**Drives Public Base** - public base URL for the drive URLs advertised to Connect; each drive is exposed as \<base\>/d/\<slug\> instead of http://localhost:\<switchboard-port\>/d/\<slug\>. Use when the switchboard is reachable through a reverse proxy. - Usage: `--drives-public-base \<str\>`
+
 **Db Path** - Database path or connection string. Use a `postgres://` URL for Postgres; otherwise treated as a PGlite filesystem path. Leave unset for in-memory PGlite. - Usage: `--db-path \<str\>`
 
 **Base** - Base path for the app - Usage: `--base \<str\>`

--- a/apps/academy/llms-full.txt
+++ b/apps/academy/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-06-09T23:23:09.384Z
+> Generated: 2026-06-11T07:28:51.215Z
 > Total Documents: 87
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -18165,6 +18165,8 @@ and real-time processing with a "Vetra" drive or connection to remote drives.
 **Default:** `3001`
 **Remote Drive** - URL of remote drive to connect to (skips switchboard initialization) - Usage: `--remote-drive \<str\>`
 
+**Drives Public Base** - public base URL for the drive URLs advertised to Connect; each drive is exposed as \<base\>/d/\<slug\> instead of http://localhost:\<switchboard-port\>/d/\<slug\>. Use when the switchboard is reachable through a reverse proxy. - Usage: `--drives-public-base \<str\>`
+
 **Db Path** - Database path or connection string. Use a `postgres://` URL for Postgres; otherwise treated as a PGlite filesystem path. Leave unset for in-memory PGlite. - Usage: `--db-path \<str\>`
 
 **Base** - Base path for the app - Usage: `--base \<str\>`
@@ -18382,6 +18384,8 @@ Build has no read mode; passing only \<key\> without \<value\> errors out (use `
 
 
 ### Flags
+**Dynamic Base** - Build one bundle that serves under any subpath; base resolved at serve time from a runtime global. Overrides --base. - Usage: `--dynamic-base`
+
 **Ignore Local** - Do not load local packages from this project - Usage: `--ignore-local`
 
 **Force** - Force dep pre-optimization regardless of whether deps have changed. - Usage: `--force`

--- a/apps/academy/static/llms-full.txt
+++ b/apps/academy/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-06-09T23:23:09.384Z
+> Generated: 2026-06-11T07:28:51.215Z
 > Total Documents: 87
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -18165,6 +18165,8 @@ and real-time processing with a "Vetra" drive or connection to remote drives.
 **Default:** `3001`
 **Remote Drive** - URL of remote drive to connect to (skips switchboard initialization) - Usage: `--remote-drive \<str\>`
 
+**Drives Public Base** - public base URL for the drive URLs advertised to Connect; each drive is exposed as \<base\>/d/\<slug\> instead of http://localhost:\<switchboard-port\>/d/\<slug\>. Use when the switchboard is reachable through a reverse proxy. - Usage: `--drives-public-base \<str\>`
+
 **Db Path** - Database path or connection string. Use a `postgres://` URL for Postgres; otherwise treated as a PGlite filesystem path. Leave unset for in-memory PGlite. - Usage: `--db-path \<str\>`
 
 **Base** - Base path for the app - Usage: `--base \<str\>`
@@ -18382,6 +18384,8 @@ Build has no read mode; passing only \<key\> without \<value\> errors out (use `
 
 
 ### Flags
+**Dynamic Base** - Build one bundle that serves under any subpath; base resolved at serve time from a runtime global. Overrides --base. - Usage: `--dynamic-base`
+
 **Ignore Local** - Do not load local packages from this project - Usage: `--ignore-local`
 
 **Force** - Force dep pre-optimization regardless of whether deps have changed. - Usage: `--force`

--- a/clis/ph-cli/COMMANDS.md
+++ b/clis/ph-cli/COMMANDS.md
@@ -274,6 +274,10 @@ port to use for the Vetra Connect<br><br>
 URL of remote drive to connect to (skips switchboard initialization)<br><br>
 **usage:** `--remote-drive <str>`<br>
 
+#### Drives Public Base <br>
+public base URL for the drive URLs advertised to Connect; each drive is exposed as <base>/d/<slug> instead of http://localhost:<switchboard-port>/d/<slug>. Use when the switchboard is reachable through a reverse proxy.<br><br>
+**usage:** `--drives-public-base <str>`<br>
+
 #### Db Path <br>
 Database path or connection string. Use a `postgres://` URL for Postgres; otherwise treated as a PGlite filesystem path. Leave unset for in-memory PGlite.<br><br>
 **usage:** `--db-path <str>`<br>

--- a/clis/ph-cli/src/services/vetra.ts
+++ b/clis/ph-cli/src/services/vetra.ts
@@ -25,6 +25,24 @@ const getDefaultVetraUrl = (port: number) =>
 const getDriveId = (driveUrl: string | undefined): string =>
   driveUrl?.split("/").pop() ?? generateProjectDriveId(VETRA_DRIVE_NAME);
 
+// Rebase a local drive URL onto --drives-public-base: keeps the /d/<slug>
+// path, swaps the loopback origin for the public base. Browser clients
+// behind a reverse proxy can't reach http://localhost:<port>. Non-loopback
+// URLs (e.g. a remote drive) are already public and pass through unchanged.
+const rebaseDriveUrl = (driveUrl: string, publicBase: string): string => {
+  // Unparseable URLs pass through unchanged, like non-loopback ones.
+  let url: URL;
+  try {
+    url = new URL(driveUrl);
+  } catch {
+    return driveUrl;
+  }
+  if (!["localhost", "127.0.0.1", "[::1]"].includes(url.hostname)) {
+    return driveUrl;
+  }
+  return `${publicBase.replace(/\/+$/, "")}${url.pathname}`;
+};
+
 function createViteLogger(color: Color) {
   const customLogger = createLogger("info");
   const loggerInfo = customLogger.info.bind(customLogger);
@@ -288,10 +306,22 @@ export async function startVetra(args: VetraArgs) {
       // runConnectStudio so it survives the `wasFlagExplicitlyPassed`
       // gating (the user didn't pass --default-drives-url; vetra is setting
       // it itself).
+      // --drives-public-base: advertise proxy-reachable drive URLs to the
+      // browser instead of the switchboard's localhost origin.
+      const publicBase = args.drivesPublicBase;
+      const browserDriveUrl = publicBase
+        ? rebaseDriveUrl(driveUrl, publicBase)
+        : driveUrl;
+      const browserPreviewDriveUrl =
+        previewDriveUrl && publicBase
+          ? rebaseDriveUrl(previewDriveUrl, publicBase)
+          : previewDriveUrl;
       const vetraDrivesOverride = {
         drives: {
           defaultDrives: parseDefaultDrivesUrl(
-            previewDriveUrl ? [driveUrl, previewDriveUrl].join(",") : driveUrl,
+            browserPreviewDriveUrl
+              ? [browserDriveUrl, browserPreviewDriveUrl].join(",")
+              : browserDriveUrl,
           ),
           preserveStrategy: "preserve-all" as const,
         },

--- a/clis/ph-cli/src/utils/cli-connect-override.ts
+++ b/clis/ph-cli/src/utils/cli-connect-override.ts
@@ -317,9 +317,10 @@ export function buildCliConnectOverride(args: ConnectBuildArgs): {
  * `wasFlagExplicitlyPassed` so cmd-ts defaults don't leak into the override.
  *
  * `callerOverride` is supplied by wrappers around studio (notably `ph vetra`,
- * which sets default drives + preserveStrategy directly) and deep-merges on
- * top of the user-flag override, so caller choices stick even when the user
- * didn't type the corresponding flag.
+ * which sets default drives + preserveStrategy directly). The flag override
+ * deep-merges on top of it: caller choices apply for every flag the user
+ * didn't type, but an explicitly passed flag (e.g. `--default-drives-url`)
+ * always wins.
  */
 export function buildStudioConnectOverride(
   args: ConnectStudioArgs,
@@ -341,5 +342,5 @@ export function buildStudioConnectOverride(
   const hasFlag = Object.keys(flagOverride).length > 0;
   if (!hasFlag) return callerOverride;
   if (callerOverride === undefined) return flagOverride;
-  return deepMerge(flagOverride, callerOverride);
+  return deepMerge(callerOverride, flagOverride);
 }

--- a/packages/shared/clis/args/vetra.ts
+++ b/packages/shared/clis/args/vetra.ts
@@ -69,6 +69,12 @@ export const vetraArgs = {
     defaultValue: () => false,
     defaultValueIsSerializable: true,
   }),
+  drivesPublicBase: option({
+    type: optional(string),
+    long: "drives-public-base",
+    description:
+      "public base URL for the drive URLs advertised to Connect; each drive is exposed as <base>/d/<slug> instead of http://localhost:<switchboard-port>/d/<slug>. Use when the switchboard is reachable through a reverse proxy.",
+  }),
   dbPath: option({
     type: optional(string),
     long: "db-path",


### PR DESCRIPTION
Rebases the drive URLs advertised to Connect (vetra + preview drives) onto a public base (`<base>/d/<slug>`) so browsers behind a reverse proxy don't receive the switchboard's localhost origin. Loopback URLs only; remote drive URLs pass through.

Also fixes `buildStudioConnectOverride` merge order: callerOverride was merged on top of explicitly-passed flags, turning `--default-drives-url` into a no-op under `ph vetra`. Flags are gated on `wasFlagExplicitlyPassed`, so merging them last gives caller defaults + user-flag wins.

Context: when `ph vetra` runs nested behind vetra-cli's proxy, the studio iframe loads through the proxy but `powerhouse.config.json` advertises `http://localhost:<switchboard-port>/d/<slug>` — unreachable from a remote browser. vetra-cli will pass `--drives-public-base <publicUrl>/reactor-project/switchboard` so the browser fetches the drive through the proxy.