### PR TITLE
fix(codegen): read reducer method names from the operations interface

### DIFF
--- a/packages/codegen/src/file-builders/document-model/src-dir.ts
+++ b/packages/codegen/src/file-builders/document-model/src-dir.ts
@@ -36,6 +36,7 @@ export async function makeReducerOperationHandlerForModule({
   module,
   version,
   srcDirPath,
+  genDirPath,
   versionImportPath,
   pascalCaseDocumentType,
   camelCaseDocumentType,
@@ -77,19 +78,23 @@ export async function makeReducerOperationHandlerForModule({
     existingOperationsInterfaceTypeImport.remove();
   }
 
-  const operationsInterfaceTypeImport = sourceFile.addImportDeclaration({
+  sourceFile.addImportDeclaration({
     namedImports: [operationsInterfaceTypeName],
     moduleSpecifier: versionImportPath,
     isTypeOnly: true,
   });
 
-  const operationsInterfaceTypeProperties = operationsInterfaceTypeImport
-    .getNamedImports()
-    .find((value) => value.getName() === operationsInterfaceTypeName)
-    ?.getNameNode()
-    .getType()
-    .getProperties()
-    .map((symbol) => symbol.getName());
+  // Read operation names from the generated operations interface's AST members;
+  // it's a source file in this project already, so no module resolution needed.
+  const operationsInterface = project
+    .getSourceFile(path.join(genDirPath, kebabCaseModuleName, "operations.ts"))
+    ?.getInterface(operationsInterfaceTypeName);
+  const operationsInterfaceTypeProperties = operationsInterface
+    ? [
+        ...operationsInterface.getProperties(),
+        ...operationsInterface.getMethods(),
+      ].map((member) => member.getName())
+    : undefined;
 
   if (!operationsInterfaceTypeProperties) {
     throw new Error("Failed to create operation handler object");


### PR DESCRIPTION
On a fresh project's first generate the gen files exist only in-memory (not yet saved), so resolving the operations interface via the import's type returns no properties and the reducer object is left `{}` — a tsc error (TS2739). Read the method names from the generated operations interface declaration directly via the AST, which needs no module resolution.