### PR TITLE
perf(switchboard): drop pnpm cache and store from prod docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,7 +88,9 @@ ARG TAG=latest
 ARG GIT_SHA=unknown
 RUN echo '{"name":"app","version":"1.0.0","type":"module","private":true}' > package.json \
  && printf 'allowBuilds:\n  "@apollo/protobufjs": true\n  "@parcel/watcher": true\n  esbuild: true\n  protobufjs: true\n  "@datadog/pprof": true\n' > pnpm-workspace.yaml \
- && pnpm add --shamefully-hoist @powerhousedao/switchboard@$TAG
+ && pnpm add --shamefully-hoist @powerhousedao/switchboard@$TAG \
+ && rm -rf /root/.cache /pnpm/store /tmp/*
+# Store is hardlinked into node_modules; cache/tmp are build-only. ~340MB.
 
 COPY docker/switchboard-entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh


### PR DESCRIPTION
## What

Delete the pnpm cache, store, and tmp in the switchboard image's install layer, right after `pnpm add @powerhousedao/switchboard`.

```dockerfile
 && pnpm add --shamefully-hoist @powerhousedao/switchboard@$TAG \
 && rm -rf /root/.cache /pnpm/store /tmp/*
```

## Why

The switchboard runtime image never installs packages again after build (the entrypoint only shells out to `pnpm add` when a tenant sets `PH_PACKAGES`, which re-populates what it needs). Everything the cleanup removes is build-only:

- `/root/.cache` — pnpm's downloaded-tarball + metadata cache (**~327 MB**), never read at runtime.
- `/pnpm/store` — the content-addressable store. Its files are **hardlinked** into `node_modules`, so deleting the store frees the store-only blocks without touching the installed tree (verified: only ~10 MB is unique; the rest survives via the `node_modules` hardlinks).
- `/tmp/*` — build scratch (~2 MB).

**~340 MB reclaimed** from the pulled image, verified by measuring the directories inside the built image.

## Verification

- Built `docker/Dockerfile --target switchboard --build-arg TAG=latest` before/after.
- Confirmed the deleted paths are build-only and that `node_modules` files remain intact after removing the hardlinked store.
- Switchboard boots normally from the slimmed image (renown identity, PGlite storage, all GraphQL subgraphs register).

## Scope / follow-ups

Scoped to the switchboard target. Not included here:
- The `connect` target's base stage carries a similar pnpm cache — same cleanup could apply there.
- Larger structural wins (~90–130 MB more) require app/package changes: switchboard importing vetra's `document-models` subpath + pruning unreachable UI/codegen packages, and making reactor-api's vite loader a lazy import. Tracked separately.