### PR TITLE
feat(renown): resolve SSR auth on the first render

### DIFF
--- a/apps/academy/docs/academy/03-Build/03-BuildingUserExperiences/07-Authorization/01-RenownAuthenticationFlow.md
+++ b/apps/academy/docs/academy/03-Build/03-BuildingUserExperiences/07-Authorization/01-RenownAuthenticationFlow.md
@@ -133,6 +133,8 @@ function Login() {
 
 Gate any component on auth with a plain `if (!user)` from `useRenownAuth()`; for a no-Suspense "still resolving" state (useful in client-only apps), use `useRenownAuthAsync()`, which returns `state: "authenticated" | "resolving" | "unauthenticated"`.
 
+`"resolving"` appears only when the answer is genuinely unknown. A visitor the first render already knows is signed out — no session cookie, no persisted user — resolves straight to `"unauthenticated"`, so logged-out visitors never sit behind a spinner while the SDK builds its keypair.
+
 `switchboardUrl` enables in-page sign-in; omit it to fall back to the redirect flow. `RenownProvider` composes `<Renown>` (SDK init), `RenownWalletProvider` (adapters), and `RenownInitialUserProvider` (first-render seed), which you can also mount individually for a custom tree.
 
 #### SSR and client-only
@@ -141,6 +143,8 @@ Gate any component on auth with a plain `if (!user)` from `useRenownAuth()`; for
 
 - **Client-only apps** (Vite, etc.): the provider seeds the first render synchronously from `localStorage`, so a returning user is authenticated on the first paint with no flash.
 - **SSR apps** (Next.js): pass a server-resolved `session` (from a verified session cookie) so authenticated content renders on the server too. Read the cookie in a Data Access Layer with `verifyRenownSession` from `@renown/sdk/node`; passing `session` also keeps the cookie in sync after login/logout. A complete Next.js reference lives in the monorepo at `test/test-fusion`, and the `@powerhousedao/reactor-browser` README ("Renown in-page sign-in") has the full API.
+
+Under SSR the cookie seeds the server render and hydration (it is the only thing readable server-side), then `localStorage` takes over once mounted, since that is the credential the SDK actually restores. Include the `documentId`/`username`/`userImage` fields in the cookie's profile hint so both sources agree on name, avatar and profile links — type the route handler with `RenownSessionCookie` rather than redeclaring the payload shape.
 
 ### Testing sign-in (mock adapter)
 

--- a/apps/academy/docs/academy/04-Reference/06-Authorization/renown-sdk/01-Authentication.md
+++ b/apps/academy/docs/academy/04-Reference/06-Authorization/renown-sdk/01-Authentication.md
@@ -561,7 +561,7 @@ export async function GET(request: Request) {
 
 To render authenticated pages on the server (Next.js and similar):
 
-1. On login the client mints a bearer token (`renown.getBearerToken()`) and stores it — with a small display hint (name/avatar) — in an HttpOnly cookie (name exported as `RENOWN_SESSION_COOKIE`, value built with `serializeRenownSessionCookie`). `RenownProvider`'s session-cookie sync does this automatically when given a `session`.
+1. On login the client mints a bearer token (`renown.getBearerToken()`) and stores it — with a `RenownSessionProfile` display hint (`name`/`avatar` plus `documentId`/`username`/`userImage`) — in an HttpOnly cookie (name exported as `RENOWN_SESSION_COOKIE`, value built with `serializeRenownSessionCookie`). `RenownProvider`'s session-cookie sync does this automatically when given a `session`. Type your route handler with the exported `RenownSessionCookie` instead of redeclaring the payload shape.
 2. A Data Access Layer reads the cookie and calls `verifyRenownSession`, memoized per request:
 
 ```typescript
@@ -576,13 +576,17 @@ export const verifySession = cache(async () => {
 });
 ```
 
-`verifyRenownSession` takes the cookie value, verifies the JWT (signature + expiry), and merges the display hint into `user` (unverified — display only). Pass `verifyCredential: true` to also re-check the credential against the switchboard so a **revoked/expired** credential is rejected; it defaults to `false` (token-only, no network). `readSessionClaims(cookieValue)` gives a cheap, signature-free decode for optimistic checks only (e.g. an edge redirect) — never trust it for access control.
+`verifyRenownSession` takes the cookie value, verifies the JWT (signature + expiry), and merges the display hint into `user` (unverified — display only), rebuilding `user.ens` and, when `documentId` is present, `user.profile`. Pass `verifyCredential: true` to also re-check the credential against the switchboard so a **revoked/expired** credential is rejected; it defaults to `false` (token-only, no network). `readSessionClaims(cookieValue)` gives a cheap, signature-free decode for optimistic checks only (e.g. an edge redirect) — never trust it for access control.
 
 3. Pass the result to `RenownProvider session={await verifySession()}` so the server render is authenticated (no flash), and consumers read it via `useRenownAuth()`.
 
-#### Revalidation on the client
+A `null` session is as useful as a populated one: it tells the first render the visitor is definitively signed out, so `useRenownAuthAsync()` reports `"unauthenticated"` immediately instead of spinning. The cookie seeds the server render and hydration; `localStorage` takes over after mount, since that holds the credential the SDK restores.
+
+#### Revalidation and profile refresh on the client
 
 On mount the client re-checks the restored credential against the switchboard and logs out if it was revoked/expired (`revalidate` prop on `RenownProvider`, default `"always"`). In the browser this is **non-blocking and fail-open** (a transient outage keeps the session); Node scripts block on it. `renown.revalidate()` runs the same check on demand.
+
+Separately, `renown.refreshProfile()` re-reads `username`/`userImage` and updates the store only if they changed. It runs on every browser start **regardless of `revalidate`**, because it can never log anyone out — so apps that set `revalidate: "never"` still pick up a renamed user or a new avatar.
 
 ## Best Practices
 

--- a/apps/academy/llms-full.txt
+++ b/apps/academy/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-07-24T18:45:19.144Z
+> Generated: 2026-07-28T11:09:31.654Z
 > Total Documents: 106
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -11625,7 +11625,7 @@ export async function GET(request: Request) {
 
 To render authenticated pages on the server (Next.js and similar):
 
-1. On login the client mints a bearer token (`renown.getBearerToken()`) and stores it — with a small display hint (name/avatar) — in an HttpOnly cookie (name exported as `RENOWN_SESSION_COOKIE`, value built with `serializeRenownSessionCookie`). `RenownProvider`'s session-cookie sync does this automatically when given a `session`.
+1. On login the client mints a bearer token (`renown.getBearerToken()`) and stores it — with a `RenownSessionProfile` display hint (`name`/`avatar` plus `documentId`/`username`/`userImage`) — in an HttpOnly cookie (name exported as `RENOWN_SESSION_COOKIE`, value built with `serializeRenownSessionCookie`). `RenownProvider`'s session-cookie sync does this automatically when given a `session`. Type your route handler with the exported `RenownSessionCookie` instead of redeclaring the payload shape.
 2. A Data Access Layer reads the cookie and calls `verifyRenownSession`, memoized per request:
 
 ```typescript
@@ -11638,13 +11638,17 @@ export const verifySession = cache(async () => {
 });
 ```
 
-`verifyRenownSession` takes the cookie value, verifies the JWT (signature + expiry), and merges the display hint into `user` (unverified — display only). Pass `verifyCredential: true` to also re-check the credential against the switchboard so a **revoked/expired** credential is rejected; it defaults to `false` (token-only, no network). `readSessionClaims(cookieValue)` gives a cheap, signature-free decode for optimistic checks only (e.g. an edge redirect) — never trust it for access control.
+`verifyRenownSession` takes the cookie value, verifies the JWT (signature + expiry), and merges the display hint into `user` (unverified — display only), rebuilding `user.ens` and, when `documentId` is present, `user.profile`. Pass `verifyCredential: true` to also re-check the credential against the switchboard so a **revoked/expired** credential is rejected; it defaults to `false` (token-only, no network). `readSessionClaims(cookieValue)` gives a cheap, signature-free decode for optimistic checks only (e.g. an edge redirect) — never trust it for access control.
 
 3. Pass the result to `RenownProvider session={await verifySession()}` so the server render is authenticated (no flash), and consumers read it via `useRenownAuth()`.
 
-#### Revalidation on the client
+A `null` session is as useful as a populated one: it tells the first render the visitor is definitively signed out, so `useRenownAuthAsync()` reports `"unauthenticated"` immediately instead of spinning. The cookie seeds the server render and hydration; `localStorage` takes over after mount, since that holds the credential the SDK restores.
+
+#### Revalidation and profile refresh on the client
 
 On mount the client re-checks the restored credential against the switchboard and logs out if it was revoked/expired (`revalidate` prop on `RenownProvider`, default `"always"`). In the browser this is **non-blocking and fail-open** (a transient outage keeps the session); Node scripts block on it. `renown.revalidate()` runs the same check on demand.
+
+Separately, `renown.refreshProfile()` re-reads `username`/`userImage` and updates the store only if they changed. It runs on every browser start **regardless of `revalidate`**, because it can never log anyone out — so apps that set `revalidate: "never"` still pick up a renamed user or a new avatar.
 
 ## Best Practices
 
@@ -22652,6 +22656,8 @@ function Login() {
 
 Gate any component on auth with a plain `if (!user)` from `useRenownAuth()`; for a no-Suspense "still resolving" state (useful in client-only apps), use `useRenownAuthAsync()`, which returns `state: "authenticated" | "resolving" | "unauthenticated"`.
 
+`"resolving"` appears only when the answer is genuinely unknown. A visitor the first render already knows is signed out — no session cookie, no persisted user — resolves straight to `"unauthenticated"`, so logged-out visitors never sit behind a spinner while the SDK builds its keypair.
+
 `switchboardUrl` enables in-page sign-in; omit it to fall back to the redirect flow. `RenownProvider` composes `<Renown>` (SDK init), `RenownWalletProvider` (adapters), and `RenownInitialUserProvider` (first-render seed), which you can also mount individually for a custom tree.
 
 #### SSR and client-only
@@ -22660,6 +22666,8 @@ Gate any component on auth with a plain `if (!user)` from `useRenownAuth()`; for
 
 - **Client-only apps** (Vite, etc.): the provider seeds the first render synchronously from `localStorage`, so a returning user is authenticated on the first paint with no flash.
 - **SSR apps** (Next.js): pass a server-resolved `session` (from a verified session cookie) so authenticated content renders on the server too. Read the cookie in a Data Access Layer with `verifyRenownSession` from `@renown/sdk/node`; passing `session` also keeps the cookie in sync after login/logout. A complete Next.js reference lives in the monorepo at `test/test-fusion`, and the `@powerhousedao/reactor-browser` README ("Renown in-page sign-in") has the full API.
+
+Under SSR the cookie seeds the server render and hydration (it is the only thing readable server-side), then `localStorage` takes over once mounted, since that is the credential the SDK actually restores. Include the `documentId`/`username`/`userImage` fields in the cookie's profile hint so both sources agree on name, avatar and profile links — type the route handler with `RenownSessionCookie` rather than redeclaring the payload shape.
 
 ### Testing sign-in (mock adapter)
 

--- a/apps/academy/static/llms-full.txt
+++ b/apps/academy/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-07-24T18:45:19.144Z
+> Generated: 2026-07-28T11:09:31.654Z
 > Total Documents: 106
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -11625,7 +11625,7 @@ export async function GET(request: Request) {
 
 To render authenticated pages on the server (Next.js and similar):
 
-1. On login the client mints a bearer token (`renown.getBearerToken()`) and stores it — with a small display hint (name/avatar) — in an HttpOnly cookie (name exported as `RENOWN_SESSION_COOKIE`, value built with `serializeRenownSessionCookie`). `RenownProvider`'s session-cookie sync does this automatically when given a `session`.
+1. On login the client mints a bearer token (`renown.getBearerToken()`) and stores it — with a `RenownSessionProfile` display hint (`name`/`avatar` plus `documentId`/`username`/`userImage`) — in an HttpOnly cookie (name exported as `RENOWN_SESSION_COOKIE`, value built with `serializeRenownSessionCookie`). `RenownProvider`'s session-cookie sync does this automatically when given a `session`. Type your route handler with the exported `RenownSessionCookie` instead of redeclaring the payload shape.
 2. A Data Access Layer reads the cookie and calls `verifyRenownSession`, memoized per request:
 
 ```typescript
@@ -11638,13 +11638,17 @@ export const verifySession = cache(async () => {
 });
 ```
 
-`verifyRenownSession` takes the cookie value, verifies the JWT (signature + expiry), and merges the display hint into `user` (unverified — display only). Pass `verifyCredential: true` to also re-check the credential against the switchboard so a **revoked/expired** credential is rejected; it defaults to `false` (token-only, no network). `readSessionClaims(cookieValue)` gives a cheap, signature-free decode for optimistic checks only (e.g. an edge redirect) — never trust it for access control.
+`verifyRenownSession` takes the cookie value, verifies the JWT (signature + expiry), and merges the display hint into `user` (unverified — display only), rebuilding `user.ens` and, when `documentId` is present, `user.profile`. Pass `verifyCredential: true` to also re-check the credential against the switchboard so a **revoked/expired** credential is rejected; it defaults to `false` (token-only, no network). `readSessionClaims(cookieValue)` gives a cheap, signature-free decode for optimistic checks only (e.g. an edge redirect) — never trust it for access control.
 
 3. Pass the result to `RenownProvider session={await verifySession()}` so the server render is authenticated (no flash), and consumers read it via `useRenownAuth()`.
 
-#### Revalidation on the client
+A `null` session is as useful as a populated one: it tells the first render the visitor is definitively signed out, so `useRenownAuthAsync()` reports `"unauthenticated"` immediately instead of spinning. The cookie seeds the server render and hydration; `localStorage` takes over after mount, since that holds the credential the SDK restores.
+
+#### Revalidation and profile refresh on the client
 
 On mount the client re-checks the restored credential against the switchboard and logs out if it was revoked/expired (`revalidate` prop on `RenownProvider`, default `"always"`). In the browser this is **non-blocking and fail-open** (a transient outage keeps the session); Node scripts block on it. `renown.revalidate()` runs the same check on demand.
+
+Separately, `renown.refreshProfile()` re-reads `username`/`userImage` and updates the store only if they changed. It runs on every browser start **regardless of `revalidate`**, because it can never log anyone out — so apps that set `revalidate: "never"` still pick up a renamed user or a new avatar.
 
 ## Best Practices
 
@@ -22652,6 +22656,8 @@ function Login() {
 
 Gate any component on auth with a plain `if (!user)` from `useRenownAuth()`; for a no-Suspense "still resolving" state (useful in client-only apps), use `useRenownAuthAsync()`, which returns `state: "authenticated" | "resolving" | "unauthenticated"`.
 
+`"resolving"` appears only when the answer is genuinely unknown. A visitor the first render already knows is signed out — no session cookie, no persisted user — resolves straight to `"unauthenticated"`, so logged-out visitors never sit behind a spinner while the SDK builds its keypair.
+
 `switchboardUrl` enables in-page sign-in; omit it to fall back to the redirect flow. `RenownProvider` composes `<Renown>` (SDK init), `RenownWalletProvider` (adapters), and `RenownInitialUserProvider` (first-render seed), which you can also mount individually for a custom tree.
 
 #### SSR and client-only
@@ -22660,6 +22666,8 @@ Gate any component on auth with a plain `if (!user)` from `useRenownAuth()`; for
 
 - **Client-only apps** (Vite, etc.): the provider seeds the first render synchronously from `localStorage`, so a returning user is authenticated on the first paint with no flash.
 - **SSR apps** (Next.js): pass a server-resolved `session` (from a verified session cookie) so authenticated content renders on the server too. Read the cookie in a Data Access Layer with `verifyRenownSession` from `@renown/sdk/node`; passing `session` also keeps the cookie in sync after login/logout. A complete Next.js reference lives in the monorepo at `test/test-fusion`, and the `@powerhousedao/reactor-browser` README ("Renown in-page sign-in") has the full API.
+
+Under SSR the cookie seeds the server render and hydration (it is the only thing readable server-side), then `localStorage` takes over once mounted, since that is the credential the SDK actually restores. Include the `documentId`/`username`/`userImage` fields in the cookie's profile hint so both sources agree on name, avatar and profile links — type the route handler with `RenownSessionCookie` rather than redeclaring the payload shape.
 
 ### Testing sign-in (mock adapter)
 

--- a/packages/reactor-browser/README.md
+++ b/packages/reactor-browser/README.md
@@ -586,8 +586,9 @@ only when you need a custom tree:
 - `<Renown appName namespace switchboardUrl revalidate? />` — SDK init (renders
   `null`; place high in the tree).
 - `RenownWalletProvider` — wallet adapters (below).
-- `RenownInitialUserProvider` — seeds the first render with a `User` (see
-  [Server-side rendering](#server-side-rendering-ssr)).
+- `RenownInitialUserProvider` — seeds the first render, via `initialAuth`
+  (three-state, preferred) or `initialUser` (a bare `User`; cannot express
+  "known signed out"). See [Server-side rendering](#server-side-rendering-ssr).
 
 ### Auth state — `useRenownAuth` / `useRenownAuthAsync`
 
@@ -616,6 +617,14 @@ function EditButton() {
 }
 ```
 
+`"resolving"` only appears when the answer is genuinely unknown. If the first
+render already knows the visitor is signed out — no session cookie on the server,
+no persisted user in `localStorage` — the state goes straight to
+`"unauthenticated"`, so a logged-out visitor never sees the skeleton while the
+SDK builds its keypair. A login you triggered (`pending`) still reports
+`"resolving"`. `useRenownInitialAuth()` exposes the underlying signal as
+`{ state: "authenticated" | "anonymous" | "unknown" }`.
+
 ### Server-side rendering (SSR)
 
 The provider tree is SSR-safe, so the logged-out shell renders on the server with
@@ -638,22 +647,43 @@ client mints a bearer token and POSTs it to `sessionEndpoint` (default
 handler that sets an HttpOnly cookie, and a Data Access Layer that verifies it
 with `verifyRenownSession` from `@renown/sdk/node` (see that package's README).
 
-### Client-only apps
+The POST body is a `RenownSessionCookie` — the bearer token plus a
+`RenownSessionProfile` display hint carrying `documentId`, `username` and
+`userImage`. Those let `verifyRenownSession` rebuild a `user.profile` matching
+the client's, so the server renders the same name, avatar and profile links the
+client will. Type your route handler with `RenownSessionCookie` rather than
+redeclaring the shape — three copies of it drift.
 
-Omit `session` and the provider seeds the first render synchronously from
-`localStorage` (`readPersistedUser`), so a returning user renders authenticated
-on the first paint — no server, no flash. The stored credential is revalidated in
-the background (see below); `useRenownAuthAsync` exposes `resolving` for the cold
-start with no stored session.
+### Seeding: which source wins
 
-### Revalidation
+The first render is seeded from whichever source can answer at that moment:
 
-On mount the provider revalidates the restored credential against the switchboard
-and logs the user out if it was revoked or expired (`revalidate` prop, default
-`"always"`; set `"never"` to skip). In the browser this runs **non-blocking** in
-the background (fail-open — a transient outage keeps the session); Node scripts
-block on it (see `@renown/sdk`). This does not replace server-side checks: the
-switchboard enforces the credential on every real operation.
+| Render | Source | Why |
+| --- | --- | --- |
+| Server | `session` (the cookie) | The only thing readable server-side |
+| Hydration | `session` | Must match the server output |
+| After mount | `localStorage` | Holds the credential the SDK actually restores |
+
+`localStorage` becomes authoritative once mounted because that is what the SDK
+reads on build; the cookie is a display hint that can go stale independently (it
+expires on its own schedule). Omit `session` entirely for client-only apps —
+`localStorage` then seeds every render, so a returning user is authenticated on
+the first paint with no server involved.
+
+### Revalidation and profile refresh
+
+Two separate background passes run on mount, neither blocking the paint:
+
+- **Credential revalidation** re-checks the restored credential against the
+  switchboard and logs the user out if it was revoked or expired. Gated by the
+  `revalidate` prop (default `"always"`; `"never"` skips it). Fail-open — a
+  transient outage keeps the session.
+- **Profile refresh** re-reads `username`/`userImage` and updates the store if
+  they changed. This runs **regardless of `revalidate`**, because it can never
+  log anyone out; apps that disabled revalidation still get fresh attributes.
+
+Neither replaces server-side checks: the switchboard enforces the credential on
+every real operation.
 
 ### `RenownWalletProvider`
 

--- a/packages/reactor-browser/src/hooks/renown.ts
+++ b/packages/reactor-browser/src/hooks/renown.ts
@@ -28,8 +28,8 @@ export function useDid() {
 /** Returns the current user from the renown instance, subscribing to user events */
 export function useUser(): User | undefined {
   const renown = useRenown();
-  // Seed (cookie for SSR, localStorage for client-only) covers the first paint;
-  // once the SDK is ready it is authoritative, so a logout/revoke clears it.
+  // Seed (cookie on the server, localStorage once mounted) covers the first
+  // paint; the SDK is authoritative after, so a logout/revoke clears it.
   const initialUser = useRenownInitialUser();
   const instance = renown ? renown : undefined;
   const [user, setUser] = useState<User | undefined>(
@@ -43,7 +43,9 @@ export function useUser(): User | undefined {
     }
   }, [instance]);
 
-  return user;
+  // useState captured only the first render, so defer to the seed until the SDK
+  // exists — that is what lands the post-mount localStorage read.
+  return instance ? user : (initialUser ?? user);
 }
 
 /** Returns the login status, subscribing to renown status events */

--- a/packages/reactor-browser/src/renown/index.ts
+++ b/packages/reactor-browser/src/renown/index.ts
@@ -2,8 +2,12 @@ export * from "./components/index.js";
 export * from "./crypto.js";
 export * from "./constants.js";
 export {
+  RENOWN_INITIAL_ANONYMOUS,
+  RENOWN_INITIAL_UNKNOWN,
   RenownInitialUserProvider,
+  type RenownInitialAuth,
   type RenownInitialUserProviderProps,
+  useRenownInitialAuth,
   useRenownInitialUser,
 } from "./initial-user.js";
 export {

--- a/packages/reactor-browser/src/renown/initial-user.tsx
+++ b/packages/reactor-browser/src/renown/initial-user.tsx
@@ -3,27 +3,57 @@
 import type { User } from "@renown/sdk";
 import { createContext, useContext, type ReactNode } from "react";
 
-// Seeds the auth store's first render (server + hydration) with a user resolved
-// server-side from a session cookie, enabling authenticated SSR without a flash.
-const RenownInitialUserContext = createContext<User | undefined>(undefined);
+/** Whether the first render already knows who (if anyone) is signed in. */
+// "anonymous" is load-bearing: it separates a signed-out visitor from an
+// unresolved one, which otherwise both have to render a spinner.
+export type RenownInitialAuth =
+  | { state: "authenticated"; user: User }
+  | { state: "anonymous" }
+  | { state: "unknown" };
+
+export const RENOWN_INITIAL_UNKNOWN: RenownInitialAuth = { state: "unknown" };
+export const RENOWN_INITIAL_ANONYMOUS: RenownInitialAuth = {
+  state: "anonymous",
+};
+
+// Seeds the auth store's first render (server + hydration) from a session
+// cookie or localStorage, enabling authenticated SSR without a flash.
+const RenownInitialUserContext = createContext<RenownInitialAuth>(
+  RENOWN_INITIAL_UNKNOWN,
+);
 
 export interface RenownInitialUserProviderProps {
+  /** Resolved first-render auth (see `RenownProvider`). Takes precedence over `initialUser`. */
+  initialAuth?: RenownInitialAuth;
   /** User resolved from a verified session cookie (see `verifyRenownSession`). */
   initialUser?: User;
   children: ReactNode;
 }
 
 export function RenownInitialUserProvider({
+  initialAuth,
   initialUser,
   children,
 }: RenownInitialUserProviderProps) {
+  // `initialUser` alone cannot express "anonymous" — absence stays "unknown".
+  const value =
+    initialAuth ??
+    (initialUser
+      ? { state: "authenticated" as const, user: initialUser }
+      : RENOWN_INITIAL_UNKNOWN);
   return (
-    <RenownInitialUserContext.Provider value={initialUser}>
+    <RenownInitialUserContext.Provider value={value}>
       {children}
     </RenownInitialUserContext.Provider>
   );
 }
 
-export function useRenownInitialUser(): User | undefined {
+/** First-render auth as a three-state value; use this to skip a spinner when anonymous. */
+export function useRenownInitialAuth(): RenownInitialAuth {
   return useContext(RenownInitialUserContext);
+}
+
+export function useRenownInitialUser(): User | undefined {
+  const initial = useRenownInitialAuth();
+  return initial.state === "authenticated" ? initial.user : undefined;
 }

--- a/packages/reactor-browser/src/renown/provider.tsx
+++ b/packages/reactor-browser/src/renown/provider.tsx
@@ -2,8 +2,13 @@
 
 import { readPersistedUser, type User } from "@renown/sdk";
 import type { WalletAdaptersConfig, WalletTheme } from "@renown/sdk/wallet";
-import { useMemo, type ReactNode } from "react";
-import { RenownInitialUserProvider } from "./initial-user.js";
+import { useMemo, useSyncExternalStore, type ReactNode } from "react";
+import {
+  RENOWN_INITIAL_ANONYMOUS,
+  RENOWN_INITIAL_UNKNOWN,
+  RenownInitialUserProvider,
+  type RenownInitialAuth,
+} from "./initial-user.js";
 import { Renown } from "./renown-init.js";
 import {
   RenownSessionSyncedContext,
@@ -29,6 +34,8 @@ export interface RenownProviderProps {
   onError?: (error: unknown) => void;
   children: ReactNode;
 }
+
+const subscribeNothing = () => () => {};
 
 // Runs the cookie sync and publishes its `synced` state to descendants, so a
 // post-login navigation can wait for the cookie (see useRenownSessionSynced).
@@ -65,10 +72,27 @@ export function RenownProvider({
   children,
 }: RenownProviderProps) {
   const isServerSession = session !== undefined;
-  const seed = useMemo<User | undefined>(() => {
-    if (isServerSession) return session?.user ?? undefined;
-    return readPersistedUser(namespace);
-  }, [isServerSession, session, namespace]);
+  // Hydration must match SSR, so the cookie answers first and localStorage
+  // takes over once mounted.
+  const mounted = useSyncExternalStore(
+    subscribeNothing,
+    () => true,
+    () => false,
+  );
+  const seed = useMemo<RenownInitialAuth>(() => {
+    // localStorage holds the credential the SDK actually restores; the cookie is
+    // a display hint that is server-only and can go stale independently.
+    if (mounted) {
+      const persisted = readPersistedUser(namespace);
+      return persisted
+        ? { state: "authenticated", user: persisted }
+        : RENOWN_INITIAL_ANONYMOUS;
+    }
+    if (!isServerSession) return RENOWN_INITIAL_UNKNOWN;
+    return session?.user
+      ? { state: "authenticated", user: session.user }
+      : RENOWN_INITIAL_ANONYMOUS;
+  }, [mounted, isServerSession, session, namespace]);
 
   return (
     <>
@@ -80,7 +104,7 @@ export function RenownProvider({
         revalidate={revalidate}
         onError={onError}
       />
-      <RenownInitialUserProvider initialUser={seed}>
+      <RenownInitialUserProvider initialAuth={seed}>
         <RenownWalletProvider adapters={adapters} theme={theme}>
           <SessionSync enabled={isServerSession} endpoint={sessionEndpoint}>
             {children}

--- a/packages/reactor-browser/src/renown/use-renown-auth.ts
+++ b/packages/reactor-browser/src/renown/use-renown-auth.ts
@@ -2,6 +2,7 @@ import type { LoginStatus, User } from "@renown/sdk";
 import type { LoginMethod, WalletSession } from "@renown/sdk/wallet";
 import { useCallback, useState } from "react";
 import { useLoginStatus, useUser } from "../hooks/renown.js";
+import { useRenownInitialAuth } from "./initial-user.js";
 import {
   getActiveWalletController,
   getWalletActivator,
@@ -154,12 +155,18 @@ export interface RenownAuthAsync extends RenownAuth {
 // "resolving" phase you can branch on, so no Suspense boundary is required.
 export function useRenownAuthAsync(): RenownAuthAsync {
   const auth = useRenownAuth();
+  const initial = useRenownInitialAuth();
   const { user, status, pending } = auth;
   let state: RenownAuthResolution;
   if (user) {
     state = "authenticated";
+  } else if (pending) {
+    state = "resolving";
+  } else if (initial.state === "anonymous" && status !== "checking") {
+    // Nothing to restore, so the SDK build cannot change the answer — resolve
+    // now instead of spinning through IndexedDB and keypair setup.
+    state = "unauthenticated";
   } else if (
-    pending ||
     status === undefined ||
     status === "loading" ||
     status === "checking"

--- a/packages/reactor-browser/src/renown/use-renown-init.ts
+++ b/packages/reactor-browser/src/renown/use-renown-init.ts
@@ -31,7 +31,8 @@ async function initRenown(
     switchboardUrl,
     revalidate,
   });
-  // Browser build() fires a non-blocking revalidate; init stays optimistic.
+  // Browser build() fires a non-blocking credential revalidate (when enabled)
+  // plus a profile refresh; init stays optimistic either way.
   const renown = await builder.build();
   setRenown(renown);
 

--- a/packages/reactor-browser/src/renown/use-renown-session-cookie.ts
+++ b/packages/reactor-browser/src/renown/use-renown-session-cookie.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import type { RenownSessionProfile } from "@renown/sdk";
 import { createContext, useContext, useEffect, useRef, useState } from "react";
 import { useRenown } from "../hooks/renown.js";
 import { useRenownAuth } from "./use-renown-auth.js";
@@ -32,6 +33,7 @@ export function useRenownSessionCookie(
   const { user, displayName, avatarUrl } = useRenownAuth();
   const renown = useRenown();
   const address = user?.address;
+  const profile = user?.profile;
   // Whether a prior render was authenticated, so we only DELETE on real logout
   // (not on an unauthenticated first load, which must not clobber the cookie).
   const hadUser = useRef(false);
@@ -52,7 +54,15 @@ export function useRenownSessionCookie(
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
               token,
-              profile: { name: displayName ?? null, avatar: avatarUrl ?? null },
+              // The richer fields let verifyRenownSession seed a `user.profile`
+              // matching this one, so SSR renders the same identity.
+              profile: {
+                name: displayName ?? null,
+                avatar: avatarUrl ?? null,
+                documentId: profile?.documentId ?? null,
+                username: profile?.username ?? null,
+                userImage: profile?.userImage ?? null,
+              } satisfies RenownSessionProfile,
             }),
           });
           if (!cancelled) setSynced(true);
@@ -71,7 +81,18 @@ export function useRenownSessionCookie(
         void fetch(endpoint, { method: "DELETE" }).catch(() => {});
       }
     }
-  }, [address, displayName, avatarUrl, renown, endpoint, expiresIn, enabled]);
+  }, [
+    address,
+    displayName,
+    avatarUrl,
+    profile?.documentId,
+    profile?.username,
+    profile?.userImage,
+    renown,
+    endpoint,
+    expiresIn,
+    enabled,
+  ]);
 
   return { synced };
 }

--- a/packages/renown/README.md
+++ b/packages/renown/README.md
@@ -149,12 +149,20 @@ const renown = await new RenownBuilder("my-cli", {
 
 `renown.revalidate()` re-checks the current credential on demand and logs out if
 it was revoked/expired; it is **fail-open** (a network error keeps the session).
+On success it then calls `renown.refreshProfile()`.
+
+`renown.refreshProfile()` re-reads profile attributes (`username`, `userImage`)
+at the source and updates the store only if they changed, resolving `true` when
+they did. It can never log anyone out, so the browser builder runs it on every
+start — including when `revalidate: "never"` disables the credential check.
 
 ### Verifying a session cookie (SSR)
 
 To gate server-rendered pages, store the bearer token from
-`renown.getBearerToken()` — plus an optional display hint (name/avatar) — in a
-cookie (name exported as `RENOWN_SESSION_COOKIE`), then verify it on the server:
+`renown.getBearerToken()` — plus an optional `RenownSessionProfile` display hint
+— in a cookie (name exported as `RENOWN_SESSION_COOKIE`), then verify it on the
+server. The payload type `RenownSessionCookie` is exported from both entry
+points; use it to type your route handler instead of redeclaring the shape:
 
 ```typescript
 import {
@@ -163,10 +171,17 @@ import {
   readSessionClaims,
 } from "@renown/sdk/node";
 
-// Build the cookie value (token + display hint) when setting the cookie:
+// Build the cookie value (token + display hint) when setting the cookie. The
+// documentId/username/userImage fields let verifySession rebuild `user.profile`.
 const cookieValue = serializeRenownSessionCookie({
   token,
-  profile: { name: "alice.eth", avatar: null },
+  profile: {
+    name: "alice.eth",
+    avatar: null,
+    documentId: "doc-123",
+    username: "alice.eth",
+    userImage: null,
+  },
 });
 
 // Verify the cookie value — checks the JWT (signature + expiry) and merges the

--- a/packages/renown/src/common.ts
+++ b/packages/renown/src/common.ts
@@ -287,9 +287,47 @@ export class Renown implements IRenown {
         await this.logout();
         return false;
       }
+      await this.refreshProfile();
       return true;
     } catch {
       return true;
+    }
+  }
+
+  // Re-read profile attributes at the source so a renamed user or changed avatar
+  // shows up on the next load. Carries no logout risk, unlike revalidate().
+  async refreshProfile(): Promise<boolean> {
+    const user = this.user;
+    if (!user || !this.#profileFetcher) return false;
+    try {
+      const profile = await this.#profileFetcher(user, this.#baseUrl);
+      if (!profile) return false;
+      // Asserted because narrowing from the pre-await read would otherwise hide
+      // that a logout during the fetch can clear this.
+      const current = this.user as User | undefined;
+      if (
+        !current ||
+        current.address !== user.address ||
+        current.chainId !== user.chainId
+      ) {
+        return false;
+      }
+      const unchanged =
+        current.profile?.documentId === profile.documentId &&
+        current.profile.username === profile.username &&
+        current.profile.userImage === profile.userImage;
+      if (unchanged) return false;
+      this.#updateUser({
+        ...current,
+        profile,
+        ens: {
+          name: profile.username ?? undefined,
+          avatarUrl: profile.userImage ?? undefined,
+        },
+      });
+      return true;
+    } catch {
+      return false;
     }
   }
 

--- a/packages/renown/src/index.ts
+++ b/packages/renown/src/index.ts
@@ -5,6 +5,9 @@ export * from "./discovery.js";
 export * from "./init.browser.js";
 export * from "./profile.js";
 export * from "./renown-builder.js";
+// Types only: the cookie payload is a contract the browser writes and the node
+// entry reads, but its verification logic stays server-side.
+export type { RenownSessionCookie, RenownSessionProfile } from "./session.js";
 export * from "./switchboard.js";
 export * from "./types.js";
 export * from "./utils.js";

--- a/packages/renown/src/init.browser.ts
+++ b/packages/renown/src/init.browser.ts
@@ -82,10 +82,14 @@ export class RenownBuilder extends BaseRenownBuilder {
     const keyStorage = await BrowserKeyStorage.create(this.#keyDbName);
     this.withKeyPairStorage(keyStorage);
     const renown = await super.build();
-    // Browser has a reactive UI, so revalidate in the background (fail-open) and
-    // let the store update if the credential was revoked; never block the paint.
-    if (this.#revalidate === "always" && renown.user) {
-      void renown.revalidate();
+    // Refresh in the background, never blocking the paint. Only the credential
+    // check can log a user out, so it stays gated; the profile refresh always runs.
+    if (renown.user) {
+      if (this.#revalidate === "always") {
+        void renown.revalidate();
+      } else {
+        void renown.refreshProfile();
+      }
     }
     return renown;
   }

--- a/packages/renown/src/session.ts
+++ b/packages/renown/src/session.ts
@@ -16,6 +16,10 @@ export interface RenownSession {
 export interface RenownSessionProfile {
   name?: string | null;
   avatar?: string | null;
+  /** Renown profile document id, so SSR can resolve profile links. */
+  documentId?: string | null;
+  username?: string | null;
+  userImage?: string | null;
 }
 
 /** The `renown_session` cookie payload: the bearer token + a display hint. */
@@ -154,12 +158,26 @@ export async function verifyRenownSession(
 
   if (!session) return undefined;
 
-  // Merge the (unverified) display hint from the envelope — display only.
-  if (profile?.name) {
-    session.user = {
-      ...session.user,
-      ens: { name: profile.name, avatarUrl: profile.avatar ?? undefined },
-    };
+  // Merge the (unverified) display hint from the envelope — display only. The
+  // richer fields make this seed shape-identical to the client's restored user.
+  if (profile) {
+    const name = profile.name ?? profile.username ?? undefined;
+    const avatarUrl = profile.avatar ?? profile.userImage ?? undefined;
+    const user = { ...session.user };
+    if (name ?? avatarUrl) {
+      user.ens = { name, avatarUrl };
+    }
+    // Only `documentId` makes a seeded profile useful (profile links); display
+    // already flows through `ens`, so there is nothing to seed without it.
+    if (profile.documentId) {
+      user.profile = {
+        documentId: profile.documentId,
+        username: profile.username ?? null,
+        userImage: profile.userImage ?? null,
+        ethAddress: session.user.address,
+      };
+    }
+    session.user = user;
   }
   return session;
 }

--- a/packages/renown/src/types.ts
+++ b/packages/renown/src/types.ts
@@ -213,8 +213,9 @@ export type RenownProfile = {
   username: string | null;
   ethAddress: string | null;
   userImage: string | null;
-  createdAt: string;
-  updatedAt: string;
+  /** Absent on a profile seeded from the session cookie (see RenownSessionProfile). */
+  createdAt?: string;
+  updatedAt?: string;
 };
 
 // Internal user type for Renown SDK (includes credential and profile)
@@ -281,6 +282,8 @@ export interface IRenown extends Pick<RenownEventEmitter, "on"> {
   logout: () => Promise<void>;
   /** Re-check the current credential at the source; logs out if revoked/expired. */
   revalidate: () => Promise<boolean>;
+  /** Re-read profile attributes at the source; never logs out. Resolves true if they changed. */
+  refreshProfile: () => Promise<boolean>;
   readonly crypto: IRenownCrypto;
   readonly signer: ISigner;
   readonly did: string;

--- a/packages/renown/test/login.node.test.ts
+++ b/packages/renown/test/login.node.test.ts
@@ -119,6 +119,7 @@ function mockRenown(overrides: Partial<IRenown> = {}): IRenown {
     signIn: vi.fn(),
     logout: vi.fn(),
     revalidate: vi.fn().mockResolvedValue(true),
+    refreshProfile: vi.fn().mockResolvedValue(false),
     crypto: {} as IRenown["crypto"],
     signer: {} as IRenown["signer"],
     did: "did:key:test123",

--- a/test/test-fusion/src/app/api/renown/session/route.ts
+++ b/test/test-fusion/src/app/api/renown/session/route.ts
@@ -1,15 +1,15 @@
 import {
   RENOWN_SESSION_COOKIE,
   serializeRenownSessionCookie,
+  type RenownSessionCookie,
 } from "@renown/sdk/node";
 import { cookies } from "next/headers";
 
 const MAX_AGE = 7 * 24 * 60 * 60; // 7 days, matching the token lifetime
 
-interface SessionBody {
-  token?: string;
-  profile?: { name?: string | null; avatar?: string | null } | null;
-}
+// The wire shape is the cookie payload itself, minus the SDK's required `token`
+// (untrusted input, validated below).
+type SessionBody = Partial<RenownSessionCookie>;
 
 // Client posts the minted bearer token (+ display hint) after sign-in; we store
 // them together in an HttpOnly cookie. DELETE clears it on logout.


### PR DESCRIPTION
## Problem

Anonymous visitors sat behind a spinner while the SDK built its keypair.

`useRenownAuthAsync()` collapsed "still checking" and "known signed out" into a single `"resolving"` state, because the first-render seed was a bare `User | undefined`. Absence could not distinguish *verified anonymous* from *not yet known* — so a `null` server session carried no information, and every logged-out visitor waited on IndexedDB plus keypair setup before rendering.

## Change

**Three-state seed.** `RenownInitialAuth` is `{ state: "authenticated"; user } | { state: "anonymous" } | { state: "unknown" }`. A `null` server session or an empty `localStorage` resolves straight to `"unauthenticated"`; `"resolving"` now appears only when the answer is genuinely unknown, or a login is pending. This also clears a hydration mismatch on the anonymous path. `RenownInitialUserProvider` keeps accepting `initialUser` (absence stays `"unknown"`), and `useRenownInitialUser()` remains as a thin projection over the new `useRenownInitialAuth()`.

**Cookie first, then localStorage.** The cookie seeds the server render and hydration — it is the only source readable server-side — and `localStorage` takes over after mount via a `useSyncExternalStore` mounted flag, since that holds the credential the SDK actually restores. The cookie is a display hint that can go stale independently.

**Shape-identical SSR seed.** `RenownSessionProfile` gains `documentId`/`username`/`userImage`, so `verifyRenownSession` can rebuild `user.profile` (still unverified, display-only) and the server seed matches what the client restores. `RenownSessionCookie` and `RenownSessionProfile` are now exported as types from `@renown/sdk` — the payload shape had been redeclared, and already drifted, in two apps; `test/test-fusion`'s route handler is switched over as the reference.

**`Renown.refreshProfile()`.** Re-reads profile attributes and updates the store only when they changed. It cannot log anyone out, unlike `revalidate()`, so the browser build runs it regardless of the `revalidate` setting: apps on `revalidate: "never"` still pick up a renamed user or a new avatar. It also runs after a successful `revalidate()`. Both stay non-blocking, so neither delays the paint.

## Breaking

- `RenownProfile.createdAt`/`updatedAt` become optional — a cookie-seeded profile has no timestamps.
- `IRenown` gains a required `refreshProfile`. The interface is exported; nothing in the repo implements it besides `Renown`.

## Verification

- `@renown/sdk`: 114/114 tests pass, `tsc` clean, lint 0 errors (1 pre-existing `no-unnecessary-condition` warning in `utils.ts`, also present on `main`).
- `@powerhousedao/reactor-browser`: 285/285 tests pass, `tsc` clean, lint 0 errors (28 pre-existing warnings, none in the changed files).

Academy docs updated in both the authentication flow guide and the `@renown/sdk` reference (plus the generated `llms-full.txt`), and the `reactor-browser` / `renown` READMEs.
