### PR TITLE
feat: gate vetra package loading behind studio mode

### DIFF
--- a/apps/connect/src/connect.config.ts
+++ b/apps/connect/src/connect.config.ts
@@ -57,6 +57,19 @@ function getBuiltInDefaults(): Omit<
   PHGlobalConfig,
   "basePath" | "routerBasename"
 > {
+  const studioMode = runtime.app?.studioMode ?? false;
+  // Drive containers, DocumentModel, and vetra builder-spec types are authored
+  // via their own drives — never creatable from a generic drive.
+  const disabledEditors = [
+    "powerhouse/document-drive",
+    "powerhouse/reactor-drive",
+    "powerhouse/document-model",
+    "powerhouse/app",
+    "powerhouse/document-editor",
+    "powerhouse/processor",
+    "powerhouse/subgraph",
+    "powerhouse/package",
+  ];
   return {
     allowList: undefined,
     allowedDocumentTypes: [],
@@ -68,7 +81,7 @@ function getBuiltInDefaults(): Omit<
     logLevel: runtime.app?.logLevel,
     requiresHardRefresh: true,
     warnOutdatedApp: false,
-    studioMode: false,
+    studioMode,
     versionCheckInterval: 60 * 60 * 1000,
     cliVersion: env.PH_CONNECT_CLI_VERSION,
     fileUploadOperationsChunkSize: 50,
@@ -76,7 +89,7 @@ function getBuiltInDefaults(): Omit<
     defaultDrivesUrl: runtime.drives?.defaultDrives?.[0]?.url,
     drivesPreserveStrategy: runtime.drives?.preserveStrategy,
     enabledEditors: undefined,
-    disabledEditors: ["powerhouse/document-drive"],
+    disabledEditors,
 
     /* Processors */
     isExternalProcessorsEnabled: true,
@@ -183,7 +196,7 @@ const PH_CONNECT_ANALYTICS_DATABASE_NAME = `${PH_CONNECT_BASE_PATH.replace(
 // soon-to-be-removed CLOUD readers point at runtime.drives.sections.remote.
 export const connectConfig = {
   appVersion: env.PH_CONNECT_VERSION,
-  studioMode: false,
+  studioMode: runtime.app?.studioMode ?? false,
   warnOutdatedApp: false,
   appVersionCheckInterval: 60 * 60 * 1000,
   routerBasename: PH_CONNECT_BASE_PATH,

--- a/apps/connect/src/package-manager.ts
+++ b/apps/connect/src/package-manager.ts
@@ -13,7 +13,6 @@ import {
   type DocumentModelLib,
   type DocumentModelModule,
 } from "@powerhousedao/shared/document-model";
-import * as vetra from "@powerhousedao/vetra";
 import vetraPkg from "@powerhousedao/vetra/package.json" with { type: "json" };
 
 type PackageMeta = {
@@ -91,9 +90,15 @@ export class BrowserPackageManager implements IPackageManager {
   async init(
     localPackage?: DocumentModelLib<any>,
     localPackageVersion?: string,
+    studioMode?: boolean,
   ) {
     this.addLocalPackage(common.manifest.name, common, commonPkg.version);
-    this.addLocalPackage(vetra.manifest.name, vetra, vetraPkg.version);
+    // Vetra is builder-only and not CDN-loadable; lazy-load it (code-split
+    // chunk, never fetched in production) only in studio mode.
+    if (studioMode) {
+      const vetra = await import("@powerhousedao/vetra");
+      this.addLocalPackage(vetra.manifest.name, vetra, vetraPkg.version);
+    }
     if (localPackage) {
       this.updateLocalPackage(localPackage, localPackageVersion);
     }

--- a/apps/connect/src/reactor-worker-client.ts
+++ b/apps/connect/src/reactor-worker-client.ts
@@ -40,6 +40,7 @@ export type WorkerReactorClientArgs = {
   relationalNamespace: string;
   cdnUrl: string;
   packageSpecs: string[];
+  studioMode?: boolean;
   documentModelModules: DocumentModelModule[];
   upgradeManifests: UpgradeManifest<readonly number[]>[];
   documentModelLoader: IDocumentModelLoader;
@@ -114,6 +115,7 @@ export function createWorkerReactorClientModule(
         relationalNamespace: args.relationalNamespace,
         cdnUrl: args.cdnUrl,
         packageSpecs: args.packageSpecs,
+        studioMode: args.studioMode,
       },
       packages: args.packageSpecs,
     },

--- a/apps/connect/src/reactor.worker.ts
+++ b/apps/connect/src/reactor.worker.ts
@@ -29,7 +29,6 @@ import {
   type IRelationalDb,
 } from "@powerhousedao/shared/processors";
 import * as commonDocumentModels from "@powerhousedao/powerhouse-vetra-packages/document-models";
-import * as vetraDocumentModels from "@powerhousedao/vetra/document-models";
 import {
   BrowserKeyStorage,
   createSignatureVerifier,
@@ -62,24 +61,36 @@ console.info("[reactor.worker] module evaluating");
 // Matches the main thread's RenownBuilder("connect").
 const RENOWN_APP_NAME = "connect";
 
-// Studio models the tab bundles as local packages; not CDN-loadable, so the worker imports them directly.
-const bundledModelCandidates: unknown[] = [
-  ...Object.values(commonDocumentModels),
-  ...Object.values(vetraDocumentModels),
-];
-const bundledDocumentModels = bundledModelCandidates.filter(
-  (m): m is DocumentModelModule =>
-    typeof m === "object" &&
-    m !== null &&
-    "documentModel" in m &&
-    "reducer" in m,
+// Common models the tab bundles as a local package; not CDN-loadable, so the
+// worker imports them directly. Vetra is builder-only and lazy-loaded below.
+function toDocumentModelModules(candidates: unknown[]): DocumentModelModule[] {
+  return candidates.filter(
+    (m): m is DocumentModelModule =>
+      typeof m === "object" &&
+      m !== null &&
+      "documentModel" in m &&
+      "reducer" in m,
+  );
+}
+
+const commonBundledModels = toDocumentModelModules(
+  Object.values(commonDocumentModels),
 );
+
+// Not CDN-loadable, so it can't ride the packageSpecs path; lazy-import the
+// bundled chunk only in studio mode.
+async function loadVetraDocumentModels(): Promise<DocumentModelModule[]> {
+  const vetraDocumentModels =
+    await import("@powerhousedao/vetra/document-models");
+  return toDocumentModelModules(Object.values(vetraDocumentModels));
+}
 
 type WorkerConstruct = {
   namespace: string;
   relationalNamespace: string;
   cdnUrl: string;
   packageSpecs: string[];
+  studioMode?: boolean;
 };
 
 type ModelRegistry = {
@@ -277,7 +288,14 @@ const host = new ReactorHost({
           import(/* @vite-ignore */ url) as Promise<Record<string, unknown>>,
       });
       const loaded = await loader.loadPackages(construct.packageSpecs);
-      const models = baseDocumentModels.concat(bundledDocumentModels, loaded);
+      const vetraModels = construct.studioMode
+        ? await loadVetraDocumentModels()
+        : [];
+      const models = baseDocumentModels.concat(
+        commonBundledModels,
+        vetraModels,
+        loaded,
+      );
       phase = "opening pglite stores";
       console.info(`[reactor.worker] boot: ${phase}`);
       const [reactor, relationalMajor] = await Promise.all([

--- a/apps/connect/src/store/reactor.ts
+++ b/apps/connect/src/store/reactor.ts
@@ -250,7 +250,11 @@ export async function createReactor(localPackage?: DocumentModelLib) {
     runtimeConfig.packageRegistryUrl ?? null,
   );
   setVetraPackageManager(packageManager);
-  await packageManager.init(localPackage, runtimeConfig.localPackage?.version);
+  await packageManager.init(
+    localPackage,
+    runtimeConfig.localPackage?.version,
+    phGlobalConfig.studioMode,
+  );
   // Register provider:"local" packages the vite plugin bundled in. The virtual
   // module only exists under phBundledPackagesPlugin (ph-cli), so a resolution
   // failure under plain vite dev is expected; the indirection + @vite-ignore
@@ -358,6 +362,7 @@ export async function createReactor(localPackage?: DocumentModelLib) {
       relationalNamespace: RELATIONAL_PGLITE_NAME,
       cdnUrl: packageManager.cdnUrl ?? "",
       packageSpecs,
+      studioMode: phGlobalConfig.studioMode,
       documentModelModules,
       upgradeManifests,
       documentModelLoader,

--- a/apps/connect/src/utils/create-drive-app-options.ts
+++ b/apps/connect/src/utils/create-drive-app-options.ts
@@ -1,11 +1,12 @@
 import type { AppOptions } from "@powerhousedao/design-system/connect";
 import type { EditorModule } from "document-model";
 
-/** Hidden from the Create Drive picker for now — re-enable when ready. */
-const HIDDEN_CREATE_DRIVE_APP_IDS = new Set(["vetra-drive-app"]);
-
-/** Generic explorer; always listed last when other drive apps are available. */
-const DEFAULT_DRIVE_EXPLORER_APP_ID = "GenericDriveExplorer";
+// Create Drive picker order: installed/custom apps first (rank 0), then the
+// generic explorer, then the vetra drive app last.
+const DRIVE_APP_RANK: Record<string, number> = {
+  GenericDriveExplorer: 1,
+  "vetra-drive-app": 2,
+};
 
 export function getCreateDriveAppOptions(
   appModules: EditorModule[] | undefined,
@@ -15,19 +16,11 @@ export function getCreateDriveAppOptions(
   }
 
   return appModules
-    .filter((pkg) => !HIDDEN_CREATE_DRIVE_APP_IDS.has(pkg.config.id))
     .map((pkg) => ({
       id: pkg.config.id,
       name: pkg.config.name,
       sharingType: "LOCAL" as const,
       availableOffline: false,
     }))
-    .sort((a, b) => {
-      const aIsDefaultExplorer = a.id === DEFAULT_DRIVE_EXPLORER_APP_ID;
-      const bIsDefaultExplorer = b.id === DEFAULT_DRIVE_EXPLORER_APP_ID;
-      if (aIsDefaultExplorer === bIsDefaultExplorer) {
-        return 0;
-      }
-      return aIsDefaultExplorer ? 1 : -1;
-    });
+    .sort((a, b) => (DRIVE_APP_RANK[a.id] ?? 0) - (DRIVE_APP_RANK[b.id] ?? 0));
 }

--- a/apps/switchboard/src/builder-defaults.mts
+++ b/apps/switchboard/src/builder-defaults.mts
@@ -9,22 +9,14 @@ import { reactorDriveDocumentModelModule } from "@powerhousedao/reactor-drive";
 import { getUniqueDocumentModels } from "@powerhousedao/reactor-api";
 import { driveDocumentModelModule } from "@powerhousedao/shared/document-drive";
 import type { DocumentModelModule } from "@powerhousedao/shared/document-model";
-import { documentModels as vetraDocumentModels } from "@powerhousedao/vetra";
 import { documentModelDocumentModelModule, type ILogger } from "document-model";
 
 export type SwitchboardReactorDefaultsOptions = {
-  /**
-   * Additional document models to register alongside switchboard's baseline.
-   * The baseline (document-model, drive, reactor-drive) is included unless
-   * `includeBaseModels` is `false`; vetra models are included unless
-   * `includeVetraModels` is `false`. Duplicates by id are removed via
-   * `getUniqueDocumentModels`.
-   */
+  // Extra models registered alongside the baseline (document-model, drive,
+  // reactor-drive). Pass vetra models here in studio/dev. Deduped by id.
   documentModels?: DocumentModelModule[];
   /** Default true. */
   includeBaseModels?: boolean;
-  /** Default true. */
-  includeVetraModels?: boolean;
   /**
    * Channel scheme. Defaults to `ChannelScheme.SWITCHBOARD`, which populates
    * `reactorModule.syncModule.syncManager` — required by reactor-api. Set
@@ -67,12 +59,10 @@ export function applySwitchboardReactorDefaults(
           reactorDriveDocumentModelModule,
         ]
       : [];
-  const vetraModels =
-    options.includeVetraModels !== false ? vetraDocumentModels : [];
   const extra = options.documentModels ?? [];
-  if (baseModels.length || vetraModels.length || extra.length) {
+  if (baseModels.length || extra.length) {
     reactorBuilder.withDocumentModels(
-      getUniqueDocumentModels(baseModels, vetraModels, extra),
+      getUniqueDocumentModels(baseModels, extra),
     );
   }
 

--- a/apps/switchboard/src/server.mts
+++ b/apps/switchboard/src/server.mts
@@ -33,7 +33,6 @@ import {
   type ReactorDriveDatabase,
 } from "@powerhousedao/reactor-drive";
 import type { DocumentModelModule } from "@powerhousedao/shared/document-model";
-import { processorFactory as vetraProcessorFactory } from "@powerhousedao/vetra/processors";
 import type { IRenown } from "@renown/sdk/node";
 import * as Sentry from "@sentry/node";
 import { childLogger, setLogLevel, type ILogger } from "document-model";
@@ -393,8 +392,23 @@ async function initServer(
       reactorBuilder,
     );
 
+    // Subpath import keeps vetra's React editors out of the node bundle.
+    const vetraDocumentModels: DocumentModelModule[] = dev
+      ? (
+          Object.values(
+            await import("@powerhousedao/vetra/document-models"),
+          ) as unknown[]
+        ).filter(
+          (m): m is DocumentModelModule =>
+            typeof m === "object" &&
+            m !== null &&
+            "documentModel" in m &&
+            "reducer" in m,
+        )
+      : [];
+
     applySwitchboardReactorDefaults(reactorBuilder, clientBuilder, {
-      documentModels,
+      documentModels: [...documentModels, ...vetraDocumentModels],
       executorConfig: hasSkipThreshold ? { maxSkipThreshold } : undefined,
       documentModelLoader:
         httpLoader && dynamicModelLoading
@@ -463,6 +477,12 @@ async function initServer(
     viteLoader = VitePackageLoader.build(vite);
   }
 
+  // Vetra is builder-only and bundled (not CDN-loadable); lazy-load its
+  // processor only in dev, where builder tooling runs (e.g. `ph vetra`).
+  const vetraProcessorFactory = dev
+    ? (await import("@powerhousedao/vetra/processors")).processorFactory
+    : undefined;
+
   // get paths to local document models
   if (!options.disableLocalPackages) {
     packages.push(basePath);
@@ -517,9 +537,9 @@ async function initServer(
       packageLoaders: packageLoaders.length > 0 ? packageLoaders : undefined,
       packages: packages,
       processorConfig: options.processorConfig,
-      processors: {
-        "@powerhousedao/vetra": [vetraProcessorFactory],
-      },
+      processors: vetraProcessorFactory
+        ? { "@powerhousedao/vetra": [vetraProcessorFactory] }
+        : {},
       configFile:
         options.configFile ??
         path.join(process.cwd(), "powerhouse.config.json"),

--- a/clis/ph-cli/src/utils/cli-connect-override.ts
+++ b/clis/ph-cli/src/utils/cli-connect-override.ts
@@ -343,8 +343,13 @@ export function buildStudioConnectOverride(
     renownNamespace: args.renownNamespace,
   }) as PHConnectRuntimeConfig;
 
-  const hasFlag = Object.keys(flagOverride).length > 0;
-  if (!hasFlag) return callerOverride;
-  if (callerOverride === undefined) return flagOverride;
-  return deepMerge(callerOverride, flagOverride);
+  // Studio commands (`ph connect studio`, `ph vetra`) always run in studio
+  // mode: Connect loads the vetra package and offers builder document types.
+  const studioOverride: PHConnectRuntimeConfig = { app: { studioMode: true } };
+  return [callerOverride, flagOverride, studioOverride]
+    .filter(
+      (o): o is PHConnectRuntimeConfig =>
+        o !== undefined && Object.keys(o).length > 0,
+    )
+    .reduce((acc, o) => deepMerge(acc, o), {} as PHConnectRuntimeConfig);
 }

--- a/packages/builder-tools/connect-utils/runtime-config.schema.json
+++ b/packages/builder-tools/connect-utils/runtime-config.schema.json
@@ -108,6 +108,11 @@
               "type": "boolean",
               "description": "When true (default), the build emits a precaching service worker so Connect's app shell works offline, and the SPA registers it at boot. Set false to opt this deployment out: no service worker is built, the SPA skips registration, and any previously-installed worker is unregistered.",
               "default": true
+            },
+            "studioMode": {
+              "type": "boolean",
+              "description": "Studio mode. Enables builder-only capabilities: Connect loads the vetra package and exposes DocumentModel (and vetra spec types) as creatable documents. Forced on by `ph vetra` / `ph connect studio`; false by default.",
+              "default": false
             }
           }
         },

--- a/packages/powerhouse-vetra-packages/editors/generic-drive-explorer/components/create-document.tsx
+++ b/packages/powerhouse-vetra-packages/editors/generic-drive-explorer/components/create-document.tsx
@@ -2,7 +2,8 @@ import { PowerhouseButton } from "@powerhousedao/design-system";
 import {
   preloadEditorModule,
   showCreateDocumentModal,
-  useDocumentModelModules,
+  useAllowedDocumentModelModules,
+  useDisabledEditors,
   useEditorModules,
   useUserPermissions,
 } from "@powerhousedao/reactor-browser";
@@ -17,21 +18,24 @@ function getDocumentSpec(doc: DocumentModelModule): DocumentModelGlobalState {
 
 export function CreateDocument() {
   const { isAllowedToCreateDocuments } = useUserPermissions();
-  const documentModelModules = useDocumentModelModules();
+  // Respect Connect config: allowedDocumentTypes (allowlist) via the hook,
+  // disabledEditors (denylist) subtracted below.
+  const allowedDocumentModelModules = useAllowedDocumentModelModules();
   const editorModules = useEditorModules();
-  // Hide "document-drive" (drive root) and vetra builder-spec types (App Module,
-  // Document Editor, Processor Module, Subgraph Module, Vetra Package) from the
-  // generic explorer's "New document" section.
-  const HIDDEN_DOCUMENT_TYPES = [
+  const disabledEditors = useDisabledEditors() ?? [];
+  // Drive containers are never documents-in-a-drive; hide them structurally so
+  // this shared editor can't fail open when disabledEditors is unset.
+  const DRIVE_CONTAINER_TYPES = [
     "powerhouse/document-drive",
-    "powerhouse/app",
-    "powerhouse/document-editor",
-    "powerhouse/processor",
-    "powerhouse/subgraph",
-    "powerhouse/package",
+    "powerhouse/reactor-drive",
   ];
-  const visibleDocumentModelModules = documentModelModules?.filter(
-    (module) => !HIDDEN_DOCUMENT_TYPES.includes(module.documentModel.global.id),
+  const visibleDocumentModelModules = allowedDocumentModelModules?.filter(
+    (module) => {
+      const id = module.documentModel.global.id;
+      return (
+        !DRIVE_CONTAINER_TYPES.includes(id) && !disabledEditors.includes(id)
+      );
+    },
   );
   const preloadEditorsForType = (documentType: string) =>
     editorModules

--- a/packages/shared/clis/source-config.schema.json
+++ b/packages/shared/clis/source-config.schema.json
@@ -251,6 +251,11 @@
               "type": "boolean",
               "description": "When true (default), the build emits a precaching service worker so Connect's app shell works offline, and the SPA registers it at boot. Set false to opt this deployment out: no service worker is built, the SPA skips registration, and any previously-installed worker is unregistered.",
               "default": true
+            },
+            "studioMode": {
+              "type": "boolean",
+              "description": "Studio mode. Enables builder-only capabilities: Connect loads the vetra package and exposes DocumentModel (and vetra spec types) as creatable documents. Forced on by `ph vetra` / `ph connect studio`; false by default.",
+              "default": false
             }
           }
         },

--- a/packages/shared/clis/types.ts
+++ b/packages/shared/clis/types.ts
@@ -61,6 +61,9 @@ export type PHConnectApp = {
   logLevel?: "debug" | "info" | "warn" | "error";
   basePath?: string;
   offline?: boolean;
+  // Builder mode: Connect loads the vetra package and exposes DocumentModel +
+  // vetra spec types as creatable docs. Forced on by `ph vetra`/studio.
+  studioMode?: boolean;
 };
 
 export type PHConnectPackages = {

--- a/packages/shared/connect/runtime-config.ts
+++ b/packages/shared/connect/runtime-config.ts
@@ -33,6 +33,7 @@ export const DEFAULT_CONNECT_CONFIG: PHConnectRuntimeConfig = {
     logLevel: "info",
     basePath: "/",
     offline: true,
+    studioMode: false,
   },
   packages: {
     externalEnabled: true,

--- a/packages/shared/connect/schema-fragments.ts
+++ b/packages/shared/connect/schema-fragments.ts
@@ -107,6 +107,12 @@ export const phConnectRuntimeConfigSchema = {
             "When true (default), the build emits a precaching service worker so Connect's app shell works offline, and the SPA registers it at boot. Set false to opt this deployment out: no service worker is built, the SPA skips registration, and any previously-installed worker is unregistered.",
           default: true,
         },
+        studioMode: {
+          type: "boolean",
+          description:
+            "Studio mode. Enables builder-only capabilities: Connect loads the vetra package and exposes DocumentModel (and vetra spec types) as creatable documents. Forced on by `ph vetra` / `ph connect studio`; false by default.",
+          default: false,
+        },
       },
     },
     packages: {

--- a/test/vetra-e2e/tests/add-drive-app-order.spec.ts
+++ b/test/vetra-e2e/tests/add-drive-app-order.spec.ts
@@ -19,22 +19,11 @@ test.use({
   },
 });
 
-// Asserts the Add Drive modal's app options after getCreateDriveAppOptions
-// (apps/connect/src/utils/create-drive-app-options.ts): "vetra-drive-app" is
-// hidden from the picker and GenericDriveExplorer ("Drive Explorer App") is
-// sorted last so any other visible app becomes the pre-selected default.
-//
-// Assertion strategy, driven by ConnectSelect rendering (design-system
-// `select.tsx`): the collapsed header shows the currently selected item; the
-// expanded menu lists every item EXCEPT the selected one.
-//
-// This spec assumes exactly the two bundled apps are present (no local
-// packages installed). With Vetra Drive App hidden, "Drive Explorer App" is
-// the only option left, so it must be the pre-selected default and
-// "Vetra Drive App" must never appear — collapsed or expanded.
+// In studio mode both bundled apps are offered; getCreateDriveAppOptions ranks
+// the generic explorer before vetra, so Drive Explorer App is default and last.
 test.describe.configure({ timeout: DESCRIBE_TIMEOUT });
 
-test("should hide Vetra Drive App and default to Drive Explorer App in the Add Drive app options", async ({
+test("should default to Drive Explorer App and list Vetra Drive App last", async ({
   page,
 }) => {
   await page.goto("/");
@@ -48,17 +37,17 @@ test("should hide Vetra Drive App and default to Drive Explorer App in the Add D
   const dialog = page.getByRole("dialog");
   await expect(dialog).toBeVisible({ timeout: 10_000 });
 
-  // Collapsed: "Drive Explorer App" is the default (visible in header).
+  // Collapsed: "Drive Explorer App" is the default (visible in the header).
   await expect(dialog.getByText("Drive Explorer App")).toBeVisible({
     timeout: 5_000,
   });
 
-  // "Vetra Drive App" is hidden from the options entirely.
-  await expect(dialog.getByText("Vetra Drive App")).toHaveCount(0);
-
-  // Expand the select and confirm Vetra Drive App is not listed there either.
+  // ConnectSelect hides non-selected items until expanded, so click to reveal
+  // "Vetra Drive App" — the other (last) option.
   await dialog.getByText("Drive Explorer App").click();
-  await expect(dialog.getByText("Vetra Drive App")).toHaveCount(0);
+  await expect(dialog.getByText("Vetra Drive App")).toBeVisible({
+    timeout: 5_000,
+  });
 
   // Close without creating a drive — keep the environment clean.
   await page.keyboard.press("Escape");

--- a/test/vetra-e2e/tests/generic-drive-hidden-vetra-documents.spec.ts
+++ b/test/vetra-e2e/tests/generic-drive-hidden-vetra-documents.spec.ts
@@ -19,15 +19,16 @@ test.use({
   },
 });
 
+// DocumentModel and the vetra builder-spec types are authored via their own
+// drives, so none are creatable from a generic drive.
 const HIDDEN_DISPLAY_NAMES = [
+  "DocumentModel",
   "App Module",
   "Document Editor",
   "Processor Module",
   "Subgraph Module",
   "Vetra Package",
 ];
-
-const VISIBLE_DISPLAY_NAME = "DocumentModel";
 
 test("vetra document types are hidden in a generic drive", async ({ page }) => {
   // 1. Navigate to the home page
@@ -42,11 +43,11 @@ test("vetra document types are hidden in a generic drive", async ({ page }) => {
   const addDriveDialog = page.getByRole("dialog");
   await expect(addDriveDialog).toBeVisible({ timeout: 10_000 });
 
-  // "Drive Explorer App" is the pre-selected default: vetra-drive-app is
-  // hidden from the picker, leaving it as the only bundled app option.
-  await expect(
-    addDriveDialog.getByText("Drive Explorer App"),
-  ).toBeVisible({ timeout: 5_000 });
+  // "Drive Explorer App" is the pre-selected default (vetra is ranked last),
+  // so the created drive uses the generic explorer.
+  await expect(addDriveDialog.getByText("Drive Explorer App")).toBeVisible({
+    timeout: 5_000,
+  });
 
   const driveNameInput = page.locator('input[placeholder="Drive name"]');
   await expect(driveNameInput).toBeVisible({ timeout: 5_000 });
@@ -64,18 +65,13 @@ test("vetra document types are hidden in a generic drive", async ({ page }) => {
   await expect(page).toHaveURL(/\/d\/[^/?]+/, { timeout: 10_000 });
   await page.waitForLoadState("networkidle");
 
-  // 4. Locate the "New document" section
-  await expect(
-    page.getByRole("heading", { name: "New document" }),
-  ).toBeVisible({ timeout: 30_000 });
+  // 4. Positive control: the "New document" section renders.
+  await expect(page.getByRole("heading", { name: "New document" })).toBeVisible(
+    { timeout: 30_000 },
+  );
   const section = page.locator(".flex.w-full.flex-wrap.gap-4");
 
-  // 5. Positive control: DocumentModel must still be visible
-  await expect(
-    section.getByRole("button").filter({ hasText: VISIBLE_DISPLAY_NAME }),
-  ).toBeVisible({ timeout: 30_000 });
-
-  // 6. All five vetra builder-spec types must be absent
+  // 5. DocumentModel + every vetra builder-spec type must be absent.
   for (const hiddenName of HIDDEN_DISPLAY_NAMES) {
     await expect(
       section.getByRole("button").filter({ hasText: hiddenName }),

--- a/test/vetra-e2e/tests/todo-document.spec.ts
+++ b/test/vetra-e2e/tests/todo-document.spec.ts
@@ -465,11 +465,11 @@ test("Install Package in Consumer Project", async ({ browser }) => {
     const addDriveDialog = page.getByRole("dialog");
     await expect(addDriveDialog).toBeVisible({ timeout: 10_000 });
 
-    // "Drive Explorer App" is the pre-selected default: vetra-drive-app is
-    // hidden from the picker, leaving it as the only bundled app option.
-    await expect(
-      addDriveDialog.getByText("Drive Explorer App"),
-    ).toBeVisible({ timeout: 5_000 });
+    // Consumer preview is a production build (studioMode off), so vetra isn't
+    // loaded and "Drive Explorer App" is the only bundled app / default.
+    await expect(addDriveDialog.getByText("Drive Explorer App")).toBeVisible({
+      timeout: 5_000,
+    });
 
     // Fill in drive name
     const driveNameInput = page.locator('input[placeholder="Drive name"]');

--- a/test/vetra-e2e/tests/todo-document.spec.ts
+++ b/test/vetra-e2e/tests/todo-document.spec.ts
@@ -781,12 +781,10 @@ test("Change registry URL at runtime and install from new registry", async () =>
   // -------------------------------------------------------------------
   // Step 7: Verify the install succeeded against the new registry
   // -------------------------------------------------------------------
-  // The strongest signal is that the "Installed Packages" count went up:
-  // before the install it sits at 3 (Common, Vetra, Local), after a
-  // successful fetch + register from the NEW registry it becomes 4. We
-  // poll the count heading so re-renders don't break the assertion.
+  // Installed count rose: before install it's 2 (Common, Local) — Vetra isn't
+  // loaded in a production build (studioMode off) — so after install it's 3.
   await expect(
-    settingsModal.getByRole("heading", { name: /Installed Packages 4/i }),
+    settingsModal.getByRole("heading", { name: /Installed Packages 3/i }),
   ).toBeVisible({ timeout: 60_000 });
 });
 


### PR DESCRIPTION
## What & why

`@powerhousedao/vetra` is a builder-only package that isn't CDN-loadable, so it was **eagerly bundled and loaded** into every Connect and Switchboard — including production. This gates it so it only loads in studio/builder contexts.

## Changes

- **`studioMode` is now a real, configurable runtime-config field** (`connect.app.studioMode`, default `false`; added to types, schema fragments, defaults, and both generated `*.schema.json`). Forced `true` by `ph vetra` and `ph connect studio` via `buildStudioConnectOverride`.
- **Connect** loads vetra lazily (dynamic `import()`) only when `studioMode` — both the main-thread package manager and the reactor worker. `common` (drive explorer, base models) stays eager. In production the vetra chunk is code-split and never fetched.
- **Switchboard** loads vetra (models + processor) lazily, gated on `dev` (which `ph vetra` forces); the `/document-models` subpath import keeps vetra's React editors out of the node bundle.
- **Generic drive "New document" list is config-driven**: uses `useAllowedDocumentModelModules()` + subtracts `disabledEditors`, with a structural floor so drive containers are never offered. Hides drive containers, `DocumentModel`, and the 5 vetra spec types; the **Vetra Drive App** is now offered in the Create-Drive picker, ordered last (after custom apps and the generic explorer).

## Testing

- `pnpm --filter` tsc passes for shared, builder-tools, connect, switchboard, ph-cli, powerhouse-vetra-packages.
- vetra-e2e: `2 passed` (drive-picker order + generic-drive hidden-docs) against a real `ph vetra` studio server.
- Schemas regenerated via `pnpm tsx scripts/emit-schemas.ts`.

## Notes for reviewers

- **Switchboard behavior change**: a non-`dev` (production) Switchboard no longer registers vetra document models or the vetra processor. Intended (vetra is builder-only), but there is no production opt-in — flagging in case any deployment relies on it.
- **API**: `applySwitchboardReactorDefaults` dropped the `includeVetraModels` option (public re-export); vetra models now flow via `documentModels`.
- Connect gates on `studioMode`, Switchboard on `dev` — two signals for the same "builder context"; coupled in practice via `ph vetra`.