### PR TITLE
perf(connect): keep Sentry SDK off the boot critical path

### DIFF
--- a/apps/connect/src/hooks/useInitSentry.ts
+++ b/apps/connect/src/hooks/useInitSentry.ts
@@ -10,6 +10,7 @@ import {
   useLocation,
   useNavigationType,
 } from "react-router-dom";
+import { setSentryModule } from "../services/sentry.js";
 import { useAcceptedCookies } from "./useAcceptedCookies.js";
 
 const logger = childLogger(["sentry"]);
@@ -68,6 +69,7 @@ async function initSentry() {
     },
   });
 
+  setSentryModule(Sentry);
   clientStarted = true;
 }
 
@@ -76,6 +78,7 @@ async function closeClient() {
     return;
   }
   const sentry = await getSentry();
+  setSentryModule(undefined);
   const client = sentry.getClient();
   return client?.close();
 }

--- a/apps/connect/src/services/logger.ts
+++ b/apps/connect/src/services/logger.ts
@@ -1,5 +1,5 @@
-import { captureException } from "@sentry/react";
 import { setErrorHandler } from "document-model";
+import { captureException } from "./sentry.js";
 
 function captureSentryException(...data: any[]) {
   let error: unknown;

--- a/apps/connect/src/services/sentry.ts
+++ b/apps/connect/src/services/sentry.ts
@@ -1,0 +1,21 @@
+// Lazy Sentry accessors: the SDK (and rrweb replay) stays off the boot path
+// until useInitSentry dynamically loads it. No-ops while Sentry is disabled.
+import type * as SentryModule from "@sentry/react";
+
+let sentry: typeof SentryModule | undefined;
+
+export function setSentryModule(mod: typeof SentryModule | undefined): void {
+  sentry = mod;
+}
+
+export function captureException(
+  ...args: Parameters<typeof SentryModule.captureException>
+): void {
+  sentry?.captureException(...args);
+}
+
+export function setUser(
+  ...args: Parameters<typeof SentryModule.setUser>
+): void {
+  sentry?.setUser(...args);
+}

--- a/apps/connect/src/store/user.ts
+++ b/apps/connect/src/store/user.ts
@@ -1,7 +1,7 @@
 import { useUser } from "@powerhousedao/reactor-browser";
 import type { User as SentryUser } from "@sentry/react";
-import { setUser as setSentryUser } from "@sentry/react";
 import { useEffect } from "react";
+import { setUser as setSentryUser } from "../services/sentry.js";
 
 export function useSetSentryUser() {
   const user = useUser();


### PR DESCRIPTION
## What
`services/logger.ts` and `store/user.ts` statically imported `captureException` / `setUser` from `@sentry/react`. Since `logger` is on the boot path, that dragged the **entire Sentry SDK + rrweb session-replay** into the boot bundle and evaluated it on the main thread at startup — **even when Sentry is disabled** (no DSN configured).

This routes those two call sites through a tiny lazy accessor (`services/sentry.ts`, a type-only reference to `@sentry/react`, so zero runtime import). `useInitSentry` — which already dynamically imports and inits the SDK — registers the loaded module into the accessor. When Sentry isn't active, the calls are no-ops and the SDK/rrweb never enter the bundle graph at boot.

## Impact (Lighthouse, 4× CPU, production build)
Measured before/after by rebuilding `apps/connect` from source (note: `ph connect build` bundles the prebuilt lib, so the lib must be rebuilt for source changes to take effect):

| | LCP | SpeedIndex | perf score | Sentry chunks at boot |
| --- | --- | --- | --- | --- |
| before | ~3221ms (bimodal 0.9–3.3s) | ~3210ms | 44 | 1 |
| after | ~588ms (== FCP, stable) | ~651ms | 70 | 0 |

**LCP −2.6s and no longer bimodal**, ~139KB less transferred at boot. FCP is unchanged (it's the Suspense skeleton, which Sentry never blocked). No behavior change when a DSN is configured — Sentry still initializes via `useInitSentry`.

## Test
Built + previewed Connect; verified the Sentry chunk is no longer statically imported by the boot graph (0 boot chunks contain `@sentry`/`rrweb`, down from 1), and Sentry still loads/inits when a DSN is present.