### PR TITLE
feat(connect): add --renown-namespace to share Renown session across Connects

### DIFF
--- a/apps/connect/src/store/reactor.ts
+++ b/apps/connect/src/store/reactor.ts
@@ -229,8 +229,15 @@ export async function createReactor(localPackage?: DocumentModelLib) {
     .build();
 
   // initialize Renown
+  // The Renown namespace is a boot-time constant (no runtime mutation), so read
+  // it straight from the runtime config rather than threading it through the
+  // PHGlobalConfig event/setter/hook machinery. baseUrl still comes from
+  // phGlobalConfig (its mutable-config home). The sync getter is safe here for
+  // the same reason as line ~244: loadComponent() warmed the cache before this.
   const renown = await new RenownBuilder("connect", {
-    basename: phGlobalConfig.routerBasename,
+    basename:
+      getRuntimeConfig().connect.renown?.namespace ??
+      phGlobalConfig.routerBasename,
     baseUrl: phGlobalConfig.renownUrl,
   })
     .withCrypto(renownCrypto)

--- a/clis/ph-cli/COMMANDS.md
+++ b/clis/ph-cli/COMMANDS.md
@@ -282,6 +282,10 @@ public base URL for the drive URLs advertised to Connect; each drive is exposed 
 Database path or connection string. Use a `postgres://` URL for Postgres; otherwise treated as a PGlite filesystem path. Leave unset for in-memory PGlite.<br><br>
 **usage:** `--db-path <str>`<br>
 
+#### Renown Namespace <br>
+Renown localStorage namespace; share it across Connects to share login.<br><br>
+**usage:** `--renown-namespace <str>`<br>
+
 #### Base <br>
 Base path for the app<br><br>
 **usage:** `--base <str>`<br>
@@ -407,6 +411,10 @@ This command:
 Port to run the dev server on.<br><br>
 **usage:** `--port <number>`<br>
 **default**: `3000`
+#### Renown Namespace <br>
+Renown localStorage namespace; share it across Connects to share login.<br><br>
+**usage:** `--renown-namespace <str>`<br>
+
 #### Base <br>
 Base path for the app<br><br>
 **usage:** `--base <str>`<br>
@@ -510,6 +518,10 @@ Override connect.renown.networkId.<br><br>
 #### Renown Chain Id <br>
 Override connect.renown.chainId.<br><br>
 **usage:** `--renown-chain-id <number>`<br>
+
+#### Renown Namespace <br>
+Renown localStorage namespace; share it across Connects to share login.<br><br>
+**usage:** `--renown-namespace <str>`<br>
 
 #### Allow Add Drive <br>
 Override connect.drives.allowAddDrive (top-level add-drive toggle).<br><br>

--- a/clis/ph-cli/src/help.ts
+++ b/clis/ph-cli/src/help.ts
@@ -70,6 +70,9 @@ Options:
   --dynamic-base              Build one bundle that serves under any subpath; base
                               resolved at serve time from a runtime global. Overrides --base.
 
+  --renown-namespace <ns>     Renown localStorage namespace; share it across Connects
+                              to share login.
+
   --mode <mode>               Vite mode to use (e.g., development, production).
 
   --config-file <configFile>  Path to the powerhouse.config.js file.
@@ -406,6 +409,9 @@ Options:
   --interactive              Enable interactive mode for code generation. When enabled, the system
                             will prompt for user confirmation before generating code. This is useful
                             for development when you want control over when code regeneration happens.
+
+  --renown-namespace <ns>    Renown localStorage namespace; share it across Connects to
+                            share login (e.g. so a preview Connect reuses the Studio session).
 
 Examples:
   $ ph vetra                                              # Start Vetra environment with defaults

--- a/clis/ph-cli/src/utils/cli-connect-override.ts
+++ b/clis/ph-cli/src/utils/cli-connect-override.ts
@@ -46,6 +46,7 @@ export type ConnectFlagInput = {
   renownUrl?: string | undefined;
   renownNetworkId?: string | undefined;
   renownChainId?: number | undefined;
+  renownNamespace?: string | undefined;
   allowAddDrive?: boolean | undefined;
   externalPackages?: boolean | undefined;
   remoteDrivesEnabled?: boolean | undefined;
@@ -142,6 +143,7 @@ export function buildConnectFlagPatch(args: ConnectFlagInput): PlainObject {
   setIfDefined(renown, "url", args.renownUrl);
   setIfDefined(renown, "networkId", args.renownNetworkId);
   setIfDefined(renown, "chainId", args.renownChainId);
+  setIfDefined(renown, "namespace", args.renownNamespace);
   if (Object.keys(renown).length > 0) out.renown = renown;
 
   const packages: PlainObject = {};
@@ -222,6 +224,7 @@ export function buildCliConnectOverride(args: ConnectBuildArgs): {
     renownUrl: args.renownUrl,
     renownNetworkId: args.renownNetworkId,
     renownChainId: args.renownChainId,
+    renownNamespace: args.renownNamespace,
     allowAddDrive: args.allowAddDrive,
     externalPackages: args.externalPackages,
     remoteDrivesEnabled: args.remoteDrivesEnabled,
@@ -337,6 +340,7 @@ export function buildStudioConnectOverride(
     drivesPreserveStrategy: wasFlagExplicitlyPassed("drive-preserve-strategy")
       ? args.drivesPreserveStrategy
       : undefined,
+    renownNamespace: args.renownNamespace,
   }) as PHConnectRuntimeConfig;
 
   const hasFlag = Object.keys(flagOverride).length > 0;

--- a/packages/builder-tools/connect-utils/runtime-config.schema.json
+++ b/packages/builder-tools/connect-utils/runtime-config.schema.json
@@ -231,6 +231,10 @@
               "type": "number",
               "description": "CAIP-2 chain reference within the network namespace.",
               "default": 1
+            },
+            "namespace": {
+              "type": "string",
+              "description": "Renown localStorage namespace; share it across Connects to share login."
             }
           }
         },

--- a/packages/builder-tools/connect-utils/vite-plugins/ph-config.test.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/ph-config.test.ts
@@ -113,7 +113,11 @@ describe("phConfigPlugin", () => {
         drives: { allowAddDrive: true },
       },
       cliConnectOverride: {
-        renown: { url: "https://cli.renown", chainId: 42 },
+        renown: {
+          url: "https://cli.renown",
+          chainId: 42,
+          namespace: "vetra-studio",
+        },
         drives: { allowAddDrive: false },
       },
     });
@@ -135,8 +139,11 @@ describe("phConfigPlugin", () => {
     expect(connect.renown.url).toBe("https://cli.renown");
     expect(connect.drives.allowAddDrive).toBe(false);
 
-    // CLI-only fields are present (deep-merged into source/default tree)
+    // CLI-only fields are present (deep-merged into source/default tree).
+    // namespace must survive schema validation — it's how the preview Connect
+    // shares the Studio's Renown session.
     expect(connect.renown.chainId).toBe(42);
+    expect(connect.renown.namespace).toBe("vetra-studio");
 
     // Source fields untouched by CLI remain populated from defaults
     expect(connect.renown.networkId).toBe(

--- a/packages/shared/clis/args/common.ts
+++ b/packages/shared/clis/args/common.ts
@@ -177,6 +177,13 @@ export const connectBasePath = option({
   defaultValue: () => "/",
 });
 
+export const renownNamespace = option({
+  type: optional(string),
+  long: "renown-namespace",
+  description:
+    "Renown localStorage namespace; share it across Connects to share login.",
+});
+
 export const drivesPreserveStrategy = option({
   type: oneOf(DRIVES_PRESERVE_STRATEGIES),
   long: "drive-preserve-strategy",

--- a/packages/shared/clis/args/connect.ts
+++ b/packages/shared/clis/args/connect.ts
@@ -20,6 +20,7 @@ import {
   defaultDrivesUrl,
   drivesPreserveStrategy,
   logLevel,
+  renownNamespace,
 } from "./common.js";
 
 // cmd-ts's built-in `boolean` is intended for `flag()` (presence/absence). With
@@ -47,6 +48,7 @@ export const connectStudioArgs = {
     defaultValue: () => DEFAULT_CONNECT_STUDIO_PORT,
     defaultValueIsSerializable: true,
   }),
+  renownNamespace,
   ...commonArgs,
   ...commonServerArgs,
 };
@@ -89,6 +91,7 @@ const connectRuntimeOverrideArgs = {
     long: "renown-chain-id",
     description: "Override connect.renown.chainId.",
   }),
+  renownNamespace,
   allowAddDrive: option({
     type: optional(cliBoolean),
     long: "allow-add-drive",

--- a/packages/shared/clis/args/vetra.ts
+++ b/packages/shared/clis/args/vetra.ts
@@ -7,6 +7,7 @@ import { getConfig } from "../file-system/get-config.js";
 import {
   commonArgs,
   commonServerArgs,
+  renownNamespace,
   vetraSwitchboardArgs,
 } from "./common.js";
 
@@ -81,6 +82,7 @@ export const vetraArgs = {
     description:
       "Database path or connection string. Use a `postgres://` URL for Postgres; otherwise treated as a PGlite filesystem path. Leave unset for in-memory PGlite.",
   }),
+  renownNamespace,
   ...commonArgs,
   ...commonServerArgs,
   ...vetraSwitchboardArgs,

--- a/packages/shared/clis/types.ts
+++ b/packages/shared/clis/types.ts
@@ -72,6 +72,8 @@ export type PHConnectRenown = {
   url?: string;
   networkId?: string;
   chainId?: number;
+  /** Renown localStorage namespace; share it across Connects to share login. */
+  namespace?: string;
 };
 
 export type PHConnectSentry = {


### PR DESCRIPTION
## What
Adds a `--renown-namespace` flag to `ph vetra`, `ph connect build`, and `ph connect studio` that flows into the Connect runtime config as `renown.namespace`. Connect uses it as the Renown localStorage `basename` (falling back to `routerBasename`), so two Connects given the same namespace share a login.

## Why
The Vetra Studio BUILD-pane preview runs a second Connect under a different base path, so it stored its Renown session under a different localStorage key and couldn't see the owner's existing login — surfacing a "Log in to access this drive" gate. Sharing the namespace lets the preview Connect reuse the already-established session with no second login, while the drive stays auth-protected.

## Notes
- Default behavior is unchanged when the flag is unset.
- The flag is defined once as a shared option and referenced from the vetra / connect build / connect studio arg sets; the studio path forwards it through `buildStudioConnectOverride`.
- `reactor.ts` reads the namespace straight from the runtime config (it's a boot-time constant, so it isn't threaded through the `PHGlobalConfig` event/setter/hook machinery).
- Runtime-config schema and `PHConnectRenown` gain an optional `namespace`; an override→emit test asserts it survives validation.