### PR TITLE
feat(connect): add --favicon flag to ph connect build

### DIFF
--- a/apps/academy/docs/academy/04-Reference/07-CLITooling/00-PowerhouseCLI.md
+++ b/apps/academy/docs/academy/04-Reference/07-CLITooling/00-PowerhouseCLI.md
@@ -635,6 +635,8 @@ Build has no read mode; passing only &lt;key&gt; without &lt;value&gt; errors ou
 
 **Sentry Tracing Enabled** - Override connect.sentry.tracing (Sentry performance tracing). - Usage: `--sentry-tracing-enabled <value>`
 
+**Favicon** - Path to a favicon file (e.g. .ico) to bundle in place of the default Connect icon. Emitted as icon.ico; resolved relative to the build cwd. - Usage: `--favicon <str>`
+
 **Base** - Base path for the app - Usage: `--base <str>`
 
 **Log Level** - Log level for the application - Usage: `--log-level <value>`

--- a/clis/ph-cli/COMMANDS.md
+++ b/clis/ph-cli/COMMANDS.md
@@ -579,6 +579,10 @@ Override connect.sentry.env (Sentry environment label).<br><br>
 Override connect.sentry.tracing (Sentry performance tracing).<br><br>
 **usage:** `--sentry-tracing-enabled <value>`<br>
 
+#### Favicon <br>
+Path to a favicon file (e.g. .ico) to bundle in place of the default Connect icon. Emitted as icon.ico; resolved relative to the build cwd.<br><br>
+**usage:** `--favicon <str>`<br>
+
 #### Base <br>
 Base path for the app<br><br>
 **usage:** `--base <str>`<br>

--- a/clis/ph-cli/src/help.ts
+++ b/clis/ph-cli/src/help.ts
@@ -70,6 +70,9 @@ Options:
   --dynamic-base              Build one bundle that serves under any subpath; base
                               resolved at serve time from a runtime global. Overrides --base.
 
+  --favicon <path>            Path to a favicon (e.g. .ico) to bundle in place of the
+                              default Connect icon. Emitted as icon.ico.
+
   --renown-namespace <ns>     Renown localStorage namespace; share it across Connects
                               to share login.
 

--- a/clis/ph-cli/src/services/connect-build.ts
+++ b/clis/ph-cli/src/services/connect-build.ts
@@ -9,7 +9,7 @@ import { buildCliConnectOverride } from "../utils/cli-connect-override.js";
 import { runBuild } from "./build.js";
 
 export async function runConnectBuild(args: ConnectBuildArgs) {
-  const { outDir, debug, dynamicBase } = args;
+  const { outDir, debug, dynamicBase, favicon } = args;
 
   const mode = "production";
   const dirname = process.cwd();
@@ -45,6 +45,7 @@ export async function runConnectBuild(args: ConnectBuildArgs) {
     cliConnectOverride: connectOverride,
     cliPackageRegistryUrl: packageRegistryUrl,
     dynamicBase,
+    favicon,
   });
 
   const buildConfig: InlineConfig = {

--- a/packages/builder-tools/connect-utils/types.ts
+++ b/packages/builder-tools/connect-utils/types.ts
@@ -29,6 +29,10 @@ export type IConnectOptions = {
   /* Build one bundle that serves under any subpath; base resolved at serve
    * time from a runtime global instead of baked in. Overrides the deploy base. */
   dynamicBase?: boolean;
+  /* Path to a custom favicon to bundle as icon.ico instead of the default
+   * Connect asset. Build input (not runtime config); from
+   * `ph connect build --favicon`. Non-absolute paths resolve against the build cwd. */
+  favicon?: string;
 };
 
 export type ConnectCommonOptions = {

--- a/packages/builder-tools/connect-utils/vite-config.ts
+++ b/packages/builder-tools/connect-utils/vite-config.ts
@@ -407,7 +407,7 @@ export function getConnectBaseViteConfig(options: IConnectOptions) {
         dirname: options.dirname,
         dev: mode !== "production" || isDebug,
       }),
-      connectFaviconPlugin(),
+      connectFaviconPlugin({ faviconPath: options.favicon }),
       // enforce: "post" — rewrites the placeholder base after all other
       // transforms have emitted their asset/chunk URLs.
       ...(options.dynamicBase ? [connectDynamicBasePlugin()] : []),

--- a/packages/builder-tools/connect-utils/vite-plugins/favicon.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/favicon.ts
@@ -1,19 +1,50 @@
 import { readFileSync } from "node:fs";
+import { extname, isAbsolute, resolve } from "node:path";
 import type { Connect, Plugin } from "vite";
 
+const CONTENT_TYPE_BY_EXT: Record<string, string> = {
+  ".ico": "image/x-icon",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+};
+
 /**
- * Vite plugin to serve the Connect favicon (icon.ico) from the connect package.
- * This ensures the favicon is available in development and included in the production build.
+ * Vite plugin to serve the Connect favicon (icon.ico) from the connect package,
+ * or from a caller-supplied file when `faviconPath` is set (e.g. `ph connect
+ * build --favicon`). The served/emitted name is always `icon.ico` so the static
+ * `<link rel="icon" href="%BASE_URL%icon.ico">` in index.html stays valid.
  */
-export function connectFaviconPlugin(): Plugin {
+export function connectFaviconPlugin(
+  opts: { faviconPath?: string } = {},
+): Plugin {
+  // Build input, not runtime config: a non-absolute path resolves against the
+  // build cwd (= the project dir during `ph connect build`).
+  const customPath = opts.faviconPath
+    ? isAbsolute(opts.faviconPath)
+      ? opts.faviconPath
+      : resolve(process.cwd(), opts.faviconPath)
+    : undefined;
+  const customContentType = customPath
+    ? (CONTENT_TYPE_BY_EXT[extname(customPath).toLowerCase()] ?? "image/x-icon")
+    : "image/x-icon";
+
   return {
     name: "copy-connect-favicon",
     configureServer(server) {
       // Vite rewrites the favicon link against `base`, so serve the
       // base-prefixed path. Keep the bare path for robustness.
       const base = server.config.base;
-      const faviconPath = `${base}icon.ico`.replace(/\/{2,}/g, "/");
+      const faviconRoute = `${base}icon.ico`.replace(/\/{2,}/g, "/");
       const handler: Connect.NextHandleFunction = (_req, res, next) => {
+        if (customPath) {
+          try {
+            res.setHeader("Content-Type", customContentType);
+            res.end(readFileSync(customPath));
+          } catch {
+            next();
+          }
+          return;
+        }
         server.pluginContainer
           .resolveId("@powerhousedao/connect/assets/icon.ico")
           .then((resolved) => {
@@ -26,7 +57,7 @@ export function connectFaviconPlugin(): Plugin {
       // Mount on the exact route(s) so the handler only runs for icon.ico.
       // Connect strips the mount prefix before matching, so mounting on
       // "/icon.ico" matches that path exactly.
-      const paths = new Set([faviconPath, "/icon.ico"]);
+      const paths = new Set([faviconRoute, "/icon.ico"]);
       for (const path of paths) {
         server.middlewares.use(path, handler);
       }
@@ -34,17 +65,23 @@ export function connectFaviconPlugin(): Plugin {
     async generateBundle(_options, bundle) {
       try {
         if ("icon.ico" in bundle) return;
-        const resolved = await this.resolve(
-          "@powerhousedao/connect/assets/icon.ico",
-        );
-        if (!resolved) return;
+        let source: Uint8Array | undefined;
+        if (customPath) {
+          source = readFileSync(customPath);
+        } else {
+          const resolved = await this.resolve(
+            "@powerhousedao/connect/assets/icon.ico",
+          );
+          if (resolved) source = readFileSync(resolved.id);
+        }
+        if (!source) return;
         this.emitFile({
           type: "asset",
           fileName: "icon.ico",
-          source: readFileSync(resolved.id),
+          source,
         });
       } catch {
-        // connect package not found, skip favicon
+        // favicon source not found, skip
       }
     },
   };

--- a/packages/shared/clis/args/connect.ts
+++ b/packages/shared/clis/args/connect.ts
@@ -205,6 +205,12 @@ export const connectBuildArgs = {
     description:
       "Build one bundle that serves under any subpath; base resolved at serve time from a runtime global. Overrides --base.",
   }),
+  favicon: option({
+    type: optional(string),
+    long: "favicon",
+    description:
+      "Path to a favicon file (e.g. .ico) to bundle in place of the default Connect icon. Emitted as icon.ico; resolved relative to the build cwd.",
+  }),
   ...commonArgs,
 };
 


### PR DESCRIPTION
Adds an optional --favicon <path> build input to `ph connect build` that bundles a custom favicon in place of the default Connect icon. The file is emitted as icon.ico (and served under that name in studio dev), so the static <link rel="icon"> in index.html stays valid and dynamic-base keeps working — no HTML or runtime-config change needed.

- shared: --favicon option on connectBuildArgs (build input, not a connect.* runtime override)
- builder-tools: connectFaviconPlugin reads the custom path in both the dev middleware and the build emit; content-type derived from extension; IConnectOptions.favicon wired through getConnectBaseViteConfig
- ph-cli: forward args.favicon to the vite config