### PR TITLE
fix(codegen): stop overwriting hand-written files and fix custom-scalar mocks

### DIFF
--- a/packages/codegen/src/codegen/graphql.ts
+++ b/packages/codegen/src/codegen/graphql.ts
@@ -79,10 +79,19 @@ export const scalarsValidation = {
 const DATE_LIKE_SCALARS = new Set(["Date", "DateTime"]);
 
 // State-field scalar -> valid mock literal (emitted verbatim into generated tests).
+//
+// Two groups need an entry here. The date-like and URL scalars validate more
+// strictly than zocker generates, so a literal keeps the generated test green.
+// `AttachmentRef` and `Address` are a harder case: they are the scalars in
+// `scalarsValidation` above that compile to `z.custom(...)`, and zocker cannot
+// synthesise a value satisfying an arbitrary predicate at all — without a
+// literal here the generated test throws on its first run.
 const SCALAR_MOCK_OVERRIDES: Record<string, string> = {
   Date: `"2024-01-01T00:00:00.000Z"`,
   DateTime: `"2024-01-01T00:00:00.000Z"`,
   URL: `"https://example.com"`,
+  AttachmentRef: `"attachment://v1:${"a".repeat(64)}"`,
+  Address: `"eip155:0x${"0".repeat(40)}"`,
 };
 
 function unwrapNamedTypeName(type: TypeNode): string | null {

--- a/packages/codegen/src/file-builders/document-model/src-dir.ts
+++ b/packages/codegen/src/file-builders/document-model/src-dir.ts
@@ -74,15 +74,22 @@ export async function makeReducerOperationHandlerForModule({
             importSpecifier.getName() === operationsInterfaceTypeName,
         ),
   );
-  if (existingOperationsInterfaceTypeImport) {
-    existingOperationsInterfaceTypeImport.remove();
-  }
 
-  sourceFile.addImportDeclaration({
-    namedImports: [operationsInterfaceTypeName],
-    moduleSpecifier: versionImportPath,
-    isTypeOnly: true,
-  });
+  // Only the module specifier is ours to manage here — it has to follow the
+  // model to a new version directory. Everything else in the declaration
+  // belongs to whoever wrote the reducer: authors routinely import state enums
+  // and other types on the same line as the operations interface. Removing the
+  // declaration and re-adding it with just our own name (as this used to do)
+  // silently deleted those siblings, and the reducer stopped compiling.
+  if (existingOperationsInterfaceTypeImport) {
+    existingOperationsInterfaceTypeImport.setModuleSpecifier(versionImportPath);
+  } else {
+    sourceFile.addImportDeclaration({
+      namedImports: [operationsInterfaceTypeName],
+      moduleSpecifier: versionImportPath,
+      isTypeOnly: true,
+    });
+  }
 
   // Read operation names from the generated operations interface's AST members;
   // it's a source file in this project already, so no module resolution needed.

--- a/packages/codegen/src/utils/source-files.ts
+++ b/packages/codegen/src/utils/source-files.ts
@@ -3,16 +3,34 @@ import type { Project } from "ts-morph";
 
 /** Gets a SourceFile by name in a ts-morph Project, or creates a new one
  * if none with that path exists.
+ *
+ * "Exists" has to mean *on disk*, not merely "already loaded in this Project".
+ * Projects here are built with `skipAddingFilesFromTsConfig` (see
+ * `buildTsMorphProject`), so they start empty and `getSourceFile` alone reports
+ * every existing file as missing. Combined with `overwrite: true` that silently
+ * discarded whatever the user had written — `alreadyExists` was always `false`,
+ * so builders that scaffold-once-then-amend (tests, reducers, subgraphs,
+ * editors, processors) re-scaffolded from scratch on every run and hand-written
+ * code was lost on `project.save()`.
+ *
+ * Reading the file in when it is on disk but not yet loaded mirrors what
+ * `DirectoryManager.createSourceFile` already does. Files that codegen fully
+ * owns are unaffected: they call `replaceWithText` immediately afterwards.
  */
 export function getOrCreateSourceFile(project: Project, filePath: string) {
   const dirName = path.dirname(filePath);
   if (!project.getDirectory(dirName)) {
     project.createDirectory(dirName);
   }
-  const sourceFile = project.getSourceFile(filePath);
+  const sourceFile =
+    project.getSourceFile(filePath) ??
+    project.addSourceFileAtPathIfExists(filePath);
   if (!sourceFile) {
+    // `overwrite: false` so that a future regression here fails loudly instead
+    // of quietly truncating a file: reaching this line now means the path is
+    // genuinely absent from both the project and the disk.
     const newSourceFile = project.createSourceFile(filePath, "", {
-      overwrite: true,
+      overwrite: false,
     });
     return {
       alreadyExists: false,

--- a/packages/shared/document-model/mock.test.ts
+++ b/packages/shared/document-model/mock.test.ts
@@ -93,6 +93,8 @@ describe("generateMock", () => {
   it("throws for a z.custom field with no override", () => {
     const schema = z.object({ sourcePdf: attachmentRefSchema() });
 
-    expect(() => generateMock(schema)).toThrow(/No generator for schema custom/);
+    expect(() => generateMock(schema)).toThrow(
+      /No generator for schema custom/,
+    );
   });
 });

--- a/packages/shared/document-model/mock.test.ts
+++ b/packages/shared/document-model/mock.test.ts
@@ -1,0 +1,98 @@
+// Regression guard for `generateMock` and the `z.custom(...)` scalars.
+//
+// Codegen emits `AttachmentRef` and `Address` as `z.custom(...)` (see
+// `scalarsValidation` in packages/codegen/src/codegen/graphql.ts). zocker cannot
+// synthesise a value satisfying an arbitrary predicate, so it throws for those
+// fields. `generateMock`'s `overrides` argument is the escape hatch — but it
+// only works if the overridden fields are skipped BEFORE generation. Generating
+// first and merging afterwards (the original implementation) threw before the
+// caller's value was ever applied, which made every generated test for a model
+// with an `AttachmentRef` field fail on its first run.
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { generateMock } from "./mock.js";
+
+// Mirrors what codegen emits for the AttachmentRef scalar.
+const attachmentRefSchema = () =>
+  z.custom<`attachment://v${number}:${string}`>((val) =>
+    /^attachment:\/\/v\d+:.+$/.test(val as string),
+  );
+
+const VALID_REF = `attachment://v1:${"a".repeat(64)}` as const;
+
+describe("generateMock", () => {
+  it("uses an override for a field zocker cannot generate", () => {
+    const schema = z.object({
+      sourcePdf: attachmentRefSchema(),
+      uploadedAt: z.iso.datetime(),
+    });
+
+    const input = generateMock(schema, {
+      sourcePdf: VALID_REF,
+      uploadedAt: "2024-01-01T00:00:00.000Z",
+    });
+
+    expect(input.sourcePdf).toBe(VALID_REF);
+    expect(schema.safeParse(input).success).toBe(true);
+  });
+
+  it("still generates the fields that were not overridden", () => {
+    const schema = z.object({
+      sourcePdf: attachmentRefSchema(),
+      name: z.string(),
+      count: z.number(),
+    });
+
+    const input = generateMock(schema, { sourcePdf: VALID_REF });
+
+    expect(input.sourcePdf).toBe(VALID_REF);
+    expect(typeof input.name).toBe("string");
+    expect(typeof input.count).toBe("number");
+  });
+
+  it("overrides win over generated values", () => {
+    const schema = z.object({ name: z.string(), count: z.number() });
+
+    const input = generateMock(schema, { name: "pinned" });
+
+    expect(input.name).toBe("pinned");
+    expect(typeof input.count).toBe("number");
+  });
+
+  it("generates without overrides", () => {
+    const schema = z.object({ name: z.string() });
+
+    expect(typeof generateMock(schema).name).toBe("string");
+  });
+
+  it("passes through an override for a key that is not in the shape", () => {
+    const schema = z.object({ name: z.string() });
+
+    const input = generateMock(schema, { extra: "kept" } as never) as Record<
+      string,
+      unknown
+    >;
+
+    expect(input.extra).toBe("kept");
+    expect(typeof input.name).toBe("string");
+  });
+
+  it("applies overrides to a non-object schema without throwing", () => {
+    const schema = z.record(z.string(), z.string());
+
+    const input = generateMock(schema, { pinned: "value" });
+
+    expect(input.pinned).toBe("value");
+  });
+
+  // Documents the intentional boundary: an override is the ONLY way to supply a
+  // `z.custom(...)` field. There is no value to invent for an arbitrary
+  // predicate, so this must keep failing loudly rather than guessing — which is
+  // why codegen carries a literal for every such scalar in SCALAR_MOCK_OVERRIDES.
+  it("throws for a z.custom field with no override", () => {
+    const schema = z.object({ sourcePdf: attachmentRefSchema() });
+
+    expect(() => generateMock(schema)).toThrow(/No generator for schema custom/);
+  });
+});

--- a/packages/shared/document-model/mock.ts
+++ b/packages/shared/document-model/mock.ts
@@ -1,11 +1,53 @@
 import { zocker } from "zocker";
-import type { z } from "zod";
+import { z } from "zod";
 
+/**
+ * Narrows to an object schema whose shape we can omit keys from. Callers may
+ * pass any `ZodType`, so this has to be checked rather than assumed.
+ */
+function isObjectSchema(schema: z.ZodType): schema is z.ZodObject {
+  return schema instanceof z.ZodObject;
+}
+
+/**
+ * Builds a mock value for a schema, with `overrides` taking precedence.
+ *
+ * Overridden fields are removed from the schema *before* generation rather than
+ * being overwritten afterwards. That ordering is what makes overrides usable as
+ * an escape hatch: some scalars compile to `z.custom(...)` (`AttachmentRef`,
+ * `Address`), and zocker cannot synthesise a value satisfying an arbitrary
+ * predicate — it throws. Generating first meant the throw happened before the
+ * caller's value was ever applied, so an override could not rescue the field it
+ * was written for.
+ *
+ * Only the overridden keys are skipped. A `z.custom(...)` field with no
+ * override still throws, which is correct: there is no way to invent a value
+ * for it, and the caller needs to say what it should be.
+ */
 export function generateMock<TSchema extends z.ZodType>(
   schema: TSchema,
   overrides?: Partial<z.infer<TSchema>>,
 ): z.infer<TSchema> {
-  const generated = zocker(schema).generate() as z.infer<TSchema>;
-  if (!overrides) return generated;
-  return { ...(generated as object), ...overrides } as z.infer<TSchema>;
+  if (!overrides) return zocker(schema).generate() as z.infer<TSchema>;
+
+  const overriddenKeys = Object.keys(overrides);
+  if (overriddenKeys.length === 0 || !isObjectSchema(schema)) {
+    // Nothing to skip, or a schema with no shape to omit from: generate the
+    // whole value and let the overrides win by merge, as before.
+    const generated = zocker(schema).generate() as z.infer<TSchema>;
+    return { ...(generated as object), ...overrides } as z.infer<TSchema>;
+  }
+
+  // Omitting a key the shape does not have is an error in zod, and an override
+  // for an unknown key should still pass through to the result.
+  const omittable = overriddenKeys.filter((key) => key in schema.shape);
+  // `omit` is typed against the shape's literal keys; ours are only known at
+  // runtime, so the mask has to be asserted into that parameter type.
+  const mask = Object.fromEntries(
+    omittable.map((key) => [key, true]),
+  ) as Parameters<typeof schema.omit>[0];
+  const schemaToGenerate = omittable.length ? schema.omit(mask) : schema;
+
+  const generated = zocker(schemaToGenerate).generate() as object;
+  return { ...generated, ...overrides } as z.infer<TSchema>;
 }

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
       "connect/pwa-config.test.ts",
       "connect/pwa-manifest.test.ts",
       "document-drive/**/*.test.ts",
+      "document-model/mock.test.ts",
       "registry/manifest-slim.test.ts",
     ],
     exclude: ["**/node_modules/**", "**/dist/**"],


### PR DESCRIPTION
## Summary

Re-running codegen destroyed hand-written code. Three defects, all in the "codegen clobbers what you wrote" family.

**1. Every existing file was treated as missing.** `getOrCreateSourceFile` used `project.getSourceFile()`, which only sees files already loaded into the ts-morph Project. Since `7c826d202` added `skipAddingFilesFromTsConfig`, projects start empty — so the lookup reported every on-disk file as absent, and `createSourceFile(..., { overwrite: true })` replaced it.

`alreadyExists` was therefore *always* `false` and every `if (alreadyExists) return` guard was dead code. Builders that scaffold once then amend — tests, reducers, subgraphs, editors, processors — re-scaffolded from scratch on every run.

That same commit already patched the identical dependency in `getPreviousVersionSourceFile`; this applies the same remedy to its neighbour. Regression spans `v6.2.0-dev.21` → `6.2.2-dev.19` (40 releases, incl. stable `6.2.0`/`6.2.1`); last good release was `v6.2.0-dev.20`.

**2. Reducer generation deleted sibling imports.** It located the import declaration *containing* the operations interface type, removed the whole declaration, then re-added one with only its own name — dropping any types the author imported on the same line (state enums, etc.) and breaking compilation. Only the module specifier is codegen's to manage, so it is now updated in place. This defect predates the regression above; it was masked while files always arrived empty.

**3. Generated tests threw for custom scalars.** `AttachmentRef` and `Address` compile to `z.custom(...)`, which zocker cannot generate. `generateMock`'s `overrides` argument was the intended escape hatch, but it generated everything first and merged overrides afterwards — so the throw happened before the caller's value applied. Overridden keys are now omitted before generation, and `SCALAR_MOCK_OVERRIDES` carries a literal for both scalars.

## Tests

- New `packages/shared/document-model/mock.test.ts` (7 cases): custom-scalar regression, override precedence, unknown-key passthrough, non-object schemas, and the intentional throw when a `z.custom` field has no override.
- `packages/shared` suite: 164/164 pass. `codegen` typecheck clean; lint 0 errors (12 pre-existing warnings, none in changed files).
- End-to-end against a real project with hand-written reducer and test code: codegen is now **idempotent** (0 files modified), typecheck and tests green. The same run previously erased a hand-written test block and broke the reducer's imports.
- A fresh model with an `AttachmentRef` field now emits a test that runs, verified by feeding the generated schema and generated literal through `generateMock`.
