### PR TITLE
perf(connect): serve Connect + heavy deps from a prebuilt vendor bundle in dev (opt-in)

### DIFF
--- a/packages/builder-tools/connect-utils/externalize-vendor.ts
+++ b/packages/builder-tools/connect-utils/externalize-vendor.ts
@@ -1,0 +1,600 @@
+/**
+ * Prebuild the heavy, stable Connect dependencies into a static ESM "vendor"
+ * bundle so the dev server never runs (or holds) the dependency optimizer /
+ * module graph for them.
+ *
+ * The reactor-project preview dev-optimizes a large UI graph (Connect itself,
+ * design-system, document-engineering, reactor-browser, …) every session —
+ * ~1–2 GB resident — even though those libs don't change; only the project's
+ * editors do. This module builds them ONCE with `vite build` (in a throwaway
+ * subprocess that exits, freeing the build's peak memory): `vite build` handles
+ * CSS/asset imports, web workers, and WASM (Connect's in-browser PGlite ships
+ * all three), and a multi-entry build with `preserveEntrySignatures: 'strict'`
+ * dedupes shared code into shared chunks. Entries for CJS deps re-export the
+ * module's named API explicitly (so `import { createRoot }` works); ESM deps
+ * use `export *`. The build runs under `base = VENDOR_URL_PREFIX` so emitted
+ * asset URLs (`new URL(…, import.meta.url)` for .wasm/.data/workers) resolve to
+ * the dev middleware, not the SPA root.
+ *
+ * The React family stays EXTERNAL (see `VENDOR_EXTERNAL`); `esmExternalRequirePlugin`
+ * owns that externalization and rewrites CJS `require("react")` → import. Vendor
+ * chunks keep bare React imports, which the dev import map resolves to Vite's
+ * pre-bundled React (`devReactImportmapPlugin`) — one React instance across the
+ * vendor, the project's editors, and CDN-loaded editors.
+ *
+ * `devReactImportmapPlugin` consumes the result: it externalizes these
+ * specifiers in the long-lived dev server, points the page import map at the
+ * vendor URLs, and serves the bundle. With Connect vendored, the dev server only
+ * processes the project's own `main` + local package; HMR for them is unaffected.
+ */
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname as pathDirname, join } from "node:path";
+
+export interface VendorPrebuildOptions {
+  /** Project root (the reactor-project dir). */
+  dirname: string;
+  /** Bare specifiers to bundle into the vendor (defaults to the heavy libs). */
+  include?: string[];
+  /** Specifiers left external to the build (defaults to the React family). */
+  external?: string[];
+  /** Directory to hold the static vendor bundle + import map. */
+  vendorDir?: string;
+  /** Filled with the failure cause when the prebuild returns null. */
+  errorRef?: { message?: string };
+}
+
+/**
+ * The stable Connect libraries worth prebuilding. The React family is NOT here —
+ * it's externalized from the build (see `VENDOR_EXTERNAL`) so the vendor shares
+ * the dev server's single React instance via the import map.
+ */
+export const DEFAULT_VENDOR_INCLUDE = [
+  "@powerhousedao/connect",
+  "document-model",
+  "zod",
+  "@powerhousedao/design-system/connect",
+  "@powerhousedao/reactor-browser",
+  "@powerhousedao/document-engineering",
+];
+
+/**
+ * React-family specifiers kept external to the vendor build. The vendor's chunks
+ * emit bare imports for these; `devReactImportmapPlugin`'s import map resolves
+ * them to Vite's pre-bundled React, so there is exactly one React instance.
+ */
+export const VENDOR_EXTERNAL = [
+  "react",
+  "react-dom",
+  "react-dom/client",
+  "react/jsx-runtime",
+  "react/jsx-dev-runtime",
+  // Dev-server virtual module (bundled local packages). Connect imports it in a
+  // try/catch; left external so the build doesn't try to resolve it and the dev
+  // server / import map resolves it at runtime.
+  "ph-bundled-packages-virtual",
+];
+
+export interface PrebuiltVendor {
+  vendorDir: string;
+  /** import map: bare specifier -> "/__vendor__/<entry>.js". */
+  imports: Record<string, string>;
+}
+
+/** URL prefix the vendor bundle is served under by the dev middleware. */
+export const VENDOR_URL_PREFIX = "/__vendor__/";
+
+/**
+ * Build the prebuilt vendor (once, in a throwaway subprocess) and return its dir
+ * + import map. Idempotent: reuses a cached vendor built for the same dep set.
+ * Returns null on any failure (caller falls back to a normal dev server).
+ */
+export async function prebuildConnectVendor(
+  options: VendorPrebuildOptions,
+): Promise<PrebuiltVendor | null> {
+  const include = expandIncludeSubpaths(
+    options.dirname,
+    options.include ?? DEFAULT_VENDOR_INCLUDE,
+  );
+  const external = options.external ?? VENDOR_EXTERNAL;
+  const vendorDir =
+    options.vendorDir ?? join(options.dirname, "node_modules/.ph-vendor");
+  const importMapPath = join(vendorDir, "import-map.json");
+  // A version change of any vendored dep must invalidate the cache, so the
+  // resolved versions are part of the key (not just the specifier lists).
+  const versionDigest = resolveVersionDigest(options.dirname, [
+    ...include,
+    ...external,
+  ]);
+
+  try {
+    const hit = readCacheHit(importMapPath, include, external, versionDigest);
+    if (hit) return { vendorDir, imports: hit };
+
+    // Serialize concurrent builders on a lock dir; a loser waits for the
+    // winner's result instead of clobbering the shared output.
+    const lockDir = `${vendorDir}.lock`;
+    const lock = acquireLock(lockDir);
+    if (!lock) {
+      const imports = await waitForCacheHit(
+        importMapPath,
+        include,
+        external,
+        versionDigest,
+        lockDir,
+      );
+      return imports ? { vendorDir, imports } : null;
+    }
+
+    try {
+      // Recheck under the lock: another builder may have finished while we
+      // were acquiring it.
+      const raced = readCacheHit(
+        importMapPath,
+        include,
+        external,
+        versionDigest,
+      );
+      if (raced) return { vendorDir, imports: raced };
+
+      const imports = await buildVendorAtomic(
+        options.dirname,
+        vendorDir,
+        include,
+        external,
+        versionDigest,
+      );
+      return imports ? { vendorDir, imports } : null;
+    } finally {
+      releaseLock(lock);
+    }
+  } catch (err) {
+    if (options.errorRef)
+      options.errorRef.message =
+        err instanceof Error ? err.message : String(err);
+    return null;
+  }
+}
+
+interface VendorCacheMeta {
+  include?: string[];
+  external?: string[];
+  versionDigest?: string;
+  imports: Record<string, string>;
+}
+
+// Return the cached import map iff the specifier sets AND the resolved-version
+// digest all match; otherwise null (forces a rebuild).
+function readCacheHit(
+  importMapPath: string,
+  include: string[],
+  external: string[],
+  versionDigest: string,
+): Record<string, string> | null {
+  if (!existsSync(importMapPath)) return null;
+  try {
+    const cached = JSON.parse(
+      readFileSync(importMapPath, "utf8"),
+    ) as VendorCacheMeta;
+    if (
+      sameSet(cached.include, include) &&
+      sameSet(cached.external, external) &&
+      cached.versionDigest === versionDigest
+    ) {
+      return cached.imports;
+    }
+  } catch {
+    // partial/corrupt import-map.json → treat as miss
+  }
+  return null;
+}
+
+// Hash the resolved version of each spec's owning package (from its installed
+// package.json). A bump or branch checkout that changes any version yields a
+// different digest, invalidating the cache. Unresolvable specs contribute a
+// sentinel so they don't silently collide.
+function resolveVersionDigest(dirname: string, specs: string[]): string {
+  const seen = new Map<string, string>();
+  for (const spec of specs) {
+    const { pkg } = parsePkg(spec);
+    if (seen.has(pkg)) continue;
+    let version = "missing";
+    try {
+      const pkgRoot = realpathSync(join(dirname, "node_modules", pkg));
+      const meta = JSON.parse(
+        readFileSync(join(pkgRoot, "package.json"), "utf8"),
+      ) as { version?: string };
+      version = String(meta.version ?? "unknown");
+    } catch {
+      // leave sentinel
+    }
+    seen.set(pkg, version);
+  }
+  const h = createHash("sha256");
+  // Fold in the build worker so a logic/build-option change busts stale bundles,
+  // not just a dep version bump.
+  const workerHash = createHash("sha256")
+    .update(VENDOR_BUILD_WORKER)
+    .digest("hex");
+  h.update(`worker:${workerHash}\n`);
+  for (const pkg of [...seen.keys()].sort()) {
+    h.update(`${pkg}@${seen.get(pkg)}\n`);
+  }
+  return h.digest("hex").slice(0, 16);
+}
+
+function sameSet(a: string[] | undefined, b: string[]): boolean {
+  if (!a || a.length !== b.length) return false;
+  const s = new Set(a);
+  return b.every((x) => s.has(x));
+}
+
+// Exclusive lock via mkdir (atomic on POSIX). The holder heartbeats an owner
+// file so a live (slow) build keeps it fresh; a crashed builder lets it go stale.
+const LOCK_STALE_MS = 5 * 60_000;
+const LOCK_HEARTBEAT_MS = 60_000;
+
+interface VendorLock {
+  dir: string;
+  token: string;
+  timer: ReturnType<typeof setInterval>;
+}
+
+const ownerFile = (lockDir: string): string => join(lockDir, "owner");
+
+// Stale iff the owner file hasn't been heartbeated within LOCK_STALE_MS. A
+// missing owner file means a builder mid-acquire — treat as fresh, don't steal.
+function lockIsStale(lockDir: string): boolean {
+  try {
+    return Date.now() - statSync(ownerFile(lockDir)).mtimeMs > LOCK_STALE_MS;
+  } catch {
+    return false;
+  }
+}
+
+function acquireLock(lockDir: string): VendorLock | null {
+  let made = false;
+  try {
+    mkdirSync(lockDir);
+    made = true;
+  } catch {
+    if (lockIsStale(lockDir)) {
+      try {
+        rmSync(lockDir, { recursive: true, force: true });
+        mkdirSync(lockDir);
+        made = true;
+      } catch {
+        // lost the reclaim race to another builder
+      }
+    }
+  }
+  if (!made) return null;
+  const token = `${process.pid}-${randomUUID()}`;
+  writeFileSync(ownerFile(lockDir), token);
+  // Refresh mtime while we still own it; stop if a stale-reclaim handed it off.
+  const timer = setInterval(() => {
+    try {
+      if (readFileSync(ownerFile(lockDir), "utf8") === token) {
+        writeFileSync(ownerFile(lockDir), token);
+      } else {
+        clearInterval(timer);
+      }
+    } catch {
+      clearInterval(timer);
+    }
+  }, LOCK_HEARTBEAT_MS);
+  timer.unref();
+  return { dir: lockDir, token, timer };
+}
+
+// Remove only if we still own it — a stale-reclaim may have handed the lock to
+// another builder, whose dir we must not delete.
+function releaseLock(lock: VendorLock): void {
+  clearInterval(lock.timer);
+  try {
+    if (readFileSync(ownerFile(lock.dir), "utf8") === lock.token) {
+      rmSync(lock.dir, { recursive: true, force: true });
+    }
+  } catch {
+    // owner file gone/unreadable — leave it for the stale path
+  }
+}
+
+// Loser path: poll for the winner to publish a matching import-map.json, until
+// the lock is released or a timeout elapses.
+async function waitForCacheHit(
+  importMapPath: string,
+  include: string[],
+  external: string[],
+  versionDigest: string,
+  lockDir: string,
+): Promise<Record<string, string> | null> {
+  const deadline = Date.now() + LOCK_STALE_MS;
+  while (Date.now() < deadline) {
+    const hit = readCacheHit(importMapPath, include, external, versionDigest);
+    if (hit) return hit;
+    if (!existsSync(lockDir)) {
+      // winner finished (or gave up); one last read
+      return readCacheHit(importMapPath, include, external, versionDigest);
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return null;
+}
+
+// Resolve an exports entry to the file it loads under browser/import
+// conditions, or null if none (e.g. document-model's node-only `./node`). Used
+// to skip node-only and CSS/JSON subpaths the browser-targeted build can't take.
+function importTarget(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object") return null;
+  const o = value as Record<string, unknown>;
+  for (const c of ["browser", "import", "module", "default"]) {
+    if (c in o) {
+      const t = importTarget(o[c]);
+      if (t) return t;
+    }
+  }
+  return null;
+}
+
+function parsePkg(spec: string): { pkg: string; sub: string } {
+  if (spec.startsWith("@")) {
+    const parts = spec.split("/");
+    return { pkg: parts.slice(0, 2).join("/"), sub: parts.slice(2).join("/") };
+  }
+  const i = spec.indexOf("/");
+  return i === -1
+    ? { pkg: spec, sub: "" }
+    : { pkg: spec.slice(0, i), sub: spec.slice(i + 1) };
+}
+
+/**
+ * Connect imports the heavy libs by subpath too (e.g.
+ * `@powerhousedao/design-system/connect/toast`, `zod/v4/core`). Those bare
+ * imports need their own import-map entry, so expand each listed spec to its
+ * package's concrete (non-wildcard, JS) subpath exports that share the spec's
+ * prefix. Unresolvable / CSS / JSON targets are skipped. Failures leave the
+ * original spec untouched.
+ */
+function expandIncludeSubpaths(dirname: string, include: string[]): string[] {
+  const out = new Set<string>(include);
+  for (const spec of include) {
+    const { pkg, sub } = parsePkg(spec);
+    let exp: unknown;
+    let pkgRoot: string;
+    try {
+      pkgRoot = realpathSync(join(dirname, "node_modules", pkg));
+      const pkgJson = JSON.parse(
+        readFileSync(join(pkgRoot, "package.json"), "utf8"),
+      ) as { exports?: unknown };
+      exp = pkgJson.exports;
+    } catch {
+      continue;
+    }
+    if (!exp || typeof exp !== "object") continue;
+    const expMap = exp as Record<string, unknown>;
+    const prefixKey = sub ? `./${sub}` : ".";
+    for (const key of Object.keys(expMap)) {
+      if (key.includes("*") || key === "./package.json") continue;
+      if (/\.(css|json|scss)$/.test(key)) continue;
+      const matches =
+        prefixKey === "."
+          ? key === "." || key.startsWith("./")
+          : key === prefixKey || key.startsWith(`${prefixKey}/`);
+      if (!matches) continue;
+      const target = importTarget(expMap[key]);
+      if (!target || /\.(css|json|scss)$/.test(target)) continue;
+      // Skip subpaths whose target file isn't shipped (e.g. a `./test` export
+      // pointing at unbuilt dist) — they'd fail the build.
+      if (!existsSync(join(pkgRoot, target))) continue;
+      out.add(key === "." ? pkg : pkg + key.slice(1));
+    }
+  }
+  return [...out];
+}
+
+/**
+ * Build the vendor into a unique temp dir, then atomically swap it into place,
+ * so a concurrent reader never sees a partial bundle or import-map.json. Runs
+ * the build in a throwaway subprocess (its peak memory is reclaimed on exit);
+ * the parent augments the import map with the version digest and does the swap.
+ * Returns the published import map, or null on failure.
+ */
+async function buildVendorAtomic(
+  dirname: string,
+  vendorDir: string,
+  include: string[],
+  external: string[],
+  versionDigest: string,
+): Promise<Record<string, string> | null> {
+  const parent = pathDirname(vendorDir);
+  mkdirSync(parent, { recursive: true });
+  const tmpDir = mkdtempSync(join(parent, ".ph-vendor.tmp-"));
+  try {
+    const { ok, stderr } = await runBuildWorker(
+      dirname,
+      tmpDir,
+      include,
+      external,
+    );
+    const tmpMap = join(tmpDir, "import-map.json");
+    if (!ok || !existsSync(tmpMap)) {
+      const detail = stderr.trim();
+      throw new Error(
+        `vendor build failed${detail ? `:\n${detail}` : " (no output captured)"}`,
+      );
+    }
+    // Stamp the version digest into the published metadata so the cache check
+    // can detect a dep bump.
+    const meta = JSON.parse(readFileSync(tmpMap, "utf8")) as VendorCacheMeta;
+    meta.versionDigest = versionDigest;
+    writeFileSync(tmpMap, JSON.stringify(meta, null, 2));
+
+    // Swap: move any existing dir aside, rename temp into place, drop the old.
+    const oldDir = `${vendorDir}.old-${process.pid}-${Date.now()}`;
+    if (existsSync(vendorDir)) renameSync(vendorDir, oldDir);
+    renameSync(tmpDir, vendorDir);
+    rmSync(oldDir, { recursive: true, force: true });
+    return meta.imports;
+  } catch (err) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    throw err;
+  }
+}
+
+/**
+ * Spawn a throwaway worker that generates one entry per specifier (CJS deps get
+ * explicit named re-exports, ESM deps `export *`), `vite build`s them into the
+ * given out dir, and writes the import map. Captures stdout/stderr so a failure
+ * is debuggable; the normal path stays quiet.
+ */
+function runBuildWorker(
+  dirname: string,
+  outDir: string,
+  include: string[],
+  external: string[],
+): Promise<{ ok: boolean; stderr: string }> {
+  const workerPath = join(outDir, "build-worker.mjs");
+  writeFileSync(workerPath, VENDOR_BUILD_WORKER);
+  return new Promise((resolve) => {
+    const child = spawn(
+      process.execPath,
+      [
+        workerPath,
+        dirname,
+        outDir,
+        JSON.stringify(include),
+        VENDOR_URL_PREFIX,
+        JSON.stringify(external),
+      ],
+      { cwd: dirname, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stderr = "";
+    child.stdout.on("data", (d) => {
+      stderr += String(d);
+    });
+    child.stderr.on("data", (d) => {
+      stderr += String(d);
+    });
+    child.on("exit", (code) => resolve({ ok: code === 0, stderr }));
+    child.on("error", (e) => resolve({ ok: false, stderr: String(e) }));
+  });
+}
+
+/**
+ * The vendor build worker, written to disk and run as a subprocess. Self-contained
+ * (only Node + the project's `vite`). argv: dirname, vendorDir, includeJSON, urlPrefix.
+ */
+const VENDOR_BUILD_WORKER = `
+import { createRequire } from 'node:module';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
+const [dirname, vendorDir, includeJSON, urlPrefix, externalJSON] = process.argv.slice(2);
+const include = JSON.parse(includeJSON);
+const external = JSON.parse(externalJSON ?? '[]');
+const externalSet = new Set(external);
+const reqProj = createRequire(join(dirname, 'noop.js'));
+const { build, esmExternalRequirePlugin } = await import(reqProj.resolve('vite'));
+const srcDir = join(vendorDir, '.entries');
+mkdirSync(srcDir, { recursive: true });
+const entryName = (spec) => spec.replace(/[^\\w]+/g, '_');
+const RESERVED = new Set('enum void null function in instanceof typeof new delete do if else return switch case break continue for while this true false class const let var default export import extends super with yield debugger finally throw try catch await implements interface package private protected public static eval arguments'.split(' '));
+const input = {};
+for (const spec of include) {
+  const name = entryName(spec);
+  let src;
+  try {
+    // Import the bare spec (not reqProj.resolve(spec)) so Node picks the same
+    // import/browser-condition module the build resolves — resolving first can
+    // pick a CJS sibling whose default-export shape differs from the ESM build.
+    const ns = await import(spec);
+    // Only fall back to re-exporting from default when the module exposes NO
+    // top-level named exports (a true CJS-interop module). If it does (e.g. zod
+    // exposes \`z\`), \`export *\` captures them; destructuring default would miss
+    // top-level names that aren't keys of the default object.
+    const named = Object.keys(ns).filter((k) => k !== 'default');
+    const cjs = named.length === 0 && ns.default && typeof ns.default === 'object';
+    if (cjs) {
+      const names = Object.keys(ns.default).filter((k) => k !== 'default' && k !== '__esModule' && /^[A-Za-z_$][\\w$]*$/.test(k));
+      const plain = names.filter((n) => !RESERVED.has(n));
+      const reserved = names.filter((n) => RESERVED.has(n));
+      src = 'import d from ' + JSON.stringify(spec) + ';\\nexport default d;\\n'
+        + (plain.length ? 'export const { ' + plain.join(', ') + ' } = d;\\n' : '');
+      // reserved words are invalid as const-binding names but valid as export
+      // aliases (export { x as enum }).
+      reserved.forEach((n, i) => {
+        src += 'const __r' + i + ' = d[' + JSON.stringify(n) + '];\\nexport { __r' + i + ' as ' + n + ' };\\n';
+      });
+    } else {
+      src = 'export * from ' + JSON.stringify(spec) + ';\\n'
+        + (('default' in ns) ? 'export { default } from ' + JSON.stringify(spec) + ';\\n' : '');
+    }
+  } catch {
+    src = 'export * from ' + JSON.stringify(spec) + ';\\n';
+  }
+  const file = join(srcDir, name + '.js');
+  writeFileSync(file, src);
+  input[name] = file;
+}
+// Prefer the bundler's browser-condition-aware resolution; fall back to resolving
+// from the worker (real install path) only for Rolldown's realpath-anchoring bug.
+const phResolveCache = new Map();
+const phVendorResolve = {
+  name: 'ph-vendor-resolve', enforce: 'pre',
+  async resolveId(source, importer, options) {
+    if (externalSet.has(source)) return null;
+    if (source[0] === '\\0' || source[0] === '.' || isAbsolute(source)) return null;
+    if (source.startsWith('node:') || source.startsWith('data:')) return null;
+    let viaBundler = null;
+    try { viaBundler = await this.resolve(source, importer, { ...options, skipSelf: true }); } catch {}
+    if (viaBundler) return viaBundler;
+    if (phResolveCache.has(source)) return phResolveCache.get(source);
+    let resolved = null;
+    try { resolved = fileURLToPath(import.meta.resolve(source)); } catch {}
+    phResolveCache.set(source, resolved);
+    return resolved;
+  },
+};
+await build({
+  root: dirname, configFile: false, logLevel: 'error',
+  // Emit asset URLs (pglite .wasm/.data, workers via \`new URL(..., import.meta.url)\`)
+  // under the vendor prefix so they resolve to the middleware, not the SPA root.
+  base: urlPrefix,
+  define: { 'process.env.NODE_ENV': '"development"' },
+  // phVendorResolve runs first (pre) so bare specifiers resolve from the worker,
+  // not the importing module's realpath. esmExternalRequirePlugin then OWNS
+  // externalization of \`external\` (react family + dev virtuals): it marks them
+  // external AND rewrites CJS require("react") to import (Rolldown keeps bare
+  // require() for external ids, which fails in the browser). It must be the sole
+  // externalizer — also listing them in rollupOptions.external prevents the
+  // require() rewrite (see vite-config.ts).
+  plugins: [phVendorResolve, esmExternalRequirePlugin({ external })],
+  // pglite (and any worker dep) ships web workers; emit them as ES-module asset
+  // chunks into the vendor so the middleware can serve them.
+  worker: { format: 'es' },
+  build: {
+    outDir: vendorDir, emptyOutDir: false, minify: false, target: 'esnext', cssCodeSplit: true,
+    rollupOptions: {
+      input, preserveEntrySignatures: 'strict',
+      output: { format: 'es', entryFileNames: '[name].js', chunkFileNames: 'chunks/[name]-[hash].js', assetFileNames: 'assets/[name]-[hash][extname]' },
+    },
+  },
+});
+rmSync(srcDir, { recursive: true, force: true });
+const imports = {};
+for (const spec of include) imports[spec] = urlPrefix + entryName(spec) + '.js';
+writeFileSync(join(vendorDir, 'import-map.json'), JSON.stringify({ include, external, imports }, null, 2));
+`;

--- a/packages/builder-tools/connect-utils/index.ts
+++ b/packages/builder-tools/connect-utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./constants.js";
+export * from "./externalize-vendor.js";
 export * from "./helpers.js";
 export * from "./runtime-config-schema.js";
 export * from "./types.js";

--- a/packages/builder-tools/connect-utils/vite-config.ts
+++ b/packages/builder-tools/connect-utils/vite-config.ts
@@ -405,7 +405,7 @@ export function getConnectBaseViteConfig(options: IConnectOptions) {
       // CDN editors load React from esm.sh while Connect uses Vite's local
       // copy → two React instances → useSyncExternalStore crash. The build
       // path stays untouched; `esmExternalRequirePlugin` below still owns it.
-      devReactImportmapPlugin(),
+      devReactImportmapPlugin(options.dirname),
       ...plugins,
       // Externalize React so both Connect and dynamically loaded registry
       // packages share the same React instance via the import map in index.html.

--- a/packages/builder-tools/connect-utils/vite-plugins/dev-external-react.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/dev-external-react.ts
@@ -1,6 +1,14 @@
 import { createRequire } from "node:module";
+import { createReadStream } from "node:fs";
 import path from "node:path";
 import type { Plugin } from "vite";
+import {
+  DEFAULT_VENDOR_INCLUDE,
+  VENDOR_URL_PREFIX,
+  prebuildConnectVendor,
+  type PrebuiltVendor,
+} from "../externalize-vendor.js";
+import { BUNDLED_PACKAGES_DEV_URL } from "./ph-bundled-packages.js";
 
 const REACT_DEPS = [
   "react",
@@ -13,10 +21,56 @@ const REACT_DEPS = [
 const SHIM_PATH = "__ph/dev-react-shim/";
 const VITE_DEPS_PATH = "node_modules/.vite/deps";
 
+// Content-Type for the asset extensions the vendor build emits; JS is the default.
+const VENDOR_MIME: Record<string, string> = {
+  ".css": "text/css",
+  ".map": "application/json",
+  ".json": "application/json",
+  ".wasm": "application/wasm",
+  ".data": "application/octet-stream",
+  ".woff2": "font/woff2",
+  ".woff": "font/woff",
+  ".ttf": "font/ttf",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
+// Opt-in: also serve the heavy stable Connect libs from a prebuilt vendor
+// bundle, so the long-lived dev server never dep-optimizes them (~1–2 GB
+// resident). Set PH_CONNECT_EXTERNALIZE_VENDOR=1 to enable.
+const VENDOR_MODE = process.env.PH_CONNECT_EXTERNALIZE_VENDOR === "1";
+// Extra specifiers to vendor on top of the defaults, comma-separated. Lets a
+// project add its own stable heavy deps without code changes.
+const VENDOR_EXTRA = (process.env.PH_CONNECT_VENDOR_EXTRA ?? "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+const HEAVY_LIBS = [...DEFAULT_VENDOR_INCLUDE, ...VENDOR_EXTRA];
+
 // Vite serves dev module URLs under the resolved `base`. Join base + path
 // while collapsing the double slash so `base: "/"` stays byte-identical.
 function withBase(base: string, p: string): string {
   return `${base}${p}`.replace(/\/{2,}/g, "/");
+}
+
+// Keep the matched specifiers bare in dev (Vite otherwise rewrites externals to
+// "/@id/<spec>") so the import map resolves them; predicate matching supported.
+type Externals = Array<string | ((id: string) => boolean)>;
+function externalizePlugin(externals: Externals): Plugin | undefined {
+  try {
+    const require = createRequire(import.meta.url);
+    const mod = require("vite-plugin-externalize-dependencies") as {
+      default?: (o: { externals: Externals }) => Plugin;
+    } & ((o: { externals: Externals }) => Plugin);
+    const factory = mod.default ?? mod;
+    return factory({ externals });
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -27,7 +81,7 @@ function withBase(base: string, p: string): string {
  * export — so a CDN editor that does `import { lazy } from "react"` would
  * fail with "no named export 'lazy'".
  *
- * This plugin:
+ * This plugin owns the page import map. It always:
  *   1. Forces React into `optimizeDeps.include` so the optimizer always knows
  *      about it.
  *   2. Serves a shim per React module at a stable URL. Each shim imports
@@ -35,15 +89,73 @@ function withBase(base: string, p: string): string {
  *      and re-exports React's named members so editors importing
  *      `{ lazy }`, `{ jsx }`, etc. work.
  *   3. Rewrites the page importmap to point at those shim URLs.
+ *
+ * When PH_CONNECT_EXTERNALIZE_VENDOR=1 it additionally prebuilds the heavy
+ * stable libs (design-system, reactor-browser, …) into a static vendor bundle,
+ * externalizes them from the dev server, serves the bundle, and adds them to
+ * the SAME import map. The vendor's React imports stay bare → resolve through
+ * the React shims above → one React instance across Connect, the vendor, and
+ * CDN editors.
  */
-export function devReactImportmapPlugin(): Plugin {
+// Async factory: in VENDOR_MODE it runs the vendor prebuild up front (Vite
+// awaits a Promise<PluginOption>), so `vendor` is known before any plugin hook
+// fires. The heavy libs are excluded from the optimizer — and the externalize
+// plugin is added — ONLY when a valid bundle will be served. On prebuild
+// failure they stay dev-optimized (no broken bare imports) and neither the
+// import map nor the externalizer touch them.
+export async function devReactImportmapPlugin(
+  projectRoot: string = process.cwd(),
+): Promise<Plugin | Plugin[]> {
   let namedExports = new Map<string, string[]>();
   let base = "/";
+  let vendor: PrebuiltVendor | null = null;
 
-  return {
+  if (VENDOR_MODE) {
+    const errorRef: { message?: string } = {};
+    vendor = await prebuildConnectVendor({
+      dirname: projectRoot,
+      include: HEAVY_LIBS,
+      errorRef,
+    });
+    if (!vendor) {
+      const detail = errorRef.message ? `: ${errorRef.message}` : "";
+      console.warn(
+        `[connect] PH_CONNECT_EXTERNALIZE_VENDOR set but vendor prebuild failed; falling back to dep-optimizing the heavy libs${detail}`,
+      );
+    }
+  }
+
+  // Externalize exactly the specifiers in the vendor import map (not broad
+  // prefixes) so an undiscovered subpath stays resolvable instead of 404ing.
+  const ext = vendor
+    ? externalizePlugin([(id) => id in vendor!.imports])
+    : undefined;
+  if (vendor && !ext) {
+    console.warn(
+      "[connect] PH_CONNECT_EXTERNALIZE_VENDOR set and vendor prebuilt, but vite-plugin-externalize-dependencies is not installed; falling back to dep-optimizing the heavy libs (install it to enable the vendor)",
+    );
+  }
+  const vendorActive = !!(vendor && ext);
+
+  const main: Plugin = {
     name: "ph-dev-react-importmap",
     apply: "serve",
-    config: () => ({ optimizeDeps: { include: REACT_DEPS } }),
+    config(cfg) {
+      cfg.optimizeDeps ??= {};
+      const include = new Set(cfg.optimizeDeps.include ?? []);
+      REACT_DEPS.forEach((d) => include.add(d));
+      if (vendorActive) {
+        // The heavy libs are served from the prebuilt vendor; force-including
+        // them would pre-bundle them anyway (and leave their excluded deps —
+        // e.g. zod subpaths — as unmapped bare imports). Drop them from include
+        // and exclude them so the optimizer never touches them.
+        HEAVY_LIBS.forEach((d) => include.delete(d));
+        cfg.optimizeDeps.exclude = [
+          ...new Set([...(cfg.optimizeDeps.exclude ?? []), ...HEAVY_LIBS]),
+        ];
+      }
+      cfg.optimizeDeps.include = [...include];
+    },
     configResolved(config) {
       base = config.base;
     },
@@ -63,6 +175,41 @@ export function devReactImportmapPlugin(): Plugin {
           }
         }),
       );
+
+      // Serve the prebuilt vendor bundle (JS/CSS/maps + shared chunks/assets).
+      if (vendorActive) {
+        const vendorDir = vendor!.vendorDir;
+        server.middlewares.use(VENDOR_URL_PREFIX, (req, res, next) => {
+          const name = (req.url ?? "").split("?")[0].replace(/^\/+/, "");
+          const file = path.join(vendorDir, name);
+          // Path-segment containment (not a string prefix): reject anything that
+          // escapes vendorDir, incl. siblings like `.ph-vendor.lock`.
+          const rel = path.relative(vendorDir, file);
+          if (!name || rel.startsWith("..") || path.isAbsolute(rel)) {
+            return next();
+          }
+          // Stream (don't buffer multi-MB wasm/.data); a missing file → next().
+          const stream = createReadStream(file);
+          stream.on("error", () => {
+            if (!res.headersSent) next();
+          });
+          stream.once("open", () => {
+            const ext = file.slice(file.lastIndexOf("."));
+            res.setHeader(
+              "Content-Type",
+              VENDOR_MIME[ext] ?? "text/javascript",
+            );
+            // Content-hashed chunks/assets are immutable; entries + map can change.
+            const hashed =
+              name.startsWith("chunks/") || name.startsWith("assets/");
+            res.setHeader(
+              "Cache-Control",
+              hashed ? "public, max-age=31536000, immutable" : "no-cache",
+            );
+            stream.pipe(res);
+          });
+        });
+      }
 
       // Match the base-prefixed shim URL, and the bare path for robustness.
       const shimPrefixes = [withBase(base, SHIM_PATH), `/${SHIM_PATH}`];
@@ -104,12 +251,28 @@ export function devReactImportmapPlugin(): Plugin {
           ctx.server?.environments.client.depsOptimizer?.metadata.browserHash;
         if (!browserHash) return;
         const shimPrefix = withBase(base, SHIM_PATH);
-        const imports = Object.fromEntries(
+        const imports: Record<string, string> = Object.fromEntries(
           REACT_DEPS.map((id) => [
             id,
             `${shimPrefix}${id}.js?v=${browserHash}`,
           ]),
         );
+        // Heavy libs resolve to the prebuilt vendor; their bare React imports
+        // fall through to the React shim entries above.
+        if (vendorActive) {
+          Object.assign(imports, vendor!.imports);
+          // When Connect is vendored it isn't dev-processed, so its dynamic
+          // `import("ph-bundled-packages-virtual")` (project local packages)
+          // can't be transformed in place. Point it at the URL Vite serves the
+          // virtual module at (phBundledPackagesPlugin), so bundled local
+          // packages still register.
+          if (vendor!.imports["@powerhousedao/connect"]) {
+            imports["ph-bundled-packages-virtual"] = withBase(
+              base,
+              BUNDLED_PACKAGES_DEV_URL,
+            );
+          }
+        }
         return html.replace(
           /<script type="importmap">[\s\S]*?<\/script>/,
           `<script type="importmap">${JSON.stringify({ imports }, null, 2)}</script>`,
@@ -117,4 +280,8 @@ export function devReactImportmapPlugin(): Plugin {
       },
     },
   };
+
+  // The externalizer runs alongside `main` so Connect's source leaves the heavy
+  // libs bare (→ import map → vendor); React stays optimized via the shims.
+  return vendorActive ? [ext!, main] : main;
 }

--- a/packages/builder-tools/connect-utils/vite-plugins/ph-bundled-packages.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/ph-bundled-packages.ts
@@ -13,8 +13,11 @@ export type PhBundledPackagesPluginOptions = {
   projectRoot?: string;
 };
 
-const VIRTUAL_ID = "ph-bundled-packages-virtual";
-const RESOLVED_VIRTUAL_ID = "\0virtual:" + VIRTUAL_ID;
+export const VIRTUAL_ID = "ph-bundled-packages-virtual";
+export const RESOLVED_VIRTUAL_ID = "\0virtual:" + VIRTUAL_ID;
+// Vite serves a resolved id at /@id/<id with \0 → __x00__>.
+export const BUNDLED_PACKAGES_DEV_URL =
+  "@id/" + RESOLVED_VIRTUAL_ID.replace("\0", "__x00__");
 
 function readBundledPackageVersion(
   projectRoot: string,

--- a/packages/builder-tools/package.json
+++ b/packages/builder-tools/package.json
@@ -41,14 +41,19 @@
     "@sentry/vite-plugin": "^4.3.0",
     "tsdown": "catalog:",
     "tsx": "catalog:",
+    "vite-plugin-externalize-dependencies": "^1.0.1",
     "vitest": "catalog:",
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "@sentry/vite-plugin": "^4.3.0"
+    "@sentry/vite-plugin": "^4.3.0",
+    "vite-plugin-externalize-dependencies": "^1.0.1"
   },
   "peerDependenciesMeta": {
     "@sentry/vite-plugin": {
+      "optional": true
+    },
+    "vite-plugin-externalize-dependencies": {
       "optional": true
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1188,6 +1188,9 @@ importers:
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
+      vite-plugin-externalize-dependencies:
+        specifier: ^1.0.1
+        version: 1.0.1
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/browser-playwright@4.1.1)(happy-dom@20.9.0)(jsdom@24.1.3)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -18614,6 +18617,9 @@ packages:
   vite-bundle-analyzer@1.3.6:
     resolution: {integrity: sha512-elFXkF9oGy4CJEeOdP1DSEHRDKWfmaEDfT9/GuF4jmyfmUF6nC//iN+ythqMEVvrtchOEHGKLumZwnu1NjoI0w==}
     hasBin: true
+
+  vite-plugin-externalize-dependencies@1.0.1:
+    resolution: {integrity: sha512-kRIizv+YcrXFwzjde1iqayKTOKLR0JE3JPVrwm/6bsrXnwGSz+3Q+pKOgamAtlASPXx13JpXB50/OfQ0GqiIUw==}
 
   vite-plugin-html@3.2.2:
     resolution: {integrity: sha512-vb9C9kcdzcIo/Oc3CLZVS03dL5pDlOFuhGlZYDCJ840BhWl/0nGeZWf3Qy7NlOayscY4Cm/QRgULCQkEZige5Q==}
@@ -39024,6 +39030,8 @@ snapshots:
       - zod
 
   vite-bundle-analyzer@1.3.6: {}
+
+  vite-plugin-externalize-dependencies@1.0.1: {}
 
   vite-plugin-html@3.2.2(vite@8.0.10(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
## What

Opt-in (`PH_CONNECT_EXTERNALIZE_VENDOR=1`) Vite-dev optimization: Connect + 6 heavy stable libs (`@powerhousedao/connect`, `design-system/connect`, `document-engineering`, `reactor-browser`, `document-model`, `zod`) are excluded from Vite's dep optimizer and served from a once-built, subprocess-generated static vendor bundle under `/__vendor__/` (via an import map; React stays externalized through the dev shim so there's one instance).

## Win (measured)

Reactor-project-start Vite dev server, fresh container, cgroup `memory.peak`, N=3 median, hardened preview-parity gate (verified the lever is genuinely active — `/__vendor__/` served 200, not a silent fallback):

| Arm | peak | vs OFF |
|---|---|---|
| OFF | 3051.6 MiB | — |
| **ON (warm cache)** | **2108.5 MiB** | **−943.1 MiB (−24%)** |
| ON (cold cache) | 3699.8 MiB | +648 MiB one-time first-run build |

## Robustness fixes on top of the original change

- **version-aware cache key + atomic, locked build** — folds a digest of vendored dep versions into the cache key (no stale bundle after a lockfile bump); builds into a temp dir + atomic rename + lock dir (no partial reads / concurrent corruption).
- **graceful degradation** — exclude heavy libs from `optimizeDeps` only when a valid vendor bundle will actually be served; on prebuild failure the app stays dev-optimized instead of breaking in the browser.
- **Rolldown resolution fix** — the vendor build's `vite build` (Rolldown 1.0.2) anchored bare-specifier resolution on the importer's realpath, which escapes the install tree under pnpm's global virtual store (how the agent image installs) → intermittent "failed to resolve" per run. The build worker now resolves bare specifiers via its own `import.meta.resolve`. Verified 10/10-fail → 0/10-fail; this is what makes the win above real.
- move `vite-plugin-externalize-dependencies` to devDependencies.

## To ship

Default-off and inert in the product until: (1) a vetra-cli release carries the `reactor-project-start` env toggle wiring; (2) `.ph-vendor` is persisted across the frequent reactor-project-start restarts so the +648 MiB ON-cold first-run penalty isn't repaid each boot. Defaulting it on is a separate product call.

(The branch also carries an incidental `feat(ph-cli): add --drives-public-base` commit, unrelated to vendoring.)