### PR TITLE
feat(ph-cli): fail build when manifest name mismatches package.json

### DIFF
--- a/clis/ph-cli/src/services/build.ts
+++ b/clis/ph-cli/src/services/build.ts
@@ -3,13 +3,52 @@ import {
   nodeBuildConfig,
 } from "@powerhousedao/shared/build-config";
 import { execSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { detect, resolveCommand } from "package-manager-detector";
+import { readPackage } from "read-pkg";
 import { build as tsdownBuild } from "tsdown";
 import type { BuildArgs } from "../types.js";
 
+/**
+ * A Powerhouse package's `powerhouse.manifest.json` "name" must match its
+ * `package.json` "name" — Connect and the registry resolve installed versions
+ * by treating the manifest name as the npm package name, so a mismatch silently
+ * breaks resolution. Fail the build early if they diverge. No-op when the
+ * project has no manifest (nothing to compare).
+ */
+export async function assertManifestNameMatchesPackage(projectPath: string) {
+  const manifestPath = join(projectPath, "powerhouse.manifest.json");
+  if (!existsSync(manifestPath)) return;
+
+  const { name: packageName } = await readPackage({ cwd: projectPath });
+
+  let manifestName: unknown;
+  try {
+    manifestName = (
+      JSON.parse(readFileSync(manifestPath, "utf-8")) as { name?: unknown }
+    ).name;
+  } catch {
+    throw new Error(
+      `Failed to parse "powerhouse.manifest.json" at ${manifestPath}. Make sure it is valid JSON.`,
+    );
+  }
+
+  if (manifestName !== packageName) {
+    throw new Error(
+      `Package name mismatch — "package.json" and "powerhouse.manifest.json" must have the same "name":\n` +
+        `  package.json             "name": ${JSON.stringify(packageName)}\n` +
+        `  powerhouse.manifest.json "name": ${JSON.stringify(manifestName)}\n\n` +
+        `Update one so they match, then run the build again.`,
+    );
+  }
+}
+
 export async function runBuild(args: BuildArgs) {
   const { outDir } = args;
+
+  // Fail fast if the manifest name and package.json name have drifted apart.
+  await assertManifestNameMatchesPackage(process.cwd());
 
   await tsdownBuild({
     ...browserBuildConfig,

--- a/clis/ph-cli/test/build-name-guard.test.ts
+++ b/clis/ph-cli/test/build-name-guard.test.ts
@@ -1,0 +1,85 @@
+// Focused tests for `assertManifestNameMatchesPackage`, the guard `runBuild`
+// runs first so a divergent `powerhouse.manifest.json` name aborts the build
+// before any heavy work happens.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { assertManifestNameMatchesPackage } from "../src/services/build.js";
+
+const created: string[] = [];
+
+/**
+ * Create a throwaway project dir with a package.json and (optionally) a
+ * powerhouse.manifest.json. Pass `manifestName: undefined` to omit the manifest.
+ */
+function makeProject(opts: {
+  packageName: string;
+  manifestName?: string;
+}): string {
+  const dir = mkdtempSync(join(tmpdir(), "ph-build-guard-"));
+  created.push(dir);
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: opts.packageName, version: "1.0.0" }, null, 2),
+  );
+  if (opts.manifestName !== undefined) {
+    writeFileSync(
+      join(dir, "powerhouse.manifest.json"),
+      JSON.stringify({ name: opts.manifestName }, null, 2),
+    );
+  }
+  return dir;
+}
+
+afterEach(() => {
+  while (created.length > 0) {
+    const dir = created.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("assertManifestNameMatchesPackage", () => {
+  it("throws when the manifest name differs from the package name", async () => {
+    const dir = makeProject({
+      packageName: "@acme/pkg",
+      manifestName: "wrong",
+    });
+    await expect(assertManifestNameMatchesPackage(dir)).rejects.toThrow(
+      /Package name mismatch/,
+    );
+  });
+
+  it("throws when the manifest name is empty", async () => {
+    const dir = makeProject({ packageName: "@acme/pkg", manifestName: "" });
+    await expect(assertManifestNameMatchesPackage(dir)).rejects.toThrow(
+      /Package name mismatch/,
+    );
+  });
+
+  it("resolves when the manifest name matches the package name", async () => {
+    const dir = makeProject({
+      packageName: "@acme/pkg",
+      manifestName: "@acme/pkg",
+    });
+    await expect(
+      assertManifestNameMatchesPackage(dir),
+    ).resolves.toBeUndefined();
+  });
+
+  it("is a no-op when the project has no powerhouse.manifest.json", async () => {
+    const dir = makeProject({ packageName: "@acme/pkg" });
+    await expect(
+      assertManifestNameMatchesPackage(dir),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws with a helpful message when the manifest is not valid JSON", async () => {
+    const dir = makeProject({ packageName: "@acme/pkg" });
+    writeFileSync(join(dir, "powerhouse.manifest.json"), "{ not json");
+    await expect(assertManifestNameMatchesPackage(dir)).rejects.toThrow(
+      /Failed to parse "powerhouse\.manifest\.json"/,
+    );
+  });
+});

--- a/test/vetra-e2e/powerhouse.manifest.json
+++ b/test/vetra-e2e/powerhouse.manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "test-package-vetra",
   "description": "",
   "category": "",
   "publisher": {


### PR DESCRIPTION
## Summary

Adds a build-time guard in `ph-cli` that fails the build when `powerhouse.manifest.json` `name` does not match `package.json` `name`. Connect and the registry resolve installed packages using the manifest name as the npm package name, so a mismatch silently breaks installation — this catches that drift early with a clear error.

Closes #2829

## What changed

- `ph-cli build` now validates manifest and package names before bundling; a mismatch aborts with both values shown side by side
- Invalid manifest JSON is rejected with a parse error message
- Projects without a `powerhouse.manifest.json` are unaffected
- The vetra-e2e test fixture manifest name was corrected to match its `package.json`
- Unit tests cover mismatch, empty name, valid match, missing manifest, and invalid JSON

## How to test

1. In a Powerhouse package that has both `package.json` and `powerhouse.manifest.json`, set different `name` values in each file
2. Run `ph-cli build` from that package directory
3. Confirm the build fails with a "Package name mismatch" error listing both names
4. Align the names and confirm the build succeeds
5. Run `pnpm exec vitest run clis/ph-cli/test/build-name-guard.test.ts` and confirm all 5 tests pass

## Snapshots

<img width="744" height="100" alt="image" src="https://github.com/user-attachments/assets/1e3f63ce-ee95-464c-85fc-346bf0b207a4" />
