### PR TITLE
fix(design-system): prevent theme toggle jump in settings modal

### DIFF
--- a/packages/design-system/src/connect/components/modal/settings-modal-v2/settings-modal.tsx
+++ b/packages/design-system/src/connect/components/modal/settings-modal-v2/settings-modal.tsx
@@ -57,7 +57,7 @@ export function SettingsModal(props: Props) {
       contentProps={{
         ...contentProps,
         className: twMerge(
-          "min-h-full w-full max-w-4xl rounded-xl",
+          "flex min-h-full w-full max-w-4xl flex-col rounded-xl",
           contentProps?.className,
         ),
       }}


### PR DESCRIPTION
## Summary

Fixes a layout jump in the Connect settings modal when the settings modal content changes its height. Related: https://github.com/powerhouse-inc/powerhouse/issues/2834

Closes #2834

## What changed

The settings modal content container now uses a flex column layout so its height stays stable when the theme changes. Previously, the modal content reflowed on theme toggle and caused the theme toggle control to visibly jump.

## Snapshots

<img width="982" height="800" alt="image" src="https://github.com/user-attachments/assets/52b6d572-278c-4a1b-b8f3-cb62df45fc13" />