### PR TITLE
feat(registry): s3-backed auth plugin with persistent accounts and package ownership

### DIFF
--- a/packages/registry/copy-dirs.ts
+++ b/packages/registry/copy-dirs.ts
@@ -1,4 +1,4 @@
-import { cp, access } from "node:fs/promises";
+import { cp, access, mkdir, writeFile } from "node:fs/promises";
 
 for (const dir of ["storage", "cdn-cache", "packages"]) {
   try {
@@ -8,3 +8,12 @@ for (const dir of ["storage", "cdn-cache", "packages"]) {
     // Directory doesn't exist yet, skip copy
   }
 }
+
+// Verdaccio loads the auth plugin with require(); mark dist/plugins as a
+// CommonJS scope so its emitted `.js` is treated as CJS even though the
+// package root is type:module.
+await mkdir("./dist/plugins", { recursive: true });
+await writeFile(
+  "./dist/plugins/package.json",
+  `${JSON.stringify({ type: "commonjs" })}\n`,
+);

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -36,9 +36,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.700.0",
     "@powerhousedao/shared": "workspace:*",
     "@renown/sdk": "workspace:*",
+    "@verdaccio/core": "8.0.0-next-8.37",
     "@verdaccio/signature": "8.0.0-next-8.29",
+    "bcryptjs": "^2.4.3",
     "cmd-ts": "catalog:",
     "express": "^4.22.1",
     "find-up": "^8.0.0",
@@ -48,6 +51,7 @@
   },
   "devDependencies": {
     "tsdown": "catalog:",
+    "@types/bcryptjs": "^2.4.6",
     "@types/express": "^4.17.21",
     "@types/node": "catalog:",
     "@types/supertest": "^6.0.2",

--- a/packages/registry/src/auth/s3-auth-plugin.ts
+++ b/packages/registry/src/auth/s3-auth-plugin.ts
@@ -1,0 +1,175 @@
+import { errorUtils } from "@verdaccio/core";
+import bcrypt from "bcryptjs";
+import type { S3Config } from "../types.js";
+import { createS3Store, type S3ObjectStore } from "./s3-store.js";
+
+/**
+ * S3-backed Verdaccio auth plugin.
+ *
+ * Closes two holes in the default htpasswd setup:
+ *  - **accounts** live in S3 (shared across replicas, survive redeploys), and
+ *    `adduser` rejects an existing username instead of the htpasswd
+ *    wrong-password-201 auto-create — so usernames can't be impersonated.
+ *  - **ownership** (npm-style TOFU): the first publisher of a name owns it;
+ *    anyone else gets 403. Self-registration stays open.
+ *
+ * Object layout (keys prefixed with the s3 keyPrefix, e.g. `vetra/`):
+ *  - `…auth/users/<username>.json`  → { name, passwordHash, createdAt }
+ *  - `…auth/owners/<enc(pkg)>.json` → { owners: string[], claimedAt }
+ */
+export interface S3AuthPluginConfig {
+  s3: S3Config;
+}
+
+interface UserRecord {
+  name: string;
+  passwordHash: string;
+  createdAt: string;
+}
+
+/** Owners is a list (single-owner today) so co-maintainers / orgs can be added
+ *  later without a storage redesign. */
+interface OwnerRecord {
+  owners: string[];
+  claimedAt: string;
+}
+
+const BCRYPT_ROUNDS = 10;
+
+function usersKey(prefix: string, name: string): string {
+  return `${prefix}auth/users/${name}.json`;
+}
+
+function ownersKey(prefix: string, pkgName: string): string {
+  return `${prefix}auth/owners/${encodeURIComponent(pkgName)}.json`;
+}
+
+// The verdaccio callback types (loose here to avoid a hard @verdaccio/types dep):
+type AuthCallback = (err: Error | null, groups?: string[] | false) => void;
+type AuthUserCallback = (err: Error | null, ok?: boolean | string) => void;
+type AuthAccessCallback = (err: Error | null, ok?: boolean) => void;
+type AccessCallback = (err: Error | null, ok?: boolean) => void;
+type RemoteUserLike = { name?: string | null; groups?: string[] };
+type PackageLike = { name?: string };
+
+function pkgName(pkg: PackageLike): string {
+  return pkg.name ?? "";
+}
+
+function internal(err: unknown): Error {
+  const msg = err instanceof Error ? err.message : String(err);
+  return errorUtils.getInternalError(msg);
+}
+
+/**
+ * Pure plugin factory over an injected store — the unit-testable core.
+ * `s3AuthPlugin` below wires it to a real S3 store.
+ */
+export function createS3AuthPlugin(store: S3ObjectStore, keyPrefix: string) {
+  return {
+    authenticate(user: string, password: string, cb: AuthCallback): void {
+      store
+        .getJSON<UserRecord>(usersKey(keyPrefix, user))
+        .then((rec) => {
+          if (!rec) return cb(null, false); // unknown user → not authenticated
+          if (!bcrypt.compareSync(password, rec.passwordHash)) {
+            return cb(errorUtils.getUnauthorized("bad username or password"));
+          }
+          return cb(null, [user]); // group set; verdaccio adds $authenticated/$all
+        })
+        .catch((err) => cb(internal(err)));
+    },
+
+    adduser(user: string, password: string, cb: AuthUserCallback): void {
+      store
+        .exists(usersKey(keyPrefix, user))
+        .then(async (exists) => {
+          // Existence checked against the SHARED store → an existing name with a
+          // wrong password can't silently re-create the account (the emptyDir
+          // pod-lottery 201 hole). Registration of a NEW name stays open.
+          if (exists)
+            return cb(errorUtils.getConflict("username already registered"));
+          const passwordHash = bcrypt.hashSync(password, BCRYPT_ROUNDS);
+          await store.putJSON(usersKey(keyPrefix, user), {
+            name: user,
+            passwordHash,
+            createdAt: new Date().toISOString(),
+          } satisfies UserRecord);
+          return cb(null, true);
+        })
+        .catch((err) => cb(internal(err)));
+    },
+
+    // Reads stay open ($all) — anonymous install works.
+    allow_access(
+      _user: RemoteUserLike,
+      _pkg: PackageLike,
+      cb: AccessCallback,
+    ): void {
+      cb(null, true);
+    },
+
+    allow_publish(
+      user: RemoteUserLike,
+      pkg: PackageLike,
+      cb: AuthAccessCallback,
+    ): void {
+      const name = pkgName(pkg);
+      const username = user.name;
+      if (!username)
+        return cb(
+          errorUtils.getForbidden("authentication required to publish"),
+        );
+      store
+        .getJSON<OwnerRecord>(ownersKey(keyPrefix, name))
+        .then(async (rec) => {
+          if (!rec) {
+            // Free name → claim it for this publisher (npm-style TOFU).
+            await store.putJSON(ownersKey(keyPrefix, name), {
+              owners: [username],
+              claimedAt: new Date().toISOString(),
+            } satisfies OwnerRecord);
+            return cb(null, true);
+          }
+          if (rec.owners.includes(username)) return cb(null, true);
+          return cb(
+            errorUtils.getForbidden(
+              `not authorized to publish "${name}" (owned by another user)`,
+            ),
+          );
+        })
+        .catch((err) => cb(internal(err)));
+    },
+
+    allow_unpublish(
+      user: RemoteUserLike,
+      pkg: PackageLike,
+      cb: AuthAccessCallback,
+    ): void {
+      const name = pkgName(pkg);
+      const username = user.name;
+      if (!username)
+        return cb(
+          errorUtils.getForbidden("authentication required to unpublish"),
+        );
+      store
+        .getJSON<OwnerRecord>(ownersKey(keyPrefix, name))
+        .then((rec) => {
+          // No auto-claim on unpublish; only the recorded owner may remove.
+          if (rec && rec.owners.includes(username)) return cb(null, true);
+          return cb(
+            errorUtils.getForbidden(`not authorized to unpublish "${name}"`),
+          );
+        })
+        .catch((err) => cb(internal(err)));
+    },
+  };
+}
+
+/** Verdaccio plugin entry. The loader calls this factory (or `new`s the
+ *  default export — both return the plugin object). */
+export default function s3AuthPlugin(pluginConfig: S3AuthPluginConfig) {
+  const s3 = pluginConfig.s3;
+  const store = createS3Store(s3);
+  return createS3AuthPlugin(store, s3.keyPrefix ?? "");
+}

--- a/packages/registry/src/auth/s3-store.ts
+++ b/packages/registry/src/auth/s3-store.ts
@@ -1,0 +1,113 @@
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import type { S3Config } from "../types.js";
+
+/** Minimal JSON object store over an S3 bucket. Keys are used as given by the
+ *  caller (the caller owns any `<keyPrefix>` prefixing). A missing object
+ *  (404 / NoSuchKey) is "absent", never an error. */
+export interface S3ObjectStore {
+  getJSON<T>(key: string): Promise<T | null>;
+  putJSON(key: string, value: unknown): Promise<void>;
+  delete(key: string): Promise<void>;
+  exists(key: string): Promise<boolean>;
+}
+
+/** Just enough of the S3 client surface for the store — lets tests inject a
+ *  fake without a network or the real SDK. */
+export interface S3SendClient {
+  send(command: unknown): Promise<unknown>;
+}
+
+/** Build a real S3 client from the same S3Config the aws-s3-storage store
+ *  uses (mirrors verdaccio-config.ts store block). */
+export function createS3Client(s3: S3Config): S3Client {
+  return new S3Client({
+    endpoint: s3.endpoint,
+    region: s3.region,
+    forcePathStyle: s3.s3ForcePathStyle ?? true,
+    ...(s3.accessKeyId && s3.secretAccessKey
+      ? {
+          credentials: {
+            accessKeyId: s3.accessKeyId,
+            secretAccessKey: s3.secretAccessKey,
+          },
+        }
+      : {}),
+  });
+}
+
+function isNotFound(err: unknown): boolean {
+  const e = err as
+    | { name?: string; $metadata?: { httpStatusCode?: number } }
+    | undefined;
+  return (
+    e?.name === "NoSuchKey" ||
+    e?.name === "NotFound" ||
+    e?.$metadata?.httpStatusCode === 404
+  );
+}
+
+/** Read a JSON object body to a string across the SDK's Node/stream shapes. */
+async function bodyToString(body: unknown): Promise<string> {
+  const b = body as
+    | { transformToString?: () => Promise<string> }
+    | undefined
+    | null;
+  if (b && typeof b.transformToString === "function") {
+    return b.transformToString();
+  }
+  // Fallback for non-standard bodies (e.g. test fakes returning a string).
+  return typeof body === "string" ? body : "";
+}
+
+/**
+ * JSON object store over S3. Pass a `client` to inject a fake in tests;
+ * defaults to a real S3 client built from `s3`.
+ */
+export function createS3Store(
+  s3: S3Config,
+  client: S3SendClient = createS3Client(s3),
+): S3ObjectStore {
+  const Bucket = s3.bucket;
+  return {
+    async getJSON<T>(key: string): Promise<T | null> {
+      try {
+        const res = (await client.send(
+          new GetObjectCommand({ Bucket, Key: key }),
+        )) as { Body?: unknown };
+        const text = await bodyToString(res.Body);
+        return text ? (JSON.parse(text) as T) : null;
+      } catch (err) {
+        if (isNotFound(err)) return null;
+        throw err;
+      }
+    },
+    async putJSON(key: string, value: unknown): Promise<void> {
+      await client.send(
+        new PutObjectCommand({
+          Bucket,
+          Key: key,
+          Body: JSON.stringify(value),
+          ContentType: "application/json",
+        }),
+      );
+    },
+    async delete(key: string): Promise<void> {
+      await client.send(new DeleteObjectCommand({ Bucket, Key: key }));
+    },
+    async exists(key: string): Promise<boolean> {
+      try {
+        await client.send(new HeadObjectCommand({ Bucket, Key: key }));
+        return true;
+      } catch (err) {
+        if (isNotFound(err)) return false;
+        throw err;
+      }
+    },
+  };
+}

--- a/packages/registry/src/run.ts
+++ b/packages/registry/src/run.ts
@@ -50,6 +50,7 @@ export async function runRegistry(args: RegistryCommandArgs) {
     authRenown,
     verdaccioSecret: verdaccioSecretArg,
     localPackages,
+    pluginsDir,
   } = args;
   const storagePath = await resolveDir(storageDir);
   const cdnCachePath = await resolveDir(cdnCacheDir);
@@ -114,7 +115,14 @@ export async function runRegistry(args: RegistryCommandArgs) {
           s3ForcePathStyle,
         },
       }),
+    ...(pluginsDir ? { pluginsDir } : {}),
   };
+
+  if (config.s3) {
+    console.log(
+      "[registry] S3-backed auth plugin active (persistent accounts + package ownership)",
+    );
+  }
   // Ensure directories exist (for relative paths resolved via findUp)
   await mkdir(storagePath, { recursive: true });
   await mkdir(cdnCachePath, { recursive: true });

--- a/packages/registry/src/types.ts
+++ b/packages/registry/src/types.ts
@@ -54,6 +54,10 @@ export interface RegistryConfig {
    *  re-publish a workspace package whose version already exists on npmjs
    *  without bumping (verdaccio would otherwise reject with 409). */
   localPackagePatterns?: string[];
+  /** Directory verdaccio loads the S3 auth plugin from. Defaults to the
+   *  `plugins` dir next to the compiled code (dist/plugins). Overridable so
+   *  tests can point at the built plugin while running from src. */
+  pluginsDir?: string;
 }
 
 export interface RegistryCommandArgs {
@@ -79,4 +83,6 @@ export interface RegistryCommandArgs {
   /** Comma-separated globs (e.g. "@powerhousedao/*,document-model,ph-cmd")
    *  served locally only — no npmjs uplink proxy. */
   localPackages?: string;
+  /** Override the dir verdaccio loads the S3 auth plugin from (tests). */
+  pluginsDir?: string;
 }

--- a/packages/registry/src/verdaccio-config.ts
+++ b/packages/registry/src/verdaccio-config.ts
@@ -1,10 +1,23 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { RegistryConfig } from "./types.js";
 
 export function buildVerdaccioConfig(config: RegistryConfig) {
   const htpasswdPath = path.join(config.storagePath, "htpasswd");
 
   const uplinkUrl = config.uplink ?? "https://registry.npmjs.org/";
+
+  // With S3 configured, use the S3-backed auth plugin (persistent accounts +
+  // npm-style package ownership). Verdaccio loads it via require() from the
+  // dist/plugins dir — a `.js` marked CommonJS by dist/plugins/package.json.
+  // Without S3 (local dev / tests), keep the built-in htpasswd path.
+  const useS3Auth = Boolean(config.s3);
+  const pluginsDir =
+    config.pluginsDir ??
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "plugins");
+  const auth = useS3Auth
+    ? { "s3-auth": { s3: config.s3 } }
+    : { htpasswd: { file: htpasswdPath } };
 
   const base: Record<string, unknown> = {
     storage: config.storagePath,
@@ -23,11 +36,8 @@ export function buildVerdaccioConfig(config: RegistryConfig) {
         },
       },
     },
-    auth: {
-      htpasswd: {
-        file: htpasswdPath,
-      },
-    },
+    auth,
+    ...(useS3Auth ? { plugins: pluginsDir } : {}),
     uplinks: {
       npmjs: {
         url: uplinkUrl,

--- a/packages/registry/tests/helpers/mock-s3.ts
+++ b/packages/registry/tests/helpers/mock-s3.ts
@@ -1,0 +1,93 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+/**
+ * Minimal in-process S3 mock for path-style requests
+ * (`<METHOD> /<bucket>/<key>`). Enough of the object API for the auth plugin's
+ * JSON store: PUT / GET / HEAD / DELETE. Ignores auth/signatures. The request
+ * path (after `/<bucket>/`) is the map key verbatim, so PUT and GET round-trip
+ * consistently regardless of key encoding.
+ */
+export interface MockS3 {
+  server: Server;
+  endpoint: string;
+  store: Map<string, Buffer>;
+  has(key: string): boolean;
+  close(): Promise<void>;
+}
+
+export async function startMockS3(bucket: string): Promise<MockS3> {
+  const store = new Map<string, Buffer>();
+  const prefix = `/${bucket}/`;
+
+  const server = createServer((req, res) => {
+    const url = req.url ?? "";
+    const pathOnly = url.split("?")[0];
+    const key = pathOnly.startsWith(prefix)
+      ? pathOnly.slice(prefix.length)
+      : pathOnly.replace(/^\//, "");
+
+    const notFound = () => {
+      res.statusCode = 404;
+      res.setHeader("content-type", "application/xml");
+      res.end(
+        `<?xml version="1.0"?><Error><Code>NoSuchKey</Code><Message>missing</Message></Error>`,
+      );
+    };
+
+    switch (req.method) {
+      case "PUT": {
+        const chunks: Buffer[] = [];
+        req.on("data", (c) => chunks.push(c as Buffer));
+        req.on("end", () => {
+          store.set(key, Buffer.concat(chunks));
+          res.setHeader("ETag", '"mock"');
+          res.statusCode = 200;
+          res.end();
+        });
+        return;
+      }
+      case "GET": {
+        const val = store.get(key);
+        if (!val) return notFound();
+        res.statusCode = 200;
+        res.setHeader("content-type", "application/json");
+        res.end(val);
+        return;
+      }
+      case "HEAD": {
+        if (!store.has(key)) {
+          res.statusCode = 404;
+          res.end();
+          return;
+        }
+        res.statusCode = 200;
+        res.end();
+        return;
+      }
+      case "DELETE": {
+        store.delete(key);
+        res.statusCode = 204;
+        res.end();
+        return;
+      }
+      default:
+        res.statusCode = 405;
+        res.end();
+    }
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  return {
+    server,
+    endpoint: `http://127.0.0.1:${port}`,
+    store,
+    has: (key: string) => store.has(key),
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}

--- a/packages/registry/tests/s3-auth-integration.test.ts
+++ b/packages/registry/tests/s3-auth-integration.test.ts
@@ -1,0 +1,237 @@
+import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME,
+  DEFAULT_STORAGE_DIR_NAME,
+} from "../src/constants.js";
+import { runRegistry } from "../src/run.js";
+import { startMockS3, type MockS3 } from "./helpers/mock-s3.js";
+
+const BUCKET = "powerhouse-registry";
+const KEY_PREFIX = "vetra/";
+
+// Verdaccio require()s the plugin from the BUILT dir; running from src, point
+// it at dist/plugins. Requires a prior `pnpm build` (the GATE runs build+test).
+const BUILT_PLUGINS_DIR = path.join(import.meta.dirname, "../dist/plugins");
+
+// Fail fast at collection time if the plugin isn't built (the GATE runs
+// build+test); this keeps setup/teardown simple below.
+if (!existsSync(path.join(BUILT_PLUGINS_DIR, "verdaccio-s3-auth.js"))) {
+  throw new Error(
+    "dist/plugins/verdaccio-s3-auth.js is missing — run `pnpm --filter @powerhousedao/registry build` before this integration test.",
+  );
+}
+
+async function bootRegistry(port: number, endpoint: string, workDir: string) {
+  await mkdir(path.join(workDir, DEFAULT_STORAGE_DIR_NAME), {
+    recursive: true,
+  });
+  await mkdir(path.join(workDir, DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME), {
+    recursive: true,
+  });
+  const server = await runRegistry({
+    port,
+    storageDir: path.join(workDir, DEFAULT_STORAGE_DIR_NAME),
+    cdnCacheDir: path.join(workDir, DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME),
+    uplink: undefined,
+    s3Bucket: BUCKET,
+    s3Endpoint: endpoint,
+    s3Region: "test",
+    s3AccessKeyId: "test",
+    s3SecretAccessKey: "test",
+    s3KeyPrefix: KEY_PREFIX,
+    s3ForcePathStyle: true,
+    webEnabled: false,
+    pluginsDir: BUILT_PLUGINS_DIR,
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  return server;
+}
+
+/**
+ * npm adduser/login flow. Sends Basic auth so verdaccio takes its login branch
+ * for an already-registered user (returns a token) instead of always routing to
+ * add_user (which 409s on an existing name). New users fall through to add_user
+ * and are created. Returns { status, token }.
+ */
+async function putUser(
+  url: string,
+  name: string,
+  password: string,
+): Promise<{ status: number; token?: string }> {
+  const basic = Buffer.from(`${name}:${password}`).toString("base64");
+  const res = await fetch(`${url}/-/user/org.couchdb.user:${name}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Basic ${basic}`,
+    },
+    body: JSON.stringify({ name, password }),
+  });
+  let token: string | undefined;
+  try {
+    token = ((await res.json()) as { token?: string }).token;
+  } catch {
+    /* no body */
+  }
+  return { status: res.status, token };
+}
+
+async function publish(
+  url: string,
+  token: string,
+  name: string,
+  version: string,
+): Promise<number> {
+  const tmpDir = path.join(import.meta.dirname, `.tmp-pub-${name}-${version}`);
+  execSync(`rm -rf "${tmpDir}" && mkdir -p "${tmpDir}"`);
+  writeFileSync(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ name, version, description: "t" }),
+  );
+  writeFileSync(path.join(tmpDir, "index.js"), "module.exports = 1;");
+  const tgz = execSync("npm pack --pack-destination .", {
+    cwd: tmpDir,
+    encoding: "utf-8",
+  }).trim();
+  const tarball = readFileSync(path.join(tmpDir, tgz));
+  execSync(`rm -rf "${tmpDir}"`);
+  const shasum = createHash("sha1").update(tarball).digest("hex");
+  const shortName = name.startsWith("@") ? name.split("/")[1] : name;
+
+  const res = await fetch(`${url}/${encodeURIComponent(name)}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      _id: name,
+      name,
+      "dist-tags": { latest: version },
+      versions: {
+        [version]: {
+          name,
+          version,
+          dist: {
+            tarball: `${url}/${name}/-/${shortName}-${version}.tgz`,
+            shasum,
+          },
+        },
+      },
+      _attachments: {
+        [`${shortName}-${version}.tgz`]: {
+          content_type: "application/octet-stream",
+          data: tarball.toString("base64"),
+          length: tarball.length,
+        },
+      },
+    }),
+  });
+  return res.status;
+}
+
+describe("s3 auth plugin — loads + accounts (integration, mock S3)", () => {
+  const PORT = 8283;
+  const URL = `http://localhost:${PORT}`;
+  const workDir = path.join(import.meta.dirname, "./.test-output-s3auth");
+  let mock: MockS3;
+  let server: Awaited<ReturnType<typeof runRegistry>>;
+
+  beforeAll(async () => {
+    await rm(workDir, { recursive: true, force: true });
+    mock = await startMockS3(BUCKET);
+    server = await bootRegistry(PORT, mock.endpoint, workDir);
+  }, 30000);
+
+  afterAll(async () => {
+    server.close();
+    await mock.close();
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  it("adduser goes through the plugin and writes the account to S3 (not htpasswd)", async () => {
+    const r = await putUser(URL, "alice", "pw-alice");
+    expect(r.status).toBeLessThan(300);
+    expect(r.token).toBeTruthy();
+    // The load-bearing proof the plugin is in effect: the account object lives
+    // in the S3 mock. htpasswd would have written a local file instead.
+    expect(mock.has(`${KEY_PREFIX}auth/users/alice.json`)).toBe(true);
+  });
+
+  it("registering an existing username with a different password is rejected", async () => {
+    const r = await putUser(URL, "alice", "different-pw");
+    expect(r.status).toBeGreaterThanOrEqual(400);
+    // And the original credentials still work — the account was not hijacked.
+    const relogin = await putUser(URL, "alice", "pw-alice");
+    expect(relogin.status).toBeLessThan(300);
+    expect(relogin.token).toBeTruthy();
+  });
+});
+
+describe("s3 auth plugin — ownership + persistence (integration, mock S3)", () => {
+  const PORT = 8284;
+  const URL = `http://localhost:${PORT}`;
+  const workDir = path.join(import.meta.dirname, "./.test-output-s3own");
+  let mock: MockS3;
+  let server: Awaited<ReturnType<typeof runRegistry>>;
+
+  beforeAll(async () => {
+    await rm(workDir, { recursive: true, force: true });
+    mock = await startMockS3(BUCKET);
+    server = await bootRegistry(PORT, mock.endpoint, workDir);
+  }, 30000);
+
+  afterAll(async () => {
+    server.close();
+    await mock.close();
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  it("first publisher claims a name; a different user gets 403", async () => {
+    const alice = await putUser(URL, "alice", "pw-a");
+    const bob = await putUser(URL, "bob", "pw-b");
+    expect(alice.token && bob.token).toBeTruthy();
+
+    const claim = await publish(URL, alice.token!, "owned-pkg", "1.0.0");
+    expect(claim).toBeLessThan(300);
+    expect(mock.has(`${KEY_PREFIX}auth/owners/owned-pkg.json`)).toBe(true);
+
+    const foreign = await publish(URL, bob.token!, "owned-pkg", "1.0.1");
+    expect(foreign).toBe(403);
+
+    // A free name is still claimable by bob.
+    const free = await publish(URL, bob.token!, "bob-pkg", "1.0.0");
+    expect(free).toBeLessThan(300);
+  });
+
+  it("accounts + ownership survive a fresh registry instance on the same S3", async () => {
+    // Simulate a pod redeploy / a second replica: a brand-new registry
+    // process pointed at the same S3 state.
+    const PORT2 = 8285;
+    const URL2 = `http://localhost:${PORT2}`;
+    const workDir2 = path.join(import.meta.dirname, "./.test-output-s3own2");
+    await rm(workDir2, { recursive: true, force: true });
+    const server2 = await bootRegistry(PORT2, mock.endpoint, workDir2);
+    try {
+      // alice authenticates against the new instance (account persisted).
+      const relogin = await putUser(URL2, "alice", "pw-a");
+      expect(relogin.status).toBeLessThan(300);
+      expect(relogin.token).toBeTruthy();
+      // bob still can't take alice's package (ownership persisted).
+      const bob = await putUser(URL2, "bob", "pw-b");
+      const foreign = await publish(URL2, bob.token!, "owned-pkg", "2.0.0");
+      expect(foreign).toBe(403);
+    } finally {
+      server2.close();
+      await rm(workDir2, { recursive: true, force: true });
+    }
+  }, 30000);
+});

--- a/packages/registry/tests/s3-auth-plugin.test.ts
+++ b/packages/registry/tests/s3-auth-plugin.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { createS3AuthPlugin } from "../src/auth/s3-auth-plugin.js";
+import type { S3ObjectStore } from "../src/auth/s3-store.js";
+
+/** In-memory S3ObjectStore for the plugin's persistence layer. */
+function memStore(): S3ObjectStore & { keys: () => string[] } {
+  const m = new Map<string, string>();
+  return {
+    getJSON<T>(k: string) {
+      return Promise.resolve(
+        m.has(k) ? (JSON.parse(m.get(k) as string) as T) : null,
+      );
+    },
+    putJSON(k: string, v: unknown) {
+      m.set(k, JSON.stringify(v));
+      return Promise.resolve();
+    },
+    delete(k: string) {
+      m.delete(k);
+      return Promise.resolve();
+    },
+    exists(k: string) {
+      return Promise.resolve(m.has(k));
+    },
+    keys: () => [...m.keys()],
+  };
+}
+
+type Result = { err: Error | null; res?: unknown };
+function call(
+  fn: (cb: (err: Error | null, res?: unknown) => void) => void,
+): Promise<Result> {
+  return new Promise((resolve) => fn((err, res) => resolve({ err, res })));
+}
+
+function status(err: Error | null): number | undefined {
+  if (!err) return undefined;
+  const e = err as { status?: number; statusCode?: number };
+  return e.status ?? e.statusCode;
+}
+
+const PREFIX = "vetra/";
+
+describe("s3 auth plugin — accounts", () => {
+  it("adduser registers a new user, then authenticate succeeds", async () => {
+    const store = memStore();
+    const p = createS3AuthPlugin(store, PREFIX);
+
+    const add = await call((cb) => p.adduser("alice", "pw1", cb));
+    expect(add.err).toBeNull();
+    expect(add.res).toBe(true);
+    expect(store.keys()).toContain("vetra/auth/users/alice.json");
+
+    const auth = await call((cb) => p.authenticate("alice", "pw1", cb));
+    expect(auth.err).toBeNull();
+    expect(auth.res).toEqual(["alice"]);
+  });
+
+  it("adduser on an existing username is rejected (no silent overwrite / 201)", async () => {
+    const store = memStore();
+    const p = createS3AuthPlugin(store, PREFIX);
+    await call((cb) => p.adduser("alice", "pw1", cb));
+
+    const again = await call((cb) => p.adduser("alice", "different", cb));
+    expect(again.err).not.toBeNull();
+    expect(status(again.err)).toBe(409);
+  });
+
+  it("authenticate with a wrong password errors", async () => {
+    const store = memStore();
+    const p = createS3AuthPlugin(store, PREFIX);
+    await call((cb) => p.adduser("alice", "pw1", cb));
+
+    const bad = await call((cb) => p.authenticate("alice", "wrong", cb));
+    expect(bad.err).not.toBeNull();
+    expect(status(bad.err)).toBe(401);
+  });
+
+  it("authenticate for an unknown user defers (no error, not authenticated)", async () => {
+    const store = memStore();
+    const p = createS3AuthPlugin(store, PREFIX);
+    const res = await call((cb) => p.authenticate("ghost", "pw", cb));
+    expect(res.err).toBeNull();
+    expect(res.res).toBe(false);
+  });
+});
+
+describe("s3 auth plugin — ownership (npm-style TOFU)", () => {
+  const alice = { name: "alice", groups: [] };
+  const bob = { name: "bob", groups: [] };
+
+  it("first publisher claims a free name; owner object is written", async () => {
+    const store = memStore();
+    const p = createS3AuthPlugin(store, PREFIX);
+
+    const pub = await call((cb) =>
+      p.allow_publish(alice, { name: "pkg-x" }, cb),
+    );
+    expect(pub.err).toBeNull();
+    expect(pub.res).toBe(true);
+    expect(store.keys()).toContain("vetra/auth/owners/pkg-x.json");
+    expect(await store.getJSON("vetra/auth/owners/pkg-x.json")).toMatchObject({
+      owners: ["alice"],
+    });
+  });
+
+  it("the owner may publish again", async () => {
+    const store = memStore();
+    const p = createS3AuthPlugin(store, PREFIX);
+    await call((cb) => p.allow_publish(alice, { name: "pkg-x" }, cb));
+
+    const again = await call((cb) =>
+      p.allow_publish(alice, { name: "pkg-x" }, cb),
+    );
+    expect(again.err).toBeNull();
+    expect(again.res).toBe(true);
+  });
+
+  it("a different user is forbidden from publishing an owned name", async () => {
+    const store = memStore();
+    const p = createS3AuthPlugin(store, PREFIX);
+    await call((cb) => p.allow_publish(alice, { name: "pkg-x" }, cb));
+
+    const foreign = await call((cb) =>
+      p.allow_publish(bob, { name: "pkg-x" }, cb),
+    );
+    expect(foreign.err).not.toBeNull();
+    expect(status(foreign.err)).toBe(403);
+  });
+
+  it("unauthenticated publish is forbidden", async () => {
+    const store = memStore();
+    const p = createS3AuthPlugin(store, PREFIX);
+    const anon = await call((cb) =>
+      p.allow_publish({ name: null }, { name: "pkg-y" }, cb),
+    );
+    expect(anon.err).not.toBeNull();
+    expect(status(anon.err)).toBe(403);
+  });
+
+  it("scoped names are keyed safely (encoded)", async () => {
+    const store = memStore();
+    const p = createS3AuthPlugin(store, PREFIX);
+    const pub = await call((cb) =>
+      p.allow_publish(alice, { name: "@scope/pkg" }, cb),
+    );
+    expect(pub.err).toBeNull();
+    expect(store.keys()).toContain("vetra/auth/owners/%40scope%2Fpkg.json");
+  });
+});
+
+describe("s3 auth plugin — unpublish + access", () => {
+  const alice = { name: "alice", groups: [] };
+  const bob = { name: "bob", groups: [] };
+
+  it("only the owner may unpublish; others 403; unclaimed 403", async () => {
+    const store = memStore();
+    const p = createS3AuthPlugin(store, PREFIX);
+    await call((cb) => p.allow_publish(alice, { name: "pkg-x" }, cb)); // alice owns
+
+    const byOwner = await call((cb) =>
+      p.allow_unpublish(alice, { name: "pkg-x" }, cb),
+    );
+    expect(byOwner.res).toBe(true);
+
+    const byOther = await call((cb) =>
+      p.allow_unpublish(bob, { name: "pkg-x" }, cb),
+    );
+    expect(status(byOther.err)).toBe(403);
+
+    const unclaimed = await call((cb) =>
+      p.allow_unpublish(alice, { name: "nope" }, cb),
+    );
+    expect(status(unclaimed.err)).toBe(403);
+  });
+
+  it("allow_access permits anonymous read", async () => {
+    const store = memStore();
+    const p = createS3AuthPlugin(store, PREFIX);
+    const res = await call((cb) =>
+      p.allow_access({ name: null }, { name: "anything" }, cb),
+    );
+    expect(res.err).toBeNull();
+    expect(res.res).toBe(true);
+  });
+});

--- a/packages/registry/tests/s3-store.test.ts
+++ b/packages/registry/tests/s3-store.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { createS3Store, type S3SendClient } from "../src/auth/s3-store.js";
+import type { S3Config } from "../src/types.js";
+
+const s3: S3Config = {
+  bucket: "test-bucket",
+  endpoint: "https://s3.test",
+  region: "test",
+};
+
+/** In-memory fake dispatching on the real AWS command class names, so no
+ *  network or real SDK client is touched. */
+class FakeS3 implements S3SendClient {
+  store = new Map<string, string>();
+  send(command: unknown): Promise<unknown> {
+    const cmd = command as {
+      constructor: { name: string };
+      input: Record<string, string>;
+    };
+    const name = cmd.constructor.name;
+    const key = cmd.input.Key;
+    switch (name) {
+      case "PutObjectCommand":
+        this.store.set(key, cmd.input.Body);
+        return Promise.resolve({});
+      case "GetObjectCommand": {
+        if (!this.store.has(key)) return Promise.reject(notFound("NoSuchKey"));
+        const body = this.store.get(key);
+        return Promise.resolve({
+          Body: { transformToString: () => Promise.resolve(body) },
+        });
+      }
+      case "HeadObjectCommand":
+        return this.store.has(key)
+          ? Promise.resolve({})
+          : Promise.reject(notFound("NotFound"));
+      case "DeleteObjectCommand":
+        this.store.delete(key);
+        return Promise.resolve({});
+      default:
+        return Promise.reject(new Error(`unexpected command ${name}`));
+    }
+  }
+}
+
+function notFound(errName: string): Error {
+  const e = new Error(errName) as Error & {
+    name: string;
+    $metadata: { httpStatusCode: number };
+  };
+  e.name = errName;
+  e.$metadata = { httpStatusCode: 404 };
+  return e;
+}
+
+describe("createS3Store", () => {
+  it("round-trips putJSON → getJSON", async () => {
+    const store = createS3Store(s3, new FakeS3());
+    await store.putJSON("auth/users/alice.json", { name: "alice", n: 1 });
+    expect(await store.getJSON("auth/users/alice.json")).toEqual({
+      name: "alice",
+      n: 1,
+    });
+  });
+
+  it("getJSON returns null for a missing key (not a throw)", async () => {
+    const store = createS3Store(s3, new FakeS3());
+    expect(await store.getJSON("auth/users/ghost.json")).toBeNull();
+  });
+
+  it("exists reflects presence, false for a missing key", async () => {
+    const store = createS3Store(s3, new FakeS3());
+    expect(await store.exists("k")).toBe(false);
+    await store.putJSON("k", { a: 1 });
+    expect(await store.exists("k")).toBe(true);
+  });
+
+  it("delete removes an object", async () => {
+    const store = createS3Store(s3, new FakeS3());
+    await store.putJSON("k", { a: 1 });
+    await store.delete("k");
+    expect(await store.exists("k")).toBe(false);
+    expect(await store.getJSON("k")).toBeNull();
+  });
+
+  it("propagates non-404 errors", async () => {
+    const broken: S3SendClient = {
+      send() {
+        return Promise.reject(new Error("kaboom"));
+      },
+    };
+    const store = createS3Store(s3, broken);
+    await expect(store.getJSON("k")).rejects.toThrow("kaboom");
+  });
+});

--- a/packages/registry/tests/verdaccio-config.test.ts
+++ b/packages/registry/tests/verdaccio-config.test.ts
@@ -5,6 +5,15 @@ import { buildVerdaccioConfig } from "../src/verdaccio-config.js";
 type VerdaccioConfig = ReturnType<typeof buildVerdaccioConfig> & {
   uplinks: Record<string, { url: string; maxage: string }>;
   packages: Record<string, { proxy?: string }>;
+  auth: Record<string, unknown>;
+  plugins?: string;
+};
+
+const s3Config = {
+  bucket: "powerhouse-registry",
+  endpoint: "https://s3.example",
+  region: "test",
+  keyPrefix: "vetra/",
 };
 
 function baseConfig(overrides: Partial<RegistryConfig> = {}): RegistryConfig {
@@ -56,5 +65,24 @@ describe("buildVerdaccioConfig", () => {
     ) as VerdaccioConfig;
 
     expect(cfg.uplinks.npmjs.maxage).toBe("30s");
+  });
+
+  it("uses the htpasswd auth path and no plugins dir when S3 is absent", () => {
+    const cfg = buildVerdaccioConfig(baseConfig()) as VerdaccioConfig;
+
+    expect(cfg.auth.htpasswd).toBeDefined();
+    expect(cfg.auth["s3-auth"]).toBeUndefined();
+    expect(cfg.plugins).toBeUndefined();
+  });
+
+  it("wires the s3-auth plugin (with plugins dir) when S3 is configured", () => {
+    const cfg = buildVerdaccioConfig(
+      baseConfig({ s3: s3Config }),
+    ) as VerdaccioConfig;
+
+    expect(cfg.auth["s3-auth"]).toEqual({ s3: s3Config });
+    expect(cfg.auth.htpasswd).toBeUndefined();
+    expect(cfg.plugins).toBeDefined();
+    expect(cfg.plugins?.endsWith("/plugins")).toBe(true);
   });
 });

--- a/packages/registry/tsdown.config.ts
+++ b/packages/registry/tsdown.config.ts
@@ -1,9 +1,24 @@
 import { defineConfig } from "tsdown";
 
-export default defineConfig({
-  entry: "./cli.ts",
-  outDir: "dist",
-  clean: true,
-  dts: true,
-  sourcemap: true,
-});
+export default defineConfig([
+  {
+    entry: "./cli.ts",
+    outDir: "dist",
+    clean: true,
+    dts: true,
+    sourcemap: true,
+  },
+  {
+    // Verdaccio auth plugin, loaded via require() from dist/plugins at runtime.
+    // Must be CommonJS AND emitted as `.js` — require() won't resolve a `.cjs`
+    // by name; the `dist/plugins/package.json {"type":"commonjs"}` (written by
+    // copy-dirs) makes the `.js` CommonJS despite the package being type:module.
+    entry: { "verdaccio-s3-auth": "./src/auth/s3-auth-plugin.ts" },
+    outDir: "dist/plugins",
+    format: "cjs",
+    clean: false,
+    dts: false,
+    sourcemap: false,
+    outExtensions: () => ({ js: ".js" }),
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2321,15 +2321,24 @@ importers:
 
   packages/registry:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.700.0
+        version: 3.1082.0
       '@powerhousedao/shared':
         specifier: workspace:*
         version: link:../shared
       '@renown/sdk':
         specifier: workspace:*
         version: link:../renown
+      '@verdaccio/core':
+        specifier: 8.0.0-next-8.37
+        version: 8.0.0-next-8.37
       '@verdaccio/signature':
         specifier: 8.0.0-next-8.29
         version: 8.0.0-next-8.29
+      bcryptjs:
+        specifier: ^2.4.3
+        version: 2.4.3
       cmd-ts:
         specifier: 'catalog:'
         version: 0.15.0
@@ -2349,6 +2358,9 @@ importers:
         specifier: ^10.4.0
         version: 10.4.0
     devDependencies:
+      '@types/bcryptjs':
+        specifier: ^2.4.6
+        version: 2.4.6
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -2363,7 +2375,7 @@ importers:
         version: 7.2.2
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@5.9.3)
+        version: 0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/browser-playwright@4.1.1)(happy-dom@20.9.0)(jsdom@24.1.3)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@8.0.10(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -3567,6 +3579,78 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@aws-sdk/checksums@3.1000.15':
+    resolution: {integrity: sha512-hAdQvjHv7zijjhjumod+/k0xxlJEoKKKCuXarKturk3KebbVpzCo8k3XmobI6M7qK5Y3Zhnr9CUQJxrcPSQ80A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1082.0':
+    resolution: {integrity: sha512-vY3uUgjYSWH+enoupP3NJ2iTYaGWc1jAjt7QdjyQLzEXZ9nCjbCZKUoHk5ZuBTgAGDhcOUvRkCxpHj1BA5AFvA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.975.0':
+    resolution: {integrity: sha512-rro0KMJz0XBZw1HChXXgylx9aaf60ITyBmZtH0x+9QG6u3SOoyM81LI9ONSGQe0nuN4554LOg4xKIY7frHpgmg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.56':
+    resolution: {integrity: sha512-cjFAqXcfmzxOyNE7vGfe8XTju6JJ7ch/2w+vr/mqQMdxukSkBpkaWd3ewXpaBQ7FP+IKYLT5eHjvwqCUQua8DA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.58':
+    resolution: {integrity: sha512-UTHgQ6j3IkOMYLXXWpil56RfprNfx+GWKdGiwhWBqKNSnxm43uH1erWg2fDv+/qPndz+wwmiLlfRArQZFmtO0Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.0':
+    resolution: {integrity: sha512-KZKwYIv7ZwcZuWWz1bb7MAr8rChzZzDXbNWNVxZlh6tbG+WwwdBBvyIwrzvCOSV+/7/q+gyd5uiAfDSK+61/1Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.62':
+    resolution: {integrity: sha512-RKVpKRuq2xSzidsSMIgFXBUvfeTP3Tu9F7FnCi6dyyjbwYupOwa+liJYu7fyhqpLUSKg+NAEFfUQvg1791Wb2Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.65':
+    resolution: {integrity: sha512-0+AbSk0KOk+5VR12KHy4PM2SDgGmO8tcdTVVSyvfG0k043i8sq4x7jSLTzNTI+BxUMjteIPSqFc8AfYm/PjxoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.56':
+    resolution: {integrity: sha512-PC8w9452qVJCf0ZaGq/Gf7uxq2oX8dIE8ON//uoRt8Smhq3ihSWwSVdlFMIK89MCN53+wwif62FL/+sudBFpJQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.0':
+    resolution: {integrity: sha512-ZCe6i8p6jl3OUKV1l8aOWI/gNUjFH/94M0LqfsRit7qGt0HdK+fdsqDOlH2H3yw15WUsFCJ+r1xqsE6kSdPVlw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.62':
+    resolution: {integrity: sha512-CrGUTJlMSkecTSSSA4J/BC+VmzXAgVXDkRKj4Wy1EvrsZPaT0L9tiCly6VPSfJTM4ypokARht+IgDSk38gmh9w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.61':
+    resolution: {integrity: sha512-L3YKtSu81xFfjUaNYJTPEWNz0KSPfKGDcDcblRC/JxVJ7/BNTskIX1lSWRd9nRKZg+3ilgvw7FTwCNPKJ0PAPQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.30':
+    resolution: {integrity: sha512-ZQpvaE4gKKChXIyU5nn/jJeA5TixpWeb3KToovyQ+Hj2HPHkTIjCWirnDHG9Za1HNwTFP4NHdAtuNuEU0PqDww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.39':
+    resolution: {integrity: sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1082.0':
+    resolution: {integrity: sha512-adHOgJ97jv3QkN8w9TNrDx+3SKAIi1+ihCsv2n4/hYMIvCuzD0QA6vgPGeb/R3fYk9ZVXD2/0SaluR0izcAY/Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.0':
+    resolution: {integrity: sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.34':
+    resolution: {integrity: sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -8932,6 +9016,30 @@ packages:
   '@slorber/remark-comment@1.0.0':
     resolution: {integrity: sha512-RCE24n7jsOj1M0UPvIQCHTe7fI0sFL4S2nwKVWwHyVr/wI/H8GosgsJGyhnsZoGFnD/P2hLf1mSbrrgSLN93NA==}
 
+  '@smithy/core@3.29.2':
+    resolution: {integrity: sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.7':
+    resolution: {integrity: sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.4':
+    resolution: {integrity: sha512-psnst7NZWdAEvJvyW8YZEE7xNVMyLrQFfHtyrVFrxNyy+dKWkQ+rqC6oI5ZhxThpUy9RSfEshgm34zqbOxzsRw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.4':
+    resolution: {integrity: sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.3':
+    resolution: {integrity: sha512-8qVKKzqh7naF27ePmx0SkUfnGP/wBI9dyaeAmhHvopnbIlItUAmB/e6PkPCU3rRb2v9BY8D4EZXSoydSibatvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.0':
+    resolution: {integrity: sha512-aVUabzlBBmY0PfvVgLKQSOGFIL5/7R54JE3uD9a5Ay/jSED61SkuAcCYENNXJzYUvJ1NPrWO0P+rAXHCkbBUKw==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -9604,6 +9712,9 @@ packages:
 
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/bcryptjs@2.4.6':
+    resolution: {integrity: sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -11032,6 +11143,9 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   boxen@5.1.2:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
@@ -20093,6 +20207,171 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
+  '@aws-sdk/checksums@3.1000.15':
+    dependencies:
+      '@aws-sdk/core': 3.975.0
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1082.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.15
+      '@aws-sdk/core': 3.975.0
+      '@aws-sdk/credential-provider-node': 3.972.65
+      '@aws-sdk/middleware-sdk-s3': 3.972.61
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/node-http-handler': 4.9.4
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.975.0':
+    dependencies:
+      '@aws-sdk/types': 3.974.0
+      '@aws-sdk/xml-builder': 3.972.34
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.2
+      '@smithy/signature-v4': 5.6.3
+      '@smithy/types': 4.16.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.56':
+    dependencies:
+      '@aws-sdk/core': 3.975.0
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.58':
+    dependencies:
+      '@aws-sdk/core': 3.975.0
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/node-http-handler': 4.9.4
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.0
+      '@aws-sdk/credential-provider-env': 3.972.56
+      '@aws-sdk/credential-provider-http': 3.972.58
+      '@aws-sdk/credential-provider-login': 3.972.62
+      '@aws-sdk/credential-provider-process': 3.972.56
+      '@aws-sdk/credential-provider-sso': 3.973.0
+      '@aws-sdk/credential-provider-web-identity': 3.972.62
+      '@aws-sdk/nested-clients': 3.997.30
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/credential-provider-imds': 4.4.7
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.62':
+    dependencies:
+      '@aws-sdk/core': 3.975.0
+      '@aws-sdk/nested-clients': 3.997.30
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.65':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.56
+      '@aws-sdk/credential-provider-http': 3.972.58
+      '@aws-sdk/credential-provider-ini': 3.973.0
+      '@aws-sdk/credential-provider-process': 3.972.56
+      '@aws-sdk/credential-provider-sso': 3.973.0
+      '@aws-sdk/credential-provider-web-identity': 3.972.62
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/credential-provider-imds': 4.4.7
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.56':
+    dependencies:
+      '@aws-sdk/core': 3.975.0
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.0
+      '@aws-sdk/nested-clients': 3.997.30
+      '@aws-sdk/token-providers': 3.1082.0
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.62':
+    dependencies:
+      '@aws-sdk/core': 3.975.0
+      '@aws-sdk/nested-clients': 3.997.30
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.975.0
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.30':
+    dependencies:
+      '@aws-sdk/core': 3.975.0
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/node-http-handler': 4.9.4
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.39':
+    dependencies:
+      '@aws-sdk/types': 3.974.0
+      '@smithy/signature-v4': 5.6.3
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1082.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.0
+      '@aws-sdk/nested-clients': 3.997.30
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.0':
+    dependencies:
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.34':
+    dependencies:
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -25451,6 +25730,14 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@oxc-resolver/binding-wasm32-wasi@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@oxc-resolver/binding-wasm32-wasi@5.3.0':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.12
@@ -26713,6 +27000,14 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16':
     optional: true
 
@@ -27164,6 +27459,39 @@ snapshots:
       micromark-factory-space: 1.1.0
       micromark-util-character: 1.2.0
       micromark-util-symbol: 1.1.0
+
+  '@smithy/core@3.29.2':
+    dependencies:
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.7':
+    dependencies:
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.4':
+    dependencies:
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.4':
+    dependencies:
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.3':
+    dependencies:
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.0':
+    dependencies:
+      tslib: 2.8.1
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -27842,6 +28170,22 @@ snapshots:
       - tsx
       - yaml
 
+  '@tsdown/css@0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(jiti@2.6.1)(postcss@8.5.12)(tsdown@0.21.1)(tsx@4.21.0)(yaml@2.8.3)':
+    dependencies:
+      lightningcss: 1.32.0
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(yaml@2.8.3)
+      rolldown: 1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      tsdown: 0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@5.9.3)
+    optionalDependencies:
+      postcss: 8.5.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - jiti
+      - tsx
+      - yaml
+    optional: true
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -27873,6 +28217,8 @@ snapshots:
   '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@types/bcryptjs@2.4.6': {}
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -27934,11 +28280,11 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   '@types/eslint@9.6.1':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
 
   '@types/esquery@1.5.4':
@@ -29769,6 +30115,8 @@ snapshots:
 
   boolbase@1.0.0: {}
 
+  bowser@2.14.1: {}
+
   boxen@5.1.2:
     dependencies:
       ansi-align: 3.0.1
@@ -31157,6 +31505,10 @@ snapshots:
     optionalDependencies:
       oxc-resolver: 11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
+  dts-resolver@2.1.3(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)):
+    optionalDependencies:
+      oxc-resolver: 11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -31872,7 +32224,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -36093,6 +36445,33 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.19.0
+      '@oxc-resolver/binding-android-arm64': 11.19.0
+      '@oxc-resolver/binding-darwin-arm64': 11.19.0
+      '@oxc-resolver/binding-darwin-x64': 11.19.0
+      '@oxc-resolver/binding-freebsd-x64': 11.19.0
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.19.0
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.19.0
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.19.0
+      '@oxc-resolver/binding-linux-arm64-musl': 11.19.0
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.19.0
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.19.0
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.19.0
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.19.0
+      '@oxc-resolver/binding-linux-x64-gnu': 11.19.0
+      '@oxc-resolver/binding-linux-x64-musl': 11.19.0
+      '@oxc-resolver/binding-openharmony-arm64': 11.19.0
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.19.0
+      '@oxc-resolver/binding-win32-ia32-msvc': 11.19.0
+      '@oxc-resolver/binding-win32-x64-msvc': 11.19.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   oxc-resolver@5.3.0:
     optionalDependencies:
       '@oxc-resolver/binding-darwin-arm64': 5.3.0
@@ -37907,6 +38286,23 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
+  rolldown-plugin-dts@0.22.5(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(rolldown@1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@5.9.3):
+    dependencies:
+      '@babel/generator': 8.0.0-rc.2
+      '@babel/helper-validator-identifier': 8.0.0-rc.2
+      '@babel/parser': 8.0.0-rc.2
+      '@babel/types': 8.0.0-rc.2
+      ast-kit: 3.0.0-beta.1
+      birpc: 4.0.0
+      dts-resolver: 2.1.3(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))
+      get-tsconfig: 4.13.7
+      obug: 2.1.1
+      rolldown: 1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - oxc-resolver
+
   rolldown@1.0.0-rc.16:
     dependencies:
       '@oxc-project/types': 0.126.0
@@ -37967,6 +38363,30 @@ snapshots:
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.8
       '@rolldown/binding-openharmony-arm64': 1.0.0-rc.8
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.8
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.8
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  rolldown@1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+    dependencies:
+      '@oxc-project/types': 0.115.0
+      '@rolldown/pluginutils': 1.0.0-rc.8
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.8
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.8
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.8
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.8
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.8
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.8
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.8
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.8
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.8
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.8
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.8
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.8
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.8
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.8
     transitivePeerDependencies:
@@ -39282,6 +39702,36 @@ snapshots:
       - synckit
       - vue-tsc
 
+  tsdown@0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@5.9.3):
+    dependencies:
+      ansis: 4.2.0
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.0
+      hookable: 6.1.1
+      import-without-cache: 0.2.5
+      obug: 2.1.1
+      picomatch: 4.0.4
+      rolldown: 1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      rolldown-plugin-dts: 0.22.5(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(rolldown@1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@5.9.3)
+      semver: 7.7.4
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      unrun: 0.2.36(synckit@0.11.12)
+    optionalDependencies:
+      '@tsdown/css': 0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(jiti@2.6.1)(postcss@8.5.12)(tsdown@0.21.1)(tsx@4.21.0)(yaml@2.8.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - synckit
+      - vue-tsc
+
   tslib@1.14.1: {}
 
   tslib@2.4.1: {}
@@ -40237,7 +40687,7 @@ snapshots:
   webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3):
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1


### PR DESCRIPTION
## Summary

Adds a Verdaccio auth plugin — **active only when S3 is configured** — that backs the registry's accounts and package ownership with S3:

- **Persistent accounts.** Accounts are stored in S3 instead of the per-pod `emptyDir` htpasswd, so a registered username is reserved across replicas and survives redeploys. Registering an existing username with a wrong password is rejected (409) instead of re-created.
- **npm-style package ownership (TOFU).** The first publisher of a name claims it (owner list stored in S3); any other user gets **403** on publish/unpublish. Free names stay claimable; reads stay anonymous. Self-registration stays open.

Without S3 (local dev / tests) the built-in htpasswd path is **unchanged**.

## Changes

- `src/auth/s3-store.ts` — small S3 JSON object store (injectable client for tests).
- `src/auth/s3-auth-plugin.ts` — `authenticate` / `adduser` + `allow_publish` / `allow_unpublish`; owner-store is a **list** of usernames (room for co-maintainers/orgs later).
- `verdaccio-config.ts` / `run.ts` — wire the plugin + `plugins` dir when `config.s3` is set; htpasswd otherwise.
- `tsdown.config.ts` / `copy-dirs.ts` — emit the plugin as a CommonJS file under `dist/plugins` (+ a `{"type":"commonjs"}` marker) so Verdaccio's loader can `require()` it by name.

## Tests

- Unit: S3 store round-trip + every plugin branch (register / dup-reject / wrong-pw, claim / owner-ok / foreign-403 / unauth, unpublish rules, anonymous read).
- Integration (real registry + in-process mock S3): `adduser` writes the account to S3, re-register with wrong password rejected, foreign publisher gets 403, and accounts + ownership survive a fresh registry instance on the same S3.
- `pnpm --filter @powerhousedao/registry build && test` → 9 files, 69 passed, 3 skipped. `tsc` clean, eslint 0 errors, prettier clean on changed files.