### PR TITLE
perf(renown): keep viem out of public .d.ts surface

### DIFF
--- a/packages/renown/src/credential.ts
+++ b/packages/renown/src/credential.ts
@@ -1,11 +1,18 @@
-import {
-  recoverTypedDataAddress,
-  type Hex,
-  type TypedDataDomain,
-  type TypedDataParameter,
-} from "viem";
+import { recoverTypedDataAddress } from "viem";
 import { CREDENTIAL_TYPES, DEFAULT_RENOWN_NETWORK_ID } from "./constants.js";
 import type { PowerhouseVerifiableCredential } from "./types.js";
+
+/* Local structural aliases (EIP-712 standard shapes) so renown's public .d.ts
+ * never names viem — a viem type in the surface drags viem's whole closure in. */
+type Hex = `0x${string}`;
+type TypedDataDomain = {
+  name?: string;
+  version?: string;
+  chainId?: number;
+  verifyingContract?: Hex;
+  salt?: Hex;
+};
+type TypedDataParameter = { name: string; type: string };
 
 /** EIP-712 domain as signed by the credential issuer. */
 export type CredentialDomain = {


### PR DESCRIPTION
## What

`renown/src/credential.ts` named three viem types in its public surface
(`Hex`, `TypedDataDomain`, `TypedDataParameter`). Replace them with local,
structurally-identical EIP-712 aliases. The runtime is unchanged — it still
value-imports `recoverTypedDataAddress` from viem.

## Why

A viem **type** named anywhere in renown's emitted `.d.ts` drags viem's entire
declaration closure into every downstream consumer's TypeScript program.
TypeScript loads a referenced `.d.ts` wholesale, so naming one viem type pulls
in viem **and** its `ox` dependency — ~455 extra files — for any package that
transitively depends on `@renown/sdk`, even when none of viem's API is used.

This inflates type-aware linting and `tsc`. In a real-install measurement of a
reactor package's codegen check (the vetra-cli flow), removing this leak drops
eslint peak RSS by ~100 MB (~7.5%) and removes 455 files from the program.

The aliases are the standard EIP-712 shapes, so the change is non-breaking:
callers passing viem's own `TypedDataDomain`/`Hex` still satisfy the structural
types.

## Verification

- `pnpm --filter @renown/sdk build` — clean.
- `grep viem dist/*.d.ts` — 0 matches (was present before).
- `tsc --noEmit -p tsconfig.json` — exit 0.
