### PR TITLE
fix(config): add files allowlist so dist ships on publish

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/powerhouse-inc/powerhouse"
   },
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "source": "./src/index.ts",


### PR DESCRIPTION
## Problem

The nightly `test-package-managers` jobs are failing at `ph connect build` across npm/yarn/pnpm ([run 29306827892](https://github.com/powerhouse-inc/powerhouse/actions/runs/29306827892)):

```
Cannot find module '.../@powerhousedao/config/dist/node.js'
  imported from '.../@powerhousedao/builder-tools/dist/index.mjs'
```

`@powerhousedao/config@6.2.1-dev.6` was published **without its `dist/` output** — the tarball contained only `src/*.ts`, while the `exports` map points at `./dist/index.js` and `./dist/node.js`. Any consumer importing `@powerhousedao/config/node` (`builder-tools`, `reactor-api`) crashes at runtime.

## Root cause

`packages/config` was the **only** package under `packages/` with no `files` field. Without it, publish ships "whatever is on disk" rather than an explicit `dist` allowlist. Earlier versions (dev.5 and back) shipped 8 dist files; dev.6 shipped 0 — config's `dist/` simply wasn't present on disk when the dev.6 release built the tarball.

## Fix

Add `"files": ["dist"]`, matching every sibling package (e.g. `builder-tools`). Verified locally: after `pnpm build`, `npm pack --dry-run` ships all of `dist/` including `dist/node.js`.

Note: the broken `6.2.1-dev.6` tarball on npm is already burned — a new dev release still needs to publish `6.2.1-dev.7` to turn the jobs green. This PR prevents the source-only publish from recurring.