### PR TITLE
feat: pre-paint theme boot script and cross-context theme sync

### DIFF
--- a/apps/connect/index.html
+++ b/apps/connect/index.html
@@ -16,13 +16,20 @@
       rel="stylesheet"
     />
     <link href="/style.css" rel="stylesheet" />
-    <script>
-      document.documentElement.classList.toggle(
-        "dark",
-        localStorage.theme === "dark" ||
-          (!("theme" in localStorage) &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches),
-      );
+    <script data-ph-theme-boot>
+      (function () {
+        try {
+          var p = new URLSearchParams(location.search).get("theme");
+          if (p === "dark" || p === "light")
+            localStorage.setItem("ph:theme", p);
+          var s = localStorage.getItem("ph:theme");
+          var d =
+            s === "dark" ||
+            ((!s || s === "system") &&
+              matchMedia("(prefers-color-scheme: dark)").matches);
+          document.documentElement.classList.toggle("dark", d);
+        } catch (e) {}
+      })();
     </script>
   </head>
 

--- a/packages/builder-tools/connect-utils/index.ts
+++ b/packages/builder-tools/connect-utils/index.ts
@@ -6,3 +6,4 @@ export * from "./types.js";
 export * from "./vite-config.js";
 export * from "./vite-plugins/dynamic-base.js";
 export * from "./vite-plugins/ph-config.js";
+export * from "./vite-plugins/theme-boot.js";

--- a/packages/builder-tools/connect-utils/vite-config.ts
+++ b/packages/builder-tools/connect-utils/vite-config.ts
@@ -30,6 +30,7 @@ import { phBundledPackagesPlugin } from "./vite-plugins/ph-bundled-packages.js";
 import { phConfigPlugin } from "./vite-plugins/ph-config.js";
 import { connectPwaPlugins } from "./vite-plugins/pwa.js";
 import { reactSelfHostPlugin } from "./vite-plugins/react-self-host.js";
+import { connectThemeBootPlugin } from "./vite-plugins/theme-boot.js";
 
 export function getConnectHtmlTags(
   options: {
@@ -408,6 +409,9 @@ export function getConnectBaseViteConfig(options: IConnectOptions) {
         dev: mode !== "production" || isDebug,
       }),
       connectFaviconPlugin({ faviconPath: options.favicon }),
+      // Pre-paint theme boot in every emitted index.html (marker-idempotent
+      // with the serve-time injection in the ph-clint connect proxy).
+      connectThemeBootPlugin(),
       // enforce: "post" — rewrites the placeholder base after all other
       // transforms have emitted their asset/chunk URLs.
       ...(options.dynamicBase ? [connectDynamicBasePlugin()] : []),

--- a/packages/builder-tools/connect-utils/vite-plugins/theme-boot.test.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/theme-boot.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { connectThemeBootPlugin, THEME_BOOT_MARKER } from "./theme-boot.js";
+
+type TransformResult =
+  | {
+      html: string;
+      tags: {
+        tag: string;
+        attrs: Record<string, string>;
+        children: string;
+        injectTo: string;
+      }[];
+    }
+  | undefined;
+
+/** Drives the plugin's transformIndexHtml hook. */
+function runTransform(html: string): TransformResult {
+  const plugin = connectThemeBootPlugin();
+  const transform = plugin.transformIndexHtml as unknown as (
+    html: string,
+  ) => TransformResult;
+  return transform(html);
+}
+
+const HTML = `<!doctype html><html><head><meta charset="utf-8"></head><body></body></html>`;
+
+describe("connectThemeBootPlugin", () => {
+  it("prepends a marked boot script to <head>", () => {
+    const result = runTransform(HTML);
+    expect(result).toBeDefined();
+    expect(result?.tags).toHaveLength(1);
+    const tag = result?.tags[0];
+    expect(tag?.tag).toBe("script");
+    expect(tag?.injectTo).toBe("head-prepend");
+    expect(tag?.attrs).toHaveProperty(THEME_BOOT_MARKER);
+    // Persists ?theme= into ph:theme, honors system preference, toggles .dark.
+    expect(tag?.children).toContain(`localStorage.setItem('ph:theme',p)`);
+    expect(tag?.children).toContain("prefers-color-scheme: dark");
+    expect(tag?.children).toContain(`classList.toggle('dark',d)`);
+  });
+
+  it("skips documents that already carry the marker", () => {
+    const withMarker = HTML.replace(
+      "<head>",
+      `<head><script ${THEME_BOOT_MARKER}>/* preset */</script>`,
+    );
+    expect(runTransform(withMarker)).toBeUndefined();
+  });
+});

--- a/packages/builder-tools/connect-utils/vite-plugins/theme-boot.ts
+++ b/packages/builder-tools/connect-utils/vite-plugins/theme-boot.ts
@@ -1,0 +1,49 @@
+import type { Plugin } from "vite";
+
+/**
+ * Marker attribute on the injected script. Serve-time injectors (e.g. the
+ * ph-clint connect proxy) and this plugin both check it, so the script is
+ * applied exactly once no matter which layer runs first.
+ */
+export const THEME_BOOT_MARKER = "data-ph-theme-boot";
+
+/**
+ * Pre-paint theme boot: `?theme=dark|light` persists to `ph:theme`, then the
+ * stored choice (or system preference) decides the `.dark` root class before
+ * hydration. Fail-silent — storage access can throw in embed/privacy contexts.
+ * Keep semantically identical to the runtime store in
+ * `@powerhousedao/reactor-browser` (hooks/theme.ts).
+ */
+const THEME_BOOT_SCRIPT =
+  `(function(){try{` +
+  `var p=new URLSearchParams(location.search).get('theme');` +
+  `if(p==='dark'||p==='light')localStorage.setItem('ph:theme',p);` +
+  `var s=localStorage.getItem('ph:theme');` +
+  `var d=s==='dark'||((!s||s==='system')&&matchMedia('(prefers-color-scheme: dark)').matches);` +
+  `document.documentElement.classList.toggle('dark',d);` +
+  `}catch(e){}})();`;
+
+/**
+ * Injects the theme boot script at the top of `<head>` of every emitted
+ * index.html, so built Connect apps render the stored theme from first paint
+ * without depending on a serve-time injector.
+ */
+export function connectThemeBootPlugin(): Plugin {
+  return {
+    name: "ph-connect-theme-boot",
+    transformIndexHtml(html) {
+      if (html.includes(THEME_BOOT_MARKER)) return;
+      return {
+        html,
+        tags: [
+          {
+            tag: "script",
+            attrs: { [THEME_BOOT_MARKER]: "" },
+            children: THEME_BOOT_SCRIPT,
+            injectTo: "head-prepend",
+          },
+        ],
+      };
+    },
+  };
+}

--- a/packages/reactor-browser/src/hooks/theme.ts
+++ b/packages/reactor-browser/src/hooks/theme.ts
@@ -110,9 +110,16 @@ export function initTheme() {
 
 function subscribeToStoredTheme(onStoreChange: () => void) {
   if (isServer) return () => {};
+  // `storage` fires in every OTHER same-origin browsing context (e.g. an
+  // embedding parent window), keeping embedded instances in sync live.
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === STORED_THEME_KEY || event.key === null) onStoreChange();
+  };
   window.addEventListener(STORED_THEME_UPDATED, onStoreChange);
+  window.addEventListener("storage", handleStorage);
   return () => {
     window.removeEventListener(STORED_THEME_UPDATED, onStoreChange);
+    window.removeEventListener("storage", handleStorage);
   };
 }
 

--- a/packages/reactor-browser/test/theme.test.tsx
+++ b/packages/reactor-browser/test/theme.test.tsx
@@ -1,0 +1,60 @@
+import { act } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { renderHook } from "vitest-browser-react";
+import { useTheme } from "../src/hooks/theme.js";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const STORED_THEME_KEY = "ph:theme";
+
+function fireStorageEvent(key: string | null, newValue: string | null) {
+  act(() => {
+    window.dispatchEvent(new StorageEvent("storage", { key, newValue }));
+  });
+}
+
+describe("useTheme", () => {
+  afterEach(() => {
+    localStorage.removeItem(STORED_THEME_KEY);
+  });
+
+  it("re-reads the stored theme on a same-origin storage event", () => {
+    localStorage.removeItem(STORED_THEME_KEY);
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.isSystem).toBe(true);
+
+    // Simulate another browsing context (e.g. the embedding parent window)
+    // writing the key: direct storage write + the storage event it fires.
+    localStorage.setItem(STORED_THEME_KEY, "dark");
+    fireStorageEvent(STORED_THEME_KEY, "dark");
+
+    expect(result.current.theme).toBe("dark");
+    expect(result.current.isSystem).toBe(false);
+  });
+
+  it("ignores storage events for unrelated keys", () => {
+    localStorage.setItem(STORED_THEME_KEY, "light");
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("light");
+
+    localStorage.setItem(STORED_THEME_KEY, "dark");
+    fireStorageEvent("some:other-key", "value");
+
+    // Not re-read: the event's key doesn't match.
+    expect(result.current.theme).toBe("light");
+  });
+
+  it("re-reads on storage.clear (null key)", () => {
+    localStorage.setItem(STORED_THEME_KEY, "dark");
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("dark");
+
+    localStorage.removeItem(STORED_THEME_KEY);
+    fireStorageEvent(null, null);
+
+    expect(result.current.isSystem).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes the dark-mode gaps behind item 2 of #2741: embedded Connect instances (e.g. the Vetra Studio BUILD preview iframe) never noticed the parent switching theme, and every Connect boot painted light until React hydration even with dark stored.

## Changes

- **reactor-browser**: the theme store now also subscribes to same-origin `storage` events (filtered to `ph:theme`, plus null-key for `storage.clear`), so sibling browsing contexts re-read the stored theme live without a reload.
- **connect**: the inline boot script in `index.html` read `localStorage.theme` while the runtime stores `ph:theme`, so it never applied dark pre-hydration. Replaced with the canonical boot script: persist `?theme=dark|light` into `ph:theme`, then apply stored choice (system preference as fallback) before first paint.
- **builder-tools**: new `connectThemeBootPlugin` emits the same boot script into every built/served `index.html` via `transformIndexHtml`, registered in `getConnectBaseViteConfig` (covers `connect build`, `connect studio`, `connect preview`). The `data-ph-theme-boot` marker keeps injection idempotent with templates or serve-time injectors that already carry it.

## Tests

- `reactor-browser`: 3 new browser-mode cases in `test/theme.test.tsx` (storage-event re-read, unrelated-key ignored, null-key/clear re-read).
- `builder-tools`: 2 new cases in `theme-boot.test.ts` (script injected head-first with marker, existing marker skipped); package suite 29/29.
- `tsc`, eslint, and prettier clean on all touched files; full `pnpm build` green.
- Verified live in Vetra Studio: with dark stored, the document root gets the `dark` class at ~1ms while the document is still parsing (no light flash), and a `?theme=` param overrides and persists over the stored choice.