### PR TITLE
fix(connect): gate drive login prompt on genuine auth rejections

### DIFF
--- a/apps/connect/src/components/use-drive-auth-gate.test.ts
+++ b/apps/connect/src/components/use-drive-auth-gate.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it } from "vitest";
 import type { ConnectionStateSnapshot } from "@powerhousedao/reactor-browser";
 import { computeNeedsLogin } from "./use-drive-auth-gate.js";
 
-// Only `state` drives the decision; the rest are filled with neutral values.
+// `state` + `requiresAuth` drive the decision; the rest are neutral.
 function snap(
   state: ConnectionStateSnapshot["state"],
+  requiresAuth = false,
 ): ConnectionStateSnapshot {
   return {
     state,
@@ -14,18 +15,24 @@ function snap(
     pushBlocked: false,
     pushFailureCount: 0,
     receivingPages: false,
+    requiresAuth,
   };
 }
 
 describe("computeNeedsLogin", () => {
-  it("never gates an authenticated user, even with an errored channel", () => {
-    const states = new Map([["studio", snap("error")]]);
+  it("never gates an authenticated user, even with an auth-rejected channel", () => {
+    const states = new Map([["studio", snap("error", true)]]);
     expect(computeNeedsLogin(true, states)).toBe(false);
   });
 
-  it("gates an anonymous user when a channel is in error", () => {
-    const states = new Map([["studio", snap("error")]]);
+  it("gates an anonymous user when a channel failed with an auth rejection", () => {
+    const states = new Map([["studio", snap("error", true)]]);
     expect(computeNeedsLogin(false, states)).toBe(true);
+  });
+
+  it("does not gate an anonymous user on a non-auth error", () => {
+    const states = new Map([["studio", snap("error", false)]]);
+    expect(computeNeedsLogin(false, states)).toBe(false);
   });
 
   it("does not gate an anonymous user when all channels are healthy", () => {

--- a/apps/connect/src/components/use-drive-auth-gate.ts
+++ b/apps/connect/src/components/use-drive-auth-gate.ts
@@ -4,20 +4,15 @@ import {
   type ConnectionStateSnapshot,
 } from "@powerhousedao/reactor-browser";
 
-/**
- * Pure decision: is the user blocked from a drive purely because they are not
- * logged in? An anonymous user with any remote channel stuck in `"error"` means
- * the auth-enabled studio's sync failed unrecoverably -> needs login. The
- * snapshot carries no error category, so "error + not authenticated" is the
- * signal. Never gate an authenticated user. No window/React access -> testable.
- */
+/** Gate an anonymous user only when a remote failed with an auth rejection
+ * (`requiresAuth`) — the switchboard refusing the caller for lack of login. */
 export function computeNeedsLogin(
   isAuthenticated: boolean,
   connectionStates: ReadonlyMap<string, ConnectionStateSnapshot>,
 ): boolean {
   if (isAuthenticated) return false;
   for (const snap of connectionStates.values()) {
-    if (snap.state === "error") return true;
+    if (snap.state === "error" && snap.requiresAuth) return true;
   }
   return false;
 }

--- a/apps/connect/src/utils/reactor.ts
+++ b/apps/connect/src/utils/reactor.ts
@@ -1,6 +1,7 @@
 import {
   addRemoteDrive,
   ChannelScheme,
+  isDriveAuthError,
   ReactorBuilder,
   ReactorClientBuilder,
   setDriveMetadata,
@@ -95,18 +96,6 @@ export function getDefaultDrives(
   runtimeConfig: RuntimePowerhouseConfig,
 ): PHConnectDefaultDrive[] {
   return runtimeConfig.connect.drives?.defaultDrives ?? [];
-}
-
-/**
- * A drive add failed because the switchboard rejected the (anonymous or
- * unverified) caller — Forbidden/Unauthorized — rather than a transient
- * reachability error. Drives the login prompt instead of retrying.
- */
-function isDriveAuthError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return /forbidden|unauthorized|insufficient permissions|\b401\b|\b403\b/i.test(
-    message,
-  );
 }
 
 /**

--- a/packages/reactor-api/src/graphql/base-subgraph.ts
+++ b/packages/reactor-api/src/graphql/base-subgraph.ts
@@ -9,7 +9,7 @@ import type {
   SubgraphArgs,
 } from "@powerhousedao/reactor-api";
 import type { DocumentNode } from "graphql";
-import { GraphQLError } from "graphql";
+import { ForbiddenError, AuthenticationRequiredError } from "./errors.js";
 import { gql } from "graphql-tag";
 import {
   AuthorizationPolicy,
@@ -93,7 +93,7 @@ export class BaseSubgraph implements ISubgraph {
     try {
       resolved = await this.reactorClient.resolveIdOrSlug(identifier);
     } catch {
-      throw new GraphQLError("Forbidden: insufficient permissions");
+      throw new ForbiddenError();
     }
 
     const canonical = resolved as CanonicalDocumentId;
@@ -133,7 +133,7 @@ export class BaseSubgraph implements ISubgraph {
       this.authorizationService.config.policy !==
       AuthorizationPolicy.DOCUMENT_PERMISSIONS
     ) {
-      throw new GraphQLError("Forbidden: insufficient permissions");
+      throw new ForbiddenError();
     }
     return this.resolveCanonicalDocumentId(identifier, ctx);
   }
@@ -204,9 +204,7 @@ export class BaseSubgraph implements ISubgraph {
       ctx.user?.address,
     );
     if (!canRead) {
-      throw new GraphQLError(
-        "Forbidden: insufficient permissions to read this document",
-      );
+      throw new ForbiddenError("to read this document");
     }
   }
 
@@ -219,9 +217,7 @@ export class BaseSubgraph implements ISubgraph {
       ctx.user?.address,
     );
     if (!canWrite) {
-      throw new GraphQLError(
-        "Forbidden: insufficient permissions to write to this document",
-      );
+      throw new ForbiddenError("to write to this document");
     }
   }
 
@@ -236,18 +232,17 @@ export class BaseSubgraph implements ISubgraph {
       ctx.user?.address,
     );
     if (!canMutate) {
-      throw new GraphQLError(
-        `Forbidden: insufficient permissions to execute operation "${operationType}" on this document`,
+      throw new ForbiddenError(
+        `to execute operation "${operationType}" on this document`,
       );
     }
   }
 
   assertCanCreate(ctx: Context): void {
     if (this.authorizationService.canCreate(ctx.user?.address)) return;
-    throw new GraphQLError(
-      ctx.user?.address
-        ? "Forbidden: insufficient permissions to create documents"
-        : "Forbidden: authentication required to create documents",
-    );
+    if (ctx.user?.address) {
+      throw new ForbiddenError("to create documents");
+    }
+    throw new AuthenticationRequiredError("to create documents");
   }
 }

--- a/packages/reactor-api/src/graphql/errors.ts
+++ b/packages/reactor-api/src/graphql/errors.ts
@@ -1,0 +1,22 @@
+import { GraphQLError } from "graphql";
+import { DRIVE_AUTH_ERROR_MESSAGES } from "@powerhousedao/reactor";
+
+/** Caller (authenticated or anonymous) lacks permission for the document. */
+export class ForbiddenError extends GraphQLError {
+  constructor(detail = "") {
+    const base = DRIVE_AUTH_ERROR_MESSAGES.forbidden;
+    super(`${base}${detail ? ` ${detail}` : ""}`, {
+      extensions: { code: "FORBIDDEN" },
+    });
+  }
+}
+
+/** Anonymous caller on an action that requires logging in. */
+export class AuthenticationRequiredError extends GraphQLError {
+  constructor(detail = "") {
+    const base = DRIVE_AUTH_ERROR_MESSAGES.authenticationRequired;
+    super(`${base}${detail ? ` ${detail}` : ""}`, {
+      extensions: { code: "UNAUTHENTICATED" },
+    });
+  }
+}

--- a/packages/reactor-api/test/graphql-errors.unit.test.ts
+++ b/packages/reactor-api/test/graphql-errors.unit.test.ts
@@ -1,0 +1,38 @@
+import { DRIVE_AUTH_ERROR_MESSAGES } from "@powerhousedao/reactor";
+import { describe, expect, it } from "vitest";
+import {
+  AuthenticationRequiredError,
+  ForbiddenError,
+} from "../src/graphql/errors.js";
+
+const INSUFFICIENT_PERMISSIONS = DRIVE_AUTH_ERROR_MESSAGES.forbidden;
+const AUTHENTICATION_REQUIRED =
+  DRIVE_AUTH_ERROR_MESSAGES.authenticationRequired;
+
+describe("ForbiddenError", () => {
+  it("carries the FORBIDDEN code", () => {
+    expect(new ForbiddenError().extensions.code).toBe("FORBIDDEN");
+  });
+
+  it("uses the shared message prefix, with and without detail", () => {
+    expect(new ForbiddenError().message).toBe(INSUFFICIENT_PERMISSIONS);
+    expect(new ForbiddenError("to read this document").message).toBe(
+      `${INSUFFICIENT_PERMISSIONS} to read this document`,
+    );
+  });
+
+  it("emits a message the client treats as an auth rejection", () => {
+    const msg = new ForbiddenError("to read this document").message;
+    expect(
+      Object.values(DRIVE_AUTH_ERROR_MESSAGES).some((m) => msg.includes(m)),
+    ).toBe(true);
+  });
+});
+
+describe("AuthenticationRequiredError", () => {
+  it("carries the UNAUTHENTICATED code and shared prefix", () => {
+    const err = new AuthenticationRequiredError("to create documents");
+    expect(err.extensions.code).toBe("UNAUTHENTICATED");
+    expect(err.message).toBe(`${AUTHENTICATION_REQUIRED} to create documents`);
+  });
+});

--- a/packages/reactor-browser/src/actions/drive.ts
+++ b/packages/reactor-browser/src/actions/drive.ts
@@ -1,6 +1,7 @@
 import {
   DocumentChangeType,
   DriveCollectionId,
+  isDriveAuthError,
   PropagationMode,
   type IReactorClient,
   type PollBehavior,
@@ -20,18 +21,6 @@ import { getUserPermissions } from "../utils/user.js";
 import { showPHModal } from "../hooks/modals.js";
 
 const DEFAULT_INITIAL_SYNC_TIMEOUT_MS = 30_000;
-
-/**
- * A drive add failed because the switchboard rejected the (anonymous or
- * unverified) caller — Forbidden/Unauthorized — rather than a transient
- * reachability error. Drives the login prompt.
- */
-function isDriveAuthError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return /forbidden|unauthorized|insufficient permissions|\b401\b|\b403\b/i.test(
-    message,
-  );
-}
 
 // In-flight remote registrations keyed by collectionId. sync.list()/sync.add()
 // is not atomic, so concurrent addRemoteDrive calls for the same drive would

--- a/packages/reactor-browser/src/re-exports.ts
+++ b/packages/reactor-browser/src/re-exports.ts
@@ -6,6 +6,7 @@ export {
   GqlRequestChannel,
   InMemoryQueue,
   IntervalPollTimer,
+  isDriveAuthError,
   PollBehavior,
   REACTOR_SCHEMA,
   ReactorBuilder,

--- a/packages/reactor/index.ts
+++ b/packages/reactor/index.ts
@@ -285,6 +285,8 @@ export {
   GqlResponseChannel,
   GqlResponseChannelFactory,
   IntervalPollTimer,
+  DRIVE_AUTH_ERROR_MESSAGES,
+  isDriveAuthError,
   Mailbox,
   PollBehavior,
   PollingChannelError,

--- a/packages/reactor/src/sync/channels/gql-req-channel.ts
+++ b/packages/reactor/src/sync/channels/gql-req-channel.ts
@@ -5,7 +5,11 @@ import type {
 } from "../../cache/operation-index-types.js";
 import type { ISyncCursorStorage } from "../../storage/interfaces.js";
 import { BufferedMailbox } from "../buffered-mailbox.js";
-import { ChannelError, GraphQLRequestError } from "../errors.js";
+import {
+  ChannelError,
+  GraphQLRequestError,
+  isDriveAuthError,
+} from "../errors.js";
 import type { ConnectionStateChangeCallback, IChannel } from "../interfaces.js";
 import { type IMailbox, Mailbox } from "../mailbox.js";
 import { SyncOperation } from "../sync-operation.js";
@@ -79,6 +83,8 @@ export class GqlRequestChannel implements IChannel {
   private receivingPages: boolean = false;
   private isRecovering: boolean = false;
   private connectionState: ConnectionState = "connecting";
+  /** Latest unrecoverable error was an auth rejection; cleared on connect. */
+  private requiresAuth: boolean = false;
   private readonly connectionStateCallbacks: Set<ConnectionStateChangeCallback> =
     new Set();
 
@@ -212,6 +218,7 @@ export class GqlRequestChannel implements IChannel {
       pushBlocked: this.pushBlocked,
       pushFailureCount: this.pushFailureCount,
       receivingPages: this.receivingPages,
+      requiresAuth: this.requiresAuth,
     };
   }
 
@@ -254,6 +261,7 @@ export class GqlRequestChannel implements IChannel {
   }
 
   private transitionConnectionState(next: ConnectionState): void {
+    if (next === "connected") this.requiresAuth = false;
     if (this.connectionState === next) return;
     this.connectionState = next;
     const snapshot = this.getConnectionState();
@@ -411,6 +419,7 @@ export class GqlRequestChannel implements IChannel {
 
     if (classification === "unrecoverable") {
       this.pollTimer.stop();
+      this.requiresAuth = isDriveAuthError(err);
       this.transitionConnectionState("error");
       return true;
     }
@@ -475,6 +484,7 @@ export class GqlRequestChannel implements IChannel {
 
           if (classification === "unrecoverable") {
             this.isRecovering = false;
+            this.requiresAuth = isDriveAuthError(err);
             this.transitionConnectionState("error");
             return;
           }
@@ -740,6 +750,7 @@ export class GqlRequestChannel implements IChannel {
           }
           this.deadLetter.add(...syncOps);
           this.outbox.remove(...syncOps);
+          this.requiresAuth = isDriveAuthError(err);
           this.transitionConnectionState("error");
         }
       });

--- a/packages/reactor/src/sync/channels/gql-res-channel.ts
+++ b/packages/reactor/src/sync/channels/gql-res-channel.ts
@@ -101,6 +101,7 @@ export class GqlResponseChannel implements IChannel {
       pushBlocked: false,
       pushFailureCount: 0,
       receivingPages: false,
+      requiresAuth: false,
     };
   }
 

--- a/packages/reactor/src/sync/errors.ts
+++ b/packages/reactor/src/sync/errors.ts
@@ -23,6 +23,30 @@ export class GraphQLRequestError extends Error {
   }
 }
 
+/** Auth-rejection message fragments the switchboard emits. Shared with
+ * reactor-api so server throws and this client check can't drift. */
+export const DRIVE_AUTH_ERROR_MESSAGES = {
+  forbidden: "Forbidden: insufficient permissions",
+  authenticationRequired: "Forbidden: authentication required",
+} as const;
+
+/** True when the remote rejected the caller as unauthenticated/unauthorized:
+ * an HTTP 401/403, or a Forbidden/Unauthorized GraphQL error. */
+export function isDriveAuthError(error: unknown): boolean {
+  if (!(error instanceof GraphQLRequestError)) {
+    return false;
+  }
+  if (error.category === "http") {
+    return error.statusCode === 401 || error.statusCode === 403;
+  }
+  if (error.category === "graphql") {
+    return Object.values(DRIVE_AUTH_ERROR_MESSAGES).some((m) =>
+      error.message.includes(m),
+    );
+  }
+  return false;
+}
+
 export class PollingChannelError extends Error {
   constructor(message: string) {
     super(message);

--- a/packages/reactor/src/sync/index.ts
+++ b/packages/reactor/src/sync/index.ts
@@ -48,7 +48,12 @@ export {
   SyncOperationAggregateError,
 } from "./sync-operation.js";
 
-export { ChannelError, PollingChannelError } from "./errors.js";
+export {
+  ChannelError,
+  PollingChannelError,
+  isDriveAuthError,
+  DRIVE_AUTH_ERROR_MESSAGES,
+} from "./errors.js";
 
 export {
   envelopesToSyncOperations,

--- a/packages/reactor/src/sync/types.ts
+++ b/packages/reactor/src/sync/types.ts
@@ -110,6 +110,9 @@ export type ConnectionStateSnapshot = {
   pushBlocked: boolean;
   pushFailureCount: number;
   receivingPages: boolean;
+  /** Latest error was the remote rejecting the caller as unauthenticated
+   * (401/403 or Forbidden GraphQL error). Only meaningful while state="error". */
+  requiresAuth: boolean;
 };
 
 export type ConnectionStateChangedEvent = {

--- a/packages/reactor/test/sync/channels/gql-req-channel/connection-state.test.ts
+++ b/packages/reactor/test/sync/channels/gql-req-channel/connection-state.test.ts
@@ -496,6 +496,8 @@ describe("GqlRequestChannel Connection State", () => {
     await vi.waitFor(() => {
       expect(channel.getConnectionState().state).toBe("error");
     });
+    // GraphQL validation rejection is not an auth failure.
+    expect(channel.getConnectionState().requiresAuth).toBe(false);
     await channel.shutdown();
   });
 
@@ -653,7 +655,54 @@ describe("GqlRequestChannel Connection State", () => {
     await manualTimer.tick();
 
     expect(channel.getConnectionState().state).toBe("error");
+    expect(channel.getConnectionState().requiresAuth).toBe(true);
     expect(manualTimer.isRunning()).toBe(false);
+    await channel.shutdown();
+  });
+
+  it("Forbidden GraphQL poll error sets requiresAuth", async () => {
+    const mockFetch = createMockFetch((body) => {
+      if (body.query.includes("touchChannel")) {
+        return {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: { touchChannel: { success: true, ackOrdinal: 0 } },
+            }),
+        };
+      }
+      // Switchboard returns HTTP 200 with a Forbidden error in the body.
+      return {
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            errors: [
+              {
+                message:
+                  "Forbidden: insufficient permissions to read this document",
+              },
+            ],
+          }),
+      };
+    });
+    global.fetch = mockFetch as unknown as typeof global.fetch;
+
+    const manualTimer = new ManualPollTimer();
+    const channel = new GqlRequestChannel(
+      createMockLogger(),
+      "channel-1",
+      "remote-1",
+      createMockCursorStorage(),
+      createTestConfig(),
+      createMockOperationIndex(),
+      manualTimer,
+    );
+
+    await channel.init();
+    await manualTimer.tick().catch(() => {});
+
+    expect(channel.getConnectionState().state).toBe("error");
+    expect(channel.getConnectionState().requiresAuth).toBe(true);
     await channel.shutdown();
   });
 
@@ -711,6 +760,7 @@ describe("GqlRequestChannel Connection State", () => {
     // First poll: 500 error (recoverable) - rethrown by handlePollError
     await manualTimer.tick().catch(() => {});
     expect(channel.getConnectionState().state).toBe("error");
+    expect(channel.getConnectionState().requiresAuth).toBe(false);
     expect(manualTimer.isRunning()).toBe(true);
 
     // Second poll succeeds - timer is still running
@@ -767,6 +817,7 @@ describe("GqlRequestChannel Connection State", () => {
 
     await vi.advanceTimersByTimeAsync(100);
     expect(channel.getConnectionState().state).toBe("error");
+    expect(channel.getConnectionState().requiresAuth).toBe(true);
     // Timer should stay stopped (not restarted)
     expect(manualTimer.isRunning()).toBe(false);
     await channel.shutdown();

--- a/packages/reactor/test/sync/channels/test-channel.ts
+++ b/packages/reactor/test/sync/channels/test-channel.ts
@@ -87,6 +87,7 @@ export class TestChannel implements IChannel {
       pushBlocked: false,
       pushFailureCount: 0,
       receivingPages: false,
+      requiresAuth: false,
     };
   }
 

--- a/packages/reactor/test/sync/errors.unit.test.ts
+++ b/packages/reactor/test/sync/errors.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   ChannelError,
   GraphQLRequestError,
+  isDriveAuthError,
   PollingChannelError,
 } from "../../src/sync/errors.js";
 import { ChannelErrorSource } from "../../src/sync/types.js";
@@ -26,6 +27,69 @@ describe("PollingChannelError", () => {
     const err = new PollingChannelError("offline");
     expect(err.name).toBe("PollingChannelError");
     expect(err.message).toBe("offline");
+  });
+});
+
+describe("isDriveAuthError", () => {
+  it("is true for HTTP 401 and 403", () => {
+    expect(isDriveAuthError(new GraphQLRequestError("nope", "http", 401))).toBe(
+      true,
+    );
+    expect(isDriveAuthError(new GraphQLRequestError("nope", "http", 403))).toBe(
+      true,
+    );
+  });
+
+  it("is false for other HTTP status codes", () => {
+    for (const status of [400, 404, 500, 503]) {
+      expect(
+        isDriveAuthError(new GraphQLRequestError("nope", "http", status)),
+      ).toBe(false);
+    }
+  });
+
+  it("is true for a Forbidden GraphQL error", () => {
+    const err = new GraphQLRequestError(
+      'GraphQL errors: [{ "message": "Forbidden: insufficient permissions to read this document" }]',
+      "graphql",
+    );
+    expect(isDriveAuthError(err)).toBe(true);
+  });
+
+  it("is true for an authentication-required GraphQL error", () => {
+    const err = new GraphQLRequestError(
+      'GraphQL errors: [{ "message": "Forbidden: authentication required to create documents" }]',
+      "graphql",
+    );
+    expect(isDriveAuthError(err)).toBe(true);
+  });
+
+  it("is false for a non-auth GraphQL error", () => {
+    const err = new GraphQLRequestError(
+      'GraphQL errors: [{ "message": "Validation failed" }]',
+      "graphql",
+    );
+    expect(isDriveAuthError(err)).toBe(false);
+  });
+
+  it("is false for network/parse/missing-data errors", () => {
+    expect(isDriveAuthError(new GraphQLRequestError("down", "network"))).toBe(
+      false,
+    );
+    expect(isDriveAuthError(new GraphQLRequestError("bad", "parse"))).toBe(
+      false,
+    );
+    expect(
+      isDriveAuthError(new GraphQLRequestError("empty", "missing-data")),
+    ).toBe(false);
+  });
+
+  it("is false for a plain Error whose message merely mentions 403", () => {
+    expect(isDriveAuthError(new Error("Failed to resolve drive (403)"))).toBe(
+      false,
+    );
+    expect(isDriveAuthError("forbidden")).toBe(false);
+    expect(isDriveAuthError(undefined)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Problem

Connect's drive login prompt (the full-page `DriveAuthGate` and the `driveAuthRequired` modal) fired on **any** drive sync error — a network failure, a 5xx, a "drive not found", or a switchboard being down all surfaced a "Log in to access this drive" prompt, even though logging in wouldn't fix any of them.

## Fix

The login prompt now fires **only for a genuine auth rejection**:

- **`reactor`** — `ConnectionStateSnapshot` carries a `requiresAuth` flag. A shared `isDriveAuthError(error)` + a `DRIVE_AUTH_ERROR_MESSAGES` constant replace **two duplicated message regexes** (previously copy-pasted in `reactor-browser` and `connect`). Detection: HTTP `401`/`403`, or a GraphQL error whose message matches the shared auth-message constants.
- **`reactor-api`** — the auth throws in `base-subgraph.ts` now use dedicated `ForbiddenError` / `AuthenticationRequiredError` classes carrying a stable `extensions.code` (`FORBIDDEN` / `UNAUTHENTICATED`). Messages are unchanged.
- **`connect`** — the gate fires only when an errored remote is an auth rejection (`state === "error" && requiresAuth`); the add-drive modal uses the same shared helper.

## Back-compat

The client matches the **message constant**, not the new code, so detection keeps working against already-deployed switchboards (which emit the message but not the code). The `extensions.code` is additive — a future client can prefer it with the message as fallback.

## How it was verified

- **Unit tests** — `isDriveAuthError` (401/403, Forbidden/auth-required GraphQL, non-auth, network/parse), channel `requiresAuth` transitions (401/403/Forbidden → true; 500/validation → false), the error classes (code + message), and the gate decision.
- **End-to-end (Playwright + real Switchboard + Connect)**:
  - Protected drive, anonymous → login prompt shown; `touchChannel` returns HTTP 200 + `Forbidden` message + `code: FORBIDDEN`.
  - Same drive, auth off (`OPEN`) → no prompt, drive syncs.
  - Mock switchboard returning HTTP 500 / connection-reset on poll → **before** the fix the prompt showed (reproduced the bug), **after** it does not.
- Reactor sync suite (469) + reactor-api error/permission tests pass; eslint + `tsc` clean across `reactor`, `reactor-api`, `reactor-browser`, `connect`.

## Notes

- The `requiresAuth` flag is set at the unrecoverable-error sites and cleared only on a successful connect, so a transient recoverable error can't wipe a real auth flag.
- `DRIVE_AUTH_ERROR_MESSAGES` is a named object (`{ forbidden, authenticationRequired }`) to avoid positional coupling between message and error code.
