### PR TITLE
fix(connect): distinguish authenticated-but-unauthorized from anonymous in drive auth gate

### DIFF
--- a/apps/connect/src/components/drive-auth-gate.test.tsx
+++ b/apps/connect/src/components/drive-auth-gate.test.tsx
@@ -4,7 +4,9 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Controls useDriveAuthGate's return between tests.
-const mockGate = vi.hoisted(() => ({ needsLogin: false }));
+const mockGate = vi.hoisted(() => ({
+  gate: null as "login" | "unauthorized" | null,
+}));
 
 vi.mock("../components/use-drive-auth-gate.js", () => ({
   useDriveAuthGate: () => mockGate,
@@ -52,18 +54,18 @@ import { Content } from "../pages/content.js";
 
 describe("Content drive auth gate wiring", () => {
   beforeEach(() => {
-    mockGate.needsLogin = false;
+    mockGate.gate = null;
   });
 
-  it("renders the login gate when needsLogin is true", () => {
-    mockGate.needsLogin = true;
+  it("renders the login gate when gate is 'login'", () => {
+    mockGate.gate = "login";
     render(<Content />);
     expect(screen.getByText("Log in to access this drive")).toBeDefined();
     expect(screen.queryByTestId("home-screen")).toBeNull();
   });
 
-  it("renders the home screen (not the gate) when needsLogin is false", () => {
-    mockGate.needsLogin = false;
+  it("renders the home screen (not the gate) when gate is null", () => {
+    mockGate.gate = null;
     render(<Content />);
     expect(screen.queryByText("Log in to access this drive")).toBeNull();
     expect(screen.getByTestId("home-screen")).toBeDefined();

--- a/apps/connect/src/components/modal/modals/DriveAuthRequiredModal.tsx
+++ b/apps/connect/src/components/modal/modals/DriveAuthRequiredModal.tsx
@@ -1,5 +1,10 @@
 import { DriveAuthGate } from "@powerhousedao/design-system/connect";
-import { openRenown, usePHModal } from "@powerhousedao/reactor-browser";
+import {
+  logout,
+  openRenown,
+  usePHModal,
+  useUser,
+} from "@powerhousedao/reactor-browser";
 import React from "react";
 
 /**
@@ -15,17 +20,25 @@ import React from "react";
  */
 export const DriveAuthRequiredModal: React.FC = () => {
   const phModal = usePHModal();
+  const user = useUser();
+  const mode = user ? "unauthorized" : "login";
   if (phModal?.type !== "driveAuthRequired") return null;
 
   return (
     <div
       role="dialog"
       aria-modal="false"
-      aria-label="Log in to access this drive"
+      aria-label={
+        mode === "unauthorized"
+          ? "You don't have access to this drive"
+          : "Log in to access this drive"
+      }
       className="pointer-events-none fixed inset-0 z-50 grid place-items-center bg-primary/30"
     >
       <DriveAuthGate
+        mode={mode}
         onLogin={() => openRenown()}
+        onLogout={() => void logout()}
         className="pointer-events-auto"
       />
     </div>

--- a/apps/connect/src/components/use-drive-auth-gate.test.ts
+++ b/apps/connect/src/components/use-drive-auth-gate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ConnectionStateSnapshot } from "@powerhousedao/reactor-browser";
-import { computeNeedsLogin } from "./use-drive-auth-gate.js";
+import { computeAuthGate } from "./use-drive-auth-gate.js";
 
 // `state` + `requiresAuth` drive the decision; the rest are neutral.
 function snap(
@@ -19,31 +19,31 @@ function snap(
   };
 }
 
-describe("computeNeedsLogin", () => {
-  it("never gates an authenticated user, even with an auth-rejected channel", () => {
+describe("computeAuthGate", () => {
+  it("returns 'unauthorized' when an authenticated user has an auth-rejected channel", () => {
     const states = new Map([["studio", snap("error", true)]]);
-    expect(computeNeedsLogin(true, states)).toBe(false);
+    expect(computeAuthGate(true, states)).toBe("unauthorized");
   });
 
-  it("gates an anonymous user when a channel failed with an auth rejection", () => {
+  it("returns 'login' when an anonymous user has an auth-rejected channel", () => {
     const states = new Map([["studio", snap("error", true)]]);
-    expect(computeNeedsLogin(false, states)).toBe(true);
+    expect(computeAuthGate(false, states)).toBe("login");
   });
 
-  it("does not gate an anonymous user on a non-auth error", () => {
+  it("does not gate on a non-auth error (anonymous)", () => {
     const states = new Map([["studio", snap("error", false)]]);
-    expect(computeNeedsLogin(false, states)).toBe(false);
+    expect(computeAuthGate(false, states)).toBeNull();
   });
 
-  it("does not gate an anonymous user when all channels are healthy", () => {
+  it("does not gate when all channels are healthy", () => {
     const states = new Map([
       ["studio", snap("connected")],
       ["other", snap("connecting")],
     ]);
-    expect(computeNeedsLogin(false, states)).toBe(false);
+    expect(computeAuthGate(false, states)).toBeNull();
   });
 
-  it("does not gate an anonymous user with no channels", () => {
-    expect(computeNeedsLogin(false, new Map())).toBe(false);
+  it("does not gate with no channels", () => {
+    expect(computeAuthGate(false, new Map())).toBeNull();
   });
 });

--- a/apps/connect/src/components/use-drive-auth-gate.ts
+++ b/apps/connect/src/components/use-drive-auth-gate.ts
@@ -4,22 +4,30 @@ import {
   type ConnectionStateSnapshot,
 } from "@powerhousedao/reactor-browser";
 
-/** Gate an anonymous user only when a remote failed with an auth rejection
- * (`requiresAuth`) — the switchboard refusing the caller for lack of login. */
-export function computeNeedsLogin(
+/** Return code for the auth gate decision:
+ * - `"login"`  : anonymous user, a channel rejected with `requiresAuth`.
+ * - `"unauthorized"` : signed in, but a channel was rejected — they aren't the owner.
+ * - `null`   : no auth barrier, carry on. */
+export type AuthGate = "login" | "unauthorized" | null;
+
+export function computeAuthGate(
   isAuthenticated: boolean,
   connectionStates: ReadonlyMap<string, ConnectionStateSnapshot>,
-): boolean {
-  if (isAuthenticated) return false;
+): AuthGate {
+  let sawAuthError = false;
   for (const snap of connectionStates.values()) {
-    if (snap.state === "error" && snap.requiresAuth) return true;
+    if (snap.state === "error" && snap.requiresAuth) {
+      sawAuthError = true;
+      break;
+    }
   }
-  return false;
+  if (!sawAuthError) return null;
+  return isAuthenticated ? "unauthorized" : "login";
 }
 
-/** Live wrapper over {@link computeNeedsLogin}. */
-export function useDriveAuthGate(): { needsLogin: boolean } {
+/** Live wrapper over {@link computeAuthGate}. */
+export function useDriveAuthGate(): { gate: AuthGate } {
   const user = useUser();
   const connectionStates = useConnectionStates();
-  return { needsLogin: computeNeedsLogin(Boolean(user), connectionStates) };
+  return { gate: computeAuthGate(Boolean(user), connectionStates) };
 }

--- a/apps/connect/src/pages/content.tsx
+++ b/apps/connect/src/pages/content.tsx
@@ -11,6 +11,7 @@ import {
 } from "@powerhousedao/design-system/connect";
 import {
   openRenown,
+  logout,
   setPHAppConfig,
   setPHDocumentEditorConfig,
   setSelectedDrive,
@@ -27,7 +28,7 @@ import { getRuntimeConfig } from "../runtime-config.js";
 import { useDriveAuthGate } from "../components/use-drive-auth-gate.js";
 
 export function Content() {
-  const { needsLogin } = useDriveAuthGate();
+  const { gate } = useDriveAuthGate();
   const [selectedDrive] = useSelectedDriveSafe();
   const selectedFolder = useSelectedFolder();
   const selectedDocumentId = useSelectedDocumentId();
@@ -48,9 +49,13 @@ export function Content() {
     !selectedDocumentId && !selectedDrive && !selectedFolder;
   return (
     <ContentContainer>
-      {needsLogin ? (
+      {gate ? (
         <div className="flex h-full items-center justify-center p-4">
-          <DriveAuthGate onLogin={openRenown} />
+          <DriveAuthGate
+            mode={gate}
+            onLogin={openRenown}
+            onLogout={() => void logout()}
+          />
         </div>
       ) : showHomeScreen ? (
         <HomeScreenContainer />

--- a/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.stories.tsx
+++ b/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.stories.tsx
@@ -20,3 +20,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const Unauthorized: Story = {
+  args: {
+    mode: "unauthorized",
+    onLogout: () => alert("Log out clicked"),
+  },
+};

--- a/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.test.tsx
+++ b/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.test.tsx
@@ -18,4 +18,24 @@ describe("DriveAuthGate", () => {
     fireEvent.click(screen.getByRole("button", { name: /log in with/i }));
     expect(onLogin).toHaveBeenCalledOnce();
   });
+
+  it('renders the unauthorized state with mode="unauthorized"', () => {
+    render(<DriveAuthGate mode="unauthorized" onLogout={() => {}} />);
+    expect(
+      screen.getByText("You don't have access to this drive"),
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        /the account you're signed in with isn't authorized to view or edit this drive/i,
+      ),
+    ).toBeDefined();
+    expect(screen.getByRole("button", { name: /log out/i })).toBeDefined();
+  });
+
+  it("calls onLogout when the Log out button is clicked", () => {
+    const onLogout = vi.fn();
+    render(<DriveAuthGate mode="unauthorized" onLogout={onLogout} />);
+    fireEvent.click(screen.getByRole("button", { name: /log out/i }));
+    expect(onLogout).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.tsx
+++ b/packages/design-system/src/connect/components/drive-auth-gate/drive-auth-gate.tsx
@@ -2,8 +2,12 @@ import { RenownLogo } from "@powerhousedao/reactor-browser/renown";
 import { twMerge } from "tailwind-merge";
 
 export interface DriveAuthGateProps {
+  /** Visual state — `"login"` (anonymous) or `"unauthorized"` (already signed in, not the owner). Defaults to `"login"`. */
+  readonly mode?: "login" | "unauthorized";
   /** Login action; the caller wires this to Renown (e.g. `openRenown`). */
   readonly onLogin?: () => void;
+  /** Logout action used in `"unauthorized"` mode. */
+  readonly onLogout?: () => void;
   readonly className?: string;
 }
 
@@ -13,7 +17,7 @@ export interface DriveAuthGateProps {
  * while inside a protected drive — so the two stay visually identical.
  */
 export function DriveAuthGate(props: DriveAuthGateProps) {
-  const { onLogin, className } = props;
+  const { mode = "login", onLogin, onLogout, className } = props;
   return (
     <div
       className={twMerge(
@@ -21,20 +25,41 @@ export function DriveAuthGate(props: DriveAuthGateProps) {
         className,
       )}
     >
-      <h2 className="text-xl font-semibold text-foreground">
-        Log in to access this drive
-      </h2>
-      <p className="text-sm text-muted-foreground">
-        This drive requires you to sign in with Renown to view or edit it.
-      </p>
-      <button
-        type="button"
-        onClick={onLogin}
-        className="mt-2 flex items-center gap-2 rounded-lg border border-border bg-card px-6 py-2.5 text-sm font-semibold text-foreground shadow-sm transition-colors hover:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-      >
-        <span>Log in with</span>
-        <RenownLogo width={58} height={16} className="-translate-y-[3px]" />
-      </button>
+      {mode === "login" ? (
+        <>
+          <h2 className="text-xl font-semibold text-foreground">
+            Log in to access this drive
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            This drive requires you to sign in with Renown to view or edit it.
+          </p>
+          <button
+            type="button"
+            onClick={onLogin}
+            className="mt-2 flex items-center gap-2 rounded-lg border border-border bg-card px-6 py-2.5 text-sm font-semibold text-foreground shadow-sm transition-colors hover:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            <span>Log in with</span>
+            <RenownLogo width={58} height={16} className="-translate-y-[3px]" />
+          </button>
+        </>
+      ) : (
+        <>
+          <h2 className="text-xl font-semibold text-foreground">
+            You don&apos;t have access to this drive
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            The account you&apos;re signed in with isn&apos;t authorized to view
+            or edit this drive. Only its owner has access.
+          </p>
+          <button
+            type="button"
+            onClick={onLogout}
+            className="mt-2 flex items-center gap-2 rounded-lg border border-border bg-card px-6 py-2.5 text-sm font-semibold text-foreground shadow-sm transition-colors hover:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            Log out
+          </button>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

Adds an `unauthorized` mode to the shared `DriveAuthGate` card so a logged-in user whose wallet isn't the drive owner sees *"You don't have access to this drive"* with a **Log out** action instead of the anonymous *"Log in to access this drive"* prompt.

Changes:
- `packages/design-system`: new `mode?: "login" | "unauthorized"` + `onLogout?` props on `DriveAuthGate` (default `"login"` keeps existing callers unchanged)
- `apps/connect` modal (`DriveAuthRequiredModal`): branches on `useUser()` truthiness to pick mode
- `apps/connect` full-page gate (`use-drive-auth-gate`): replaces the `boolean needsLogin` signal with a tri-state `AuthGate` (`"login" | "unauthorized" | null`)

## Why

In a locked-down Vetra Studio (`ADMINS=<owner>`), a visitor who is **already logged in with Renown but is not the owner** is refused by the switchboard (`Forbidden`) and Connect shows the "Log in to access this drive" gate — nonsensical, since they *are* logged in. The server can't tell anonymous vs. wrong-wallet apart on this path, so we discriminate client-side on `useUser()` truthiness: `isDriveAuthError(error) && useUser()` ⟹ *authenticated but not authorized*.

## Testing

- `pnpm typecheck` clean
- `pnpm --filter @powerhousedao/design-system test` — 268 pass
- `pnpm --filter @powerhousedao/connect test` — 100 pass
- `pnpm build` — full monorepo clean
- Manual e2e in a linked Studio: anonymous → login card; logged-in non-owner → "You don't have access…" + Log out, no Renown button