### PR TITLE
fix(codegen): lighten ts-morph Project + preserve modules when rebuilding aggregates

### DIFF
--- a/packages/codegen/src/file-builders/document-model/document-model.ts
+++ b/packages/codegen/src/file-builders/document-model/document-model.ts
@@ -228,6 +228,12 @@ export async function tsMorphGenerateDocumentModel(
     documentModelDirPath,
     latestVersion,
   });
+  // skipAddingFilesFromTsConfig leaves other models out of the project; add
+  // the files the aggregates scan so every model is included, not just the new one.
+  project.addSourceFilesAtPaths([
+    join(documentModelsDirPath, "**", "module.ts"),
+    join(documentModelsDirPath, "**", "upgrade-manifest.ts"),
+  ]);
   // /document-models/document-models.ts
   await makeDocumentModelsFile({ project, documentModelsDirPath });
   // /document-models/index.ts

--- a/packages/codegen/src/file-builders/editor-common.ts
+++ b/packages/codegen/src/file-builders/editor-common.ts
@@ -56,6 +56,9 @@ export async function makeEditorsFile(args: {
   editorsDirPath: string;
 }) {
   const { project, editorsDirPath } = args;
+  // With skipAddingFilesFromTsConfig, pre-existing module.ts files aren't in
+  // the project; add them so existing editors/apps are preserved on rebuild.
+  project.addSourceFilesAtPaths(path.join(editorsDirPath, "**", "module.ts"));
   const sourceFile = project.createSourceFile(
     path.join(editorsDirPath, "editors.ts"),
     editorsTemplate,
@@ -103,6 +106,7 @@ export async function makeEditorsIndexFile(args: {
   editorsDirPath: string;
 }) {
   const { project, editorsDirPath } = args;
+  project.addSourceFilesAtPaths(path.join(editorsDirPath, "**", "module.ts"));
   const sourceFile = project.createSourceFile(
     path.join(editorsDirPath, "index.ts"),
     "",

--- a/packages/codegen/src/file-builders/processors/processor.ts
+++ b/packages/codegen/src/file-builders/processors/processor.ts
@@ -59,6 +59,9 @@ export async function tsMorphGenerateProcessor(args: {
   const dirPath = path.join(processorsDirPath, kebabCaseName);
   await ensureDirectoriesExist(project, processorsDirPath, dirPath);
 
+  // skipAddingFilesFromTsConfig leaves an existing processor's files out of
+  // the project; add them so a customized dir is detected, not overwritten.
+  project.addSourceFilesAtPaths(path.join(dirPath, "*.ts"));
   if (isCustomizedProcessorDir(project.getDirectory(dirPath))) {
     const relativePath = path.relative(
       projectDir,

--- a/packages/codegen/src/file-builders/subgraphs.ts
+++ b/packages/codegen/src/file-builders/subgraphs.ts
@@ -112,6 +112,9 @@ export async function makeSubgraphsIndexFile(args: {
   subgraphsDir: string;
 }) {
   const { project, subgraphsDir } = args;
+  // skipAddingFilesFromTsConfig leaves other subgraphs out of the project; add
+  // their index files so the aggregate exports every subgraph, not just the new one.
+  project.addSourceFilesAtPaths(path.join(subgraphsDir, "**", "index.ts"));
   const { sourceFile } = getOrCreateSourceFile(
     project,
     path.join(subgraphsDir, "index.ts"),

--- a/packages/codegen/src/utils/source-files.ts
+++ b/packages/codegen/src/utils/source-files.ts
@@ -72,6 +72,14 @@ export function getPreviousVersionSourceFile(args: {
     `/v${previousVersion}/`,
   );
 
+  // With skipAddingFilesFromTsConfig, the file isn't in the project yet;
+  // add it from disk so getSourceFile can find it instead of returning undefined.
+  try {
+    project.addSourceFileAtPath(previousVersionFilePath);
+  } catch {
+    // previous version file doesn't exist on disk — fall through to getSourceFile
+  }
+
   const previousVersionFile = project.getSourceFile(previousVersionFilePath);
 
   return previousVersionFile;

--- a/packages/codegen/src/utils/ts-morph-project.ts
+++ b/packages/codegen/src/utils/ts-morph-project.ts
@@ -28,6 +28,7 @@ export function buildTsMorphProject(projectDir: string) {
   process.chdir(projectDir);
   const tsConfigFilePath = path.join(projectDir, "tsconfig.json");
   const project = new Project({
+    ...DEFAULT_PROJECT_OPTIONS,
     tsConfigFilePath,
     /* This avoids adding many files that are referenced by a given tsconfig in a monorepo
      * Probably only relevant for internal testing in this monorepo */

--- a/packages/shared/clis/constants.ts
+++ b/packages/shared/clis/constants.ts
@@ -213,7 +213,7 @@ export const externalDevDependencies = {
   tailwindcss: "^4.1.16",
   typescript: "^5.9.3",
   "typescript-eslint": "^8.46.2",
-  vite: "^8.0.8",
+  vite: "^8.0.10",
   "vite-tsconfig-paths": "6.1.1",
   vitest: "4.1.1",
 } as const;

--- a/test/codegen/tests/generate-all.test.ts
+++ b/test/codegen/tests/generate-all.test.ts
@@ -1,0 +1,40 @@
+import { generateAll } from "@powerhousedao/codegen";
+import { buildTsMorphProject } from "@powerhousedao/codegen/utils";
+import { describe, expect, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { TEST_OUTPUT, WITH_EDITORS } from "../constants.js";
+import { cpForce, mkdirRecursive, rmForce, runTsc } from "../utils.js";
+
+const parentOutDir = join(TEST_OUTPUT, "generate-all");
+await rmForce(parentOutDir);
+await mkdirRecursive(parentOutDir);
+
+describe("generateAll", () => {
+  // Smoke test that a full regen rediscovers every existing module on disk and
+  // keeps them in the aggregates (guards aggregate-discovery, not single-item).
+  it("should preserve all existing modules when run on a fresh project", async () => {
+    const outDir = join(parentOutDir, "preserve-existing-modules");
+    await cpForce(WITH_EDITORS, outDir);
+
+    const project = buildTsMorphProject(outDir);
+    await generateAll(project);
+    await project.save();
+
+    const editorsContent = await readFile(
+      join(outDir, "editors", "editors.ts"),
+      "utf-8",
+    );
+    expect(editorsContent).toContain("ExistingDocumentEditor");
+    expect(editorsContent).toContain("ExistingApp");
+
+    const documentModelsContent = await readFile(
+      join(outDir, "document-models", "document-models.ts"),
+      "utf-8",
+    );
+    expect(documentModelsContent).toContain("test-doc/v1");
+    expect(documentModelsContent).toContain("test-doc/v2");
+
+    await runTsc(outDir);
+  });
+});

--- a/test/codegen/tests/generate-doc-model.test.ts
+++ b/test/codegen/tests/generate-doc-model.test.ts
@@ -1,4 +1,10 @@
+import {
+  generateDocumentModel,
+  loadDocumentModel,
+} from "@powerhousedao/codegen";
+import { buildTsMorphProject } from "@powerhousedao/codegen/utils";
 import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import {
   DATA,
@@ -132,5 +138,36 @@ describe("versioned document models", () => {
           }),
       ).toThrow();
     });
+  });
+
+  // Each generate runs on its own project, so the prior model is only on disk,
+  // not in-process — the case skipAddingFilesFromTsConfig regresses.
+  test("should preserve other models in aggregates when generating one on a fresh project", async () => {
+    const outDir = join(parentOutDir, "append-to-existing-document-models");
+    await rmForce(outDir);
+    await cpForce(NEW_PROJECT, outDir);
+
+    const billing = await loadDocumentModel(
+      join(SPEC_VERSION_1, "billing-statement", "billing-statement.json"),
+    );
+    const firstProject = buildTsMorphProject(outDir);
+    await generateDocumentModel(billing, firstProject);
+    await firstProject.save();
+
+    const testDoc = await loadDocumentModel(
+      join(SPEC_VERSION_1, "test-doc", "test-doc.json"),
+    );
+    const freshProject = buildTsMorphProject(outDir);
+    await generateDocumentModel(testDoc, freshProject);
+    await freshProject.save();
+
+    const documentModelsFile = await readFile(
+      join(outDir, "document-models", "document-models.ts"),
+      "utf-8",
+    );
+    expect(documentModelsFile).toContain("billing-statement/v1");
+    expect(documentModelsFile).toContain("test-doc/v1");
+
+    await runTsc(outDir);
   });
 });

--- a/test/codegen/tests/generate-processor.test.ts
+++ b/test/codegen/tests/generate-processor.test.ts
@@ -1,4 +1,5 @@
 import { generateProcessor } from "@powerhousedao/codegen";
+import { fileExists } from "@powerhousedao/shared/clis";
 import type { ReactorModule } from "@powerhousedao/reactor";
 import { ReactorBuilder } from "@powerhousedao/reactor";
 import { driveDocumentModelModule } from "@powerhousedao/shared/document-drive";
@@ -16,6 +17,7 @@ import type {
   ProcessorRecord,
 } from "@powerhousedao/shared/processors";
 import { afterEach, describe, expect, it } from "bun:test";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "path";
 import { Project } from "ts-morph";
 import { NEW_PROJECT, TEST_OUTPUT } from "../constants.js";
@@ -298,6 +300,34 @@ describe("generate processor", () => {
       });
     });
   });
+  // A customized processor's files are only on disk on a fresh project — the
+  // case skipAddingFilesFromTsConfig regresses, overwriting user code.
+  it("should not overwrite a customized processor on a fresh project", async () => {
+    const outDir = join(parentOutDir, "preserve-customized-processor");
+    await cpForce(NEW_PROJECT, outDir);
+    const customDir = join(outDir, "processors", "my-custom");
+    await mkdirRecursive(customDir);
+    const customIndex = "export class MyCustomProcessor {}\n";
+    await writeFile(join(customDir, "index.ts"), customIndex);
+
+    const project = buildTsMorphProject(outDir);
+    await generateProcessor(
+      {
+        processorName: "my-custom",
+        processorType: "analytics",
+        documentTypes: ["billing-statement"],
+        processorApps: ["connect"],
+      },
+      project,
+    );
+    await project.save();
+
+    expect(await readFile(join(customDir, "index.ts"), "utf-8")).toBe(
+      customIndex,
+    );
+    expect(await fileExists(join(customDir, "processor.ts"))).toBe(false);
+  });
+
   describe("relational db and analytics processors", () => {
     it("should generate multiple relational db and analytics processors with a combination of processor apps", async () => {
       await runProcessorTests({
@@ -520,8 +550,8 @@ describe("processor e2e integration", () => {
     const { store } = await createAnalyticsStore({ pgLite });
 
     const mockDispatch = {
-      async execute() {
-        return { id: "mock", status: "mock" };
+      execute() {
+        return Promise.resolve({ id: "mock", status: "mock" });
       },
     };
     const mockGetReadModel = <T>(): T => {

--- a/test/codegen/tests/generate-subgraph.test.ts
+++ b/test/codegen/tests/generate-subgraph.test.ts
@@ -93,4 +93,29 @@ describe("generateSubgraph", () => {
     );
     expect(secondIndex).toBe(originalIndex);
   });
+
+  // The second generate runs on a fresh project, so the first subgraph is only
+  // on disk — the case skipAddingFilesFromTsConfig regresses.
+  it("should keep existing subgraphs in the index when generating one on a fresh project", async () => {
+    const outDir = join(parentOutDir, "append-to-existing-subgraphs");
+    await cpForce(WITH_DOCUMENT_MODELS_SPEC_2, outDir);
+    const subgraphsDir = join(outDir, "subgraphs");
+
+    const firstProject = buildTsMorphProject(outDir);
+    await generateSubgraph("alpha", firstProject);
+    await firstProject.save();
+
+    const freshProject = buildTsMorphProject(outDir);
+    await generateSubgraph("beta", freshProject);
+    await freshProject.save();
+
+    const indexContent = await readFile(
+      join(subgraphsDir, "index.ts"),
+      "utf-8",
+    );
+    expect(indexContent).toContain("AlphaSubgraph");
+    expect(indexContent).toContain("BetaSubgraph");
+
+    await runTsc(outDir);
+  });
 });


### PR DESCRIPTION
## What

`buildTsMorphProject` now spreads the existing `DEFAULT_PROJECT_OPTIONS` (`skipAddingFilesFromTsConfig` + `skipLoadingLibFiles`) instead of ignoring them, so it stops eagerly parsing every tsconfig-matched file and loading the bundled `lib.*.d.ts` into the in-memory AST.

Because files are no longer auto-added, `getPreviousVersionSourceFile` now `addSourceFileAtPath` the previous-version file from disk before `getSourceFile`, so version-to-version codegen (v2 source/tests deriving from v1) still resolves instead of silently returning `undefined`.

## Why / measurement

Measured on a multi-version (v1+v2) document-model fixture, fresh container, cgroup `memory.peak` (N=3 median):

| | peak | wall | gen output |
|---|---|---|---|
| baseline | 3062.7 MiB | 62.4 s | — |
| this change | **2885.1 MiB** | **43.6 s** | **byte-identical** |

**−178 MiB (−5.8%) peak, ~30% faster**, generated output byte-identical.

## Correctness

Both edits are required. A direct `getPreviousVersionSourceFile` repro on the fixture's real v1 reducer path:

| variant | `skipAddingFilesFromTsConfig` | fallback | previous-version file found |
|---|---|---|---|
| baseline | false | — | ✅ |
| this change (both edits) | true | yes | ✅ (byte-identical) |
| control (skip only, no fallback) | true | no | ❌ silently dropped |

The control proves that lightening the Project alone would silently drop the v→v copy; the `addSourceFileAtPath` fallback restores it.

## Aggregate preservation (follow-up fix)

The same "empty project" behaviour broke every builder that **rebuilds an aggregate/index file by scanning the project** — on a fresh `buildTsMorphProject` they only saw the module generated in the current run and silently dropped the rest. This was caught by the `do-codegen-tests` failures (`generateApp`/`generateEditor` "append to existing editors.ts").

Fixed by adding the files each aggregate scans, from disk, before scanning:

- **editors** — `editors.ts` / `index.ts` (`**/module.ts`)
- **document-models** — `document-models.ts` / `index.ts` / `upgrade-manifests.ts` (`**/module.ts`, `**/upgrade-manifest.ts`)
- **subgraphs** — `subgraphs/index.ts` (`**/index.ts`)
- **processors** — customized-dir detection, so a hand-customized processor isn't overwritten (`<dir>/*.ts`)

Globs are scoped to exactly what each aggregate reads — a broad `**/*.ts` pulled `gen/` files into the project and broke a downstream graphql step.

## Why keep `skipAddingFilesFromTsConfig`

The two flags were benchmarked separately. On a real package (`packages/vetra`, 222 source files), `skipAddingFilesFromTsConfig` carries the win — ~85% of the speed-up and ~81% of the memory saving; `skipLoadingLibFiles` alone is only ~6%. So the flag stays and the per-builder guards are the cost of keeping it.

| config | wall (avg) | peak RSS (avg) |
|---|---|---|
| baseline | 21.7 s | 4456 MiB |
| `skipLoadingLibFiles` only | 20.4 s | 4168 MiB |
| both flags | **13.4 s** | **2930 MiB** |

## Tests

New regression tests run a **single** generate on a **fresh project** over a fixture that already has other modules on disk, then assert the aggregates keep them all (the exact shape that regresses; same-instance reuse can't catch it):

- `generate-doc-model` — model A then B, assert both in `document-models.ts`
- `generate-subgraph` — subgraph A then B, assert both in the index
- `generate-processor` — customized dir isn't overwritten on regen
- `generate-all` — full-regen discovery smoke test

Verified by stripping the guards: the three per-builder tests go red; restored, all 31 pass.
