### PR TITLE
fix(connect): stop missing model banner from causing layout overflow

### DIFF
--- a/apps/connect/src/components/missing-model-banner.tsx
+++ b/apps/connect/src/components/missing-model-banner.tsx
@@ -1,10 +1,10 @@
-import { Modal } from "@powerhousedao/design-system";
+import { Icon, Modal } from "@powerhousedao/design-system";
 import {
   usePackageDiscoveryService,
   type FailedInstallation,
   type FailedInstallationReason,
 } from "@powerhousedao/reactor-browser";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { twMerge } from "tailwind-merge";
 import { useFailedInstallations } from "../hooks/useFailedInstallations.js";
 
@@ -23,26 +23,50 @@ function canRetry(reason: FailedInstallationReason): boolean {
 
 export function MissingModelBanner() {
   const failed = useFailedInstallations();
+  const discoveryService = usePackageDiscoveryService();
   const [open, setOpen] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    return discoveryService?.subscribeEvents((event) => {
+      if (event.type === "load-failed") {
+        setDismissed(false);
+      }
+    });
+  }, [discoveryService]);
 
   if (failed.length === 0) return null;
 
   return (
     <>
-      <div className="flex items-center justify-between gap-3 bg-warning/10 px-4 py-2 text-sm text-warning">
-        <span>
-          {failed.length === 1
-            ? "1 document type couldn't load (missing model)."
-            : `${failed.length} document types couldn't load (missing models).`}
-        </span>
-        <button
-          type="button"
-          onClick={() => setOpen(true)}
-          className="rounded-md border border-warning bg-background px-3 py-1 text-warning hover:hover-effect"
-        >
-          View
-        </button>
-      </div>
+      {dismissed ? null : (
+        <div className="absolute inset-x-0 top-0 z-200 bg-background">
+          <div className="flex items-center justify-between gap-3 bg-warning/10 px-4 py-2 text-sm text-warning">
+            <span>
+              {failed.length === 1
+                ? "1 document type couldn't load (missing model)."
+                : `${failed.length} document types couldn't load (missing models).`}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setOpen(true)}
+                className="rounded-md border border-warning bg-background px-3 py-1 text-warning hover:hover-effect"
+              >
+                View
+              </button>
+              <button
+                type="button"
+                onClick={() => setDismissed(true)}
+                aria-label="Dismiss"
+                className="flex items-center text-warning hover:hover-effect"
+              >
+                <Icon name="XmarkLight" size={16} />
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       <MissingModelDetailsModal
         open={open}
         failed={failed}


### PR DESCRIPTION
## Summary

Fixes an unwanted layout overflow that appears when the missing-model warning banner is shown during document import. Related: https://github.com/powerhouse-inc/powerhouse/issues/2830

Closes #2830

## What changed

- Renders the missing-model banner as an absolute overlay at the top of the viewport instead of in the document flow, so it no longer pushes page content and causes scroll overflow.
- Adds a dismiss control so users can hide the banner without losing access to the details modal.
- Re-shows the banner when a new package load failure occurs.

## How to test

1. Open Connect and import a document whose model package is not installed.
2. Confirm the missing-model warning banner appears at the top.
3. Verify the page no longer gains unwanted vertical overflow or layout shift when the banner is visible.
4. Dismiss the banner with the X button and confirm content returns to normal.
5. Trigger another load failure and confirm the banner reappears.
6. Open the "View" details modal and confirm retry/close behavior still works.
