### PR TITLE
feat(registry): postgres-backed auth plugin with persistent accounts and package ownership

### DIFF
--- a/packages/registry/cli.ts
+++ b/packages/registry/cli.ts
@@ -140,6 +140,15 @@ export const registryCommand = command({
       defaultValue: () => process.env.PH_REGISTRY_LOCAL_PACKAGES,
       defaultValueIsSerializable: true,
     }),
+    databaseUrl: option({
+      long: "database-url",
+      type: optional(string),
+      description:
+        "Postgres connection string. When set, the registry uses the DB-backed auth plugin (persistent accounts + npm-style package ownership) instead of the built-in htpasswd.",
+      defaultValue: () =>
+        process.env.PH_REGISTRY_DATABASE_URL ?? process.env.DATABASE_URL,
+      defaultValueIsSerializable: true,
+    }),
   },
   handler: async (args) => {
     console.log(args);

--- a/packages/registry/copy-dirs.ts
+++ b/packages/registry/copy-dirs.ts
@@ -1,4 +1,4 @@
-import { cp, access } from "node:fs/promises";
+import { cp, access, mkdir, writeFile } from "node:fs/promises";
 
 for (const dir of ["storage", "cdn-cache", "packages"]) {
   try {
@@ -8,3 +8,12 @@ for (const dir of ["storage", "cdn-cache", "packages"]) {
     // Directory doesn't exist yet, skip copy
   }
 }
+
+// Verdaccio loads the auth plugin with require(); mark dist/plugins as a
+// CommonJS scope so its emitted `.js` is treated as CJS even though the
+// package root is type:module.
+await mkdir("./dist/plugins", { recursive: true });
+await writeFile(
+  "./dist/plugins/package.json",
+  `${JSON.stringify({ type: "commonjs" })}\n`,
+);

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -38,19 +38,25 @@
   "dependencies": {
     "@powerhousedao/shared": "workspace:*",
     "@renown/sdk": "workspace:*",
+    "@verdaccio/core": "8.0.0-next-8.37",
     "@verdaccio/signature": "8.0.0-next-8.29",
+    "bcryptjs": "^2.4.3",
     "cmd-ts": "catalog:",
     "express": "^4.22.1",
     "find-up": "^8.0.0",
+    "pg": "catalog:",
     "tar": "^7.5.11",
     "verdaccio": "^6.5.0",
     "verdaccio-aws-s3-storage": "^10.4.0"
   },
   "devDependencies": {
     "tsdown": "catalog:",
+    "@types/bcryptjs": "^2.4.6",
     "@types/express": "^4.17.21",
     "@types/node": "catalog:",
+    "@types/pg": "catalog:",
     "@types/supertest": "^6.0.2",
+    "pg-mem": "^3.0.14",
     "supertest": "^7.1.0",
     "vitest": "catalog:"
   },

--- a/packages/registry/src/auth/auth-store.ts
+++ b/packages/registry/src/auth/auth-store.ts
@@ -1,0 +1,54 @@
+/**
+ * Persistence contract for the registry's accounts + package ownership.
+ *
+ * The ownership claim is **atomic** (`claimOwner`): the first publisher of a
+ * name wins even under a concurrent race, and everyone reads the same
+ * resulting owner set. This is the property a flat file / plain object store
+ * can't give and a relational DB can.
+ */
+export interface UserRecord {
+  passwordHash: string;
+}
+
+export interface AuthStore {
+  /** Create schema if needed. Safe to call repeatedly. */
+  init(): Promise<void>;
+  getUser(username: string): Promise<UserRecord | null>;
+  /** Atomic create. Returns false if the username already exists. */
+  createUser(username: string, passwordHash: string): Promise<boolean>;
+  getOwners(pkg: string): Promise<string[] | null>;
+  /**
+   * Atomically claim `pkg` for `username` if it has no owner, then return the
+   * resulting owner list. If already owned, returns the existing owners
+   * unchanged (so the caller checks membership to allow/deny).
+   */
+  claimOwner(pkg: string, username: string): Promise<string[]>;
+  close(): Promise<void>;
+}
+
+/**
+ * In-memory AuthStore for tests. JS is single-threaded so the map operations
+ * model the atomicity the real (Postgres) store enforces with constraints.
+ */
+export function createMemoryAuthStore(): AuthStore {
+  const users = new Map<string, UserRecord>();
+  const owners = new Map<string, string[]>();
+  return {
+    init: () => Promise.resolve(),
+    getUser: (u) => Promise.resolve(users.get(u) ?? null),
+    createUser: (u, passwordHash) => {
+      if (users.has(u)) return Promise.resolve(false);
+      users.set(u, { passwordHash });
+      return Promise.resolve(true);
+    },
+    getOwners: (pkg) => Promise.resolve(owners.get(pkg) ?? null),
+    claimOwner: (pkg, username) => {
+      const existing = owners.get(pkg);
+      if (existing) return Promise.resolve(existing);
+      const claimed = [username];
+      owners.set(pkg, claimed);
+      return Promise.resolve(claimed);
+    },
+    close: () => Promise.resolve(),
+  };
+}

--- a/packages/registry/src/auth/pg-store.ts
+++ b/packages/registry/src/auth/pg-store.ts
@@ -1,0 +1,93 @@
+import { Pool } from "pg";
+import type { AuthStore, UserRecord } from "./auth-store.js";
+
+/** Build a real Postgres pool from a connection string. */
+export function createPgPool(databaseUrl: string): Pool {
+  return new Pool({ connectionString: databaseUrl });
+}
+
+/**
+ * Postgres-backed AuthStore. Two small tables:
+ *  - registry_users(username PK, password_hash, created_at)
+ *  - registry_package_owners(package_name PK, owners text[], claimed_at)
+ *
+ * Ownership claim is race-free: `INSERT ... ON CONFLICT DO NOTHING` means the
+ * first publisher wins atomically; the follow-up read returns the actual
+ * owners so a losing racer is denied.
+ *
+ * Takes an already-built `pg.Pool` (tests inject a pg-mem pool cast to Pool).
+ */
+export function createPgStore(pool: Pool): AuthStore {
+  let initialized: Promise<void> | null = null;
+
+  return {
+    init(): Promise<void> {
+      initialized ??= (async () => {
+        await pool.query(`
+          CREATE TABLE IF NOT EXISTS registry_users (
+            username      text PRIMARY KEY,
+            password_hash text NOT NULL,
+            created_at    timestamptz NOT NULL DEFAULT now()
+          )`);
+        await pool.query(`
+          CREATE TABLE IF NOT EXISTS registry_package_owners (
+            package_name text PRIMARY KEY,
+            owners       text[] NOT NULL,
+            claimed_at   timestamptz NOT NULL DEFAULT now()
+          )`);
+      })();
+      return initialized;
+    },
+
+    async getUser(username: string): Promise<UserRecord | null> {
+      const res = await pool.query<{ password_hash: string }>(
+        "SELECT password_hash FROM registry_users WHERE username = $1",
+        [username],
+      );
+      const row = res.rows[0] as { password_hash: string } | undefined;
+      return row ? { passwordHash: row.password_hash } : null;
+    },
+
+    async createUser(username: string, passwordHash: string): Promise<boolean> {
+      // Atomic: the PRIMARY KEY enforces uniqueness. A duplicate raises a
+      // unique-violation (SQLSTATE 23505) — catch it as "already registered".
+      try {
+        await pool.query(
+          "INSERT INTO registry_users (username, password_hash) VALUES ($1, $2)",
+          [username, passwordHash],
+        );
+        return true;
+      } catch (err) {
+        if ((err as { code?: string }).code === "23505") return false;
+        throw err;
+      }
+    },
+
+    async getOwners(pkg: string): Promise<string[] | null> {
+      const res = await pool.query<{ owners: string[] }>(
+        "SELECT owners FROM registry_package_owners WHERE package_name = $1",
+        [pkg],
+      );
+      return res.rows[0]?.owners ?? null;
+    },
+
+    async claimOwner(pkg: string, username: string): Promise<string[]> {
+      // First publisher wins atomically; then read the actual owners.
+      await pool.query(
+        `INSERT INTO registry_package_owners (package_name, owners)
+         VALUES ($1, ARRAY[$2]::text[])
+         ON CONFLICT (package_name) DO NOTHING`,
+        [pkg, username],
+      );
+      const res = await pool.query<{ owners: string[] }>(
+        "SELECT owners FROM registry_package_owners WHERE package_name = $1",
+        [pkg],
+      );
+      return res.rows[0]?.owners ?? [];
+    },
+
+    close(): Promise<void> {
+      return pool.end();
+    },
+  };
+}

--- a/packages/registry/src/auth/registry-auth-plugin.ts
+++ b/packages/registry/src/auth/registry-auth-plugin.ts
@@ -1,0 +1,149 @@
+import { errorUtils } from "@verdaccio/core";
+import bcrypt from "bcryptjs";
+import { type AuthStore } from "./auth-store.js";
+import { createPgPool, createPgStore } from "./pg-store.js";
+
+/**
+ * Postgres-backed Verdaccio auth plugin.
+ *
+ * Replaces htpasswd with a shared, persistent store so accounts survive
+ * redeploys and are consistent across the registry's replicas, and adds
+ * npm-style package ownership (first publisher owns the name; others get 403).
+ * Active only when a database URL is configured; otherwise the registry keeps
+ * the built-in htpasswd path.
+ */
+export interface RegistryAuthPluginConfig {
+  databaseUrl?: string;
+  /** Injected store (tests). Takes precedence over databaseUrl. */
+  store?: AuthStore;
+}
+
+const BCRYPT_ROUNDS = 10;
+
+type AuthCallback = (err: Error | null, groups?: string[] | false) => void;
+type AuthUserCallback = (err: Error | null, ok?: boolean | string) => void;
+type AuthAccessCallback = (err: Error | null, ok?: boolean) => void;
+type AccessCallback = (err: Error | null, ok?: boolean) => void;
+type RemoteUserLike = { name?: string | null; groups?: string[] };
+type PackageLike = { name?: string };
+
+function internal(err: unknown): Error {
+  const msg = err instanceof Error ? err.message : String(err);
+  return errorUtils.getInternalError(msg);
+}
+
+/**
+ * Pure plugin factory over an injected store — the unit-testable core.
+ * `registryAuthPlugin` below wires it to a real Postgres store.
+ */
+export function createRegistryAuthPlugin(store: AuthStore) {
+  // Ensure the schema exists before any op; init() is idempotent + memoized.
+  const ready = store.init();
+
+  return {
+    authenticate(user: string, password: string, cb: AuthCallback): void {
+      ready
+        .then(() => store.getUser(user))
+        .then((rec) => {
+          if (!rec) return cb(null, false); // unknown user → not authenticated
+          if (!bcrypt.compareSync(password, rec.passwordHash)) {
+            return cb(errorUtils.getUnauthorized("bad username or password"));
+          }
+          return cb(null, [user]);
+        })
+        .catch((err) => cb(internal(err)));
+    },
+
+    adduser(user: string, password: string, cb: AuthUserCallback): void {
+      ready
+        .then(() =>
+          store.createUser(user, bcrypt.hashSync(password, BCRYPT_ROUNDS)),
+        )
+        .then((created) => {
+          // createUser is atomic: false means the name is taken — reject
+          // rather than silently overwrite (the htpasswd 201 hole).
+          if (!created) {
+            return cb(errorUtils.getConflict("username already registered"));
+          }
+          return cb(null, true);
+        })
+        .catch((err) => cb(internal(err)));
+    },
+
+    // Reads stay open ($all) — anonymous install works.
+    allow_access(
+      _user: RemoteUserLike,
+      _pkg: PackageLike,
+      cb: AccessCallback,
+    ): void {
+      cb(null, true);
+    },
+
+    allow_publish(
+      user: RemoteUserLike,
+      pkg: PackageLike,
+      cb: AuthAccessCallback,
+    ): void {
+      const name = pkg.name ?? "";
+      const username = user.name;
+      if (!username) {
+        return cb(
+          errorUtils.getForbidden("authentication required to publish"),
+        );
+      }
+      ready
+        .then(() => store.claimOwner(name, username))
+        .then((owners) => {
+          // Atomic claim already ran: if we're in the owner set, allow.
+          if (owners.includes(username)) return cb(null, true);
+          return cb(
+            errorUtils.getForbidden(
+              `not authorized to publish "${name}" (owned by another user)`,
+            ),
+          );
+        })
+        .catch((err) => cb(internal(err)));
+    },
+
+    allow_unpublish(
+      user: RemoteUserLike,
+      pkg: PackageLike,
+      cb: AuthAccessCallback,
+    ): void {
+      const name = pkg.name ?? "";
+      const username = user.name;
+      if (!username) {
+        return cb(
+          errorUtils.getForbidden("authentication required to unpublish"),
+        );
+      }
+      ready
+        .then(() => store.getOwners(name))
+        .then((owners) => {
+          if (owners && owners.includes(username)) return cb(null, true);
+          return cb(
+            errorUtils.getForbidden(`not authorized to unpublish "${name}"`),
+          );
+        })
+        .catch((err) => cb(internal(err)));
+    },
+  };
+}
+
+/** Verdaccio plugin entry. The loader calls this factory (or `new`s the
+ *  default export — both return the plugin object). */
+export default function registryAuthPlugin(config: RegistryAuthPluginConfig) {
+  const store =
+    config.store ??
+    createPgStore(
+      createPgPool(
+        config.databaseUrl ??
+          (() => {
+            throw new Error(
+              "registry-auth plugin requires a databaseUrl (or an injected store)",
+            );
+          })(),
+      ),
+    );
+  return createRegistryAuthPlugin(store);
+}

--- a/packages/registry/src/run.ts
+++ b/packages/registry/src/run.ts
@@ -50,6 +50,9 @@ export async function runRegistry(args: RegistryCommandArgs) {
     authRenown,
     verdaccioSecret: verdaccioSecretArg,
     localPackages,
+    databaseUrl,
+    pluginsDir,
+    authStore,
   } = args;
   const storagePath = await resolveDir(storageDir);
   const cdnCachePath = await resolveDir(cdnCacheDir);
@@ -114,7 +117,16 @@ export async function runRegistry(args: RegistryCommandArgs) {
           s3ForcePathStyle,
         },
       }),
+    ...(databaseUrl ? { databaseUrl } : {}),
+    ...(pluginsDir ? { pluginsDir } : {}),
+    ...(authStore ? { authStore } : {}),
   };
+
+  if (config.databaseUrl || config.authStore) {
+    console.log(
+      "[registry] Postgres-backed auth plugin active (persistent accounts + package ownership)",
+    );
+  }
   // Ensure directories exist (for relative paths resolved via findUp)
   await mkdir(storagePath, { recursive: true });
   await mkdir(cdnCachePath, { recursive: true });

--- a/packages/registry/src/types.ts
+++ b/packages/registry/src/types.ts
@@ -54,6 +54,17 @@ export interface RegistryConfig {
    *  re-publish a workspace package whose version already exists on npmjs
    *  without bumping (verdaccio would otherwise reject with 409). */
   localPackagePatterns?: string[];
+  /** Postgres connection string. When set, the registry uses the DB-backed
+   *  auth plugin (persistent accounts + package ownership) instead of the
+   *  built-in htpasswd. */
+  databaseUrl?: string;
+  /** Directory verdaccio loads the auth plugin from. Defaults to the
+   *  `plugins` dir next to the compiled code (dist/plugins). Overridable so
+   *  tests can point at the built plugin while running from src. */
+  pluginsDir?: string;
+  /** Injected AuthStore (tests only) — passed to the auth plugin instead of
+   *  building one from `databaseUrl`. */
+  authStore?: unknown;
 }
 
 export interface RegistryCommandArgs {
@@ -79,4 +90,10 @@ export interface RegistryCommandArgs {
   /** Comma-separated globs (e.g. "@powerhousedao/*,document-model,ph-cmd")
    *  served locally only — no npmjs uplink proxy. */
   localPackages?: string;
+  /** Postgres connection string for the DB-backed auth plugin. */
+  databaseUrl?: string;
+  /** Override the dir verdaccio loads the auth plugin from (tests). */
+  pluginsDir?: string;
+  /** Injected AuthStore (tests only). */
+  authStore?: unknown;
 }

--- a/packages/registry/src/verdaccio-config.ts
+++ b/packages/registry/src/verdaccio-config.ts
@@ -1,10 +1,28 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { RegistryConfig } from "./types.js";
 
 export function buildVerdaccioConfig(config: RegistryConfig) {
   const htpasswdPath = path.join(config.storagePath, "htpasswd");
 
   const uplinkUrl = config.uplink ?? "https://registry.npmjs.org/";
+
+  // With a database configured, use the Postgres-backed auth plugin
+  // (persistent accounts + npm-style package ownership). Verdaccio loads it
+  // via require() from the dist/plugins dir. Without a DB (local dev / tests),
+  // keep the built-in htpasswd path.
+  const usePgAuth = Boolean(config.databaseUrl || config.authStore);
+  const pluginsDir =
+    config.pluginsDir ??
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "plugins");
+  const auth = usePgAuth
+    ? {
+        "registry-auth": {
+          ...(config.databaseUrl ? { databaseUrl: config.databaseUrl } : {}),
+          ...(config.authStore ? { store: config.authStore } : {}),
+        },
+      }
+    : { htpasswd: { file: htpasswdPath } };
 
   const base: Record<string, unknown> = {
     storage: config.storagePath,
@@ -23,11 +41,8 @@ export function buildVerdaccioConfig(config: RegistryConfig) {
         },
       },
     },
-    auth: {
-      htpasswd: {
-        file: htpasswdPath,
-      },
-    },
+    auth,
+    ...(usePgAuth ? { plugins: pluginsDir } : {}),
     uplinks: {
       npmjs: {
         url: uplinkUrl,

--- a/packages/registry/tests/pg-store.test.ts
+++ b/packages/registry/tests/pg-store.test.ts
@@ -1,0 +1,51 @@
+import type { Pool } from "pg";
+import { newDb } from "pg-mem";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AuthStore } from "../src/auth/auth-store.js";
+import { createPgStore } from "../src/auth/pg-store.js";
+
+/** Fresh in-memory Postgres per test, wired to createPgStore via pg-mem's
+ *  node-postgres adapter (no real database needed). */
+function pgMemStore(): AuthStore {
+  const db = newDb();
+  const { Pool: PgMemPool } = db.adapters.createPg() as {
+    Pool: new () => unknown;
+  };
+  return createPgStore(new PgMemPool() as unknown as Pool);
+}
+
+describe("PgStore (pg-mem)", () => {
+  let store: AuthStore;
+
+  beforeEach(async () => {
+    store = pgMemStore();
+    await store.init();
+  });
+
+  it("createUser is atomic: second create of the same name returns false", async () => {
+    expect(await store.createUser("alice", "hash1")).toBe(true);
+    expect(await store.createUser("alice", "hash2")).toBe(false);
+    // original hash preserved (not overwritten)
+    expect(await store.getUser("alice")).toEqual({ passwordHash: "hash1" });
+  });
+
+  it("getUser returns null for an unknown user", async () => {
+    expect(await store.getUser("ghost")).toBeNull();
+  });
+
+  it("claimOwner claims a free name and is idempotent for the owner", async () => {
+    expect(await store.claimOwner("pkg-x", "alice")).toEqual(["alice"]);
+    // a second claim by a different user does NOT change ownership (ON CONFLICT)
+    expect(await store.claimOwner("pkg-x", "bob")).toEqual(["alice"]);
+    expect(await store.getOwners("pkg-x")).toEqual(["alice"]);
+  });
+
+  it("getOwners returns null for an unclaimed name", async () => {
+    expect(await store.getOwners("nope")).toBeNull();
+  });
+
+  it("init is idempotent (safe to call twice)", async () => {
+    await store.init();
+    expect(await store.createUser("bob", "h")).toBe(true);
+  });
+});

--- a/packages/registry/tests/registry-auth-integration.test.ts
+++ b/packages/registry/tests/registry-auth-integration.test.ts
@@ -1,0 +1,225 @@
+import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import type { Pool } from "pg";
+import { newDb, type IMemoryDb } from "pg-mem";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { AuthStore } from "../src/auth/auth-store.js";
+import { createPgStore } from "../src/auth/pg-store.js";
+import {
+  DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME,
+  DEFAULT_STORAGE_DIR_NAME,
+} from "../src/constants.js";
+import { runRegistry } from "../src/run.js";
+
+// Verdaccio require()s the plugin from the BUILT dir; running from src, point
+// it there. Requires a prior `pnpm build` (the GATE runs build+test).
+const BUILT_PLUGINS_DIR = path.join(import.meta.dirname, "../dist/plugins");
+if (!existsSync(path.join(BUILT_PLUGINS_DIR, "verdaccio-registry-auth.js"))) {
+  throw new Error(
+    "dist/plugins/verdaccio-registry-auth.js is missing — run `pnpm --filter @powerhousedao/registry build` first.",
+  );
+}
+
+/** A store over a shared pg-mem database — two stores over the same db model
+ *  two registry pods sharing one Postgres. */
+function storeFromDb(db: IMemoryDb): AuthStore {
+  const { Pool: PgMemPool } = db.adapters.createPg() as {
+    Pool: new () => unknown;
+  };
+  return createPgStore(new PgMemPool() as unknown as Pool);
+}
+
+async function bootRegistry(port: number, workDir: string, store: AuthStore) {
+  await mkdir(path.join(workDir, DEFAULT_STORAGE_DIR_NAME), {
+    recursive: true,
+  });
+  await mkdir(path.join(workDir, DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME), {
+    recursive: true,
+  });
+  const server = await runRegistry({
+    port,
+    storageDir: path.join(workDir, DEFAULT_STORAGE_DIR_NAME),
+    cdnCacheDir: path.join(workDir, DEFAULT_REGISTRY_CDN_CACHE_DIR_NAME),
+    uplink: undefined,
+    s3Bucket: undefined,
+    s3Endpoint: undefined,
+    s3Region: undefined,
+    s3AccessKeyId: undefined,
+    s3SecretAccessKey: undefined,
+    s3KeyPrefix: undefined,
+    s3ForcePathStyle: true,
+    webEnabled: false,
+    pluginsDir: BUILT_PLUGINS_DIR,
+    authStore: store,
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  return server;
+}
+
+/** npm login/adduser with Basic auth so verdaccio takes its login branch for
+ *  an existing user (returns a token) instead of always routing to add_user. */
+async function putUser(url: string, name: string, password: string) {
+  const basic = Buffer.from(`${name}:${password}`).toString("base64");
+  const res = await fetch(`${url}/-/user/org.couchdb.user:${name}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Basic ${basic}`,
+    },
+    body: JSON.stringify({ name, password }),
+  });
+  let token: string | undefined;
+  try {
+    token = ((await res.json()) as { token?: string }).token;
+  } catch {
+    /* no body */
+  }
+  return { status: res.status, token };
+}
+
+async function publish(
+  url: string,
+  token: string,
+  name: string,
+  version: string,
+): Promise<number> {
+  const tmpDir = path.join(
+    import.meta.dirname,
+    `.tmp-pgpub-${name}-${version}`,
+  );
+  execSync(`rm -rf "${tmpDir}" && mkdir -p "${tmpDir}"`);
+  writeFileSync(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ name, version, description: "t" }),
+  );
+  writeFileSync(path.join(tmpDir, "index.js"), "module.exports = 1;");
+  const tgz = execSync("npm pack --pack-destination .", {
+    cwd: tmpDir,
+    encoding: "utf-8",
+  }).trim();
+  const tarball = readFileSync(path.join(tmpDir, tgz));
+  execSync(`rm -rf "${tmpDir}"`);
+  const shasum = createHash("sha1").update(tarball).digest("hex");
+  const shortName = name.startsWith("@") ? name.split("/")[1] : name;
+  const res = await fetch(`${url}/${encodeURIComponent(name)}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      _id: name,
+      name,
+      "dist-tags": { latest: version },
+      versions: {
+        [version]: {
+          name,
+          version,
+          dist: {
+            tarball: `${url}/${name}/-/${shortName}-${version}.tgz`,
+            shasum,
+          },
+        },
+      },
+      _attachments: {
+        [`${shortName}-${version}.tgz`]: {
+          content_type: "application/octet-stream",
+          data: tarball.toString("base64"),
+          length: tarball.length,
+        },
+      },
+    }),
+  });
+  return res.status;
+}
+
+describe("registry auth plugin — accounts (integration, verdaccio + pg-mem)", () => {
+  const PORT = 8293;
+  const URL = `http://localhost:${PORT}`;
+  const workDir = path.join(import.meta.dirname, "./.test-output-pgauth");
+  let server: Awaited<ReturnType<typeof runRegistry>>;
+
+  beforeAll(async () => {
+    await rm(workDir, { recursive: true, force: true });
+    server = await bootRegistry(PORT, workDir, storeFromDb(newDb()));
+  }, 30000);
+
+  afterAll(async () => {
+    server.close();
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  it("adduser goes through the plugin (Postgres), then wrong-password re-register is rejected", async () => {
+    const r = await putUser(URL, "alice", "pw-alice");
+    expect(r.status).toBeLessThan(300);
+    expect(r.token).toBeTruthy();
+
+    const dup = await putUser(URL, "alice", "different-pw");
+    expect(dup.status).toBeGreaterThanOrEqual(400);
+
+    const relogin = await putUser(URL, "alice", "pw-alice");
+    expect(relogin.status).toBeLessThan(300);
+    expect(relogin.token).toBeTruthy();
+  });
+});
+
+describe("registry auth plugin — ownership + persistence (integration, verdaccio + pg-mem)", () => {
+  const PORT = 8294;
+  const URL = `http://localhost:${PORT}`;
+  const workDir = path.join(import.meta.dirname, "./.test-output-pgown");
+  const db = newDb(); // shared Postgres for both "pods"
+  const sharedStore = storeFromDb(db); // one pool over the shared db
+  let server: Awaited<ReturnType<typeof runRegistry>>;
+
+  beforeAll(async () => {
+    await rm(workDir, { recursive: true, force: true });
+    server = await bootRegistry(PORT, workDir, sharedStore);
+  }, 30000);
+
+  afterAll(async () => {
+    server.close();
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  it("first publisher claims a name; a different user gets 403; free names claimable", async () => {
+    const alice = await putUser(URL, "alice", "pw-a");
+    const bob = await putUser(URL, "bob", "pw-b");
+    expect(alice.token && bob.token).toBeTruthy();
+
+    expect(await publish(URL, alice.token!, "owned-pkg", "1.0.0")).toBeLessThan(
+      300,
+    );
+    expect(await publish(URL, bob.token!, "owned-pkg", "1.0.1")).toBe(403);
+    expect(await publish(URL, bob.token!, "bob-pkg", "1.0.0")).toBeLessThan(
+      300,
+    );
+  });
+
+  it("accounts + ownership survive a fresh registry instance on the same Postgres", async () => {
+    const PORT2 = 8295;
+    const URL2 = `http://localhost:${PORT2}`;
+    const workDir2 = path.join(import.meta.dirname, "./.test-output-pgown2");
+    await rm(workDir2, { recursive: true, force: true });
+    // A brand-new registry process over the SAME Postgres (second pod). Reuse
+    // the shared store: init() is memoized so tables aren't re-created (pg-mem
+    // can't re-run CREATE TABLE IF NOT EXISTS; real Postgres no-ops it fine).
+    const server2 = await bootRegistry(PORT2, workDir2, sharedStore);
+    try {
+      const relogin = await putUser(URL2, "alice", "pw-a");
+      expect(relogin.status).toBeLessThan(300);
+      expect(relogin.token).toBeTruthy();
+
+      const bob = await putUser(URL2, "bob", "pw-b");
+      expect(await publish(URL2, bob.token!, "owned-pkg", "2.0.0")).toBe(403);
+    } finally {
+      server2.close();
+      await rm(workDir2, { recursive: true, force: true });
+    }
+  }, 30000);
+});

--- a/packages/registry/tests/registry-auth-plugin.test.ts
+++ b/packages/registry/tests/registry-auth-plugin.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { createMemoryAuthStore } from "../src/auth/auth-store.js";
+import { createRegistryAuthPlugin } from "../src/auth/registry-auth-plugin.js";
+
+type Result = { err: Error | null; res?: unknown };
+function call(
+  fn: (cb: (err: Error | null, res?: unknown) => void) => void,
+): Promise<Result> {
+  return new Promise((resolve) => fn((err, res) => resolve({ err, res })));
+}
+
+function status(err: Error | null): number | undefined {
+  if (!err) return undefined;
+  const e = err as { status?: number; statusCode?: number };
+  return e.status ?? e.statusCode;
+}
+
+describe("registry auth plugin — accounts", () => {
+  it("adduser registers a new user, then authenticate succeeds", async () => {
+    const p = createRegistryAuthPlugin(createMemoryAuthStore());
+
+    const add = await call((cb) => p.adduser("alice", "pw1", cb));
+    expect(add.err).toBeNull();
+    expect(add.res).toBe(true);
+
+    const auth = await call((cb) => p.authenticate("alice", "pw1", cb));
+    expect(auth.err).toBeNull();
+    expect(auth.res).toEqual(["alice"]);
+  });
+
+  it("adduser on an existing username is rejected (atomic, no overwrite)", async () => {
+    const p = createRegistryAuthPlugin(createMemoryAuthStore());
+    await call((cb) => p.adduser("alice", "pw1", cb));
+
+    const again = await call((cb) => p.adduser("alice", "different", cb));
+    expect(status(again.err)).toBe(409);
+  });
+
+  it("authenticate with a wrong password errors (401)", async () => {
+    const p = createRegistryAuthPlugin(createMemoryAuthStore());
+    await call((cb) => p.adduser("alice", "pw1", cb));
+
+    const bad = await call((cb) => p.authenticate("alice", "wrong", cb));
+    expect(status(bad.err)).toBe(401);
+  });
+
+  it("authenticate for an unknown user defers (no error, not authenticated)", async () => {
+    const p = createRegistryAuthPlugin(createMemoryAuthStore());
+    const res = await call((cb) => p.authenticate("ghost", "pw", cb));
+    expect(res.err).toBeNull();
+    expect(res.res).toBe(false);
+  });
+});
+
+describe("registry auth plugin — ownership (npm-style TOFU)", () => {
+  const alice = { name: "alice", groups: [] };
+  const bob = { name: "bob", groups: [] };
+
+  it("first publisher claims a free name; others get 403", async () => {
+    const p = createRegistryAuthPlugin(createMemoryAuthStore());
+
+    const claim = await call((cb) =>
+      p.allow_publish(alice, { name: "pkg-x" }, cb),
+    );
+    expect(claim.res).toBe(true);
+
+    const owner = await call((cb) =>
+      p.allow_publish(alice, { name: "pkg-x" }, cb),
+    );
+    expect(owner.res).toBe(true);
+
+    const foreign = await call((cb) =>
+      p.allow_publish(bob, { name: "pkg-x" }, cb),
+    );
+    expect(status(foreign.err)).toBe(403);
+  });
+
+  it("a free name stays claimable by anyone", async () => {
+    const p = createRegistryAuthPlugin(createMemoryAuthStore());
+    await call((cb) => p.allow_publish(alice, { name: "pkg-x" }, cb));
+    const free = await call((cb) =>
+      p.allow_publish(bob, { name: "pkg-y" }, cb),
+    );
+    expect(free.res).toBe(true);
+  });
+
+  it("unauthenticated publish is forbidden", async () => {
+    const p = createRegistryAuthPlugin(createMemoryAuthStore());
+    const anon = await call((cb) =>
+      p.allow_publish({ name: null }, { name: "z" }, cb),
+    );
+    expect(status(anon.err)).toBe(403);
+  });
+});
+
+describe("registry auth plugin — unpublish + access", () => {
+  const alice = { name: "alice", groups: [] };
+  const bob = { name: "bob", groups: [] };
+
+  it("only the owner may unpublish; others 403; unclaimed 403", async () => {
+    const p = createRegistryAuthPlugin(createMemoryAuthStore());
+    await call((cb) => p.allow_publish(alice, { name: "pkg-x" }, cb)); // alice owns
+
+    const byOwner = await call((cb) =>
+      p.allow_unpublish(alice, { name: "pkg-x" }, cb),
+    );
+    expect(byOwner.res).toBe(true);
+
+    const byOther = await call((cb) =>
+      p.allow_unpublish(bob, { name: "pkg-x" }, cb),
+    );
+    expect(status(byOther.err)).toBe(403);
+
+    const unclaimed = await call((cb) =>
+      p.allow_unpublish(alice, { name: "nope" }, cb),
+    );
+    expect(status(unclaimed.err)).toBe(403);
+  });
+
+  it("allow_access permits anonymous read", async () => {
+    const p = createRegistryAuthPlugin(createMemoryAuthStore());
+    const res = await call((cb) =>
+      p.allow_access({ name: null }, { name: "any" }, cb),
+    );
+    expect(res.res).toBe(true);
+  });
+});

--- a/packages/registry/tests/verdaccio-config.test.ts
+++ b/packages/registry/tests/verdaccio-config.test.ts
@@ -5,6 +5,8 @@ import { buildVerdaccioConfig } from "../src/verdaccio-config.js";
 type VerdaccioConfig = ReturnType<typeof buildVerdaccioConfig> & {
   uplinks: Record<string, { url: string; maxage: string }>;
   packages: Record<string, { proxy?: string }>;
+  auth: Record<string, unknown>;
+  plugins?: string;
 };
 
 function baseConfig(overrides: Partial<RegistryConfig> = {}): RegistryConfig {
@@ -56,5 +58,25 @@ describe("buildVerdaccioConfig", () => {
     ) as VerdaccioConfig;
 
     expect(cfg.uplinks.npmjs.maxage).toBe("30s");
+  });
+
+  it("uses the htpasswd auth path and no plugins dir when no database is set", () => {
+    const cfg = buildVerdaccioConfig(baseConfig()) as VerdaccioConfig;
+
+    expect(cfg.auth.htpasswd).toBeDefined();
+    expect(cfg.auth["registry-auth"]).toBeUndefined();
+    expect(cfg.plugins).toBeUndefined();
+  });
+
+  it("wires the registry-auth plugin (with plugins dir) when a database is set", () => {
+    const cfg = buildVerdaccioConfig(
+      baseConfig({ databaseUrl: "postgres://u:p@host:5432/registry" }),
+    ) as VerdaccioConfig;
+
+    expect(cfg.auth["registry-auth"]).toEqual({
+      databaseUrl: "postgres://u:p@host:5432/registry",
+    });
+    expect(cfg.auth.htpasswd).toBeUndefined();
+    expect(cfg.plugins?.endsWith("/plugins")).toBe(true);
   });
 });

--- a/packages/registry/tsdown.config.ts
+++ b/packages/registry/tsdown.config.ts
@@ -1,9 +1,24 @@
 import { defineConfig } from "tsdown";
 
-export default defineConfig({
-  entry: "./cli.ts",
-  outDir: "dist",
-  clean: true,
-  dts: true,
-  sourcemap: true,
-});
+export default defineConfig([
+  {
+    entry: "./cli.ts",
+    outDir: "dist",
+    clean: true,
+    dts: true,
+    sourcemap: true,
+  },
+  {
+    // Verdaccio auth plugin, loaded via require() from dist/plugins at runtime.
+    // Must be CommonJS AND emitted as `.js` — require() won't resolve a `.cjs`
+    // by name; the `dist/plugins/package.json {"type":"commonjs"}` (written by
+    // copy-dirs) makes the `.js` CommonJS despite the package being type:module.
+    entry: { "verdaccio-registry-auth": "./src/auth/registry-auth-plugin.ts" },
+    outDir: "dist/plugins",
+    format: "cjs",
+    clean: false,
+    dts: false,
+    sourcemap: false,
+    outExtensions: () => ({ js: ".js" }),
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2327,9 +2327,15 @@ importers:
       '@renown/sdk':
         specifier: workspace:*
         version: link:../renown
+      '@verdaccio/core':
+        specifier: 8.0.0-next-8.37
+        version: 8.0.0-next-8.37
       '@verdaccio/signature':
         specifier: 8.0.0-next-8.29
         version: 8.0.0-next-8.29
+      bcryptjs:
+        specifier: ^2.4.3
+        version: 2.4.3
       cmd-ts:
         specifier: 'catalog:'
         version: 0.15.0
@@ -2339,6 +2345,9 @@ importers:
       find-up:
         specifier: ^8.0.0
         version: 8.0.0
+      pg:
+        specifier: 'catalog:'
+        version: 8.18.0
       tar:
         specifier: ^7.5.11
         version: 7.5.11
@@ -2349,21 +2358,30 @@ importers:
         specifier: ^10.4.0
         version: 10.4.0
     devDependencies:
+      '@types/bcryptjs':
+        specifier: ^2.4.6
+        version: 2.4.6
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
       '@types/node':
         specifier: 'catalog:'
         version: 25.2.3
+      '@types/pg':
+        specifier: 'catalog:'
+        version: 8.16.0
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.3
+      pg-mem:
+        specifier: ^3.0.14
+        version: 3.0.14(knex@3.1.0(pg@8.18.0))(kysely@0.28.16)
       supertest:
         specifier: ^7.1.0
         version: 7.2.2
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@5.9.3)
+        version: 0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/browser-playwright@4.1.1)(happy-dom@20.9.0)(jsdom@24.1.3)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@8.0.10(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -9605,6 +9623,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/bcryptjs@2.4.6':
+    resolution: {integrity: sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -12175,6 +12196,9 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  discontinuous-range@1.0.0:
+    resolution: {integrity: sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==}
+
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
@@ -13215,6 +13239,9 @@ packages:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
     engines: {node: '>= 0.4'}
 
+  functional-red-black-tree@1.0.1:
+    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
+
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
@@ -13823,6 +13850,9 @@ packages:
   immutable@3.7.6:
     resolution: {integrity: sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==}
     engines: {node: '>=0.8.0'}
+
+  immutable@4.3.9:
+    resolution: {integrity: sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -14537,6 +14567,10 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stable-stringify@1.3.0:
+    resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
+    engines: {node: '>= 0.4'}
+
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -14554,6 +14588,9 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jsonify@0.0.1:
+    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
 
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
@@ -14962,6 +14999,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
 
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
@@ -15468,12 +15509,18 @@ packages:
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
+  moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
+
   monocart-coverage-reports@2.12.9:
     resolution: {integrity: sha512-vtFqbC3Egl4nVa1FSIrQvMPO6HZtb9lo+3IW7/crdvrLNW2IH8lUsxaK0TsKNmMO2mhFWwqQywLV2CZelqPgwA==}
     hasBin: true
 
   monocart-locator@1.0.2:
     resolution: {integrity: sha512-v8W5hJLcWMIxLCcSi/MHh+VeefI+ycFmGz23Froer9QzWjrbg4J3gFJBuI/T1VLNoYxF47bVPPxq8ZlNX4gVCw==}
+
+  moo@0.5.3:
+    resolution: {integrity: sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==}
 
   mqemitter@7.1.0:
     resolution: {integrity: sha512-GnBDNz3lxmllW201ne0mrmdy5tPOTnc79jjVcsfUa2LG2pUGeyGWVeiae6ZysfC/64XrYOqCKRAQYrB7pGyBVQ==}
@@ -15559,6 +15606,10 @@ packages:
   ndjson@2.0.0:
     resolution: {integrity: sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==}
     engines: {node: '>=10'}
+    hasBin: true
+
+  nearley@2.20.1:
+    resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
     hasBin: true
 
   negotiator@0.6.3:
@@ -15737,6 +15788,10 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@2.2.0:
+    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
+    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -16140,6 +16195,41 @@ packages:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
+  pg-mem@3.0.14:
+    resolution: {integrity: sha512-G9m8OD0A+YS083smidSUJddTX2dEDPT8mRMG3sQGNiGfS/mkvAgd9Kf1/onD5633bFN7HcQK/Tn2x7qjBMFRUQ==}
+    peerDependencies:
+      '@mikro-orm/core': '>=4.5.3'
+      '@mikro-orm/postgresql': '>=4.5.3'
+      knex: '>=0.20'
+      kysely: '>=0.26'
+      mikro-orm: '*'
+      pg-promise: '>=10.8.7'
+      pg-server: ^0.1.5
+      postgres: ^3.4.4
+      slonik: '>=23.0.1'
+      typeorm: '>=0.2.29'
+    peerDependenciesMeta:
+      '@mikro-orm/core':
+        optional: true
+      '@mikro-orm/postgresql':
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mikro-orm:
+        optional: true
+      pg-promise:
+        optional: true
+      pg-server:
+        optional: true
+      postgres:
+        optional: true
+      slonik:
+        optional: true
+      typeorm:
+        optional: true
+
   pg-pool@3.12.0:
     resolution: {integrity: sha512-eIJ0DES8BLaziFHW7VgJEBPi5hg3Nyng5iKpYtj3wbcAUV9A1wLgWiY7ajf/f/oO1wfxt83phXPY8Emztg7ITg==}
     peerDependencies:
@@ -16163,6 +16253,9 @@ packages:
 
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  pgsql-ast-parser@12.0.2:
+    resolution: {integrity: sha512-1WWa96Sw6h4uv9GLw98EzH/+xoBTC8j2TwV/AMW3E+Ir/fHOu/jLLbj6kPiz3y2bGISTKNYvKWwHoqvQ5FLuAw==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -16899,6 +16992,13 @@ packages:
   rache@1.0.0:
     resolution: {integrity: sha512-e0k0g0w/8jOCB+7YqCIlOa+OJ38k0wrYS4x18pMSmqOvLKoyhmMhmQyCcvfY6VaP8D75cqkEnlakXs+RYYLqNg==}
 
+  railroad-diagrams@1.0.0:
+    resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
+
+  randexp@0.4.6:
+    resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
+    engines: {node: '>=0.12'}
+
   randexp@0.5.3:
     resolution: {integrity: sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==}
     engines: {node: '>=4'}
@@ -17394,6 +17494,10 @@ packages:
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  ret@0.1.15:
+    resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
+    engines: {node: '>=0.12'}
 
   ret@0.2.2:
     resolution: {integrity: sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==}
@@ -25451,6 +25555,14 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@oxc-resolver/binding-wasm32-wasi@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@oxc-resolver/binding-wasm32-wasi@5.3.0':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.12
@@ -26713,6 +26825,14 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16':
     optional: true
 
@@ -27842,6 +27962,22 @@ snapshots:
       - tsx
       - yaml
 
+  '@tsdown/css@0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(jiti@2.6.1)(postcss@8.5.12)(tsdown@0.21.1)(tsx@4.21.0)(yaml@2.8.3)':
+    dependencies:
+      lightningcss: 1.32.0
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(yaml@2.8.3)
+      rolldown: 1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      tsdown: 0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@5.9.3)
+    optionalDependencies:
+      postcss: 8.5.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - jiti
+      - tsx
+      - yaml
+    optional: true
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -27873,6 +28009,8 @@ snapshots:
   '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@types/bcryptjs@2.4.6': {}
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -27934,11 +28072,11 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   '@types/eslint@9.6.1':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
 
   '@types/esquery@1.5.4':
@@ -31057,6 +31195,8 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  discontinuous-range@1.0.0: {}
+
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
@@ -31156,6 +31296,10 @@ snapshots:
   dts-resolver@2.1.3(oxc-resolver@11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)):
     optionalDependencies:
       oxc-resolver: 11.19.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+
+  dts-resolver@2.1.3(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)):
+    optionalDependencies:
+      oxc-resolver: 11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
 
   dunder-proto@1.0.1:
     dependencies:
@@ -31872,7 +32016,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -32493,6 +32637,8 @@ snapshots:
       functions-have-names: 1.2.3
       hasown: 2.0.2
       is-callable: 1.2.7
+
+  functional-red-black-tree@1.0.1: {}
 
   functions-have-names@1.2.3: {}
 
@@ -33334,6 +33480,8 @@ snapshots:
   immediate@3.0.6: {}
 
   immutable@3.7.6: {}
+
+  immutable@4.3.9: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -34234,6 +34382,14 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stable-stringify@1.3.0:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      isarray: 2.0.5
+      jsonify: 0.0.1
+      object-keys: 1.1.1
+
   json-stringify-safe@5.0.1: {}
 
   json-to-pretty-yaml@1.2.2:
@@ -34250,6 +34406,8 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonify@0.0.1: {}
 
   jsonparse@1.3.1: {}
 
@@ -34639,6 +34797,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
 
   lru-cache@7.18.3: {}
 
@@ -35429,6 +35591,8 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
+  moment@2.30.1: {}
+
   monocart-coverage-reports@2.12.9:
     dependencies:
       acorn: 8.16.0
@@ -35445,6 +35609,8 @@ snapshots:
       monocart-locator: 1.0.2
 
   monocart-locator@1.0.2: {}
+
+  moo@0.5.3: {}
 
   mqemitter@7.1.0:
     dependencies:
@@ -35604,6 +35770,13 @@ snapshots:
       readable-stream: 3.6.2
       split2: 3.2.2
       through2: 4.0.2
+
+  nearley@2.20.1:
+    dependencies:
+      commander: 2.20.3
+      moo: 0.5.3
+      railroad-diagrams: 1.0.0
+      randexp: 0.4.6
 
   negotiator@0.6.3: {}
 
@@ -35920,6 +36093,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-hash@2.2.0: {}
+
   object-inspect@1.13.4: {}
 
   object-is@1.1.6:
@@ -36092,6 +36267,33 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.19.0
+      '@oxc-resolver/binding-android-arm64': 11.19.0
+      '@oxc-resolver/binding-darwin-arm64': 11.19.0
+      '@oxc-resolver/binding-darwin-x64': 11.19.0
+      '@oxc-resolver/binding-freebsd-x64': 11.19.0
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.19.0
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.19.0
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.19.0
+      '@oxc-resolver/binding-linux-arm64-musl': 11.19.0
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.19.0
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.19.0
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.19.0
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.19.0
+      '@oxc-resolver/binding-linux-x64-gnu': 11.19.0
+      '@oxc-resolver/binding-linux-x64-musl': 11.19.0
+      '@oxc-resolver/binding-openharmony-arm64': 11.19.0
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.19.0
+      '@oxc-resolver/binding-win32-ia32-msvc': 11.19.0
+      '@oxc-resolver/binding-win32-x64-msvc': 11.19.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
 
   oxc-resolver@5.3.0:
     optionalDependencies:
@@ -36392,6 +36594,19 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
+  pg-mem@3.0.14(knex@3.1.0(pg@8.18.0))(kysely@0.28.16):
+    dependencies:
+      functional-red-black-tree: 1.0.1
+      immutable: 4.3.9
+      json-stable-stringify: 1.3.0
+      lru-cache: 6.0.0
+      moment: 2.30.1
+      object-hash: 2.2.0
+      pgsql-ast-parser: 12.0.2
+    optionalDependencies:
+      knex: 3.1.0(pg@8.18.0)
+      kysely: 0.28.16
+
   pg-pool@3.12.0(pg@8.18.0):
     dependencies:
       pg: 8.18.0
@@ -36419,6 +36634,11 @@ snapshots:
   pgpass@1.0.5:
     dependencies:
       split2: 4.2.0
+
+  pgsql-ast-parser@12.0.2:
+    dependencies:
+      moo: 0.5.3
+      nearley: 2.20.1
 
   picocolors@1.1.1: {}
 
@@ -37211,6 +37431,13 @@ snapshots:
 
   rache@1.0.0: {}
 
+  railroad-diagrams@1.0.0: {}
+
+  randexp@0.4.6:
+    dependencies:
+      discontinuous-range: 1.0.0
+      ret: 0.1.15
+
   randexp@0.5.3:
     dependencies:
       drange: 1.1.1
@@ -37850,6 +38077,8 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  ret@0.1.15: {}
+
   ret@0.2.2: {}
 
   ret@0.5.0: {}
@@ -37904,6 +38133,23 @@ snapshots:
       rolldown: 1.0.0-rc.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optionalDependencies:
       typescript: 6.0.3
+    transitivePeerDependencies:
+      - oxc-resolver
+
+  rolldown-plugin-dts@0.22.5(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(rolldown@1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@5.9.3):
+    dependencies:
+      '@babel/generator': 8.0.0-rc.2
+      '@babel/helper-validator-identifier': 8.0.0-rc.2
+      '@babel/parser': 8.0.0-rc.2
+      '@babel/types': 8.0.0-rc.2
+      ast-kit: 3.0.0-beta.1
+      birpc: 4.0.0
+      dts-resolver: 2.1.3(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))
+      get-tsconfig: 4.13.7
+      obug: 2.1.1
+      rolldown: 1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optionalDependencies:
+      typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -37967,6 +38213,30 @@ snapshots:
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.8
       '@rolldown/binding-openharmony-arm64': 1.0.0-rc.8
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.8
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.8
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  rolldown@1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+    dependencies:
+      '@oxc-project/types': 0.115.0
+      '@rolldown/pluginutils': 1.0.0-rc.8
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.8
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.8
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.8
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.8
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.8
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.8
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.8
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.8
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.8
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.8
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.8
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.8
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.8
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.8
     transitivePeerDependencies:
@@ -39282,6 +39552,36 @@ snapshots:
       - synckit
       - vue-tsc
 
+  tsdown@0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@tsdown/css@0.21.1)(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(synckit@0.11.12)(typescript@5.9.3):
+    dependencies:
+      ansis: 4.2.0
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.0
+      hookable: 6.1.1
+      import-without-cache: 0.2.5
+      obug: 2.1.1
+      picomatch: 4.0.4
+      rolldown: 1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      rolldown-plugin-dts: 0.22.5(oxc-resolver@11.19.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(rolldown@1.0.0-rc.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@5.9.3)
+      semver: 7.7.4
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      unrun: 0.2.36(synckit@0.11.12)
+    optionalDependencies:
+      '@tsdown/css': 0.21.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(jiti@2.6.1)(postcss@8.5.12)(tsdown@0.21.1)(tsx@4.21.0)(yaml@2.8.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - synckit
+      - vue-tsc
+
   tslib@1.14.1: {}
 
   tslib@2.4.1: {}
@@ -40237,7 +40537,7 @@ snapshots:
   webpack@5.105.2(@swc/core@1.11.31)(esbuild@0.27.3):
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1


### PR DESCRIPTION
## Summary

Adds a Verdaccio auth plugin, active when a database URL is configured, that backs the registry's accounts and package ownership with Postgres:

- **Persistent accounts** (`registry_users`), shared across replicas and surviving redeploys; registering an existing username is rejected (409) instead of the htpasswd wrong-password re-create.
- **npm-style package ownership** (`registry_package_owners`): the first publisher claims a name **atomically** via `INSERT ... ON CONFLICT DO NOTHING`; any other user gets **403** on publish/unpublish. Free names stay claimable; reads stay anonymous.

Without a database (local dev / tests) the built-in htpasswd path is **unchanged**.

**Companion PR (infra / k8s):** powerhouse-inc/powerhouse-k8s-hosting#111 — https://github.com/powerhouse-inc/powerhouse-k8s-hosting/pull/111 (provisions the isolated `registry_db` + role).

## Changes

- `src/auth/auth-store.ts` — `AuthStore` contract + in-memory store (tests).
- `src/auth/pg-store.ts` — Postgres store (tables, atomic claim) + pool factory.
- `src/auth/registry-auth-plugin.ts` — `authenticate`/`adduser` + `allow_publish`/`allow_unpublish` over the store.
- `verdaccio-config.ts` / `run.ts` / `cli.ts` — wire the plugin + `PH_REGISTRY_DATABASE_URL` when a DB is set; htpasswd otherwise.
- The plugin is emitted as a CommonJS file under `dist/plugins` so Verdaccio's loader can `require()` it by name.

## Tests

- Unit: plugin branches (in-memory store) and `PgStore` SQL / atomic claim (via pg-mem).
- Integration: a real registry + injected pg-mem store — accounts, ownership 403, and accounts + ownership surviving a fresh registry instance.
- `pnpm --filter @powerhousedao/registry build && test` → 66 passed, 3 skipped. `tsc` clean, eslint 0 errors, prettier clean.

## Deploy

The plugin activates once this registry image is published and deployed to a tenant with a database configured — via powerhouse-inc/powerhouse-k8s-hosting#111.