### PR TITLE
ci: publish academy.vetra.io on production releases

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -144,9 +144,10 @@ jobs:
           if [[ "$TAG" == *"-dev."* ]]; then
             echo "targets=dev" >> $GITHUB_OUTPUT
           elif [[ "$TAG" == *"-staging."* ]]; then
-            echo "targets=staging academy" >> $GITHUB_OUTPUT
+            echo "targets=staging" >> $GITHUB_OUTPUT
           else
-            echo "Skipping k8s update for production tags"
+            # Production tags publish academy.vetra.io (the `academy` tenant).
+            echo "targets=academy" >> $GITHUB_OUTPUT
           fi
 
       - name: Update academy image tag in k8s-hosting


### PR DESCRIPTION
## What
Make the `update-k8s-academy` job in `publish-docker-images.yml` bump the `academy` tenant (which serves **academy.vetra.io**) on **production** releases, and drop `academy` from the **staging** target so it no longer flip-flops.

| Tag shape | Before | After |
|---|---|---|
| `-dev.*` | `dev` | `dev` |
| `-staging.*` | `staging academy` | `staging` |
| production `vX.Y.Z` | *skipped* | `academy` |

## Why
academy.vetra.io was only ever bumped by staging releases and was explicitly skipped for production tags, so it was stuck on the last staging image (`v6.1.0-staging.0`) while production had moved to `v6.2.1`. This makes the public docs site track the latest production release automatically.

The current gap was closed manually by bumping the `academy` tenant to `v6.2.1` in `powerhouse-k8s-hosting`; this change prevents it from recurring.