### PR TITLE
feat(reactor-browser): preload editor chunks during idle and on hover

### DIFF
--- a/apps/connect/src/components/app.tsx
+++ b/apps/connect/src/components/app.tsx
@@ -10,7 +10,7 @@ import {
   DocumentEditorDebugTools,
   serviceWorkerManager,
 } from "@powerhousedao/connect/utils";
-import { useTheme } from "@powerhousedao/reactor-browser";
+import { useEditorPreloader, useTheme } from "@powerhousedao/reactor-browser";
 import { useEffect } from "react";
 import { ToastContainer } from "../services/toast.js";
 import { MissingModelBanner } from "./missing-model-banner.js";
@@ -18,6 +18,7 @@ import { PackageInstallPrompt } from "./package-install-prompt.js";
 
 export const App = () => {
   useTheme(); // keeps the OS-preference change listener active
+  useEditorPreloader(); // warms editor chunks during idle time
 
   // refresh page on vite preload error due to outdated chunks — but only when
   // the failing dynamic import is one of Connect's own chunks. External

--- a/packages/design-system/src/connect/components/file-item/file-item.tsx
+++ b/packages/design-system/src/connect/components/file-item/file-item.tsx
@@ -1,10 +1,12 @@
 import { Icon } from "#design-system";
 import {
   getSyncStatusSync,
+  preloadEditorModule,
   setSelectedNode,
   showDeleteNodeModal,
   useDownloadDocument,
   useDragNode,
+  useEditorModulesForDocumentType,
   useNodeActions,
   useSelectedDriveSafe,
   useUserPermissions,
@@ -56,6 +58,11 @@ export function FileItem(props: Props) {
     parentId: fileNode.parentFolder ?? undefined,
   });
   const { isAllowedToCreateDocuments } = useUserPermissions();
+  const editorModules = useEditorModulesForDocumentType(fileNode.documentType);
+  const preloadEditors = () =>
+    editorModules?.forEach((editorModule) => {
+      void preloadEditorModule(editorModule);
+    });
   const { onRenameNode, onRenameDriveNodes, onDuplicateNode } =
     useNodeActions();
   const downloadDocument = useDownloadDocument(fileNode.id);
@@ -186,6 +193,7 @@ export function FileItem(props: Props) {
     <div
       className="relative w-64"
       onClick={isReadMode ? () => setSelectedNode(fileNode) : undefined}
+      onMouseEnter={preloadEditors}
       {...dragProps}
     >
       <div className={containerStyles}>

--- a/packages/powerhouse-vetra-packages/editors/generic-drive-explorer/components/create-document.tsx
+++ b/packages/powerhouse-vetra-packages/editors/generic-drive-explorer/components/create-document.tsx
@@ -1,7 +1,9 @@
 import { PowerhouseButton } from "@powerhousedao/design-system";
 import {
+  preloadEditorModule,
   showCreateDocumentModal,
   useDocumentModelModules,
+  useEditorModules,
   useUserPermissions,
 } from "@powerhousedao/reactor-browser";
 import type {
@@ -16,9 +18,18 @@ function getDocumentSpec(doc: DocumentModelModule): DocumentModelGlobalState {
 export function CreateDocument() {
   const { isAllowedToCreateDocuments } = useUserPermissions();
   const documentModelModules = useDocumentModelModules();
+  const editorModules = useEditorModules();
   const nonDriveDocumentModelModules = documentModelModules?.filter(
     (module) => module.documentModel.global.id !== "powerhouse/document-drive",
   );
+  const preloadEditorsForType = (documentType: string) =>
+    editorModules
+      ?.filter((editorModule) =>
+        editorModule.documentTypes.includes(documentType),
+      )
+      .forEach((editorModule) => {
+        void preloadEditorModule(editorModule);
+      });
   if (!isAllowedToCreateDocuments) return null;
   return (
     <div className="px-6 py-4">
@@ -33,6 +44,8 @@ export function CreateDocument() {
               color="light"
               title={`${spec.name}${versionLabel}`}
               aria-description={spec.description}
+              onMouseEnter={() => preloadEditorsForType(spec.id)}
+              onFocus={() => preloadEditorsForType(spec.id)}
               onClick={() => showCreateDocumentModal(spec.id)}
             >
               <span className="text-sm">

--- a/packages/reactor-browser/src/hooks/index.ts
+++ b/packages/reactor-browser/src/hooks/index.ts
@@ -20,6 +20,7 @@ export * from "./download-document.js";
 export * from "./drive-by-id.js";
 export * from "./drives.js";
 export * from "./editor-modules.js";
+export * from "./use-editor-preloader.js";
 export * from "./features.js";
 export * from "./file-drag-and-drop.js";
 export * from "./folder-by-id.js";

--- a/packages/reactor-browser/src/hooks/use-editor-preloader.ts
+++ b/packages/reactor-browser/src/hooks/use-editor-preloader.ts
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+import {
+  hasPreloadBandwidth,
+  preloadEditorModule,
+} from "../utils/preload-editor.js";
+import { useAppModules, useEditorModules } from "./editor-modules.js";
+
+type IdleDeadline = { didTimeout: boolean; timeRemaining: () => number };
+
+function requestIdle(cb: (deadline: IdleDeadline) => void): number {
+  if (typeof window.requestIdleCallback === "function") {
+    return window.requestIdleCallback(cb);
+  }
+  // Fallback: hand out a short, draining time budget so pump processes a slice
+  // and reschedules, rather than emptying the whole queue in one task.
+  return window.setTimeout(() => {
+    const start = Date.now();
+    cb({
+      didTimeout: false,
+      timeRemaining: () => Math.max(0, 8 - (Date.now() - start)),
+    });
+  }, 200);
+}
+
+function cancelIdle(handle: number): void {
+  if (typeof window.cancelIdleCallback === "function") {
+    window.cancelIdleCallback(handle);
+  } else {
+    window.clearTimeout(handle);
+  }
+}
+
+// Warms every registered editor's lazy chunk during browser idle time when
+// bandwidth allows, so opening a document doesn't wait on a network fetch.
+export function useEditorPreloader(): void {
+  const editorModules = useEditorModules();
+  const appModules = useAppModules();
+
+  useEffect(() => {
+    const queue = [...(editorModules ?? []), ...(appModules ?? [])];
+    if (queue.length === 0 || !hasPreloadBandwidth()) return;
+
+    let cancelled = false;
+    let handle = 0;
+
+    const pump = (deadline: IdleDeadline) => {
+      while (
+        !cancelled &&
+        queue.length > 0 &&
+        (deadline.didTimeout || deadline.timeRemaining() > 0)
+      ) {
+        const editorModule = queue.shift()!;
+        void preloadEditorModule(editorModule);
+      }
+      if (!cancelled && queue.length > 0) handle = requestIdle(pump);
+    };
+
+    handle = requestIdle(pump);
+
+    return () => {
+      cancelled = true;
+      if (handle) cancelIdle(handle);
+    };
+  }, [editorModules, appModules]);
+}

--- a/packages/reactor-browser/src/utils/index.ts
+++ b/packages/reactor-browser/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from "./drives.js";
 export * from "./download-document.js";
 export * from "./get-revision-from-date.js";
 export * from "./nodes.js";
+export * from "./preload-editor.js";
 export * from "./switchboard.js";
 export * from "./url.js";
 export * from "./user.js";

--- a/packages/reactor-browser/src/utils/preload-editor.ts
+++ b/packages/reactor-browser/src/utils/preload-editor.ts
@@ -1,0 +1,52 @@
+import type { EditorModule } from "document-model";
+
+// React.lazy internals + an optional explicit preload hook.
+type PreloadableComponent = EditorModule["Component"] & {
+  preload?: () => Promise<unknown>;
+  _payload?: { _status: number };
+  _init?: (payload: unknown) => unknown;
+};
+
+// Starts an editor's lazy chunk download without rendering it. Returns the
+// in-flight promise while uninitialized/pending, undefined once loaded.
+export function preloadEditorModule(
+  module: EditorModule,
+): Promise<unknown> | undefined {
+  const Component = module.Component as PreloadableComponent;
+
+  if (typeof Component.preload === "function") {
+    return Component.preload();
+  }
+
+  const payload = Component._payload;
+  const init = Component._init;
+  if (!payload || typeof init !== "function") return undefined;
+
+  // _init triggers the import: returns the module once resolved, throws the
+  // pending promise while in flight (or the error if the load already failed).
+  try {
+    init(payload);
+  } catch (thrown) {
+    if (thrown && typeof (thrown as PromiseLike<unknown>).then === "function") {
+      return thrown as Promise<unknown>;
+    }
+  }
+  return undefined;
+}
+
+type NetworkInformation = {
+  saveData?: boolean;
+  effectiveType?: string;
+};
+
+// Whether the connection is good enough for speculative preloading.
+// Unknown connection info is treated as "ok".
+export function hasPreloadBandwidth(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const connection = (
+    navigator as Navigator & { connection?: NetworkInformation }
+  ).connection;
+  if (!connection) return true;
+  if (connection.saveData) return false;
+  return !["slow-2g", "2g"].includes(connection.effectiveType ?? "");
+}

--- a/packages/reactor-browser/test/preload-editor.test.ts
+++ b/packages/reactor-browser/test/preload-editor.test.ts
@@ -1,0 +1,76 @@
+import { lazy } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EditorModule } from "document-model";
+import {
+  hasPreloadBandwidth,
+  preloadEditorModule,
+} from "../src/utils/preload-editor.js";
+
+function asModule(Component: unknown): EditorModule {
+  return { Component } as unknown as EditorModule;
+}
+
+function setConnection(value: unknown): void {
+  Object.defineProperty(navigator, "connection", {
+    value,
+    configurable: true,
+  });
+}
+
+afterEach(() => {
+  // Remove the stub so unrelated tests see the real (absent) connection.
+  delete (navigator as { connection?: unknown }).connection;
+});
+
+describe("hasPreloadBandwidth", () => {
+  it("allows preloading when connection info is unavailable", () => {
+    setConnection(undefined);
+    expect(hasPreloadBandwidth()).toBe(true);
+  });
+
+  it("blocks preloading when data-saver is on", () => {
+    setConnection({ saveData: true, effectiveType: "4g" });
+    expect(hasPreloadBandwidth()).toBe(false);
+  });
+
+  it("blocks preloading on 2g / slow-2g", () => {
+    setConnection({ saveData: false, effectiveType: "slow-2g" });
+    expect(hasPreloadBandwidth()).toBe(false);
+    setConnection({ saveData: false, effectiveType: "2g" });
+    expect(hasPreloadBandwidth()).toBe(false);
+  });
+
+  it("allows preloading on a fast connection", () => {
+    setConnection({ saveData: false, effectiveType: "4g" });
+    expect(hasPreloadBandwidth()).toBe(true);
+  });
+});
+
+describe("preloadEditorModule", () => {
+  it("calls an explicit preload() hook when present", () => {
+    const preload = vi.fn(() => Promise.resolve("done"));
+    const Component = Object.assign(() => null, { preload });
+    const result = preloadEditorModule(asModule(Component));
+    expect(preload).toHaveBeenCalledTimes(1);
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it("triggers a React.lazy import and returns the in-flight promise", async () => {
+    const ctor = vi.fn(() => Promise.resolve({ default: () => null }));
+    const Component = lazy(ctor);
+
+    const inflight = preloadEditorModule(asModule(Component));
+    expect(ctor).toHaveBeenCalledTimes(1);
+    expect(inflight).toBeInstanceOf(Promise);
+
+    await inflight;
+
+    // Once loaded, re-preloading is a no-op and returns undefined.
+    expect(preloadEditorModule(asModule(Component))).toBeUndefined();
+    expect(ctor).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns undefined for a component with no lazy payload", () => {
+    expect(preloadEditorModule(asModule(() => null))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Preloads editor lazy-chunks so opening a document doesn't wait on a network fetch.

- **`useEditorPreloader`** — during browser idle time (via `requestIdleCallback`), warms every registered editor's lazy chunk. Gated on bandwidth: skips when the connection reports `save-data` or `slow-2g`/`2g`.
- **`preloadEditorModule`** — primitive that triggers a `React.lazy` component's chunk fetch without rendering it (calls an optional `.preload()`, else pokes the lazy payload's initializer). Returns the in-flight promise, or `undefined` if already loaded.
- **Hover/focus preloads** — file items preload editors for their document type on `mouseenter`; create-document buttons preload on `mouseenter`/`focus`.

Fetching goes through the browser's native module loader, so import-map resolution and the full static dependency graph are handled correctly, and an active service worker caches the chunks for offline reuse.

## Scope

This is the latency-preload half only. The proactive offline package-crawl explored alongside it is intentionally left out of this PR.

https://claude.ai/code/session_0127TGgoLBfpzBodQrLsrcPh