### PR TITLE
ci: decouple academy docs release & deployment from npm package releases

### DIFF
--- a/.github/workflows/academy.yml
+++ b/.github/workflows/academy.yml
@@ -1,0 +1,20 @@
+name: Academy
+
+# Auto-build + deploy the docs site to dev on any docs change merged to main.
+# Promote to staging/production with the "Deploy Academy" workflow.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/academy/**"
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-dev:
+    uses: ./.github/workflows/deploy-academy.yml
+    with:
+      branch: main
+      environment: dev
+    secrets: inherit

--- a/.github/workflows/deploy-academy.yml
+++ b/.github/workflows/deploy-academy.yml
@@ -1,0 +1,141 @@
+name: Deploy Academy
+
+# Build the academy docs site from a branch and publish it to a site. Runnable
+# manually (defaults main -> production) and callable by other workflows.
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "Branch to build and publish."
+        required: true
+        type: string
+      environment:
+        description: "Target site: academy (production), staging, or dev."
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to build and publish."
+        required: true
+        default: main
+        type: string
+      environment:
+        description: "Where to publish."
+        type: choice
+        options:
+          - academy # academy.vetra.io (production)
+          - staging # academy.staging.vetra.io
+          - dev # academy.dev.vetra.io
+        default: academy
+
+permissions:
+  contents: read
+
+# One deploy per site at a time; queue rather than cancel.
+concurrency:
+  group: deploy-academy-${{ inputs.environment }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: cr.vetra.io/academy/academy
+
+jobs:
+  publish:
+    name: Publish ${{ inputs.branch }} to ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout ${{ inputs.branch }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Compute image tag and channel
+        id: meta
+        env:
+          TARGET_ENV: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          # Channel pointer per target: production is `latest`, else the env name.
+          if [ "$TARGET_ENV" = "academy" ]; then
+            echo "channel=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "channel=$TARGET_ENV" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Harbor
+        uses: docker/login-action@v3
+        with:
+          registry: cr.vetra.io
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Build and push academy image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./apps/academy
+          push: true
+          # Immutable per-commit tag (pinned by k8s) + moving channel pointer.
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.meta.outputs.sha }}
+            ${{ env.IMAGE }}:${{ steps.meta.outputs.channel }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            TAG=${{ steps.meta.outputs.sha }}
+            GIT_SHA=${{ github.sha }}
+
+      - name: Deploy to k8s-hosting
+        env:
+          K8S_REPO_PAT: ${{ secrets.K8S_REPO_PAT }}
+          TAG: ${{ steps.meta.outputs.sha }}
+          TARGET_ENV: ${{ inputs.environment }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+          git clone "https://x-access-token:${K8S_REPO_PAT}@github.com/powerhouse-inc/powerhouse-k8s-hosting.git"
+          cd powerhouse-k8s-hosting
+
+          git config user.name "Github Actions Bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          VALUES_FILE="tenants/${TARGET_ENV}/powerhouse-values.yaml"
+          sed -i '\|repository: cr.vetra.io/academy/academy|{n;s|\(.*tag: \).*|\1'"${TAG}"'|}' "$VALUES_FILE"
+
+          # Fail loudly if the tag wasn't set (block moved/reformatted → sed no-op).
+          got=$(sed -n '\|repository: cr.vetra.io/academy/academy|{n;s|.*tag: *||p;}' "$VALUES_FILE")
+          if [ "$got" != "$TAG" ]; then
+            echo "::error::Could not set academy tag in ${VALUES_FILE} (found '${got}', expected '${TAG}')"
+            exit 1
+          fi
+
+          git add "$VALUES_FILE"
+          if git diff --cached --quiet; then
+            echo "${TARGET_ENV} already on ${TAG} — nothing to deploy"
+            exit 0
+          fi
+          git commit -m "chore(academy): publish ${BRANCH}@${TAG} to ${TARGET_ENV}"
+
+          pushed=false
+          for i in 1 2 3; do
+            if git pull --rebase origin main && git push; then pushed=true; break; fi
+            # Leave no half-finished rebase behind, or the next attempt can't start clean.
+            git rebase --abort 2>/dev/null || true
+            echo "Push attempt $i failed, retrying..."
+            sleep 5
+          done
+          [ "$pushed" = true ] || { echo "::error::Failed to push to powerhouse-k8s-hosting after 3 attempts"; exit 1; }
+
+      - name: Summary
+        if: ${{ always() }}
+        env:
+          BRANCH: ${{ inputs.branch }}
+          TARGET_ENV: ${{ inputs.environment }}
+          TAG: ${{ steps.meta.outputs.sha }}
+        run: |
+          echo "Published \`${BRANCH}\` (\`${TAG}\`) to **${TARGET_ENV}**." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -21,8 +21,6 @@ jobs:
         include:
           - image: registry
             context: ./packages/registry
-          - image: academy
-            context: ./apps/academy
           - image: connect
             context: .
             dockerfile: docker/Dockerfile
@@ -76,11 +74,7 @@ jobs:
       - name: Set image paths
         run: |
           HARBOR_PROJECT="${GITHUB_REPOSITORY//\//-}"
-          if [ "${{ matrix.image }}" = "academy" ]; then
-            echo "HARBOR_PATH=academy/academy" >> $GITHUB_ENV
-          else
-            echo "HARBOR_PATH=${HARBOR_PROJECT}/${{ matrix.image }}" >> $GITHUB_ENV
-          fi
+          echo "HARBOR_PATH=${HARBOR_PROJECT}/${{ matrix.image }}" >> $GITHUB_ENV
       - name: Determine additional tag
         run: |
           if [[ "${{ env.GITHUB_TAG }}" == *"-dev."* ]]; then
@@ -129,54 +123,6 @@ jobs:
           build-args: |
             TAG=${{ env.GITHUB_TAG }}
             GIT_SHA=${{ github.sha }}
-
-  update-k8s-academy:
-    name: Update Academy Image in K8s Hosting
-    needs: build
-    if: ${{ needs.build.outputs.tag != '' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Determine target environments
-        id: env
-        env:
-          TAG: ${{ needs.build.outputs.tag }}
-        run: |
-          if [[ "$TAG" == *"-dev."* ]]; then
-            echo "targets=dev" >> $GITHUB_OUTPUT
-          elif [[ "$TAG" == *"-staging."* ]]; then
-            echo "targets=staging" >> $GITHUB_OUTPUT
-          else
-            # Production tags publish academy.vetra.io (the `academy` tenant).
-            echo "targets=academy" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Update academy image tag in k8s-hosting
-        if: ${{ steps.env.outputs.targets != '' }}
-        env:
-          TAG: ${{ needs.build.outputs.tag }}
-          TARGETS: ${{ steps.env.outputs.targets }}
-          K8S_REPO_PAT: ${{ secrets.K8S_REPO_PAT }}
-        run: |
-          git clone "https://x-access-token:${K8S_REPO_PAT}@github.com/powerhouse-inc/powerhouse-k8s-hosting.git"
-          cd powerhouse-k8s-hosting
-
-          git config user.name "Github Actions Bot"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          for TARGET_ENV in $TARGETS; do
-            VALUES_FILE="tenants/${TARGET_ENV}/powerhouse-values.yaml"
-            # Update academy image tag (matches the line after academy's repository line)
-            sed -i '/repository: cr.vetra.io\/academy\/academy/{n;s/\(.*tag: \).*/\1'"${TAG}"'/}' "$VALUES_FILE"
-            git add "$VALUES_FILE"
-          done
-
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore(academy): update academy image tag to ${TAG}"
-          for i in 1 2 3; do
-            git pull --rebase origin main && git push && break
-            echo "Push attempt $i failed, retrying..."
-            sleep 5
-          done
 
   notify-auto-update:
     name: Notify Cloud Auto-Update

--- a/apps/academy/README.md
+++ b/apps/academy/README.md
@@ -3,8 +3,8 @@
 Comprehensive documentation and learning resources for the Powerhouse ecosystem.
 
 This documentation website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
-To contribute to the documentation please work on a feature branch in case of big refactors, and build & serve before pushing to the development branch.
-Pushing from the dev branch to the main branch will trigger an auto deployment in Heroku for the staging deployment.
+
+To contribute, edit the MDX under `docs/academy/` on a branch and open a PR against `main`. Build and serve locally before pushing — the build fails on broken links. Merging to `main` auto-deploys the **dev** site; see [Updating and deploying the docs](#updating-and-deploying-the-docs) for how changes reach staging and production.
 
 ## 🤖 LLM-Optimized Documentation
 
@@ -54,21 +54,27 @@ $ npm run build
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
 
-### Deployment
+### Updating and deploying the docs
 
-Using SSH:
+The site is built as a Docker image (`cr.vetra.io/academy/academy`) and served on Kubernetes — it is **not** published to npm, GitHub Pages, or Heroku. Its build and deploy are fully decoupled from the monorepo's npm package releases.
 
-```
-$ USE_SSH=true yarn deploy
-```
+| Site | URL |
+| ---- | --- |
+| Production | https://academy.vetra.io |
+| Staging | https://academy.staging.vetra.io |
+| Dev | https://academy.dev.vetra.io |
 
-Not using SSH:
+There are two ways docs get deployed:
 
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
-```
+1. **Automatic → dev.** Any change under `apps/academy` merged to `main` triggers the `Academy` workflow (`.github/workflows/academy.yml`): it builds a short-SHA-tagged image and deploys it to **academy.dev.vetra.io**.
 
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+2. **Manual publish → any site.** The `Deploy Academy` workflow (`.github/workflows/deploy-academy.yml`) builds a chosen branch and publishes it to a chosen site. GitHub → **Actions** → **Deploy Academy** → **Run workflow**:
+   - **branch** (default `main`) — the branch to build.
+   - **environment** (default `academy`) — the target site (`academy` = production).
+
+   Ship the latest docs to **production** by running it with the defaults. Preview a feature branch by picking it and targeting `dev`. Roll back by running it against an earlier branch or commit.
+
+Images are tagged `cr.vetra.io/academy/academy:<short-sha>` (immutable, pinned by Kubernetes) plus a moving channel pointer (`dev`, `staging`, or `latest` for production).
 
 ### Slides
 

--- a/apps/academy/package.json
+++ b/apps/academy/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@powerhousedao/academy",
   "version": "6.2.1-dev.1",
+  "private": true,
   "homepage": "https://powerhouse.academy",
   "packageManager": "pnpm@10.9.0",
   "repository": {


### PR DESCRIPTION
## Why
The academy docs site was chained to the monorepo npm release pipeline — it only rebuilt/redeployed when a release ran, and was even published to npm despite having no consumers. Academy is a standalone Docusaurus site (build context is just `apps/academy`, zero `@powerhousedao` deps), so its release/deploy cadence should be independent of package versioning.

## What changed
1. **Removed academy from the npm release pipeline** — dropped the `academy` entry from the `publish-docker-images.yml` build matrix and deleted its `update-k8s-academy` job. Releases no longer build or deploy academy.
2. **Marked `@powerhousedao/academy` private** — stops npm publishing (nx still version-bumps it in lockstep; `nx-release-publish` skips private packages).
3. **New `academy.yml` workflow** — on any docs change merged to `main` (`apps/academy/**`), builds the image (short-SHA tag + moving `dev` channel tag) and auto-deploys to **academy.dev.vetra.io**.
4. **`deploy-academy.yml` — "publish a branch to a site"** — a `workflow_dispatch` job with two inputs:
   - **branch** (default `main`) — the branch to build.
   - **environment** (default `academy` = production) — where to publish.

   It builds academy from that branch and deploys it to the chosen site. **Defaults to publishing `main` to production**, so the common case is just clicking *Run workflow*.

## Deploy model
- **Docs merged to main → auto-deploy to dev** (academy.dev.vetra.io) via `academy.yml`.
- **Publish to any site on demand** via Deploy Academy: pick a branch + target, run. Rollback = run it against an older branch/commit.

## Tagging
Images are `cr.vetra.io/academy/academy:<short-sha>` (immutable, pinned by k8s) plus moving channel pointers (`dev`, `staging`, `latest` for production).

## Hardening
`docker buildx imagetools inspect`/`create` (not experimental-gated `docker manifest`); tenant `sed` asserts the tag actually changed; push retries fail the step if all attempts fail; `sed` uses `|` delimiters.

## No k8s-repo changes required
Both workflows edit the existing `tenants/<env>/powerhouse-values.yaml` academy blocks in-place.