### PR TITLE
fix(reactor-api): guard top-level dotenv.config() against missing process.cwd

### DIFF
--- a/packages/reactor-api/src/graphql/system/env/index.ts
+++ b/packages/reactor-api/src/graphql/system/env/index.ts
@@ -1,6 +1,15 @@
 import dotenv from "dotenv";
 import { getAdminUsers } from "./getters.js";
 
-dotenv.config();
+// `dotenv.config()` reads a .env file relative to `process.cwd()`. This module
+// is pulled in whenever a package's subgraph is loaded, including by the
+// reactor's CDN/edge package loader, whose runtime has no full `process`
+// (`process.cwd` is not a function). Calling it there throws
+// "process.cwd is not a function" and aborts package loading. Guard it: only
+// load a .env file in a real Node context — elsewhere env already lives in
+// `process.env`, so there is nothing to load.
+if (typeof process !== "undefined" && typeof process.cwd === "function") {
+  dotenv.config();
+}
 
 export const ADMIN_USERS = getAdminUsers();


### PR DESCRIPTION
## Problem
`packages/reactor-api/src/graphql/system/env/index.ts` calls `dotenv.config()` at **module top-level**. `dotenv` calls `process.cwd()` to locate the `.env` file, so **importing this module throws `TypeError: process.cwd is not a function`** in any runtime without a full Node `process` — including the reactor's own **`HttpPackageLoader`** (the CDN/edge package loader), which executes a package's bundled `node` build in a process-less scope.

This module is imported transitively whenever a package's subgraph loads (`class X extends BaseSubgraph` → `@powerhousedao/reactor-api`), so the crash **aborts package loading** — a freshly-built package's subgraphs return 404 on the switchboard. It's non-deterministic across packages (depends on how the CDN chunk-splits the `dotenv.config()` call), which is why some packages load and others don't.

## Root cause evidence
Reproduced by importing a package's `dist/node/subgraphs/index.mjs` with `process.cwd` unset:
```
process.cwd is not a function
  at dotenv.configDotenv (dotenv/lib/main.js:212)
  at dotenv.config       (dotenv/lib/main.js:291)
  at @powerhousedao/reactor-api/dist/index.mjs:4203   // top-level dotenv.config()
```
With the guard applied, the same import loads cleanly.

## Fix
Only load a `.env` file in a real Node context (`typeof process.cwd === "function"`). Elsewhere env already lives in `process.env`, so there's nothing to load — behavior in Node dev is unchanged.

Discovered while migrating `vetra-builder-package` to the 6.2 stack: its subgraphs 404'd on the switchboard purely because its CDN bundle exposed this top-level call.