### PR TITLE
fix(connect): re-import a deleted document as a copy

### DIFF
--- a/packages/reactor-browser/src/actions/document.ts
+++ b/packages/reactor-browser/src/actions/document.ts
@@ -108,6 +108,56 @@ async function isDocumentInLocation(
   return { isDuplicate: false };
 }
 
+/**
+ * Recognizes the failure raised when CREATE_DOCUMENT targets a document id the
+ * reactor still owns.
+ *
+ * Deleting a document appends a tombstone but retains its operation history, so
+ * the id stays owned. No read path reveals this before the write: the document
+ * view, `resolveIdOrSlug` and `getOperations` all hide soft-deleted documents,
+ * making a tombstoned id indistinguishable from an unused one. The operation
+ * store is the only component that still sees the history, and it rejects the
+ * create at revision 0. Callers recover by importing under a fresh id.
+ */
+export function isDocumentIdTakenError(error: unknown): boolean {
+  let current: unknown = error;
+  while (current instanceof Error) {
+    if (/revision mismatch/i.test(current.message)) {
+      return true;
+    }
+    current = current.cause;
+  }
+  return false;
+}
+
+/**
+ * Removes the drive node left behind by a create that failed on a taken id.
+ *
+ * `drives.addFile` submits the document create and the drive's ADD_FILE as two
+ * jobs, and their `dependsOn` link only orders them — it does not gate on
+ * success. A create rejected for a taken id therefore still commits the node,
+ * which then points at a document that was never created. Left in place it also
+ * collides with the retry, which would inherit a "(copy)" name.
+ *
+ * Removal is best effort: `removeNode` also tombstones the child document, which
+ * here does not exist, so it reports a failure after the node is already gone.
+ */
+async function removeDanglingNode(
+  driveId: string,
+  nodeId: string,
+): Promise<void> {
+  const reactorClient = window.ph?.reactorClient;
+  if (!reactorClient) {
+    return;
+  }
+
+  try {
+    await reactorClient.drives.removeNode(driveId, nodeId);
+  } catch {
+    // The node removal commits even when the child tombstone step reports failure.
+  }
+}
+
 function getDocumentTypeIcon(
   document: PHDocument,
 ): DocumentTypeIcon | undefined {
@@ -413,49 +463,63 @@ export async function addFile(
 
   const document = await loadFile(file);
 
-  let duplicateId = false;
-
   const reactorClient = window.ph?.reactorClient;
   if (!reactorClient) {
     throw new Error("ReactorClient not initialized");
   }
 
+  let duplicateId = false;
   try {
     await reactorClient.get(document.header.id);
     duplicateId = true;
   } catch {
-    // document id not found
+    // A rejection does not prove the id is free: the view hides soft-deleted
+    // documents whose retained history still owns it. That case is recovered
+    // below, once the create surfaces it.
   }
 
-  const documentId = duplicateId ? generateId() : document.header.id;
-  const header = createPresignedHeader(
-    documentId,
-    document.header.documentType,
-  );
-  header.lastModifiedAtUtcIso = document.header.createdAtUtcIso;
-  header.meta = document.header.meta;
-  header.name = name || document.header.name;
+  const buildInitialDocument = (id: string): PHDocument => {
+    const header = createPresignedHeader(id, document.header.documentType);
+    header.lastModifiedAtUtcIso = document.header.createdAtUtcIso;
+    header.meta = document.header.meta;
+    header.name = name || document.header.name;
 
-  // copy the document at it's initial state
-  const initialDocument = {
-    ...document,
-    header,
-    state: document.initialState,
-    operations: Object.keys(document.operations).reduce((acc, key) => {
-      acc[key] = [];
-      return acc;
-    }, {} as DocumentOperations),
+    // copy the document at it's initial state
+    return {
+      ...document,
+      header,
+      state: document.initialState,
+      operations: Object.keys(document.operations).reduce((acc, key) => {
+        acc[key] = [];
+        return acc;
+      }, {} as DocumentOperations),
+    };
   };
 
-  await addDocument(
-    driveId,
-    name || document.header.name,
-    document.header.documentType,
-    parentFolder,
-    initialDocument,
-    documentId,
-    document.header.meta?.preferredEditor,
-  );
+  const createDocumentWithId = (id: string) =>
+    addDocument(
+      driveId,
+      name || document.header.name,
+      document.header.documentType,
+      parentFolder,
+      buildInitialDocument(id),
+      id,
+      document.header.meta?.preferredEditor,
+    );
+
+  let documentId = duplicateId ? generateId() : document.header.id;
+  try {
+    await createDocumentWithId(documentId);
+  } catch (createError) {
+    if (!isDocumentIdTakenError(createError)) {
+      throw createError;
+    }
+    // The id is owned by a soft-deleted document — import as a copy, after
+    // clearing the node the failed create left pointing at nothing.
+    await removeDanglingNode(driveId, documentId);
+    documentId = generateId();
+    await createDocumentWithId(documentId);
+  }
 
   // then add all the operations in chunks (exclude document-scope ops —
   // the reactor already generated CREATE_DOCUMENT + UPGRADE_DOCUMENT above)
@@ -564,38 +628,54 @@ export async function addFileWithProgress(
       await reactor.get(document.header.id);
       duplicateId = true;
     } catch {
-      // document id not found
+      // A rejection does not prove the id is free: the view hides soft-deleted
+      // documents whose retained history still owns it. That case is recovered
+      // below, once the create surfaces it.
     }
 
-    const documentId = duplicateId ? generateId() : document.header.id;
-    const header = createPresignedHeader(
-      documentId,
-      document.header.documentType,
-    );
-    header.lastModifiedAtUtcIso = document.header.createdAtUtcIso;
-    header.meta = document.header.meta;
-    header.name = name || document.header.name;
+    const buildInitialDocument = (id: string): PHDocument => {
+      const header = createPresignedHeader(id, document.header.documentType);
+      header.lastModifiedAtUtcIso = document.header.createdAtUtcIso;
+      header.meta = document.header.meta;
+      header.name = name || document.header.name;
 
-    // copy the document at it's initial state
-    const initialDocument = {
-      ...document,
-      header,
-      state: document.initialState,
-      operations: Object.keys(document.operations).reduce((acc, key) => {
-        acc[key] = [];
-        return acc;
-      }, {} as DocumentOperations),
+      // copy the document at it's initial state
+      return {
+        ...document,
+        header,
+        state: document.initialState,
+        operations: Object.keys(document.operations).reduce((acc, key) => {
+          acc[key] = [];
+          return acc;
+        }, {} as DocumentOperations),
+      };
     };
 
-    const fileNode = await addDocument(
-      driveId,
-      name || document.header.name,
-      document.header.documentType,
-      parentFolder,
-      initialDocument,
-      documentId,
-      document.header.meta?.preferredEditor,
-    );
+    const createDocumentWithId = (id: string) =>
+      addDocument(
+        driveId,
+        name || document.header.name,
+        document.header.documentType,
+        parentFolder,
+        buildInitialDocument(id),
+        id,
+        document.header.meta?.preferredEditor,
+      );
+
+    let documentId = duplicateId ? generateId() : document.header.id;
+    let fileNode;
+    try {
+      fileNode = await createDocumentWithId(documentId);
+    } catch (createError) {
+      if (!isDocumentIdTakenError(createError)) {
+        throw createError;
+      }
+      // The id is owned by a soft-deleted document — import as a copy, after
+      // clearing the node the failed create left pointing at nothing.
+      await removeDanglingNode(driveId, documentId);
+      documentId = generateId();
+      fileNode = await createDocumentWithId(documentId);
+    }
 
     if (!fileNode) {
       throw new Error("There was an error adding file");

--- a/packages/reactor-browser/test/import-conflict.node.test.ts
+++ b/packages/reactor-browser/test/import-conflict.node.test.ts
@@ -1,0 +1,217 @@
+import type { IReactorClient } from "@powerhousedao/reactor";
+import { driveDocumentModelModule } from "@powerhousedao/shared/document-drive";
+import { createZip } from "@powerhousedao/shared/document-model";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  addFileWithProgress,
+  isDocumentIdTakenError,
+} from "../src/actions/document.js";
+import type { FileUploadProgress } from "../src/types/upload.js";
+
+/**
+ * Regression tests for importing a .phd whose document id is already owned by
+ * the reactor — in particular by a soft-deleted document, whose retained
+ * operation history rejects a CREATE_DOCUMENT at revision 0.
+ *
+ * A soft-deleted id cannot be detected before the write: the document view,
+ * `resolveIdOrSlug` and `getOperations` all hide soft-deleted documents, so a
+ * tombstoned id is indistinguishable from an unused one. The import therefore
+ * attempts the create and recovers from the revision mismatch under a fresh id.
+ */
+
+/** The error the reactor's job executor surfaces for a taken document id. */
+const REVISION_MISMATCH_ERROR = new Error(
+  "Job failed after 4 attempts:\n[Attempt 1] Failed to write operation to " +
+    "IOperationStore: Revision mismatch: expected 3, got 0",
+);
+
+describe("isDocumentIdTakenError", () => {
+  it("recognizes the executor's wrapped revision mismatch", () => {
+    expect(isDocumentIdTakenError(REVISION_MISMATCH_ERROR)).toBe(true);
+  });
+
+  it("unwraps the error wrapper addDocument adds", () => {
+    const wrapped = new Error("There was an error adding document", {
+      cause: REVISION_MISMATCH_ERROR,
+    });
+    expect(isDocumentIdTakenError(wrapped)).toBe(true);
+  });
+
+  it("does not match unrelated failures", () => {
+    expect(isDocumentIdTakenError(new Error("Network unreachable"))).toBe(
+      false,
+    );
+    expect(isDocumentIdTakenError("Revision mismatch")).toBe(false);
+  });
+});
+
+describe("addFileWithProgress with a taken document id", () => {
+  const driveDoc = driveDocumentModelModule.utils.createDocument();
+  const driveId = driveDoc.header.id;
+
+  let fileDoc: ReturnType<typeof driveDocumentModelModule.utils.createDocument>;
+  let fileBuffer: Uint8Array;
+  let events: FileUploadProgress[];
+
+  beforeEach(async () => {
+    fileDoc = driveDocumentModelModule.utils.createDocument();
+    fileBuffer = await createZip(fileDoc);
+    events = [];
+  });
+
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Builds a reactor client that tracks created documents, so `get` resolves
+   * for ids the import has just written — as a real reactor does.
+   */
+  function makeClient(options: {
+    /** The file's own id already resolves before the import (live duplicate). */
+    fileIdLive?: boolean;
+    /** Creating under the file's own id is rejected (soft-deleted owner). */
+    rejectFileId?: boolean;
+    /** Replaces the addFile mock outright. */
+    addFile?: ReturnType<typeof vi.fn>;
+  }) {
+    const created = new Set<string>();
+
+    const addFile =
+      options.addFile ??
+      vi.fn((_driveId: string, document: { header: { id: string } }) => {
+        if (options.rejectFileId && document.header.id === fileDoc.header.id) {
+          return Promise.reject(REVISION_MISMATCH_ERROR);
+        }
+        created.add(document.header.id);
+        return Promise.resolve(document);
+      });
+
+    // Mirrors the reactor: the node is removed, then tombstoning the child
+    // document that was never created reports a failure.
+    const removeNode = vi.fn(() =>
+      Promise.reject(new Error("Document was deleted at 2026-07-27T00:00:00Z")),
+    );
+
+    const get = vi.fn((id: string): Promise<unknown> => {
+      if (id === driveId) return Promise.resolve(driveDoc);
+      if (created.has(id)) return Promise.resolve(fileDoc);
+      if (id === fileDoc.header.id && options.fileIdLive) {
+        return Promise.resolve(fileDoc);
+      }
+      return Promise.reject(new Error("Document not found"));
+    });
+
+    const client = {
+      resolveIdOrSlug: vi.fn((id: string) => Promise.resolve(id)),
+      get,
+      getDocumentModelModules: vi.fn(() =>
+        // `createDocument` stamps UPGRADE_DOCUMENT.toVersion 0, so the replay
+        // config must key this module's reducer at version 0.
+        Promise.resolve({
+          results: [{ ...driveDocumentModelModule, version: 0 }],
+        }),
+      ),
+      getDocumentModelModule: vi.fn(() =>
+        Promise.resolve(driveDocumentModelModule),
+      ),
+      drives: { addFile, removeNode },
+    };
+
+    (globalThis as { window?: unknown }).window = {
+      ph: { reactorClient: client as unknown as IReactorClient },
+    };
+
+    return { addFile, removeNode };
+  }
+
+  function run() {
+    return addFileWithProgress(
+      fileBuffer as unknown as File,
+      driveId,
+      undefined,
+      undefined,
+      (progress) => events.push(progress),
+    );
+  }
+
+  function idOfCall(addFile: ReturnType<typeof vi.fn>, call: number): string {
+    return (addFile.mock.calls[call][1] as { header: { id: string } }).header
+      .id;
+  }
+
+  it("imports a copy when the id is owned by a soft-deleted document", async () => {
+    const { addFile } = makeClient({ rejectFileId: true });
+
+    const result = await run();
+
+    expect(result).toBeDefined();
+    // The first attempt reuses the file's id and is rejected; the retry mints one.
+    expect(addFile).toHaveBeenCalledTimes(2);
+    expect(idOfCall(addFile, 0)).toBe(fileDoc.header.id);
+    expect(idOfCall(addFile, 1)).not.toBe(fileDoc.header.id);
+    expect(events.at(-1)?.stage).toBe("complete");
+    expect(events.some((e) => e.stage === "failed")).toBe(false);
+  });
+
+  it("clears the node the failed create left behind, before retrying", async () => {
+    const { addFile, removeNode } = makeClient({ rejectFileId: true });
+
+    await run();
+
+    expect(removeNode).toHaveBeenCalledTimes(1);
+    expect(removeNode).toHaveBeenCalledWith(driveId, fileDoc.header.id);
+    // Cleanup has to precede the retry, or the copy lands beside a phantom node.
+    expect(removeNode.mock.invocationCallOrder[0]).toBeLessThan(
+      addFile.mock.invocationCallOrder[1],
+    );
+  });
+
+  it("does not touch existing nodes when no conflict occurs", async () => {
+    const { removeNode } = makeClient({});
+
+    await run();
+
+    expect(removeNode).not.toHaveBeenCalled();
+  });
+
+  it("returns the copy under the freshly minted id", async () => {
+    const { addFile } = makeClient({ rejectFileId: true });
+
+    const result = await run();
+
+    expect(result?.id).toBe(idOfCall(addFile, 1));
+  });
+
+  it("does not retry failures that are not id conflicts", async () => {
+    const addFile = vi.fn(() => Promise.reject(new Error("Network down")));
+    makeClient({ addFile });
+
+    await expect(run()).rejects.toThrow(/error adding document/);
+    expect(addFile).toHaveBeenCalledTimes(1);
+    expect(events.at(-1)?.stage).toBe("failed");
+  });
+
+  it("silently mints a fresh id for a live duplicate id (existing behavior)", async () => {
+    const { addFile } = makeClient({ fileIdLive: true });
+
+    const result = await run();
+
+    expect(result).toBeDefined();
+    expect(addFile).toHaveBeenCalledTimes(1);
+    expect(idOfCall(addFile, 0)).not.toBe(fileDoc.header.id);
+    expect(events.some((e) => e.stage === "conflict")).toBe(false);
+  });
+
+  it("keeps the file's id when it is free (existing behavior)", async () => {
+    const { addFile } = makeClient({});
+
+    const result = await run();
+
+    expect(result).toBeDefined();
+    expect(addFile).toHaveBeenCalledTimes(1);
+    expect(idOfCall(addFile, 0)).toBe(fileDoc.header.id);
+    expect(events.some((e) => e.stage === "conflict")).toBe(false);
+  });
+});

--- a/packages/reactor/test/integration/import-conflict.test.ts
+++ b/packages/reactor/test/integration/import-conflict.test.ts
@@ -1,0 +1,176 @@
+import { PGlite } from "@electric-sql/pglite";
+import { driveDocumentModelModule } from "@powerhousedao/shared/document-drive";
+import { generateId } from "@powerhousedao/shared/document-model";
+import { Kysely } from "kysely";
+import { PGliteDialect } from "kysely-pglite-dialect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database, ReactorClientModule } from "../../index.js";
+import { ReactorBuilder, ReactorClientBuilder } from "../../index.js";
+
+/**
+ * Regression tests for the delete → re-import flow.
+ *
+ * Deleting a document appends a DELETE_DOCUMENT tombstone; its operation
+ * history is retained, so the id stays owned by the reactor. No read path
+ * exposes that ownership: `get`, `resolveIdOrSlug` and `getOperations` all
+ * hide soft-deleted documents, so a tombstoned id is indistinguishable from an
+ * unused one. Importers therefore cannot probe first — reusing the id fails
+ * with a revision mismatch on CREATE_DOCUMENT@0, and the recovery is to import
+ * under a fresh id ("create a copy").
+ */
+describe("import after delete (document id conflict)", () => {
+  let pg: PGlite;
+  let db: Kysely<unknown>;
+  let module: ReactorClientModule;
+
+  beforeEach(async () => {
+    pg = new PGlite();
+    db = new Kysely<unknown>({ dialect: new PGliteDialect(pg) });
+    const reactorBuilder = new ReactorBuilder()
+      .withDocumentModels([driveDocumentModelModule as never])
+      .withKysely(db as Kysely<Database>);
+    module = await new ReactorClientBuilder()
+      .withReactorBuilder(reactorBuilder)
+      .buildModule();
+  });
+
+  afterEach(async () => {
+    module.reactor.kill();
+    await db.destroy();
+  });
+
+  function newDoc() {
+    return driveDocumentModelModule.utils.createDocument();
+  }
+
+  async function driveNodes(driveId: string) {
+    const drive = await module.client.get(driveId);
+    const state = drive.state as unknown as {
+      global: { nodes: { id: string; name: string }[] };
+    };
+    return state.global.nodes.map((node) => ({ id: node.id, name: node.name }));
+  }
+
+  it("commits the drive node even when the document create fails", async () => {
+    const drive = newDoc();
+    await module.client.create(drive);
+
+    const file = newDoc();
+    file.header.name = "new one";
+    await module.client.drives.addFile(drive.header.id, file);
+    await module.client.drives.removeNode(drive.header.id, file.header.id);
+    expect(await driveNodes(drive.header.id)).toEqual([]);
+
+    // addFile submits the create and the drive's ADD_FILE as two jobs whose
+    // dependsOn link only orders them, so the node lands despite the rejection.
+    await expect(
+      module.client.drives.addFile(drive.header.id, file),
+    ).rejects.toThrow(/revision mismatch/i);
+
+    expect(await driveNodes(drive.header.id)).toEqual([
+      { id: file.header.id, name: "new one" },
+    ]);
+  });
+
+  it("leaves a single node once the dangling one is cleared before the retry", async () => {
+    const drive = newDoc();
+    await module.client.create(drive);
+
+    const file = newDoc();
+    file.header.name = "new one";
+    await module.client.drives.addFile(drive.header.id, file);
+    await module.client.drives.removeNode(drive.header.id, file.header.id);
+
+    await expect(
+      module.client.drives.addFile(drive.header.id, file),
+    ).rejects.toThrow(/revision mismatch/i);
+
+    // removeNode reports failure because it also tombstones the child document,
+    // which was never created — the node removal itself still commits.
+    await expect(
+      module.client.drives.removeNode(drive.header.id, file.header.id),
+    ).rejects.toThrow();
+    expect(await driveNodes(drive.header.id)).toEqual([]);
+
+    const copy = structuredClone(file);
+    copy.header.id = generateId();
+    copy.header.slug = "";
+    await module.client.drives.addFile(drive.header.id, copy);
+
+    // One entry, keeping the original name rather than gaining a "(copy)" suffix.
+    expect(await driveNodes(drive.header.id)).toEqual([
+      { id: copy.header.id, name: "new one" },
+    ]);
+  });
+
+  it("hides a deleted document from every read path", async () => {
+    const doc = newDoc();
+    await module.client.create(doc);
+
+    const ops = await module.client.getOperations(doc.header.id);
+    expect(ops.results.length).toBeGreaterThan(0);
+
+    await module.client.deleteDocument(doc.header.id);
+
+    await expect(module.client.get(doc.header.id)).rejects.toThrow(
+      "Document not found",
+    );
+    await expect(module.client.resolveIdOrSlug(doc.header.id)).rejects.toThrow(
+      "Document not found",
+    );
+    // Retained history is not reachable either, so it cannot serve as a probe.
+    await expect(module.client.getOperations(doc.header.id)).rejects.toThrow(
+      "Document not found",
+    );
+  });
+
+  it("reports a deleted id exactly as it reports an unused one", async () => {
+    const doc = newDoc();
+    await module.client.create(doc);
+    await module.client.deleteDocument(doc.header.id);
+
+    const unused = generateId();
+    const probe = async (id: string) => {
+      try {
+        await module.client.resolveIdOrSlug(id);
+        return "resolved";
+      } catch (e) {
+        return (e as Error).message.replace(id, "<id>");
+      }
+    };
+
+    expect(await probe(doc.header.id)).toBe(await probe(unused));
+  });
+
+  it("rejects re-creating a deleted document under its original id", async () => {
+    const doc = newDoc();
+    await module.client.create(doc);
+    await module.client.deleteDocument(doc.header.id);
+
+    await expect(module.client.create(doc)).rejects.toThrow(
+      /revision mismatch/i,
+    );
+  });
+
+  it("imports a copy of a deleted document under a fresh id", async () => {
+    const doc = newDoc();
+    await module.client.create(doc);
+    await module.client.deleteDocument(doc.header.id);
+
+    // "Create Copy": same content, fresh identity — mirrors the import flow.
+    const copy = structuredClone(doc);
+    copy.header.id = generateId();
+    copy.header.slug = copy.header.id;
+
+    const created = await module.client.create(copy);
+    expect(created.header.id).toBe(copy.header.id);
+
+    const fetched = await module.client.get(copy.header.id);
+    expect(fetched.header.id).toBe(copy.header.id);
+
+    // The original stays deleted and untouched.
+    await expect(module.client.get(doc.header.id)).rejects.toThrow(
+      "Document not found",
+    );
+  });
+});


### PR DESCRIPTION
Deleting a document in Connect hides it but keeps its history, so its id stays taken. Re-importing the same file reuses that id and fails with "Revision mismatch: expected 3, got 0".

Since a deleted id is indistinguishable from an unused one, the importer cannot check up front. It now catches the reactor's rejection, generates a new id, and imports the file again under it, so the document comes back as a copy with its contents intact. Both import paths behave this way, and unrelated failures are still surfaced as errors.