### PR TITLE
feat(connect): self-host React + base-aware externalize-vendor

### DIFF
--- a/apps/connect/index.html
+++ b/apps/connect/index.html
@@ -15,7 +15,6 @@
       href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
       rel="stylesheet"
     />
-    <link rel="preconnect" href="https://esm.sh" crossorigin />
     <link href="/style.css" rel="stylesheet" />
     <script>
       document.documentElement.classList.toggle(
@@ -24,16 +23,6 @@
           (!("theme" in localStorage) &&
             window.matchMedia("(prefers-color-scheme: dark)").matches),
       );
-    </script>
-    <script type="importmap">
-      {
-        "imports": {
-          "react": "https://esm.sh/react@19.2.0",
-          "react/": "https://esm.sh/react@19.2.0/",
-          "react-dom": "https://esm.sh/react-dom@19.2.0",
-          "react-dom/": "https://esm.sh/react-dom@19.2.0/"
-        }
-      }
     </script>
   </head>
 

--- a/packages/builder-tools/connect-utils/externalize-vendor.ts
+++ b/packages/builder-tools/connect-utils/externalize-vendor.ts
@@ -12,9 +12,11 @@
  * all three), and a multi-entry build with `preserveEntrySignatures: 'strict'`
  * dedupes shared code into shared chunks. Entries for CJS deps re-export the
  * module's named API explicitly (so `import { createRoot }` works); ESM deps
- * use `export *`. The build runs under `base = VENDOR_URL_PREFIX` so emitted
- * asset URLs (`new URL(…, import.meta.url)` for .wasm/.data/workers) resolve to
- * the dev middleware, not the SPA root.
+ * use `export *`. The build runs under a dynamic-base placeholder + vendor
+ * segment (`connectDynamicBasePlugin`), so emitted asset/chunk URLs
+ * (`new URL(…, import.meta.url)` for .wasm/.data/workers) carry the placeholder
+ * and resolve at serve time to `<deploy-base>__vendor__/`, while the vendored
+ * Connect's `import.meta.env.BASE_URL` resolves to the deploy base.
  *
  * The React family stays EXTERNAL (see `VENDOR_EXTERNAL`); `esmExternalRequirePlugin`
  * owns that externalization and rewrites CJS `require("react")` → import. Vendor
@@ -41,6 +43,8 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname as pathDirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { DYNAMIC_BASE_PLACEHOLDER } from "./vite-plugins/dynamic-base.js";
 
 export interface VendorPrebuildOptions {
   /** Project root (the reactor-project dir). */
@@ -94,6 +98,10 @@ export interface PrebuiltVendor {
 
 /** URL prefix the vendor bundle is served under by the dev middleware. */
 export const VENDOR_URL_PREFIX = "/__vendor__/";
+
+// Vite `base` for the vendor build: dynamic-base placeholder + vendor segment.
+// connectDynamicBasePlugin rewrites it so chunk/asset URLs resolve at serve time.
+const VENDOR_DYNAMIC_BASE = `${DYNAMIC_BASE_PLACEHOLDER}${VENDOR_URL_PREFIX.replace(/^\/+/, "")}`;
 
 /**
  * Build the prebuilt vendor (once, in a throwaway subprocess) and return its dir
@@ -468,6 +476,9 @@ function runBuildWorker(
 ): Promise<{ ok: boolean; stderr: string }> {
   const workerPath = join(outDir, "build-worker.mjs");
   writeFileSync(workerPath, VENDOR_BUILD_WORKER);
+  // Absolute path to this (built) module so the worker can import the
+  // dynamic-base plugin from builder-tools' own bundle.
+  const selfModulePath = fileURLToPath(import.meta.url);
   return new Promise((resolve) => {
     const child = spawn(
       process.execPath,
@@ -478,6 +489,8 @@ function runBuildWorker(
         JSON.stringify(include),
         VENDOR_URL_PREFIX,
         JSON.stringify(external),
+        VENDOR_DYNAMIC_BASE,
+        selfModulePath,
       ],
       { cwd: dirname, stdio: ["ignore", "pipe", "pipe"] },
     );
@@ -494,20 +507,25 @@ function runBuildWorker(
 }
 
 /**
- * The vendor build worker, written to disk and run as a subprocess. Self-contained
- * (only Node + the project's `vite`). argv: dirname, vendorDir, includeJSON, urlPrefix.
+ * The vendor build worker, written to disk and run as a subprocess. Loads
+ * `vite` from the project and `connectDynamicBasePlugin` from builder-tools' own
+ * built bundle (selfModulePath). argv: dirname, vendorDir, includeJSON,
+ * urlPrefix, externalJSON, dynamicBase, selfModulePath.
  */
 const VENDOR_BUILD_WORKER = `
 import { createRequire } from 'node:module';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join, isAbsolute } from 'node:path';
-import { fileURLToPath } from 'node:url';
-const [dirname, vendorDir, includeJSON, urlPrefix, externalJSON] = process.argv.slice(2);
+import { fileURLToPath, pathToFileURL } from 'node:url';
+const [dirname, vendorDir, includeJSON, urlPrefix, externalJSON, dynamicBase, selfModulePath] = process.argv.slice(2);
 const include = JSON.parse(includeJSON);
 const external = JSON.parse(externalJSON ?? '[]');
 const externalSet = new Set(external);
 const reqProj = createRequire(join(dirname, 'noop.js'));
 const { build, esmExternalRequirePlugin } = await import(reqProj.resolve('vite'));
+// Load the dynamic-base plugin from builder-tools' own built bundle (passed as
+// an absolute path) — it isn't resolvable as a bare specifier from the worker.
+const { connectDynamicBasePlugin, DYNAMIC_BASE_PLACEHOLDER } = await import(pathToFileURL(selfModulePath));
 const srcDir = join(vendorDir, '.entries');
 mkdirSync(srcDir, { recursive: true });
 const entryName = (spec) => spec.replace(/[^\\w]+/g, '_');
@@ -570,21 +588,21 @@ const phVendorResolve = {
 };
 await build({
   root: dirname, configFile: false, logLevel: 'error',
-  // Emit asset URLs (pglite .wasm/.data, workers via \`new URL(..., import.meta.url)\`)
-  // under the vendor prefix so they resolve to the middleware, not the SPA root.
-  base: urlPrefix,
-  define: { 'process.env.NODE_ENV': '"development"' },
-  // phVendorResolve runs first (pre) so bare specifiers resolve from the worker,
-  // not the importing module's realpath. esmExternalRequirePlugin then OWNS
-  // externalization of \`external\` (react family + dev virtuals): it marks them
-  // external AND rewrites CJS require("react") to import (Rolldown keeps bare
-  // require() for external ids, which fails in the browser). It must be the sole
-  // externalizer — also listing them in rollupOptions.external prevents the
-  // require() rewrite (see vite-config.ts).
-  plugins: [phVendorResolve, esmExternalRequirePlugin({ external })],
-  // pglite (and any worker dep) ships web workers; emit them as ES-module asset
-  // chunks into the vendor so the middleware can serve them.
-  worker: { format: 'es' },
+  // Dynamic-base placeholder + vendor segment: connectDynamicBasePlugin rewrites
+  // emitted chunk/asset URLs to resolve against the deploy base at serve time.
+  base: dynamicBase,
+  define: {
+    'process.env.NODE_ENV': '"development"',
+    // BASE_URL resolves to the deploy base (not the vendor prefix) so vendored
+    // Connect's router basename + BASE_URL-relative fetches use the right path.
+    'import.meta.env.BASE_URL': JSON.stringify(DYNAMIC_BASE_PLACEHOLDER),
+  },
+  // phVendorResolve (pre) resolves bares from the worker; esmExternalRequirePlugin owns
+  // react/virtual externalization; connectDynamicBasePlugin (post) rewrites the placeholder base.
+  plugins: [phVendorResolve, esmExternalRequirePlugin({ external }), connectDynamicBasePlugin()],
+  // pglite ships web workers as ES-module chunks. workerStripPrefix is the vendor
+  // segment so the worker recovers the deploy base, not the vendor prefix.
+  worker: { format: 'es', plugins: () => [connectDynamicBasePlugin({ forWorker: true, workerStripPrefix: urlPrefix.replace(/^\\/+/, '') })] },
   build: {
     outDir: vendorDir, emptyOutDir: false, minify: false, target: 'esnext', cssCodeSplit: true,
     rollupOptions: {

--- a/packages/builder-tools/connect-utils/vite-config.ts
+++ b/packages/builder-tools/connect-utils/vite-config.ts
@@ -28,21 +28,7 @@ import {
 import { connectFaviconPlugin } from "./vite-plugins/favicon.js";
 import { phBundledPackagesPlugin } from "./vite-plugins/ph-bundled-packages.js";
 import { phConfigPlugin } from "./vite-plugins/ph-config.js";
-
-const REACT_VERSION = "19.2.0";
-
-// Importmap injected into Connect's HTML in production builds. The build
-// pipeline externalizes react/react-dom via Rolldown's
-// `esmExternalRequirePlugin` (see below), so the browser resolves bare
-// `react` imports through this map → CDN editor packages and Connect share
-// the same React instance via esm.sh. In dev, `devReactImportmapPlugin`
-// rewrites this map to point at Vite's pre-bundled React instead.
-const REACT_IMPORTMAP_IMPORTS: Record<string, string> = {
-  react: `https://esm.sh/react@${REACT_VERSION}`,
-  "react/": `https://esm.sh/react@${REACT_VERSION}/`,
-  "react-dom": `https://esm.sh/react-dom@${REACT_VERSION}`,
-  "react-dom/": `https://esm.sh/react-dom@${REACT_VERSION}/`,
-};
+import { reactSelfHostPlugin } from "./vite-plugins/react-self-host.js";
 
 export function getConnectHtmlTags(
   options: {
@@ -56,7 +42,7 @@ export function getConnectHtmlTags(
       tag: "meta",
       attrs: {
         "http-equiv": "Content-Security-Policy",
-        content: `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://esm.sh${registryUrl ? " " + registryUrl : ""}; worker-src 'self' blob:; object-src 'none'; base-uri 'self';`,
+        content: `script-src 'self' 'unsafe-inline' 'unsafe-eval'${registryUrl ? " " + registryUrl : ""}; worker-src 'self' blob:; object-src 'none'; base-uri 'self';`,
       },
       injectTo,
     },
@@ -251,25 +237,27 @@ export function getConnectBaseViteConfig(options: IConnectOptions) {
     registryUrl: phPackageRegistryUrl,
   });
 
+  // Dev needs a placeholder importmap for devReactImportmapPlugin to rewrite;
+  // builds get their map from reactSelfHostPlugin's boot script instead.
+  const devImportmapTag =
+    mode === "development"
+      ? [
+          {
+            tag: "script",
+            attrs: { type: "importmap" },
+            children: JSON.stringify({ imports: {} }),
+            injectTo: "head-prepend" as const,
+          },
+        ]
+      : [];
+
   const plugins: PluginOption[] = [
     tailwind(),
     react(),
     createHtmlPlugin({
       minify: false,
       inject: {
-        tags: [
-          ...connectHtmlTags,
-          {
-            tag: "script",
-            attrs: { type: "importmap" },
-            children: JSON.stringify(
-              { imports: REACT_IMPORTMAP_IMPORTS },
-              null,
-              2,
-            ),
-            injectTo: "head-prepend",
-          },
-        ],
+        tags: [...connectHtmlTags, ...devImportmapTag],
       },
     }),
   ] as const;
@@ -400,25 +388,19 @@ export function getConnectBaseViteConfig(options: IConnectOptions) {
         packages: localPackagesFromConfig,
         projectRoot: options.dirname,
       }),
-      // Dev-only: rewrite the importmap so it points at Vite's pre-bundled
-      // React (the same URL Connect's own modules resolve to). Without this,
-      // CDN editors load React from esm.sh while Connect uses Vite's local
-      // copy → two React instances → useSyncExternalStore crash. The build
-      // path stays untouched; `esmExternalRequirePlugin` below still owns it.
+      // Dev-only: rewrite the importmap to Vite's pre-bundled React so Connect
+      // and CDN editors share one instance (build uses reactSelfHostPlugin).
       devReactImportmapPlugin(options.dirname),
       ...plugins,
-      // Externalize React so both Connect and dynamically loaded registry
-      // packages share the same React instance via the import map in index.html.
-      // Without this, Vite bundles React into Connect's chunks while registry
-      // packages resolve React from the import map (esm.sh), creating two
-      // separate React instances that don't share context/state.
-      //
-      // In Vite 8 (Rolldown), require() calls for external modules are preserved
-      // as-is, which fails in browsers. esmExternalRequirePlugin handles both
-      // externalization AND converting require() to import statements.
-      // NOTE: Do NOT also list these in build.rolldownOptions.external — overlapping
-      // entries prevent the plugin from transforming require() calls.
+      // Externalize React so Connect + CDN editors share one instance via the
+      // import map (reactSelfHostPlugin URLs); also rewrites external require().
       esmExternalRequirePlugin({ external: reactExternal }),
+      // Build-only: emit the React family into the dist + static import map, so
+      // React is self-hosted (not esm.sh). Dev React for non-prod/debug builds.
+      reactSelfHostPlugin({
+        dirname: options.dirname,
+        dev: mode !== "production" || isDebug,
+      }),
       connectFaviconPlugin(),
       // enforce: "post" — rewrites the placeholder base after all other
       // transforms have emitted their asset/chunk URLs.

--- a/packages/builder-tools/connect-utils/vite-plugins/dev-external-react.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/dev-external-react.ts
@@ -176,11 +176,19 @@ export async function devReactImportmapPlugin(
         }),
       );
 
-      // Serve the prebuilt vendor bundle (JS/CSS/maps + shared chunks/assets).
+      // Serve the prebuilt vendor bundle. Match the base-prefixed URL (chunk/asset
+      // URLs carry the deploy base) and the bare prefix; strip whichever matched.
       if (vendorActive) {
         const vendorDir = vendor!.vendorDir;
-        server.middlewares.use(VENDOR_URL_PREFIX, (req, res, next) => {
-          const name = (req.url ?? "").split("?")[0].replace(/^\/+/, "");
+        const vendorPrefixes = [
+          withBase(base, VENDOR_URL_PREFIX),
+          VENDOR_URL_PREFIX,
+        ];
+        server.middlewares.use((req, res, next) => {
+          const url = (req.url ?? "").split("?")[0];
+          const prefix = vendorPrefixes.find((p) => url.startsWith(p));
+          if (!prefix) return next();
+          const name = url.slice(prefix.length).replace(/^\/+/, "");
           const file = path.join(vendorDir, name);
           // Path-segment containment (not a string prefix): reject anything that
           // escapes vendorDir, incl. siblings like `.ph-vendor.lock`.
@@ -257,25 +265,28 @@ export async function devReactImportmapPlugin(
             `${shimPrefix}${id}.js?v=${browserHash}`,
           ]),
         );
-        // Heavy libs resolve to the prebuilt vendor; their bare React imports
-        // fall through to the React shim entries above.
+        // Heavy libs resolve to the prebuilt vendor (base-prefixed); their bare
+        // React imports fall through to the React shim entries above.
+        let dynamicBaseScript = "";
         if (vendorActive) {
-          Object.assign(imports, vendor!.imports);
-          // When Connect is vendored it isn't dev-processed, so its dynamic
-          // `import("ph-bundled-packages-virtual")` (project local packages)
-          // can't be transformed in place. Point it at the URL Vite serves the
-          // virtual module at (phBundledPackagesPlugin), so bundled local
-          // packages still register.
+          for (const [spec, url] of Object.entries(vendor!.imports)) {
+            imports[spec] = withBase(base, url);
+          }
+          // Connect vendored isn't dev-processed, so its dynamic
+          // `import("ph-bundled-packages-virtual")` points at the virtual URL.
           if (vendor!.imports["@powerhousedao/connect"]) {
             imports["ph-bundled-packages-virtual"] = withBase(
               base,
               BUNDLED_PACKAGES_DEV_URL,
             );
           }
+          // Set the runtime base global so the vendor's rewritten URL exprs
+          // resolve to the dev/deploy base (mirrors the proxy at serve time).
+          dynamicBaseScript = `<script>globalThis.__PH_DYNAMIC_BASE__=${JSON.stringify(base)};</script>\n`;
         }
         return html.replace(
           /<script type="importmap">[\s\S]*?<\/script>/,
-          `<script type="importmap">${JSON.stringify({ imports }, null, 2)}</script>`,
+          `${dynamicBaseScript}<script type="importmap">${JSON.stringify({ imports }, null, 2)}</script>`,
         );
       },
     },

--- a/packages/builder-tools/connect-utils/vite-plugins/dynamic-base.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/dynamic-base.ts
@@ -23,17 +23,14 @@ const RUNTIME_GLOBAL = "globalThis.__PH_DYNAMIC_BASE__";
 // base prefix appears in emitted JS.
 const BASE_EXPR = `(${RUNTIME_GLOBAL}||"/")`;
 
-/**
- * Worker scope has its own global object; the proxy injects the runtime global
- * into the main-thread `<head>` only, so a worker chunk's rewritten references
- * would fall back to "/" and fetch siblings (pglite .data/.wasm) without the
- * deploy prefix. Prepended to worker chunks, this defines the global in worker
- * scope from the worker's own script URL: the worker loads from
- * `<base>assets/<name>-<hash>.js`, so stripping `assets/<file>` off
- * `self.location.pathname` yields the same trailing-slash base the main thread
- * holds ("/myagent/" or "/").
- */
-const WORKER_PRELUDE = `${RUNTIME_GLOBAL}=self.location.pathname.replace(/assets\\/[^/]*$/,"");\n`;
+// Worker prelude: derive the deploy base in worker scope from the worker's own
+// URL (proxy sets the global on the main thread only).
+function workerPrelude(stripPrefix: string): string {
+  // `stripPrefix` is the segment between the deploy base and `assets/` (default
+  // "" → strip `assets/<file>`; vendor passes "__vendor__/").
+  const prefix = escapeForRegExp(stripPrefix).replace(/\//g, "\\/");
+  return `${RUNTIME_GLOBAL}=self.location.pathname.replace(/${prefix}assets\\/[^/]*$/,"");\n`;
+}
 
 // Match a string literal whose content STARTS with the placeholder, in any of
 // the three JS quote styles Rolldown emits (double, single, backtick). Group 1
@@ -80,7 +77,7 @@ const PLACEHOLDER_LITERAL = new RegExp(
  * prefix (which the HTML substitution handles).
  */
 export function connectDynamicBasePlugin(
-  options: { forWorker?: boolean } = {},
+  options: { forWorker?: boolean; workerStripPrefix?: string } = {},
 ): Plugin {
   return {
     name: "ph-connect-dynamic-base",
@@ -104,7 +101,7 @@ export function connectDynamicBasePlugin(
       // sets the runtime global; derive it from the worker's script URL so
       // the rewritten references above resolve against the deploy base.
       if (options.forWorker) {
-        s.prepend(WORKER_PRELUDE);
+        s.prepend(workerPrelude(options.workerStripPrefix ?? ""));
         this.info(
           `dynamic-base: worker prelude prepended to ${chunk.fileName}`,
         );

--- a/packages/builder-tools/connect-utils/vite-plugins/react-self-host.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/react-self-host.ts
@@ -1,0 +1,205 @@
+// Self-host React: emit the React family into the Connect dist and point the
+// page import map at it, instead of resolving react/react-dom from esm.sh.
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { dirname as pathDirname, join, resolve } from "node:path";
+import type { Plugin } from "vite";
+
+// URL path (under base) the React bundle is emitted/served at.
+const REACT_URL_DIR = "__react__";
+
+// Packages whose every browser-importable subpath is self-hosted.
+const REACT_PACKAGES = ["react", "react-dom"];
+
+// Resolve an exports value to its browser-preferred target, or null.
+function importTarget(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object") return null;
+  const o = value as Record<string, unknown>;
+  for (const c of ["browser", "import", "module", "default"]) {
+    if (c in o) {
+      const t = importTarget(o[c]);
+      if (t) return t;
+    }
+  }
+  return null;
+}
+
+// All browser-usable subpaths of react/react-dom, mapped to the absolute file
+// their browser condition resolves to. Node/bun-only targets are skipped.
+function resolveReactEntries(dirname: string): Record<string, string> {
+  const require = createRequire(join(dirname, "noop.js"));
+  const out: Record<string, string> = {};
+  for (const pkg of REACT_PACKAGES) {
+    let pkgRoot: string;
+    let exp: unknown;
+    try {
+      const pkgJsonPath = require.resolve(`${pkg}/package.json`);
+      pkgRoot = pathDirname(pkgJsonPath);
+      exp = JSON.parse(readFileSync(pkgJsonPath, "utf8")).exports;
+    } catch {
+      continue;
+    }
+    if (!exp || typeof exp !== "object") continue;
+    for (const key of Object.keys(exp as Record<string, unknown>)) {
+      if (key === "./package.json" || key.includes("*")) continue;
+      const target = importTarget((exp as Record<string, unknown>)[key]);
+      // Skip non-JS and runtime-only (node/bun) targets — unusable in a browser.
+      if (!target || /\.(json|css)$/.test(target)) continue;
+      if (/\.(node|bun)\.js$/.test(target)) continue;
+      const file = join(pkgRoot, target);
+      if (!existsSync(file)) continue;
+      out[key === "." ? pkg : `${pkg}${key.slice(1)}`] = file;
+    }
+  }
+  return out;
+}
+
+export interface ReactSelfHostOptions {
+  // Project root used to resolve react/react-dom and run the sub-build.
+  dirname: string;
+  // Emit the development React build (warnings/act) instead of production.
+  dev?: boolean;
+}
+
+// Emits one React variant (dev or prod, per options.dev) into the dist and
+// injects a static import map pointing every react/react-dom subpath at it.
+export function reactSelfHostPlugin(options: ReactSelfHostOptions): Plugin {
+  const entries = resolveReactEntries(options.dirname);
+  let absOutDir = resolve(options.dirname, "dist");
+  let importMap: Record<string, string> = {};
+  return {
+    name: "ph-react-self-host",
+    apply: "build",
+    configResolved(config) {
+      absOutDir = resolve(config.root, config.build.outDir);
+      // Entry URLs mirror the specifier (react-dom/client -> __react__/react-dom/client.js)
+      // so the trailing-slash catch-alls below resolve any subpath to the same file.
+      importMap = Object.fromEntries(
+        Object.keys(entries).map((spec) => [
+          spec,
+          `${config.base}${REACT_URL_DIR}/${spec}.js`,
+        ]),
+      );
+      // Catch-all per package: an unenumerated react/* import resolves to the single
+      // self-hosted instance (same-origin) instead of failing import-map resolution.
+      for (const pkg of REACT_PACKAGES) {
+        importMap[`${pkg}/`] = `${config.base}${REACT_URL_DIR}/${pkg}/`;
+      }
+    },
+    transformIndexHtml() {
+      if (!Object.keys(importMap).length) return;
+      return [
+        {
+          tag: "script",
+          attrs: { type: "importmap" },
+          children: JSON.stringify({ imports: importMap }),
+          injectTo: "head-prepend",
+        },
+      ];
+    },
+    async closeBundle() {
+      if (!Object.keys(entries).length) return;
+      const { ok, stderr } = await runReactBuild(
+        options.dirname,
+        join(absOutDir, REACT_URL_DIR),
+        entries,
+        options.dev ? "development" : "production",
+      );
+      if (!ok) {
+        this.error(
+          `react self-host build failed${stderr.trim() ? `:\n${stderr.trim()}` : ""}`,
+        );
+      }
+    },
+  };
+}
+
+// Spawn a throwaway worker that builds the React family; peak build memory is
+// reclaimed when the subprocess exits.
+function runReactBuild(
+  dirname: string,
+  outDir: string,
+  entries: Record<string, string>,
+  nodeEnv: "development" | "production",
+): Promise<{ ok: boolean; stderr: string }> {
+  mkdirSync(outDir, { recursive: true });
+  const workerPath = join(outDir, "build-worker.mjs");
+  writeFileSync(workerPath, REACT_BUILD_WORKER);
+  return new Promise((resolvePromise) => {
+    const child = spawn(
+      process.execPath,
+      [workerPath, dirname, outDir, JSON.stringify(entries), nodeEnv],
+      { cwd: dirname, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let out = "";
+    child.stdout.on("data", (d) => (out += String(d)));
+    child.stderr.on("data", (d) => (out += String(d)));
+    const done = (r: { ok: boolean; stderr: string }) => {
+      rmSync(workerPath, { force: true });
+      resolvePromise(r);
+    };
+    child.on("exit", (code) => done({ ok: code === 0, stderr: out }));
+    child.on("error", (e) => done({ ok: false, stderr: String(e) }));
+  });
+}
+
+// Worker: one ESM entry per subpath with explicit named re-exports. Names come
+// from the browser-resolved file (node names differ for server/static).
+const REACT_BUILD_WORKER = `
+import { createRequire } from 'node:module';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+const [dirname, outDir, entriesJSON, nodeEnv] = process.argv.slice(2);
+const entries = JSON.parse(entriesJSON);
+const reqProj = createRequire(join(dirname, 'noop.js'));
+const { build } = await import(reqProj.resolve('vite'));
+const srcDir = join(outDir, '.entries');
+mkdirSync(srcDir, { recursive: true });
+const entryName = (spec) => spec.replace(/[^\\w]+/g, '_');
+const RESERVED = new Set('enum void null function in instanceof typeof new delete do if else return switch case break continue for while this true false class const let var default export import extends super with yield debugger finally throw try catch await implements interface package private protected public static eval arguments'.split(' '));
+const input = {};
+for (const [spec, file] of Object.entries(entries)) {
+  const name = entryName(spec);
+  let names = [];
+  try {
+    const ns = await import(pathToFileURL(file).href);
+    const obj = (ns.default && typeof ns.default === 'object') ? ns.default : ns;
+    names = Object.keys(obj).filter((k) => k !== 'default' && k !== '__esModule' && /^[A-Za-z_$][\\w$]*$/.test(k));
+  } catch {}
+  const plain = names.filter((n) => !RESERVED.has(n));
+  const reserved = names.filter((n) => RESERVED.has(n));
+  let src = 'import __m from ' + JSON.stringify(spec) + ';\\nexport default __m;\\n';
+  if (plain.length) src += 'export const { ' + plain.join(', ') + ' } = __m;\\n';
+  reserved.forEach((n, i) => {
+    src += 'const __r' + i + ' = __m[' + JSON.stringify(n) + '];\\nexport { __r' + i + ' as ' + n + ' };\\n';
+  });
+  const entryFile = join(srcDir, name + '.js');
+  writeFileSync(entryFile, src);
+  // Key by the full spec so the output path mirrors the subpath
+  // (react-dom/client -> react-dom/client.js), matching the catch-all import map.
+  input[spec] = entryFile;
+}
+await build({
+  root: dirname, configFile: false, logLevel: 'error',
+  base: './', publicDir: false,
+  define: { 'process.env.NODE_ENV': JSON.stringify(nodeEnv) },
+  resolve: { conditions: ['browser', 'import', 'module', 'default'] },
+  build: {
+    outDir, emptyOutDir: false, minify: nodeEnv === 'production', target: 'esnext',
+    rollupOptions: {
+      input, preserveEntrySignatures: 'strict',
+      output: { format: 'es', entryFileNames: '[name].js', chunkFileNames: 'chunks/[name]-[hash].js', assetFileNames: 'assets/[name]-[hash][extname]' },
+    },
+  },
+});
+rmSync(srcDir, { recursive: true, force: true });
+`;

--- a/packages/builder-tools/connect-utils/vite-plugins/react-self-host.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/react-self-host.ts
@@ -43,7 +43,9 @@ function resolveReactEntries(dirname: string): Record<string, string> {
     try {
       const pkgJsonPath = require.resolve(`${pkg}/package.json`);
       pkgRoot = pathDirname(pkgJsonPath);
-      exp = JSON.parse(readFileSync(pkgJsonPath, "utf8")).exports;
+      exp = (
+        JSON.parse(readFileSync(pkgJsonPath, "utf8")) as { exports?: unknown }
+      ).exports;
     } catch {
       continue;
     }
@@ -188,18 +190,26 @@ for (const [spec, file] of Object.entries(entries)) {
   // (react-dom/client -> react-dom/client.js), matching the catch-all import map.
   input[spec] = entryFile;
 }
-await build({
-  root: dirname, configFile: false, logLevel: 'error',
-  base: './', publicDir: false,
-  define: { 'process.env.NODE_ENV': JSON.stringify(nodeEnv) },
-  resolve: { conditions: ['browser', 'import', 'module', 'default'] },
-  build: {
-    outDir, emptyOutDir: false, minify: nodeEnv === 'production', target: 'esnext',
-    rollupOptions: {
-      input, preserveEntrySignatures: 'strict',
-      output: { format: 'es', entryFileNames: '[name].js', chunkFileNames: 'chunks/[name]-[hash].js', assetFileNames: 'assets/[name]-[hash][extname]' },
+try {
+  await build({
+    root: dirname, configFile: false, logLevel: 'error',
+    base: './', publicDir: false,
+    define: { 'process.env.NODE_ENV': JSON.stringify(nodeEnv) },
+    resolve: { conditions: ['browser', 'import', 'module', 'default'] },
+    build: {
+      outDir, emptyOutDir: false, minify: nodeEnv === 'production', target: 'esnext',
+      rollupOptions: {
+        input, preserveEntrySignatures: 'strict',
+        output: { format: 'es', entryFileNames: '[name].js', chunkFileNames: 'chunks/[name]-[hash].js', assetFileNames: 'assets/[name]-[hash][extname]' },
+      },
     },
-  },
-});
-rmSync(srcDir, { recursive: true, force: true });
+  });
+  rmSync(srcDir, { recursive: true, force: true });
+  // Force exit: rolldown can leave native worker threads alive that keep the
+  // event loop open, hanging the parent's spawn() promise indefinitely.
+  process.exit(0);
+} catch (err) {
+  console.error(err instanceof Error ? (err.stack ?? err.message) : String(err));
+  process.exit(1);
+}
 `;


### PR DESCRIPTION
## Self-host React
Connect's prod build now emits the React family into `dist/connect/__react__/` and points the page import map there, instead of `https://esm.sh`. `reactSelfHostPlugin` enumerates react/react-dom's `exports` with a subpath-mirroring layout (`react-dom/client` → `__react__/react-dom/client.js`) and adds `react/` + `react-dom/` catch-all entries so any subpath resolves to the single self-hosted instance. The esm.sh preconnect + hardcoded importmap are removed from `apps/connect/index.html`, and `https://esm.sh` is dropped from the CSP.

## Base-aware externalize-vendor (dev)
The opt-in dev vendor (`PH_CONNECT_EXTERNALIZE_VENDOR=1`) is now correct under a deploy/proxy subpath (e.g. vetra-cli's `/reactor-project/vetra-studio/`):
- vendor built under `DYNAMIC_BASE_PLACEHOLDER + __vendor__/` + `connectDynamicBasePlugin` (chunk/asset/dynamic-import URLs resolve at serve time);
- `import.meta.env.BASE_URL` defined to the deploy base (router/`ph-packages.json` use the right path, not the vendor prefix);
- dev plugin base-prefixes the vendor import map and base-matches the serving middleware, and injects the runtime base global;
- vendor worker prelude strips the `__vendor__/` segment so pglite's wasm/.data resolve correctly.

## Validation
Studio renders with self-hosted React (no esm.sh, no console errors); the dev vendor serves under the proxy base and the seeded studio-build e2e passes on the prod-close image (reactor-project dev server ~2.0 → 1.23 GiB).

## Notes
- Consumed by vetra-cli's warm-vendor bake (powerhouse-inc/vetra-cli#16) once published.
- Pre-existing lint to address: `react-self-host.ts:51` `no-unsafe-member-access` (type the parsed package.json).