### PR TITLE
feat(connect): prompt login for auth-protected drives

### DIFF
--- a/apps/connect/src/components/drive-auth-gate.test.tsx
+++ b/apps/connect/src/components/drive-auth-gate.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Controls useDriveAuthGate's return between tests.
+const mockGate = vi.hoisted(() => ({ needsLogin: false }));
+
+vi.mock("../components/use-drive-auth-gate.js", () => ({
+  useDriveAuthGate: () => mockGate,
+}));
+
+// The real gate lives in design-system; stub it (with the real copy) plus the
+// home-screen exports so rendering Content needs no design-system barrel.
+vi.mock("@powerhousedao/design-system/connect", () => ({
+  DriveAuthGate: () => <div>Log in to access this drive</div>,
+  HomeScreen: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="home-screen">{children}</div>
+  ),
+  HomeScreenAddDriveItem: () => null,
+  HomeScreenItem: () => null,
+}));
+
+vi.mock("@powerhousedao/connect/components", () => ({
+  AppContainer: () => <div data-testid="app-container" />,
+  DriveIcon: () => null,
+}));
+
+vi.mock("@powerhousedao/connect/config", () => ({
+  defaultPHAppConfig: {},
+  defaultPHDocumentEditorConfig: {},
+}));
+
+vi.mock("../runtime-config.js", () => ({
+  getRuntimeConfig: () => ({ connect: {} }),
+}));
+
+vi.mock("@powerhousedao/reactor-browser", () => ({
+  openRenown: vi.fn(),
+  setPHAppConfig: vi.fn(),
+  setPHDocumentEditorConfig: vi.fn(),
+  setSelectedDrive: vi.fn(),
+  useAppModuleById: () => undefined,
+  useDrives: () => [],
+  useIsAddDriveEnabled: () => false,
+  useSelectedDocumentId: () => undefined,
+  useSelectedDriveSafe: () => [undefined],
+  useSelectedFolder: () => undefined,
+}));
+
+import { Content } from "../pages/content.js";
+
+describe("Content drive auth gate wiring", () => {
+  beforeEach(() => {
+    mockGate.needsLogin = false;
+  });
+
+  it("renders the login gate when needsLogin is true", () => {
+    mockGate.needsLogin = true;
+    render(<Content />);
+    expect(screen.getByText("Log in to access this drive")).toBeDefined();
+    expect(screen.queryByTestId("home-screen")).toBeNull();
+  });
+
+  it("renders the home screen (not the gate) when needsLogin is false", () => {
+    mockGate.needsLogin = false;
+    render(<Content />);
+    expect(screen.queryByText("Log in to access this drive")).toBeNull();
+    expect(screen.getByTestId("home-screen")).toBeDefined();
+  });
+});

--- a/apps/connect/src/components/modal/modals-container.tsx
+++ b/apps/connect/src/components/modal/modals-container.tsx
@@ -72,6 +72,11 @@ const MissingPackageModal = lazy(() =>
     default: m.ConnectMissingPackageModal,
   })),
 );
+const DriveAuthRequiredModal = lazy(() =>
+  import("./modals/DriveAuthRequiredModal.js").then((m) => ({
+    default: m.DriveAuthRequiredModal,
+  })),
+);
 const modalComponents = {
   addDrive: AddDriveModal,
   clearStorage: ClearStorageModal,
@@ -87,6 +92,7 @@ const modalComponents = {
   settings: SettingsModal,
   upgradeDrive: UpgradeDriveModal,
   missingPackage: MissingPackageModal,
+  driveAuthRequired: DriveAuthRequiredModal,
 } as const;
 
 export const ModalsContainer = lazy(() => {

--- a/apps/connect/src/components/modal/modals/AddDriveModal.tsx
+++ b/apps/connect/src/components/modal/modals/AddDriveModal.tsx
@@ -136,9 +136,10 @@ export function AddDriveModal() {
       requestPublicDrive={async (url: string) => {
         try {
           if (user) {
+            // aud omitted: server verifies without an audience, so aud-bearing
+            // tokens are rejected. Re-enable once both sides support it.
             const authToken = await renown?.getBearerToken?.({
               expiresIn: 10,
-              aud: url,
             });
             return requestPublicDriveFromReactor(url, {
               Authorization: `Bearer ${authToken}`,

--- a/apps/connect/src/components/modal/modals/DriveAuthRequiredModal.tsx
+++ b/apps/connect/src/components/modal/modals/DriveAuthRequiredModal.tsx
@@ -1,0 +1,33 @@
+import { DriveAuthGate } from "@powerhousedao/design-system/connect";
+import { openRenown, usePHModal } from "@powerhousedao/reactor-browser";
+import React from "react";
+
+/**
+ * Shown when a protected drive can't be added because the user isn't logged in.
+ *
+ * Deliberately NOT a Radix modal dialog: a modal dialog blocks all outside
+ * interaction, which would trap the cookie banner (rendered above at z-10000)
+ * and prevent accepting/rejecting it. Instead this is a non-blocking overlay —
+ * `pointer-events-none` on the backdrop (so the banner and page stay clickable)
+ * with `pointer-events-auto` on the card — sitting below the cookie banner. The
+ * card itself is the shared {@link DriveAuthGate}, identical to the full-page
+ * gate. It stays up until login (the Renown CTA full-page-redirects).
+ */
+export const DriveAuthRequiredModal: React.FC = () => {
+  const phModal = usePHModal();
+  if (phModal?.type !== "driveAuthRequired") return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="false"
+      aria-label="Log in to access this drive"
+      className="pointer-events-none fixed inset-0 z-50 grid place-items-center bg-gray-900/30 dark:bg-slate-900/70"
+    >
+      <DriveAuthGate
+        onLogin={() => openRenown()}
+        className="pointer-events-auto"
+      />
+    </div>
+  );
+};

--- a/apps/connect/src/components/use-drive-auth-gate.test.ts
+++ b/apps/connect/src/components/use-drive-auth-gate.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { ConnectionStateSnapshot } from "@powerhousedao/reactor-browser";
+import { computeNeedsLogin } from "./use-drive-auth-gate.js";
+
+// Only `state` drives the decision; the rest are filled with neutral values.
+function snap(
+  state: ConnectionStateSnapshot["state"],
+): ConnectionStateSnapshot {
+  return {
+    state,
+    failureCount: 0,
+    lastSuccessUtcMs: 0,
+    lastFailureUtcMs: 0,
+    pushBlocked: false,
+    pushFailureCount: 0,
+    receivingPages: false,
+  };
+}
+
+describe("computeNeedsLogin", () => {
+  it("never gates an authenticated user, even with an errored channel", () => {
+    const states = new Map([["studio", snap("error")]]);
+    expect(computeNeedsLogin(true, states)).toBe(false);
+  });
+
+  it("gates an anonymous user when a channel is in error", () => {
+    const states = new Map([["studio", snap("error")]]);
+    expect(computeNeedsLogin(false, states)).toBe(true);
+  });
+
+  it("does not gate an anonymous user when all channels are healthy", () => {
+    const states = new Map([
+      ["studio", snap("connected")],
+      ["other", snap("connecting")],
+    ]);
+    expect(computeNeedsLogin(false, states)).toBe(false);
+  });
+
+  it("does not gate an anonymous user with no channels", () => {
+    expect(computeNeedsLogin(false, new Map())).toBe(false);
+  });
+});

--- a/apps/connect/src/components/use-drive-auth-gate.ts
+++ b/apps/connect/src/components/use-drive-auth-gate.ts
@@ -1,0 +1,30 @@
+import {
+  useConnectionStates,
+  useUser,
+  type ConnectionStateSnapshot,
+} from "@powerhousedao/reactor-browser";
+
+/**
+ * Pure decision: is the user blocked from a drive purely because they are not
+ * logged in? An anonymous user with any remote channel stuck in `"error"` means
+ * the auth-enabled studio's sync failed unrecoverably -> needs login. The
+ * snapshot carries no error category, so "error + not authenticated" is the
+ * signal. Never gate an authenticated user. No window/React access -> testable.
+ */
+export function computeNeedsLogin(
+  isAuthenticated: boolean,
+  connectionStates: ReadonlyMap<string, ConnectionStateSnapshot>,
+): boolean {
+  if (isAuthenticated) return false;
+  for (const snap of connectionStates.values()) {
+    if (snap.state === "error") return true;
+  }
+  return false;
+}
+
+/** Live wrapper over {@link computeNeedsLogin}. */
+export function useDriveAuthGate(): { needsLogin: boolean } {
+  const user = useUser();
+  const connectionStates = useConnectionStates();
+  return { needsLogin: computeNeedsLogin(Boolean(user), connectionStates) };
+}

--- a/apps/connect/src/pages/content.tsx
+++ b/apps/connect/src/pages/content.tsx
@@ -4,11 +4,13 @@ import {
   defaultPHDocumentEditorConfig,
 } from "@powerhousedao/connect/config";
 import {
+  DriveAuthGate,
   HomeScreen,
   HomeScreenAddDriveItem,
   HomeScreenItem,
 } from "@powerhousedao/design-system/connect";
 import {
+  openRenown,
   setPHAppConfig,
   setPHDocumentEditorConfig,
   setSelectedDrive,
@@ -22,8 +24,10 @@ import {
 import type { DocumentDriveDocument } from "@powerhousedao/shared/document-drive";
 import { useEffect } from "react";
 import { getRuntimeConfig } from "../runtime-config.js";
+import { useDriveAuthGate } from "../components/use-drive-auth-gate.js";
 
 export function Content() {
+  const { needsLogin } = useDriveAuthGate();
   const [selectedDrive] = useSelectedDriveSafe();
   const selectedFolder = useSelectedFolder();
   const selectedDocumentId = useSelectedDocumentId();
@@ -44,7 +48,13 @@ export function Content() {
     !selectedDocumentId && !selectedDrive && !selectedFolder;
   return (
     <ContentContainer>
-      {showHomeScreen ? <HomeScreenContainer /> : <AppContainer />}
+      {needsLogin ? (
+        <DriveAuthGate onLogin={openRenown} />
+      ) : showHomeScreen ? (
+        <HomeScreenContainer />
+      ) : (
+        <AppContainer />
+      )}
     </ContentContainer>
   );
 }

--- a/apps/connect/src/pages/content.tsx
+++ b/apps/connect/src/pages/content.tsx
@@ -49,7 +49,9 @@ export function Content() {
   return (
     <ContentContainer>
       {needsLogin ? (
-        <DriveAuthGate onLogin={openRenown} />
+        <div className="flex h-full items-center justify-center p-4">
+          <DriveAuthGate onLogin={openRenown} />
+        </div>
       ) : showHomeScreen ? (
         <HomeScreenContainer />
       ) : (

--- a/apps/connect/src/store/reactor.ts
+++ b/apps/connect/src/store/reactor.ts
@@ -367,9 +367,11 @@ export async function createReactor(localPackage?: DocumentModelLib) {
       // malformed URL — skip attachment service construction
     }
     if (switchboardOrigin) {
-      const attachmentJwtHandler = async (url: string) => {
+      const attachmentJwtHandler = async (_url: string) => {
         if (!renown.user) return undefined;
-        return renown.getBearerToken({ expiresIn: 10, aud: url });
+        // aud omitted: server verifies without an audience, so aud-bearing
+        // tokens are rejected. Re-enable once both sides support it.
+        return renown.getBearerToken({ expiresIn: 10 });
       };
       const attachmentService = createRemoteAttachmentService({
         remoteUrl: switchboardOrigin,

--- a/apps/connect/src/utils/reactor.ts
+++ b/apps/connect/src/utils/reactor.ts
@@ -43,11 +43,13 @@ export async function createBrowserReactor(
     verifier: createSignatureVerifier(),
   };
 
-  const jwtHandler: JwtHandler = async (url: string) => {
+  const jwtHandler: JwtHandler = async (_url: string) => {
     if (!renown.user) {
       return undefined;
     }
-    return renown.getBearerToken({ expiresIn: 10, aud: url });
+    // aud omitted: server verifies without an audience, so aud-bearing tokens
+    // are rejected. Re-enable once both sides support audience restriction.
+    return renown.getBearerToken({ expiresIn: 10 });
   };
 
   const detected = await detectReactorPgMajor();

--- a/apps/connect/src/utils/reactor.ts
+++ b/apps/connect/src/utils/reactor.ts
@@ -98,6 +98,18 @@ export function getDefaultDrives(
 }
 
 /**
+ * A drive add failed because the switchboard rejected the (anonymous or
+ * unverified) caller — Forbidden/Unauthorized — rather than a transient
+ * reachability error. Drives the login prompt instead of retrying.
+ */
+function isDriveAuthError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /forbidden|unauthorized|insufficient permissions|\b401\b|\b403\b/i.test(
+    message,
+  );
+}
+
+/**
  * Add default drives for the new reactor via sync manager.
  *
  * Drives register concurrently so a slow or unreachable drive can't delay the
@@ -121,6 +133,11 @@ export async function addDefaultDrivesForNewReactor(
           driveId = await addRemoteDrive(drive.url);
           break;
         } catch (error) {
+          if (isDriveAuthError(error)) {
+            // addRemoteDrive already surfaces the login modal; auth failures
+            // don't self-heal, so don't burn the remaining retries.
+            break;
+          }
           if (attempt === MAX_ATTEMPTS) {
             console.error(
               `Failed to add default drive ${drive.url} after ${MAX_ATTEMPTS} attempts:`,

--- a/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.stories.tsx
+++ b/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
     onLogin: () => alert("Log in clicked"),
   },
   render: (args) => (
-    <div className="flex h-screen w-full flex-col">
+    <div className="flex h-screen w-full items-center justify-center bg-gray-100 dark:bg-slate-900">
       <DriveAuthGate {...args} />
     </div>
   ),
@@ -20,9 +20,3 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
-
-// Toggle the Storybook theme toolbar to dark to preview the dark page styles;
-// darkMode switches the Renown CTA's inline button styles.
-export const DarkMode: Story = {
-  args: { darkMode: true },
-};

--- a/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.stories.tsx
+++ b/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DriveAuthGate } from "./drive-auth-gate.js";
+
+const meta = {
+  title: "Connect/Components/Drive Auth Gate",
+  component: DriveAuthGate,
+  args: {
+    // No-op so the story doesn't trigger the real Renown redirect.
+    onLogin: () => alert("Log in clicked"),
+  },
+  render: (args) => (
+    <div className="flex h-screen w-full flex-col">
+      <DriveAuthGate {...args} />
+    </div>
+  ),
+} satisfies Meta<typeof DriveAuthGate>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+// Toggle the Storybook theme toolbar to dark to preview the dark page styles;
+// darkMode switches the Renown CTA's inline button styles.
+export const DarkMode: Story = {
+  args: { darkMode: true },
+};

--- a/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.test.tsx
+++ b/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.test.tsx
@@ -9,17 +9,13 @@ describe("DriveAuthGate", () => {
     expect(
       screen.getByText(/sign in with Renown to view or edit it/i),
     ).toBeDefined();
-    expect(
-      screen.getByRole("button", { name: /log in with renown/i }),
-    ).toBeDefined();
+    expect(screen.getByRole("button", { name: /log in with/i })).toBeDefined();
   });
 
   it("calls onLogin when the CTA is clicked", () => {
     const onLogin = vi.fn();
     render(<DriveAuthGate onLogin={onLogin} />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /log in with renown/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /log in with/i }));
     expect(onLogin).toHaveBeenCalledOnce();
   });
 });

--- a/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.test.tsx
+++ b/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DriveAuthGate } from "./drive-auth-gate.js";
+
+describe("DriveAuthGate", () => {
+  it("renders the heading, explanation, and a login CTA", () => {
+    render(<DriveAuthGate onLogin={() => {}} />);
+    expect(screen.getByText("Log in to access this drive")).toBeDefined();
+    expect(
+      screen.getByText(/sign in with Renown to view or edit it/i),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: /log in with renown/i }),
+    ).toBeDefined();
+  });
+
+  it("calls onLogin when the CTA is clicked", () => {
+    const onLogin = vi.fn();
+    render(<DriveAuthGate onLogin={onLogin} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /log in with renown/i }),
+    );
+    expect(onLogin).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.tsx
+++ b/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.tsx
@@ -1,34 +1,40 @@
-import { RenownLoginButton } from "@powerhousedao/reactor-browser/renown";
+import { RenownLogo } from "@powerhousedao/reactor-browser/renown";
 import { twMerge } from "tailwind-merge";
 
 export interface DriveAuthGateProps {
-  /** Login action; defaults to the Renown redirect when omitted. */
+  /** Login action; the caller wires this to Renown (e.g. `openRenown`). */
   readonly onLogin?: () => void;
-  readonly darkMode?: boolean;
   readonly className?: string;
 }
 
 /**
- * Shown in place of the content area when a drive requires the user to log in.
- * Presentational only — rendered when the caller has already decided the user
- * is gated. The CTA delegates to {@link RenownLoginButton}.
+ * Reusable "log in to access this drive" card. Used both as the content of the
+ * drive-add auth modal and as the full-page gate shown when the user logs out
+ * while inside a protected drive — so the two stay visually identical.
  */
 export function DriveAuthGate(props: DriveAuthGateProps) {
-  const { onLogin, darkMode, className } = props;
+  const { onLogin, className } = props;
   return (
     <div
       className={twMerge(
-        "flex h-full flex-col items-center justify-center gap-4 p-8 text-center",
+        "flex w-[28rem] max-w-[calc(100%-2rem)] flex-col items-center gap-4 rounded-3xl bg-gray-50 p-8 text-center shadow-2xl ring-1 ring-black/5 dark:bg-slate-700 dark:ring-white/10",
         className,
       )}
     >
       <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-50">
         Log in to access this drive
       </h2>
-      <p className="max-w-md text-sm text-gray-600 dark:text-slate-300">
+      <p className="text-sm text-gray-600 dark:text-slate-300">
         This drive requires you to sign in with Renown to view or edit it.
       </p>
-      <RenownLoginButton onLogin={onLogin} darkMode={darkMode} />
+      <button
+        type="button"
+        onClick={onLogin}
+        className="mt-2 flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-6 py-2.5 text-sm font-semibold text-gray-900 shadow-sm transition-colors hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-700"
+      >
+        <span>Log in with</span>
+        <RenownLogo width={58} height={16} className="-translate-y-[3px]" />
+      </button>
     </div>
   );
 }

--- a/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.tsx
+++ b/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.tsx
@@ -1,0 +1,34 @@
+import { RenownLoginButton } from "@powerhousedao/reactor-browser/renown";
+import { twMerge } from "tailwind-merge";
+
+export interface DriveAuthGateProps {
+  /** Login action; defaults to the Renown redirect when omitted. */
+  readonly onLogin?: () => void;
+  readonly darkMode?: boolean;
+  readonly className?: string;
+}
+
+/**
+ * Shown in place of the content area when a drive requires the user to log in.
+ * Presentational only — rendered when the caller has already decided the user
+ * is gated. The CTA delegates to {@link RenownLoginButton}.
+ */
+export function DriveAuthGate(props: DriveAuthGateProps) {
+  const { onLogin, darkMode, className } = props;
+  return (
+    <div
+      className={twMerge(
+        "flex h-full flex-col items-center justify-center gap-4 p-8 text-center",
+        className,
+      )}
+    >
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-50">
+        Log in to access this drive
+      </h2>
+      <p className="max-w-md text-sm text-gray-600 dark:text-slate-300">
+        This drive requires you to sign in with Renown to view or edit it.
+      </p>
+      <RenownLoginButton onLogin={onLogin} darkMode={darkMode} />
+    </div>
+  );
+}

--- a/packages/design-system/src/connect/components/index.ts
+++ b/packages/design-system/src/connect/components/index.ts
@@ -11,6 +11,7 @@ export * from "./divider/divider.js";
 export * from "./document-state-viewer/document-state-viewer.js";
 export * from "./document-timeline/document-timeline.js";
 export * from "./document-toolbar/index.js";
+export * from "./drive-auth-gate/drive-auth-gate.js";
 export * from "./drop-zone/drop-zone-wrapper.js";
 export * from "./drop-zone/drop-zone.js";
 export * from "./drop-zone/upload-file-list-container.js";

--- a/packages/reactor-browser/src/actions/drive.ts
+++ b/packages/reactor-browser/src/actions/drive.ts
@@ -17,8 +17,21 @@ import {
 } from "@powerhousedao/shared/document-drive";
 import type { PHDocument } from "@powerhousedao/shared/document-model";
 import { getUserPermissions } from "../utils/user.js";
+import { showPHModal } from "../hooks/modals.js";
 
 const DEFAULT_INITIAL_SYNC_TIMEOUT_MS = 30_000;
+
+/**
+ * A drive add failed because the switchboard rejected the (anonymous or
+ * unverified) caller — Forbidden/Unauthorized — rather than a transient
+ * reachability error. Drives the login prompt.
+ */
+function isDriveAuthError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /forbidden|unauthorized|insufficient permissions|\b401\b|\b403\b/i.test(
+    message,
+  );
+}
 
 // In-flight remote registrations keyed by collectionId. sync.list()/sync.add()
 // is not atomic, so concurrent addRemoteDrive calls for the same drive would
@@ -168,34 +181,45 @@ export async function addRemoteDrive(
   const collectionId = DriveCollectionId.forDrive(resolvedDriveId);
 
   const inFlight = inFlightRemoteRegistrations.get(collectionId.key);
-  if (inFlight) {
-    await inFlight;
-  } else {
-    const existingRemote = sync
-      .list()
-      .find((remote) => remote.collectionId.equals(collectionId));
+  try {
+    if (inFlight) {
+      await inFlight;
+    } else {
+      const existingRemote = sync
+        .list()
+        .find((remote) => remote.collectionId.equals(collectionId));
 
-    if (!existingRemote) {
-      const remoteName = crypto.randomUUID();
-      const registration = sync
-        .add(
-          remoteName,
-          collectionId,
-          {
-            type: "gql",
-            parameters: {
-              url: driveInfo.graphqlEndpoint,
+      if (!existingRemote) {
+        const remoteName = crypto.randomUUID();
+        const registration = sync
+          .add(
+            remoteName,
+            collectionId,
+            {
+              type: "gql",
+              parameters: {
+                url: driveInfo.graphqlEndpoint,
+              },
             },
-          },
-          undefined,
-          options?.pollBehavior
-            ? { pollBehavior: options.pollBehavior }
-            : undefined,
-        )
-        .finally(() => inFlightRemoteRegistrations.delete(collectionId.key));
-      inFlightRemoteRegistrations.set(collectionId.key, registration);
-      await registration;
+            undefined,
+            options?.pollBehavior
+              ? { pollBehavior: options.pollBehavior }
+              : undefined,
+          )
+          .finally(() => inFlightRemoteRegistrations.delete(collectionId.key));
+        inFlightRemoteRegistrations.set(collectionId.key, registration);
+        await registration;
+      }
     }
+  } catch (error) {
+    // Any drive add that fails because the caller isn't authorized (the
+    // switchboard rejected it — Forbidden/Unauthorized) prompts a login,
+    // regardless of which flow triggered the add. Re-throw so callers still
+    // see the failure.
+    if (isDriveAuthError(error)) {
+      showPHModal({ type: "driveAuthRequired" });
+    }
+    throw error;
   }
 
   if (options?.awaitInitialSync) {

--- a/packages/reactor-browser/src/types/modals.ts
+++ b/packages/reactor-browser/src/types/modals.ts
@@ -29,4 +29,5 @@ export type PHModal =
   | { type: "cookiesPolicy" }
   | { type: "downloadDocumentWithErrors"; documentId: string }
   | { type: "inspector" }
-  | { type: "missingPackage"; documentType: string };
+  | { type: "missingPackage"; documentType: string }
+  | { type: "driveAuthRequired" };


### PR DESCRIPTION
## Summary
Connect-side support for auth-enabled switchboards: let the env owner in, and prompt everyone else to log in instead of failing silently.

## Changes
- **Drop the `aud` claim** from Connect's minted Renown bearer tokens (sync `jwtHandler`, attachment `jwtHandler`, and the `AddDriveModal` drive-info request). The switchboard verifies tokens without an audience, so `aud`-bearing tokens were rejected — even the logged-in owner's, 401ing them out. The SDK `audience?` option is left in place so real audience restriction can be re-enabled later.
- **Prompt login when a protected drive can't be accessed**, via a single reusable `DriveAuthGate` card (heading + Renown CTA):
  - **Modal** — `addRemoteDrive` surfaces a `driveAuthRequired` modal on any auth error (Forbidden/Unauthorized), so every add flow is covered (default drives, `?driveUrl`, the Add-Drive modal). Rendered as a non-blocking overlay so the cookie banner stays usable; default-drive adds stop retrying on auth errors.
  - **Full-page gate** — when sync fails while the user is inside a drive (`useDriveAuthGate` reads the remote connection state), `Content()` renders the same `DriveAuthGate` card.
- **`DriveAuthGate`** moves to `design-system` as the shared card consumed by both prompts, with a story + unit tests; new `PHModal` `driveAuthRequired` type.

## Notes
- Self-gating: with switchboard auth off (local/open drives) sync succeeds, so neither prompt appears.
- Scope is Connect only; no reactor-api/switchboard changes.


<img width="1992" height="1489" alt="2026-06-16 18 23 29" src="https://github.com/user-attachments/assets/63a3bef9-4150-49a9-a24b-a778a366bee8" />
