### PR TITLE
feat(renown): issue credentials via renown_issueCredential + authenticated profile writes

### DIFF
--- a/packages/renown/src/common.ts
+++ b/packages/renown/src/common.ts
@@ -166,23 +166,48 @@ export class Renown implements IRenown {
       });
 
       await this.#switchboard.issueCredential(credential);
-      await this.#switchboard.findOrCreateUser(address, {
-        username,
-        userImage,
-      });
 
       const userDid = `did:pkh:${DEFAULT_RENOWN_NETWORK_ID}:${chainId}:${address.toLowerCase()}`;
       // Authenticate from the freshly signed credential — no read-back, which
       // avoids racing the read-model processor that indexes the write.
-      return await this.#completeLogin(
+      const user = await this.#completeLogin(
         userDid,
         parsePkhDid(userDid),
         credential,
       );
+
+      // Deferred best-effort profile write; never blocks or fails sign-in.
+      if (username !== undefined || userImage !== undefined) {
+        await this.#writeProfile(address, { username, userImage }).catch(
+          () => undefined,
+        );
+      }
+
+      return user;
     } catch (error) {
       this.#updateUser(undefined);
       this.#updateStatus("not-authorized");
       throw error;
+    }
+  }
+
+  // Write the profile via an authenticated request, retrying while the reactor's
+  // read model catches up to the just-issued credential (needed to authenticate).
+  async #writeProfile(
+    address: string,
+    profile: { username?: string; userImage?: string },
+  ): Promise<void> {
+    if (!this.#switchboard) return;
+    const token = await this.#crypto.getBearerToken(address);
+    const attempts = 5;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        await this.#switchboard.upsertUserProfile(address, profile, { token });
+        return;
+      } catch (error) {
+        if (attempt === attempts) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 600));
+      }
     }
   }
 

--- a/packages/renown/src/index.ts
+++ b/packages/renown/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./common.js";
+export * from "./constants.js";
 export * from "./credential.js";
 export * from "./crypto/index.js";
 export * from "./discovery.js";

--- a/packages/renown/src/switchboard.ts
+++ b/packages/renown/src/switchboard.ts
@@ -120,8 +120,49 @@ const MUTATE_DOCUMENT_MUTATION = /* GraphQL */ `
   }
 `;
 
+// Dedicated renown-package mutations that write through the reactor client,
+// bypassing the authorization policy so unauthenticated sign-in can bootstrap.
+const ISSUE_CREDENTIAL_MUTATION = /* GraphQL */ `
+  mutation RenownIssueCredential(
+    $input: RenownCredential_InitInput!
+    $username: String
+    $userImage: String
+    $userDocId: PHID
+  ) {
+    renown_issueCredential(
+      input: $input
+      username: $username
+      userImage: $userImage
+      userDocId: $userDocId
+    )
+  }
+`;
+
 const RENOWN_CREDENTIAL_DOC_TYPE = "powerhouse/renown-credential";
 const RENOWN_USER_DOC_TYPE = "powerhouse/renown-user";
+
+// GraphQL validation-error fragments meaning the switchboard's schema lacks a
+// field/type — i.e. it runs an older renown-package without the custom subgraph.
+const SCHEMA_ERROR_HINTS = [
+  "Cannot query field",
+  "Unknown field",
+  "Unknown type",
+  "Unknown argument",
+  "not defined",
+];
+
+// True when `error` is a schema-shape error naming one of `identifiers` — a
+// missing custom mutation/input, not a resolver rejection (bad signature, etc.).
+function isUnknownSchemaError(
+  error: unknown,
+  ...identifiers: string[]
+): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    identifiers.some((id) => message.includes(id)) &&
+    SCHEMA_ERROR_HINTS.some((hint) => message.includes(hint))
+  );
+}
 
 // Rebuild the nested EIP-712 verifiable credential from a flat read-model row.
 function reshapeCredential(
@@ -196,10 +237,14 @@ export class SwitchboardClient {
   async #request<T>(
     query: string,
     variables: Record<string, unknown>,
+    token?: string,
   ): Promise<T> {
     const response = await fetch(this.#endpoint, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
       body: JSON.stringify({ query, variables }),
     });
     if (!response.ok) {
@@ -277,34 +322,40 @@ export class SwitchboardClient {
   }
 
   // Create an empty document of the given type; returns its document id.
+  // Pass a bearer token to authenticate the write when auth is enabled.
   async createEmptyDocument(
     documentType: string,
     parentIdentifier?: string,
+    token?: string,
   ): Promise<string> {
     const { createEmptyDocument } = await this.#request<{
       createEmptyDocument: { id: string };
-    }>(CREATE_EMPTY_DOCUMENT_MUTATION, { documentType, parentIdentifier });
+    }>(
+      CREATE_EMPTY_DOCUMENT_MUTATION,
+      { documentType, parentIdentifier },
+      token,
+    );
     return createEmptyDocument.id;
   }
 
   // Apply reactor action envelopes to a document; returns its document id.
+  // Pass a bearer token to authenticate the write when auth is enabled.
   async mutateDocument(
     documentIdentifier: string,
     actions: Action[],
+    token?: string,
   ): Promise<string> {
     const { mutateDocument } = await this.#request<{
       mutateDocument: { id: string };
-    }>(MUTATE_DOCUMENT_MUTATION, { documentIdentifier, actions });
+    }>(MUTATE_DOCUMENT_MUTATION, { documentIdentifier, actions }, token);
     return mutateDocument.id;
   }
 
-  // Issue a signed credential: create a renown-credential doc and INIT it.
+  // Issue a signed credential via the renown-package `renown_issueCredential`
+  // mutation, which validates the proof and writes without requiring auth.
   async issueCredential(
     credential: PowerhouseVerifiableCredential,
   ): Promise<string> {
-    const documentId = await this.createEmptyDocument(
-      RENOWN_CREDENTIAL_DOC_TYPE,
-    );
     const input: Record<string, unknown> = {
       id: credential.id,
       context: credential["@context"],
@@ -339,22 +390,46 @@ export class SwitchboardClient {
         },
       },
     };
-    await this.mutateDocument(documentId, [createAction("INIT", input)]);
-    return documentId;
+    try {
+      const { renown_issueCredential } = await this.#request<{
+        renown_issueCredential: string;
+      }>(ISSUE_CREDENTIAL_MUTATION, { input });
+      return renown_issueCredential;
+    } catch (error) {
+      // Fallback for a switchboard on an older renown-package without the
+      // issuance subgraph: write via the generic reactor mutations instead.
+      if (
+        !isUnknownSchemaError(
+          error,
+          "renown_issueCredential",
+          "RenownCredential_InitInput",
+        )
+      ) {
+        throw error;
+      }
+      const documentId = await this.createEmptyDocument(
+        RENOWN_CREDENTIAL_DOC_TYPE,
+      );
+      await this.mutateDocument(documentId, [createAction("INIT", input)]);
+      return documentId;
+    }
   }
 
-  // Find the RenownUser for an address or create one; returns its document id.
-  async findOrCreateUser(
+  // Create or update the RenownUser profile for an address. Pass a bearer token
+  // so the switchboard authorizes the write as that address (prevents spoofing).
+  async upsertUserProfile(
     address: string,
-    profile: { username?: string; userImage?: string } = {},
+    profile: { username?: string; userImage?: string },
+    options: { token?: string } = {},
   ): Promise<string> {
+    const { token } = options;
     const updates: Action[] = [];
-    if (profile.username !== undefined) {
+    if (profile.username != null) {
       updates.push(
         createAction("SET_USERNAME", { username: profile.username }),
       );
     }
-    if (profile.userImage !== undefined) {
+    if (profile.userImage != null) {
       updates.push(
         createAction("SET_USER_IMAGE", { userImage: profile.userImage }),
       );
@@ -363,15 +438,20 @@ export class SwitchboardClient {
     const existing = await this.getProfileByAddress(address);
     if (existing) {
       if (updates.length)
-        await this.mutateDocument(existing.documentId, updates);
+        await this.mutateDocument(existing.documentId, updates, token);
       return existing.documentId;
     }
 
-    const documentId = await this.createEmptyDocument(RENOWN_USER_DOC_TYPE);
-    await this.mutateDocument(documentId, [
-      createAction("SET_ETH_ADDRESS", { ethAddress: address }),
-      ...updates,
-    ]);
+    const documentId = await this.createEmptyDocument(
+      RENOWN_USER_DOC_TYPE,
+      undefined,
+      token,
+    );
+    await this.mutateDocument(
+      documentId,
+      [createAction("SET_ETH_ADDRESS", { ethAddress: address }), ...updates],
+      token,
+    );
     return documentId;
   }
 

--- a/packages/renown/test/signin.test.ts
+++ b/packages/renown/test/signin.test.ts
@@ -17,6 +17,7 @@ const SB = "http://sb.test/graphql";
 interface ReactorCall {
   query: string;
   variables: Record<string, unknown>;
+  authorization?: string;
 }
 
 // Route reactor writes and the user existence-check; record request bodies.
@@ -26,10 +27,13 @@ function mockReactor() {
     const body = JSON.parse(
       (init?.body as string | undefined) ?? "{}",
     ) as ReactorCall;
-    calls.push(body);
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    calls.push({ ...body, authorization: headers.Authorization });
     let data: unknown = {};
     if (body.query.includes("renownUsers")) {
       data = { renownUsers: [] };
+    } else if (body.query.includes("renown_issueCredential")) {
+      data = { renown_issueCredential: "cred-doc" };
     } else if (body.query.includes("createEmptyDocument")) {
       data = { createEmptyDocument: { id: "doc-new" } };
     } else if (body.query.includes("mutateDocument")) {
@@ -57,15 +61,6 @@ async function makeRenown(withSwitchboard = true) {
   );
 }
 
-function actionTypes(calls: ReactorCall[]): string[] {
-  return calls.flatMap(
-    (c) =>
-      (c.variables.actions as { type: string }[] | undefined)?.map(
-        (a) => a.type,
-      ) ?? [],
-  );
-}
-
 describe("Renown.signIn", () => {
   afterEach(() => vi.restoreAllMocks());
 
@@ -77,6 +72,7 @@ describe("Renown.signIn", () => {
       address: ACCOUNT.address,
       chainId: 1,
       signTypedData: sign,
+      username: "alice",
     });
 
     expect(user.address).toBe(ACCOUNT.address);
@@ -85,10 +81,13 @@ describe("Renown.signIn", () => {
     expect(renown.status).toBe("authorized");
     expect(renown.user?.address).toBe(ACCOUNT.address);
 
-    // Credential was issued (INIT) and the user document created.
-    const types = actionTypes(calls);
-    expect(types).toContain("INIT");
-    expect(types).toContain("SET_ETH_ADDRESS");
+    // Credential issued via the auth-bypassing mutation; the profile is then
+    // written as a separate authenticated request (carries a bearer token).
+    expect(calls.some((c) => c.query.includes("renown_issueCredential"))).toBe(
+      true,
+    );
+    const profileWrite = calls.find((c) => c.query.includes("mutateDocument"));
+    expect(profileWrite?.authorization).toMatch(/^Bearer /);
   });
 
   it("throws when no switchboard endpoint is configured", async () => {

--- a/packages/renown/test/switchboard.test.ts
+++ b/packages/renown/test/switchboard.test.ts
@@ -6,21 +6,39 @@ import type { PowerhouseVerifiableCredential } from "../src/types.js";
 interface ReactorCall {
   query: string;
   variables: Record<string, unknown>;
+  authorization?: string;
 }
 
-// Route reactor mutations/queries by operation and record request bodies.
+// Route reactor mutations/queries by operation and record request bodies. Any
+// request matching an `errors` marker fails, simulating a missing operation.
 function mockReactor(
-  opts: { renownUsers?: unknown[]; createId?: string } = {},
+  opts: {
+    renownUsers?: unknown[];
+    createId?: string;
+    errors?: { match: string; message: string }[];
+  } = {},
 ) {
   const calls: ReactorCall[] = [];
   vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
     const body = JSON.parse(
       (init?.body as string | undefined) ?? "{}",
     ) as ReactorCall;
-    calls.push(body);
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    calls.push({ ...body, authorization: headers.Authorization });
+    const failure = opts.errors?.find((e) => body.query.includes(e.match));
+    if (failure) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ errors: [{ message: failure.message }] }),
+          { status: 200 },
+        ),
+      );
+    }
     let data: unknown = {};
     if (body.query.includes("renownUsers")) {
       data = { renownUsers: opts.renownUsers ?? [] };
+    } else if (body.query.includes("renown_issueCredential")) {
+      data = { renown_issueCredential: opts.createId ?? "doc-new" };
     } else if (body.query.includes("createEmptyDocument")) {
       data = { createEmptyDocument: { id: opts.createId ?? "doc-new" } };
     } else if (body.query.includes("mutateDocument")) {
@@ -233,46 +251,106 @@ describe("SwitchboardClient", () => {
   });
 
   describe("issueCredential", () => {
-    it("creates a credential doc and INITs it with the credential fields", async () => {
+    it("issues via renown_issueCredential with the credential fields", async () => {
       const calls = mockReactor({ createId: "cred-doc-1" });
       const documentId = await client.issueCredential(makeCredential());
 
       expect(documentId).toBe("cred-doc-1");
-      const [init] = mutateActions(calls);
-      expect(init.type).toBe("INIT");
-      expect(init.input.id).toBe("urn:uuid:cred-1");
-      expect(init.input.credentialSubject).toEqual({
+      const issue = calls.find((c) =>
+        c.query.includes("renown_issueCredential"),
+      );
+      const input = issue?.variables.input as {
+        id: string;
+        credentialSubject: { id: string; app: string };
+        proof: { proofValue: string };
+      };
+      expect(input.id).toBe("urn:uuid:cred-1");
+      expect(input.credentialSubject).toEqual({
         id: APP_DID,
         app: "test-app",
       });
-      const proof = init.input.proof as { proofValue: string };
-      expect(proof.proofValue).toBe("0xsignature");
+      expect(input.proof.proofValue).toBe("0xsignature");
+    });
+
+    it("falls back to generic createEmptyDocument + INIT on an older switchboard", async () => {
+      const calls = mockReactor({
+        createId: "cred-doc-1",
+        errors: [
+          {
+            match: "renown_issueCredential",
+            message:
+              'Cannot query field "renown_issueCredential" on type "Mutation".',
+          },
+        ],
+      });
+      const documentId = await client.issueCredential(makeCredential());
+
+      expect(documentId).toBe("cred-doc-1");
+      expect(
+        calls.some((c) => c.query.includes("renown_issueCredential")),
+      ).toBe(true);
+      expect(calls.some((c) => c.query.includes("createEmptyDocument"))).toBe(
+        true,
+      );
+      const [init] = mutateActions(calls);
+      expect(init.type).toBe("INIT");
+    });
+
+    it("does NOT fall back when the resolver rejects the credential", async () => {
+      const calls = mockReactor({
+        errors: [
+          {
+            match: "renown_issueCredential",
+            message:
+              "Invalid request: EIP-712 proof signature does not match issuer",
+          },
+        ],
+      });
+
+      await expect(client.issueCredential(makeCredential())).rejects.toThrow(
+        /signature/i,
+      );
+      // A resolver rejection must not silently write via the generic path.
+      expect(calls.some((c) => c.query.includes("createEmptyDocument"))).toBe(
+        false,
+      );
     });
   });
 
-  describe("findOrCreateUser", () => {
-    it("creates a user with SET_ETH_ADDRESS when none exists", async () => {
+  describe("upsertUserProfile", () => {
+    it("creates a user and sends the bearer token when none exists", async () => {
       const calls = mockReactor({ renownUsers: [], createId: "user-doc-1" });
-      const documentId = await client.findOrCreateUser(ADDRESS, {
-        username: "alice",
-      });
+      const documentId = await client.upsertUserProfile(
+        ADDRESS,
+        { username: "alice" },
+        { token: "jwt-token" },
+      );
 
       expect(documentId).toBe("user-doc-1");
+      expect(calls.some((c) => c.query.includes("createEmptyDocument"))).toBe(
+        true,
+      );
       const actions = mutateActions(calls);
       expect(actions.map((a) => a.type)).toEqual([
         "SET_ETH_ADDRESS",
         "SET_USERNAME",
       ]);
-      expect(actions[0].input).toEqual({ ethAddress: ADDRESS });
+      // The write carried the bearer token so the switchboard can authorize it.
+      const createCall = calls.find((c) =>
+        c.query.includes("createEmptyDocument"),
+      );
+      expect(createCall?.authorization).toBe("Bearer jwt-token");
     });
 
-    it("updates an existing user without recreating it", async () => {
+    it("updates an existing user without creating a document", async () => {
       const calls = mockReactor({
         renownUsers: [{ documentId: "user-doc-9", ethAddress: ADDRESS }],
       });
-      const documentId = await client.findOrCreateUser(ADDRESS, {
-        userImage: "http://img.test/a.png",
-      });
+      const documentId = await client.upsertUserProfile(
+        ADDRESS,
+        { userImage: "http://img.test/a.png" },
+        { token: "jwt-token" },
+      );
 
       expect(documentId).toBe("user-doc-9");
       expect(calls.some((c) => c.query.includes("createEmptyDocument"))).toBe(


### PR DESCRIPTION
## What

Updates `@renown/sdk`'s `SwitchboardClient` and `signIn` to work with a switchboard that has authorization enabled — the sign-in bootstrap in #2881. Companion to the `renown-credential-issuance` subgraph PR in `powerhouse-inc/renown-package` (which adds the server-side `renown_issueCredential` mutation).

## Changes

- **`issueCredential`** now calls the dedicated **`renown_issueCredential`** mutation (validates the EIP-712 proof and writes without requiring auth), with a **fallback** to the generic `createEmptyDocument` + `INIT` path when the switchboard runs an older renown-package that lacks the mutation. It only falls back on a *schema* error (missing field/type), never on a resolver validation rejection.
- **Profile writes are now authenticated.** `signIn` no longer writes the RenownUser profile through an unauthenticated path; it defers to a best-effort `upsertUserProfile` using the caller's bearer token, retried past the read-model indexing lag. A profile can therefore only be written by someone who has proven control of the address — **prevents profile impersonation**.
- `#request` / `createEmptyDocument` / `mutateDocument` accept an optional bearer token (`Authorization: Bearer …`).
- `index.ts` re-exports `./constants.js` so `CREDENTIAL_TYPES` is part of the public API (matches the published surface).

## Tests

`test/switchboard.test.ts` + `test/signin.test.ts` — 15 tests, covering issuance, the older-switchboard fallback, no-fallback-on-rejection, authenticated `upsertUserProfile` (asserts the bearer token is sent), and the deferred profile write during sign-in.

## Note

Depends on the renown-package PR being deployed for the primary (non-fallback) issuance path to be available on a given switchboard.