### PR TITLE
fix(codegen): resolve graphql-codegen plugins from this package

### DIFF
--- a/packages/codegen/src/codegen/graphql.ts
+++ b/packages/codegen/src/codegen/graphql.ts
@@ -11,9 +11,49 @@ import type {
 } from "@powerhousedao/shared/document-model";
 import type { DocumentModelFileMakerArgs } from "file-builders";
 import type { ValidationSchemaPluginConfig } from "graphql-codegen-typescript-validation-schema";
+import { realpathSync } from "node:fs";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { format } from "prettier";
+
+/* Resolve graphql-codegen plugins from this package's own install rather than
+ * graphql-codegen's default loader. The default resolves relative to graphql-
+ * codegen's location and is sensitive to the install layout (which cli copy,
+ * cwd), so it can report "Unable to find template plugin matching '<name>'"
+ * even when the plugins are installed. This package depends on its plugins
+ * directly, so resolving from here is deterministic. (selfReal covers
+ * --preserve-symlinks, where import.meta.url is the symlink path.) graphql-
+ * codegen probes candidate names; unresolved ones throw MODULE_NOT_FOUND so it
+ * falls through to the next candidate. */
+type PluginLoader = NonNullable<CodegenConfig["pluginLoader"]>;
+type CodegenPlugin = Awaited<ReturnType<PluginLoader>>;
+function makePluginLoader(): PluginLoader {
+  const selfPath = fileURLToPath(import.meta.url);
+  let selfReal = selfPath;
+  try {
+    selfReal = realpathSync(selfPath);
+  } catch {
+    // keep selfPath
+  }
+  const requirers = [createRequire(selfPath), createRequire(selfReal)];
+  return async (name: string) => {
+    let lastErr: unknown;
+    for (const requireFrom of requirers) {
+      try {
+        return (await import(
+          pathToFileURL(requireFrom.resolve(name)).href
+        )) as CodegenPlugin;
+      } catch (err) {
+        lastErr = err;
+      }
+    }
+    throw lastErr;
+  };
+}
+
+const pluginLoader = makePluginLoader();
 
 export const scalars = {
   Unknown: "unknown",
@@ -111,6 +151,7 @@ export async function generateTypesAndZodSchemasFromGraphql(
   const config: CodegenConfig = {
     overwrite: true,
     watch: false,
+    pluginLoader,
     hooks: {
       beforeOneFileWrite: formatContentWithPrettier,
     },


### PR DESCRIPTION
## Problem

`@powerhousedao/codegen` runs `@graphql-codegen/cli` to generate `types.ts` / `zod.ts` from a document model's GraphQL schema. graphql-codegen's **default** plugin loader resolves plugin modules relative to its own install location and the process `cwd`. Under strict pnpm this fails to find `@graphql-codegen/typescript` and `@graphql-codegen/add` — even though this package declares them as **direct dependencies** — so codegen reports:

```
Unable to find template plugin matching 'typescript'
```

This surfaces whenever codegen runs **in-process from a host CLI** (e.g. vetra-cli's `spec-generate`) rather than via a project-local `ph generate`: the host's strict-pnpm closure can't resolve the plugin as a bare specifier, and the cwd-based fallback doesn't reach an installed copy. Any "generate a document model" flow on such an image dead-ends at codegen.

## Fix

Pass a custom `pluginLoader` to the codegen config that resolves plugin names with `createRequire` anchored at this module (`graphql.ts`), so resolution is deterministic regardless of install layout or `cwd`. Because this package depends on its plugins directly, resolving from here always finds them. `selfReal` (via `realpathSync`) covers `--preserve-symlinks`, where `import.meta.url` is the symlink path. graphql-codegen probes candidate plugin names and expects unresolved ones to throw `MODULE_NOT_FOUND` so it can fall through to the next candidate — the loader preserves that by rethrowing the last error.

`graphql.ts` is the single chokepoint that invokes graphql-codegen's `generate()`, so this one loader covers both `types.ts` and `zod.ts` for every spec type.

## Validation

Reproduced and verified against a real clint-agent image (`@powerhousedao/codegen@6.2.0-dev.11`):

- **Without the loader** (default resolver): `Unable to find template plugin matching 'typescript'` / `'add'`.
- **With the loader**, using the image's own installed plugins: graphql-codegen resolves `typescript` + `add` and generates `types.ts` + `zod.ts` cleanly.

Same image, same installed plugins, same package — the loader was the only variable.