### PR TITLE
fix(renown): start Privy OAuth logins at the provider

### DIFF
--- a/packages/renown/src/wallet/privy/adapter.ts
+++ b/packages/renown/src/wallet/privy/adapter.ts
@@ -24,6 +24,17 @@ const PRIVY_METHOD_MAP: Partial<Record<LoginMethod, PrivyLoginMethodId>> = {
   [LoginMethod.EMAIL]: "email",
 };
 
+type PrivyOAuthProviderId = "google" | "apple";
+
+// Methods Privy can start headlessly with initOAuth. Opening the modal for these
+// would only render a single button for a provider the caller already picked.
+const PRIVY_OAUTH_PROVIDERS: Partial<
+  Record<LoginMethod, PrivyOAuthProviderId>
+> = {
+  [LoginMethod.GOOGLE]: "google",
+  [LoginMethod.APPLE]: "apple",
+};
+
 // Resolve config `methods` (LoginMethod string values) to the supported set,
 // falling back to the default when none are provided.
 export function resolvePrivyMethods(methods?: string[]): LoginMethod[] {
@@ -43,6 +54,7 @@ export function resolvePrivyMethods(methods?: string[]): LoginMethod[] {
 // runs, connect/disconnect calls throw.
 export interface PrivyBindings {
   openLoginModal: (options?: LoginModalOptions) => void;
+  initOAuth: (options: { provider: PrivyOAuthProviderId }) => Promise<void>;
   logout: () => Promise<void>;
   signTypedData: (
     args: Parameters<SignCredentialTypedData>[0],
@@ -159,16 +171,24 @@ export class PrivyCore {
       throw new Error(`PrivyAdapter does not support login method "${chosen}"`);
     }
 
-    // Open Privy's modal (social OAuth runs in a popup, keeping this page alive)
-    // so the pending promise resolves in-page and Renown sign-in can run.
     const bindings = this.bindings;
+    const oauthProvider = PRIVY_OAUTH_PROVIDERS[chosen];
     return new Promise<WalletSession>((resolve, reject) => {
       this.pending = { resolve, reject };
-      try {
-        bindings.openLoginModal({ loginMethods: [privyMethod] });
-      } catch (error) {
+      const fail = (error: unknown) => {
         this.pending = null;
         reject(error instanceof Error ? error : new Error(String(error)));
+      };
+      try {
+        // initOAuth navigates away, so this promise stays pending until the page
+        // unloads; syncFromEmbeddedWallet emits the session on the redirect back.
+        if (oauthProvider) {
+          bindings.initOAuth({ provider: oauthProvider }).catch(fail);
+        } else {
+          bindings.openLoginModal({ loginMethods: [privyMethod] });
+        }
+      } catch (error) {
+        fail(error);
       }
     });
   }

--- a/packages/renown/src/wallet/privy/bridge.tsx
+++ b/packages/renown/src/wallet/privy/bridge.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import {
   getEmbeddedConnectedWallet,
   useLogin,
+  useLoginWithOAuth,
   useLogout,
   usePrivy,
   useSignTypedData,
@@ -25,17 +26,23 @@ export function PrivyAdapterBridge({ core }: PrivyAdapterBridgeProps) {
   const { login: openLoginModal } = useLogin({
     onError: (error) => core.handleLoginError(error),
   });
+  // Also mounts this hook on the page Privy redirects back to, which is what
+  // lets it finish the OAuth flow there.
+  const { initOAuth } = useLoginWithOAuth({
+    onError: (error) => core.handleLoginError(error),
+  });
 
   // Privy returns fresh function references each render. A ref keeps the bind
   // stable so we bind once per core instead of re-binding every render.
-  const fnsRef = useRef({ openLoginModal, logout, signTypedData });
+  const fnsRef = useRef({ openLoginModal, initOAuth, logout, signTypedData });
   useEffect(() => {
-    fnsRef.current = { openLoginModal, logout, signTypedData };
-  }, [openLoginModal, logout, signTypedData]);
+    fnsRef.current = { openLoginModal, initOAuth, logout, signTypedData };
+  }, [openLoginModal, initOAuth, logout, signTypedData]);
 
   useEffect(() => {
     return core.bind({
       openLoginModal: (opts) => fnsRef.current.openLoginModal(opts),
+      initOAuth: (opts) => fnsRef.current.initOAuth(opts),
       logout: () => fnsRef.current.logout(),
       // Privy owns the embedded wallet keys, so showWalletUIs:false signs the
       // credential typed-data silently as part of login.


### PR DESCRIPTION
## Problem

`PrivyCore.connect(LoginMethod.GOOGLE)` calls `openLoginModal({ loginMethods: ['google'] })`. Privy renders its login modal containing a single Google button — so a host that already offers a "Continue with Google" button makes the user click Google twice.

## Change

Route the methods Privy can start headlessly (Google, Apple) through `useLoginWithOAuth().initOAuth({ provider })`, which redirects straight to the provider. Email keeps the modal, since it needs the input field.

`initOAuth` navigates away, so the pending promise stays unsettled until the page unloads. The session is emitted from `syncFromEmbeddedWallet` on the redirect back — the same path the modal's OAuth flow already took, and the one #2885 added the completion handling for. The hook is mounted in `PrivyAdapterBridge`, which also places it on the redirect-back page so Privy can finish the flow there.

Error handling is unified into a local `fail()` so a rejected `initOAuth` clears `pending` and rejects `connect()`, matching the previous `try/catch` behaviour around `openLoginModal`.

## Breaking

`PrivyBindings` gains a required `initOAuth` member. The interface is exported, so any external implementor needs the new field. Nothing inside the repo implements it besides the bridge.

## Verification

Checked against a consumer app (vetra.to) running the built package with this change patched in:

- Clicking "Continue with Google" navigates in one click to `accounts.google.com/v3/signin/identifier` — no intermediate Privy modal.
- The generated auth URL carries `prompt=select_account`.
- Email still opens Privy's modal with the address input.

`pnpm tsc`, `pnpm lint`, and `pnpm build` are clean in `packages/renown` (the one `no-unnecessary-condition` warning in `utils.ts` is pre-existing on `main`).

Follows #2885, which landed the OAuth-redirect sign-in completion this relies on.