### PR TITLE
refactor(connect): share one PGlite instance for reactor and relational db

### DIFF
--- a/apps/connect/src/pglite.db.ts
+++ b/apps/connect/src/pglite.db.ts
@@ -1,5 +1,4 @@
 import type { PGlite } from "@electric-sql/pglite";
-import type { PGliteWorker } from "@electric-sql/pglite/worker";
 import { createRelationalDb } from "@powerhousedao/shared/processors";
 import { Kysely } from "kysely";
 import { PGliteDialect } from "kysely-pglite-dialect";
@@ -65,7 +64,7 @@ let sharedPGlite: Promise<PGlite> | undefined;
 // (kept in their own schemas). Memoized so the WASM/data load happens once.
 export function getSharedPGlite(): Promise<PGlite> {
   if (sharedPGlite) return sharedPGlite;
-  sharedPGlite = (async () => {
+  const pending = (async () => {
     const major = resolvePgMajorForRuntime(await detectReactorPgMajor());
     if (major !== 17) {
       console.warn(
@@ -76,14 +75,19 @@ export function getSharedPGlite(): Promise<PGlite> {
       ? createWorkerPGlite(major)
       : createMainThreadPGlite(major);
   })();
-  return sharedPGlite;
+  // Don't cache a rejection: let a later call retry a transient IDB/wasm failure.
+  sharedPGlite = pending;
+  pending.catch(() => {
+    if (sharedPGlite === pending) sharedPGlite = undefined;
+  });
+  return pending;
 }
 
 export async function getDb() {
   const pgLite = await getSharedPGlite();
   const relationalDb = createRelationalDb(
     new Kysely({
-      dialect: new PGliteDialect(pgLite as unknown as PGliteWorker),
+      dialect: new PGliteDialect(pgLite),
     }),
   );
   return { pgLite, relationalDb };

--- a/apps/connect/src/pglite.db.ts
+++ b/apps/connect/src/pglite.db.ts
@@ -1,20 +1,37 @@
+import type { PGlite } from "@electric-sql/pglite";
 import type { PGliteWorker } from "@electric-sql/pglite/worker";
 import { createRelationalDb } from "@powerhousedao/shared/processors";
 import { Kysely } from "kysely";
 import { PGliteDialect } from "kysely-pglite-dialect";
 import {
-  detectRelationalPgMajor,
+  detectReactorPgMajor,
+  loadPGliteModule,
   resolvePgMajorForRuntime,
   type SupportedPgMajor,
 } from "./utils/pglite-runtime.js";
-import { RELATIONAL_PGLITE_NAME } from "./utils/storage-namespace.js";
+import { REACTOR_PGLITE_NAME } from "./utils/storage-namespace.js";
 
-async function createPGliteWorkerForMajor(
+// Run the shared reactor/relational PGlite in a Web Worker instead of the main
+// thread. Off by default: the worker hides `Module.FS`, which the Inspector needs.
+export const PGLITE_USE_WORKER: boolean = false;
+
+async function createMainThreadPGlite(
   major: SupportedPgMajor,
-): Promise<PGliteWorker> {
-  // The worker reads the data-dir name from meta so the namespace is owned on
-  // the main thread alongside the other origin-scoped stores.
-  const meta = { dbName: RELATIONAL_PGLITE_NAME };
+): Promise<PGlite> {
+  const { PGlite } = await loadPGliteModule(major);
+  const { live } =
+    major === 16
+      ? await import("pglite-legacy-02/live")
+      : await import("@electric-sql/pglite/live");
+  return new PGlite(`idb://${REACTOR_PGLITE_NAME}`, {
+    relaxedDurability: true,
+    extensions: { live },
+  }) as unknown as PGlite;
+}
+
+async function createWorkerPGlite(major: SupportedPgMajor): Promise<PGlite> {
+  // dbName is owned here so the namespace matches the other origin-scoped stores.
+  const meta = { dbName: REACTOR_PGLITE_NAME };
   if (major === 16) {
     const [legacyWorker, legacyLive] = await Promise.all([
       import("pglite-legacy-02/worker"),
@@ -27,7 +44,7 @@ async function createPGliteWorkerForMajor(
     return legacyWorker.PGliteWorker.create(worker, {
       meta,
       extensions: { live: legacyLive.live },
-    }) as unknown as PGliteWorker;
+    }) as unknown as PGlite;
   }
   const [{ PGliteWorker }, { live }] = await Promise.all([
     import("@electric-sql/pglite/worker"),
@@ -36,25 +53,38 @@ async function createPGliteWorkerForMajor(
   const worker = new Worker(new URL("./pglite.worker.js", import.meta.url), {
     type: "module",
   });
-  return PGliteWorker.create(worker, { meta, extensions: { live } });
+  return PGliteWorker.create(worker, {
+    meta,
+    extensions: { live },
+  }) as unknown as PGlite;
+}
+
+let sharedPGlite: Promise<PGlite> | undefined;
+
+// Single PGlite shared by the reactor store and the relational read models
+// (kept in their own schemas). Memoized so the WASM/data load happens once.
+export function getSharedPGlite(): Promise<PGlite> {
+  if (sharedPGlite) return sharedPGlite;
+  sharedPGlite = (async () => {
+    const major = resolvePgMajorForRuntime(await detectReactorPgMajor());
+    if (major !== 17) {
+      console.warn(
+        `[reactor] Opening legacy Postgres ${major} data dir. Migrate to PG17 from the banner or the Inspector → Debug tab.`,
+      );
+    }
+    return PGLITE_USE_WORKER
+      ? createWorkerPGlite(major)
+      : createMainThreadPGlite(major);
+  })();
+  return sharedPGlite;
 }
 
 export async function getDb() {
-  const detected = await detectRelationalPgMajor();
-  const major = resolvePgMajorForRuntime(detected);
-  if (major !== 17) {
-    console.warn(
-      `[reactor] Relational worker is opening legacy Postgres ${major} data dir. Migrate to PG17 from the banner or the Inspector → Debug tab.`,
-    );
-  }
-
-  const pgLite = await createPGliteWorkerForMajor(major);
-
-  const kysely = new Kysely({
-    dialect: new PGliteDialect(pgLite),
-  });
-
-  const relationalDb = createRelationalDb(kysely);
-
+  const pgLite = await getSharedPGlite();
+  const relationalDb = createRelationalDb(
+    new Kysely({
+      dialect: new PGliteDialect(pgLite as unknown as PGliteWorker),
+    }),
+  );
   return { pgLite, relationalDb };
 }

--- a/apps/connect/src/utils/reactor.ts
+++ b/apps/connect/src/utils/reactor.ts
@@ -22,12 +22,7 @@ import { createSignatureVerifier, type IRenown } from "@renown/sdk";
 import { ConsoleLogger } from "document-model";
 import { Kysely } from "kysely";
 import { PGliteDialect } from "kysely-pglite-dialect";
-import {
-  detectReactorPgMajor,
-  loadPGliteModule,
-  resolvePgMajorForRuntime,
-} from "./pglite-runtime.js";
-import { REACTOR_PGLITE_NAME } from "./storage-namespace.js";
+import { getSharedPGlite } from "../pglite.db.js";
 
 /**
  * Creates a Reactor that plugs into legacy storage but syncs through the new
@@ -53,17 +48,7 @@ export async function createBrowserReactor(
     return renown.getBearerToken({ expiresIn: 10 });
   };
 
-  const detected = await detectReactorPgMajor();
-  const major = resolvePgMajorForRuntime(detected);
-  if (major !== 17) {
-    console.warn(
-      `[reactor] Running against legacy PGlite data dir (Postgres ${major}). Migrate to PG17 from the banner or the Inspector → Debug tab.`,
-    );
-  }
-  const { PGlite } = await loadPGliteModule(major);
-  const pg = new PGlite(`idb://${REACTOR_PGLITE_NAME}`, {
-    relaxedDurability: true,
-  });
+  const pg = await getSharedPGlite();
   const logger = new ConsoleLogger(["reactor-client"]);
   const builder = new ReactorClientBuilder()
     .withLogger(logger)


### PR DESCRIPTION
## What
Reactor document store and relational-processor read models now share a **single memoized PGlite instance** (`getSharedPGlite()`) instead of the reactor running its own main-thread PGlite while the relational DB ran in a separate Web Worker. Read models live in their own Postgres schemas, so they coexist in one database.

## Why
The two instances each fetched, compiled, and held the ~8.6MB Postgres WASM + ~5MB data — a duplicate cold-network fetch and roughly **2× the PGlite CPU/memory**. Sharing collapses that to one load, and removes a worker + a second IndexedDB data dir.

A `PGLITE_USE_WORKER` flag (default `false`) can move the shared instance off the main thread; left off because `PGliteWorker` hides `Module.FS`, which the Inspector's DB explorer and `pg_dump` use directly.

## Performance note
This is a **resource/cleanup** change, not a boot-speed win. Benchmarking (Lighthouse, 4× CPU) showed FCP/LCP/score unchanged vs. the two-instance setup — `WebAssembly.instantiateStreaming` already compiles off the main thread, so the duplicate compile was never blocking. The actual boot cost is main-bundle JS evaluation (~2.4s throttled), tracked separately.

## Test
Built + previewed Connect against a local package with a processor factory (triggers the relational path); reactor boots on the shared instance, single wasm/data fetch confirmed.