### PR TITLE
fix(reactor-browser): load document lazily in useDownloadDocument

### DIFF
--- a/packages/reactor-browser/src/hooks/download-document.ts
+++ b/packages/reactor-browser/src/hooks/download-document.ts
@@ -1,13 +1,20 @@
 import { downloadDocument } from "../utils/download-document.js";
-import { useDocumentById } from "./document-by-id.js";
+import { useGetDocument } from "./document-cache.js";
 import { usePHToast } from "./toast.js";
 
 export function useDownloadDocument(id: string | undefined) {
-  const [document] = useDocumentById(id);
+  const getDocument = useGetDocument();
   const toast = usePHToast();
 
-  return () =>
-    downloadDocument(document, (error) =>
-      toast?.(`Failed to export document: ${error.message}`),
-    );
+  return async () => {
+    if (!id) return;
+    const handleError = (error: Error) =>
+      toast?.(`Failed to export document: ${error.message}`);
+    try {
+      const document = await getDocument(id);
+      downloadDocument(document, handleError);
+    } catch (error) {
+      handleError(error as Error);
+    }
+  };
 }


### PR DESCRIPTION
## Problem

`FileItem` calls `useDownloadDocument(fileNode.id)` only to build a download click handler, but the hook read the document **at render** (`useDocumentById` → `useDocument` → `use()`). Two consequences in the generic drive explorer (`FileContentView`):

1. **Suspense gating** — every file row suspended on its own document, so the whole drive view rendered as a single unit gated behind document loading.
2. **Crash on a missing document** — `documentCache.get(id)` rejects for an unavailable/dangling document; `use()` re-throws that rejection during render. With no error boundary around the file grid, it propagates to Connect's top-level `ErrorBoundary` and replaces the **entire drive editor** with “Something went wrong”. A single orphaned file node takes down the whole drive.

Verified in Connect (generic drive explorer) via Playwright: forcing one file's document to be unavailable replaced the drive editor with the error fallback on the old code, and rendered all file cards cleanly with this change.

## Fix

`useDownloadDocument` now uses `useGetDocument()` (lazy fetch) and loads the document **inside the click handler**, wrapped in try/catch. `FileItem` no longer reads any per-file document at render, so it can't suspend or throw — a missing document just makes the download fail gracefully on click instead of crashing the drive.

Scoped intentionally to this hook: the cache's reject-on-missing behavior is unchanged, and the suspending `useDocument`/error-boundary contract is left intact for consumers that genuinely render document state.

## Other consumer

`document-toolbar`'s `DownloadButton` also uses this hook; it already had the current document from props and now simply fetches lazily on click. Return type changes from `() => void` to `() => Promise<void>`, transparent to both click-handler call sites.