### PR TITLE
build(vetra): add engine-free @powerhousedao/vetra/codegen/spec export

### DIFF
--- a/packages/vetra/codegen/spec.ts
+++ b/packages/vetra/codegen/spec.ts
@@ -1,0 +1,2 @@
+export * from "./spec-api.js";
+export * from "./specs.js";

--- a/packages/vetra/package.json
+++ b/packages/vetra/package.json
@@ -51,6 +51,11 @@
       "types": "./dist/codegen/index.d.ts",
       "import": "./dist/codegen/index.js"
     },
+    "./codegen/spec": {
+      "source": "./codegen/spec.ts",
+      "types": "./dist/codegen/spec.d.ts",
+      "import": "./dist/codegen/spec.js"
+    },
     "./manifest": "./dist/powerhouse.manifest.json",
     "./style.css": "./style.css",
     "./package.json": "./package.json"

--- a/packages/vetra/tsdown.config.ts
+++ b/packages/vetra/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     "processors/index.ts",
     "processors/*/index.ts",
     "codegen/index.ts",
+    "codegen/spec.ts",
     "powerhouse.manifest.json",
   ],
   platform: "neutral",


### PR DESCRIPTION
Adds a lean `@powerhousedao/vetra/codegen/spec` subpath export that re-exports only the spec **definitions** (`specs.ts`) and file-backed **CRUD** (`spec-api.ts`) — `getSpecEntry`, `createDocument`, reducers/actions, `getDocuments`, `saveSpec`, `deleteDocument`, etc.

Its transitive import graph is **engine-free**: no `@graphql-codegen`, no `ts-morph` (verified — 12-file closure vs 56 with all three for the default `./codegen` entry).

## Why
A consumer (vetra-cli) needs the spec definitions in-process for create/validate/save/delete while routing actual code generation to a `ph generate` subprocess — so it must import the definitions without pulling the graphql-codegen / ts-morph engine into its bundle. The heavy `generate-from-document` + `extract` modules can't move into `@powerhousedao/codegen` (vetra already references codegen; TS project references forbid the cycle), so the split lives here as a new subpath.

## Scope
Purely additive — 3 files (new `codegen/spec.ts` barrel, the `./codegen/spec` export, its tsdown entry). The default `./codegen` entry (generate-from-document + extract) and all of ph-cli are unchanged; `ph generate --extract` is untouched.

Consumed by the vetra-cli bundling PR (powerhouse-inc/vetra-cli), which is blocked on a release of this.

https://claude.ai/code/session_019fYvo7fo6fUFUPeFWyEpcA