### PR TITLE
fix(renown): wallet-connect fallbacks, one-chain identity, and provider-owned login methods

### DIFF
--- a/apps/academy/docs/academy/03-Build/03-BuildingUserExperiences/07-Authorization/01-RenownAuthenticationFlow.md
+++ b/apps/academy/docs/academy/03-Build/03-BuildingUserExperiences/07-Authorization/01-RenownAuthenticationFlow.md
@@ -73,7 +73,7 @@ In-page sign-in is opt-in and configured entirely through `powerhouse.config.jso
 
 - **`connect.renown.switchboardUrl`** — the Switchboard GraphQL endpoint. When set, Connect attempts in-page sign-in; if it is absent (or no wallet session can be produced) Connect falls back to the redirect flow automatically, so nothing breaks when it is left unset.
 - **`connect.renown.adapters`** — selects the wallet adapters that power in-page sign-in. Presence of a key enables that adapter:
-  - **`rainbow`** (`{ walletConnectProjectId }`) — external wallets via RainbowKit + wagmi.
+  - **`rainbow`** (`{ walletConnectProjectId }`) — external wallets via RainbowKit + wagmi. Treat `walletConnectProjectId` as required in practice: without it only an installed browser wallet (or a Safe App iframe) can sign in, because every other RainbowKit wallet connects over the WalletConnect relay, which needs a project id. Those wallets are omitted rather than offered and failing.
   - **`privy`** (`{ appId, clientId?, methods? }`) — embedded wallets plus social / email login via Privy. `methods` defaults to `["google", "email"]`.
 
 ```json
@@ -86,6 +86,8 @@ In-page sign-in is opt-in and configured entirely through `powerhouse.config.jso
   }
 }
 ```
+
+Sign-in happens on **one chain**, Ethereum mainnet by default. The chain is part of the user's DID (`did:pkh:eip155:<chainId>:<address>`), so the same wallet on another chain would be a different user with different credentials; a wallet session from another chain is rejected rather than accepted as a second identity. Wallets are offered for the issuing chain only, so a user on another network is prompted to switch.
 
 Each adapter's wallet library is fetched only on the first login click, so enabling in-page auth adds nothing to startup cost. Connect ships with every adapter's peer dependencies installed, so operators only edit the config. Social and email login run inside Privy's own modal (OAuth in a popup, so the page stays alive and sign-in completes in-page). Only **public** identifiers belong in the config — a Privy **App Secret** is server-only and must never be placed in `powerhouse.config.json`. Each social/email method must be enabled in the Privy dashboard, with Connect's origin allowlisted.
 

--- a/apps/academy/docs/academy/03-Build/03-BuildingUserExperiences/07-Authorization/01-RenownAuthenticationFlow.md
+++ b/apps/academy/docs/academy/03-Build/03-BuildingUserExperiences/07-Authorization/01-RenownAuthenticationFlow.md
@@ -125,9 +125,11 @@ function Providers({ children }) {
   );
 }
 
+// useRenownLoginMethods reads the mounted provider's adapters, so a login UI
+// works even when it is not rendered inside `Providers`.
 function Login() {
   const { user, login, pending, logout } = useRenownAuth();
-  const methods = useRenownLoginMethods(adapters);
+  const methods = useRenownLoginMethods();
   if (user) return <button onClick={() => void logout()}>Log out</button>;
   return methods.map((m) => (
     <button key={m.id} disabled={pending} onClick={() => login(undefined, m.id)}>

--- a/apps/academy/llms-full.txt
+++ b/apps/academy/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-07-29T08:13:38.146Z
+> Generated: 2026-07-29T09:40:23.999Z
 > Total Documents: 106
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -22596,7 +22596,7 @@ In-page sign-in is opt-in and configured entirely through `powerhouse.config.jso
 
 - **`connect.renown.switchboardUrl`** — the Switchboard GraphQL endpoint. When set, Connect attempts in-page sign-in; if it is absent (or no wallet session can be produced) Connect falls back to the redirect flow automatically, so nothing breaks when it is left unset.
 - **`connect.renown.adapters`** — selects the wallet adapters that power in-page sign-in. Presence of a key enables that adapter:
-  - **`rainbow`** (`{ walletConnectProjectId }`) — external wallets via RainbowKit + wagmi.
+  - **`rainbow`** (`{ walletConnectProjectId }`) — external wallets via RainbowKit + wagmi. Treat `walletConnectProjectId` as required in practice: without it only an installed browser wallet (or a Safe App iframe) can sign in, because every other RainbowKit wallet connects over the WalletConnect relay, which needs a project id. Those wallets are omitted rather than offered and failing.
   - **`privy`** (`{ appId, clientId?, methods? }`) — embedded wallets plus social / email login via Privy. `methods` defaults to `["google", "email"]`.
 
 ```json
@@ -22609,6 +22609,8 @@ In-page sign-in is opt-in and configured entirely through `powerhouse.config.jso
   }
 }
 ```
+
+Sign-in happens on **one chain**, Ethereum mainnet by default. The chain is part of the user's DID (`did:pkh:eip155:<chainId>:<address>`), so the same wallet on another chain would be a different user with different credentials; a wallet session from another chain is rejected rather than accepted as a second identity. Wallets are offered for the issuing chain only, so a user on another network is prompted to switch.
 
 Each adapter's wallet library is fetched only on the first login click, so enabling in-page auth adds nothing to startup cost. Connect ships with every adapter's peer dependencies installed, so operators only edit the config. Social and email login run inside Privy's own modal (OAuth in a popup, so the page stays alive and sign-in completes in-page). Only **public** identifiers belong in the config — a Privy **App Secret** is server-only and must never be placed in `powerhouse.config.json`. Each social/email method must be enabled in the Privy dashboard, with Connect's origin allowlisted.
 

--- a/apps/academy/llms-full.txt
+++ b/apps/academy/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-07-28T14:24:50.667Z
+> Generated: 2026-07-29T08:13:38.146Z
 > Total Documents: 106
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -22646,9 +22646,11 @@ function Providers({ children }) {
   );
 }
 
+// useRenownLoginMethods reads the mounted provider's adapters, so a login UI
+// works even when it is not rendered inside `Providers`.
 function Login() {
   const { user, login, pending, logout } = useRenownAuth();
-  const methods = useRenownLoginMethods(adapters);
+  const methods = useRenownLoginMethods();
   if (user) return <button onClick={() => void logout()}>Log out</button>;
   return methods.map((m) => (
     <button key={m.id} disabled={pending} onClick={() => login(undefined, m.id)}>

--- a/apps/academy/static/llms-full.txt
+++ b/apps/academy/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-07-29T08:13:38.146Z
+> Generated: 2026-07-29T09:40:23.999Z
 > Total Documents: 106
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -22596,7 +22596,7 @@ In-page sign-in is opt-in and configured entirely through `powerhouse.config.jso
 
 - **`connect.renown.switchboardUrl`** — the Switchboard GraphQL endpoint. When set, Connect attempts in-page sign-in; if it is absent (or no wallet session can be produced) Connect falls back to the redirect flow automatically, so nothing breaks when it is left unset.
 - **`connect.renown.adapters`** — selects the wallet adapters that power in-page sign-in. Presence of a key enables that adapter:
-  - **`rainbow`** (`{ walletConnectProjectId }`) — external wallets via RainbowKit + wagmi.
+  - **`rainbow`** (`{ walletConnectProjectId }`) — external wallets via RainbowKit + wagmi. Treat `walletConnectProjectId` as required in practice: without it only an installed browser wallet (or a Safe App iframe) can sign in, because every other RainbowKit wallet connects over the WalletConnect relay, which needs a project id. Those wallets are omitted rather than offered and failing.
   - **`privy`** (`{ appId, clientId?, methods? }`) — embedded wallets plus social / email login via Privy. `methods` defaults to `["google", "email"]`.
 
 ```json
@@ -22609,6 +22609,8 @@ In-page sign-in is opt-in and configured entirely through `powerhouse.config.jso
   }
 }
 ```
+
+Sign-in happens on **one chain**, Ethereum mainnet by default. The chain is part of the user's DID (`did:pkh:eip155:<chainId>:<address>`), so the same wallet on another chain would be a different user with different credentials; a wallet session from another chain is rejected rather than accepted as a second identity. Wallets are offered for the issuing chain only, so a user on another network is prompted to switch.
 
 Each adapter's wallet library is fetched only on the first login click, so enabling in-page auth adds nothing to startup cost. Connect ships with every adapter's peer dependencies installed, so operators only edit the config. Social and email login run inside Privy's own modal (OAuth in a popup, so the page stays alive and sign-in completes in-page). Only **public** identifiers belong in the config — a Privy **App Secret** is server-only and must never be placed in `powerhouse.config.json`. Each social/email method must be enabled in the Privy dashboard, with Connect's origin allowlisted.
 

--- a/apps/academy/static/llms-full.txt
+++ b/apps/academy/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-07-28T14:24:50.667Z
+> Generated: 2026-07-29T08:13:38.146Z
 > Total Documents: 106
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -22646,9 +22646,11 @@ function Providers({ children }) {
   );
 }
 
+// useRenownLoginMethods reads the mounted provider's adapters, so a login UI
+// works even when it is not rendered inside `Providers`.
 function Login() {
   const { user, login, pending, logout } = useRenownAuth();
-  const methods = useRenownLoginMethods(adapters);
+  const methods = useRenownLoginMethods();
   if (user) return <button onClick={() => void logout()}>Log out</button>;
   return methods.map((m) => (
     <button key={m.id} disabled={pending} onClick={() => login(undefined, m.id)}>

--- a/apps/connect/RUNTIME-CONFIG.md
+++ b/apps/connect/RUNTIME-CONFIG.md
@@ -83,6 +83,8 @@ Only **public** identifiers belong here (`walletConnectProjectId`, Privy `appId`
 
 `switchboardUrl` can be overridden at build time with `ph connect config --renown-switchboard-url <url>` (or the `PH_CONNECT_CONFIG_JSON` env override); `adapters` is set via the config file / `PH_CONNECT_CONFIG_JSON`.
 
+`networkId` and `chainId` are **not consumed yet**. They reach `phGlobalConfig` but nothing reads them, so Connect signs in on Ethereum mainnet whatever they say. `@renown/sdk` does support a configurable issuing chain (`RenownBuilder().withChainId()`); honouring these keys means passing it in `store/reactor.ts` **and** to the reactor worker, which builds its own crypto for bearer tokens and has no access to runtime config. Wiring only the main thread would leave the worker minting tokens for the wrong chain, so both move together or neither does.
+
 ## Setting values — the precedence ladder
 
 When `ph connect build` runs, the _dist_ `powerhouse.config.json` is produced by deep-merging in this order (lowest → highest):

--- a/apps/connect/RUNTIME-CONFIG.md
+++ b/apps/connect/RUNTIME-CONFIG.md
@@ -83,7 +83,9 @@ Only **public** identifiers belong here (`walletConnectProjectId`, Privy `appId`
 
 `switchboardUrl` can be overridden at build time with `ph connect config --renown-switchboard-url <url>` (or the `PH_CONNECT_CONFIG_JSON` env override); `adapters` is set via the config file / `PH_CONNECT_CONFIG_JSON`.
 
-`networkId` and `chainId` are **not consumed yet**. They reach `phGlobalConfig` but nothing reads them, so Connect signs in on Ethereum mainnet whatever they say. `@renown/sdk` does support a configurable issuing chain (`RenownBuilder().withChainId()`); honouring these keys means passing it in `store/reactor.ts` **and** to the reactor worker, which builds its own crypto for bearer tokens and has no access to runtime config. Wiring only the main thread would leave the worker minting tokens for the wrong chain, so both move together or neither does.
+`chainId` (default `1`) is the chain Renown issues credentials on. It is part of the user's DID, so the same wallet on another chain is a different user, and sign-in from a wallet on a different chain is rejected. Setting it moves three things together: the credential, the bearer token — including the reactor worker's, which builds its own crypto and receives the chain through its construct message since it cannot read runtime config — and the chain the wallet UI offers, so the user is prompted to switch rather than rejected at the end of the flow.
+
+Only chains Connect bundles can be offered (`1`, `11155111`, `137`, `10`, `42161`, `8453`); any other id logs an error and leaves in-page sign-in unusable. `networkId` remains unread — `did:pkh` identities here are always `eip155`.
 
 ## Setting values — the precedence ladder
 

--- a/apps/connect/src/components/renown-adapter-descriptors.ts
+++ b/apps/connect/src/components/renown-adapter-descriptors.ts
@@ -6,7 +6,15 @@ import {
   type PHRenownMockAdapterConfig,
 } from "@renown/sdk/wallet/mock";
 import { privyAdapter, type PrivyLoginMethod } from "@renown/sdk/wallet/privy";
-import { rainbowAdapter } from "@renown/sdk/wallet/rainbow";
+import { rainbowAdapter, type PHRenownChain } from "@renown/sdk/wallet/rainbow";
+import {
+  arbitrum,
+  base,
+  mainnet,
+  optimism,
+  polygon,
+  sepolia,
+} from "wagmi/chains";
 
 // `mock` is deliberately absent from the published config schema (TEST/DEV only
 // — it signs with a well-known key), so it is read off the runtime config here.
@@ -31,17 +39,47 @@ function describe(
   }
 }
 
-/** Map Connect's declarative `connect.renown.adapters` config to the descriptors `RenownWalletProvider` takes. Array order sets the order of the login buttons. A rejected adapter config is dropped (logged), leaving the others working. */
+// `connect.renown.chainId` is an id, but the adapter needs the chain object, so
+// only a listed chain can be offered.
+const CHAINS_BY_ID = new Map<number, PHRenownChain>(
+  [mainnet, sepolia, polygon, optimism, arbitrum, base].map((chain) => [
+    chain.id,
+    chain,
+  ]),
+);
+
+// Renown issues on one chain and rejects a session from any other, so the wallet
+// UI has to offer that chain and no other.
+function chainsFor(
+  chainId: number | undefined,
+): readonly [PHRenownChain, ...PHRenownChain[]] | undefined {
+  if (chainId === undefined) return undefined;
+  const chain = CHAINS_BY_ID.get(chainId);
+  if (!chain) {
+    console.error(
+      `[connect] connect.renown.chainId ${chainId} is not a chain Connect can offer, so in-page sign-in will be rejected. Supported: ${[...CHAINS_BY_ID.keys()].join(", ")}.`,
+    );
+    return undefined;
+  }
+  return [chain];
+}
+
+/** Map Connect's declarative `connect.renown.adapters` config to the descriptors `RenownWalletProvider` takes. Array order sets the order of the login buttons. A rejected adapter config is dropped (logged), leaving the others working. `chainId` is `connect.renown.chainId`, the chain Renown issues credentials on. */
 export function configToDescriptors(
   config: ConnectRenownAdapters | undefined,
+  chainId?: number,
 ): WalletAdapterDescriptor[] {
   if (!config) return [];
   const { rainbow, privy, mock } = config;
   const descriptors: WalletAdapterDescriptor[] = [];
+  const chains = chainsFor(chainId);
   // Every adapter Connect can offer is imported statically (hence Connect
   // installs all their peers), but each library stays behind a lazy loader.
   if (rainbow) {
-    descriptors.push(...describe("rainbow", () => rainbowAdapter(rainbow)));
+    descriptors.push(
+      ...describe("rainbow", () =>
+        rainbowAdapter({ ...rainbow, ...(chains ? { chains } : {}) })),
+    );
   }
   if (privy) {
     // appId is optional in the config schema but required by the adapter: an

--- a/apps/connect/src/components/renown-wallet-providers.tsx
+++ b/apps/connect/src/components/renown-wallet-providers.tsx
@@ -27,9 +27,13 @@ export function RenownWalletProviders({ children }: { children: ReactNode }) {
   const config = getRuntimeConfig().connect.renown?.adapters as
     | ConnectRenownAdapters
     | undefined;
+  const chainId = getRuntimeConfig().connect.renown?.chainId;
   const { theme } = useTheme();
   // Descriptors carry only eager metadata; no wallet library loads here.
-  const adapters = useMemo(() => configToDescriptors(config), [config]);
+  const adapters = useMemo(
+    () => configToDescriptors(config, chainId),
+    [config, chainId],
+  );
 
   // Resolve colors (forced style reads) only when an adapter is configured,
   // so a wallet-less deployment does no probing work at mount.

--- a/apps/connect/src/hooks/use-renown-login.ts
+++ b/apps/connect/src/hooks/use-renown-login.ts
@@ -6,20 +6,11 @@ import {
   useRenownLoginMethods,
 } from "@powerhousedao/reactor-browser";
 import { useCallback, useMemo } from "react";
-import {
-  configToDescriptors,
-  type ConnectRenownAdapters,
-} from "../components/renown-adapter-descriptors.js";
-import { getRuntimeConfig } from "../runtime-config.js";
 
 // Opens the in-page login modal when wallet adapters are configured; otherwise
 // redirects straight to the Renown portal (no modal with only a redirect button).
 export function useOpenRenownLogin(): () => void {
-  const config = getRuntimeConfig().connect.renown?.adapters as
-    | ConnectRenownAdapters
-    | undefined;
-  const adapters = useMemo(() => configToDescriptors(config), [config]);
-  const methods = useRenownLoginMethods(adapters);
+  const methods = useRenownLoginMethods();
   return useCallback(() => {
     if (methods.length > 0) {
       showPHModal({ type: "login" });
@@ -62,13 +53,9 @@ export function useRenownLoginProps(): RenownLoginProps {
   const { login, pending, error } = useRenownAuth();
   const onLogin = useCallback(() => login(), [login]);
 
-  const config = getRuntimeConfig().connect.renown?.adapters as
-    | ConnectRenownAdapters
-    | undefined;
-  const adapters = useMemo(() => configToDescriptors(config), [config]);
   // Method list (labels) comes from the shared primitive; Connect adds the
   // last-used badge + the onSelect wiring for its design-system card.
-  const baseMethods = useRenownLoginMethods(adapters);
+  const baseMethods = useRenownLoginMethods();
 
   const methods = useMemo<RenownLoginOption[]>(() => {
     const lastUsed = getLastLoginMethod();

--- a/apps/connect/src/reactor-worker-client.ts
+++ b/apps/connect/src/reactor-worker-client.ts
@@ -41,6 +41,8 @@ export type WorkerReactorClientArgs = {
   cdnUrl: string;
   packageSpecs: string[];
   studioMode?: boolean;
+  /** Chain the worker's bearer tokens are scoped to; matches the main thread's Renown instance. */
+  renownChainId?: number;
   documentModelModules: DocumentModelModule[];
   upgradeManifests: UpgradeManifest<readonly number[]>[];
   documentModelLoader: IDocumentModelLoader;
@@ -116,6 +118,7 @@ export function createWorkerReactorClientModule(
         cdnUrl: args.cdnUrl,
         packageSpecs: args.packageSpecs,
         studioMode: args.studioMode,
+        renownChainId: args.renownChainId,
       },
       packages: args.packageSpecs,
     },

--- a/apps/connect/src/reactor.worker.ts
+++ b/apps/connect/src/reactor.worker.ts
@@ -91,6 +91,9 @@ type WorkerConstruct = {
   cdnUrl: string;
   packageSpecs: string[];
   studioMode?: boolean;
+  // The worker has no runtime config, so the chain its bearer tokens are scoped
+  // to is passed in; leaving it unset would sign for a chain nobody issues on.
+  renownChainId?: number;
 };
 
 type ModelRegistry = {
@@ -149,9 +152,13 @@ function registerNewModules(): void {
 }
 
 // Rebuild renown crypto from the shared renownKeyDB keypair (origin-scoped IndexedDB).
-async function buildWorkerCrypto() {
+async function buildWorkerCrypto(chainId: number | undefined) {
   const keyStorage = await BrowserKeyStorage.create();
-  return new RenownCryptoBuilder().withKeyPairStorage(keyStorage).build();
+  const builder = new RenownCryptoBuilder().withKeyPairStorage(keyStorage);
+  if (chainId !== undefined) {
+    builder.withChainId(chainId);
+  }
+  return builder.build();
 }
 
 // Open against the major already on disk so a legacy PG16 dir isn't read by PG17.
@@ -321,7 +328,7 @@ const host = new ReactorHost({
       }
       phase = "building crypto";
       console.info(`[reactor.worker] boot: ${phase}`);
-      const crypto = await buildWorkerCrypto();
+      const crypto = await buildWorkerCrypto(construct.renownChainId);
       signer = new RenownCryptoSigner(
         crypto,
         RENOWN_APP_NAME,

--- a/apps/connect/src/store/reactor.ts
+++ b/apps/connect/src/store/reactor.ts
@@ -225,10 +225,18 @@ export async function createReactor(localPackage?: DocumentModelLib) {
     JSON.stringify(Object.fromEntries(features), null, 2),
   );
 
+  // Credentials and the bearer token must be scoped to the same chain, and the
+  // worker mints its own tokens, so this value is passed to it too (see below).
+  const renownChainId = getRuntimeConfig().connect.renown?.chainId;
+
   const keyPairStorage = await BrowserKeyStorage.create();
-  const renownCrypto = await new RenownCryptoBuilder()
-    .withKeyPairStorage(keyPairStorage)
-    .build();
+  const cryptoBuilder = new RenownCryptoBuilder().withKeyPairStorage(
+    keyPairStorage,
+  );
+  if (renownChainId !== undefined) {
+    cryptoBuilder.withChainId(renownChainId);
+  }
+  const renownCrypto = await cryptoBuilder.build();
 
   // Renown namespace is a boot-time constant, so read it from runtime config
   // rather than the PHGlobalConfig machinery; baseUrl stays in phGlobalConfig.
@@ -238,6 +246,7 @@ export async function createReactor(localPackage?: DocumentModelLib) {
       phGlobalConfig.routerBasename,
     baseUrl: phGlobalConfig.renownUrl,
     switchboardUrl: phGlobalConfig.switchboardUrl,
+    chainId: renownChainId,
   })
     .withCrypto(renownCrypto)
     .build();
@@ -364,6 +373,7 @@ export async function createReactor(localPackage?: DocumentModelLib) {
       cdnUrl: packageManager.cdnUrl ?? "",
       packageSpecs,
       studioMode: phGlobalConfig.studioMode,
+      renownChainId,
       documentModelModules,
       upgradeManifests,
       documentModelLoader,

--- a/packages/reactor-browser/README.md
+++ b/packages/reactor-browser/README.md
@@ -557,8 +557,9 @@ aliases. See the `@renown/sdk` README for the per-adapter peer list.
 The provider is **SSR-safe** — it renders on the server without `ssr: false`;
 the wallet libraries only load client-side on the first login click.
 
-Then build the login UI with `useRenownLoginMethods` (derives the button list
-from the adapters) and `useRenownAuth` (login + user state):
+Then build the login UI with `useRenownLoginMethods` (the button list, read from
+the mounted provider) and `useRenownAuth` (login + user state). Neither takes the
+adapters, so the login UI need not sit inside the provider's subtree:
 
 ```tsx
 import {
@@ -566,9 +567,9 @@ import {
   useRenownLoginMethods,
 } from "@powerhousedao/reactor-browser/renown";
 
-function Login({ adapters }) {
+function Login() {
   const { user, login, pending, error, logout } = useRenownAuth();
-  const methods = useRenownLoginMethods(adapters);
+  const methods = useRenownLoginMethods();
   if (user) return <button onClick={() => void logout()}>Log out</button>;
   return (
     <>
@@ -703,12 +704,18 @@ adapter bridges (each library's modal portals to `<body>`), never your
 `children`, so activating login never remounts your app. Props: `adapters`
 (`WalletAdapterDescriptor[]`), `theme?`, `children`.
 
-### `useRenownLoginMethods(adapters, labels?)`
+### `useRenownLoginMethods(labels?)`
 
-Returns `{ id, label }[]` — one per login method the adapters offer, deduped, in
-adapter-array order — reading each descriptor's eager metadata only (no wallet
-libraries load). Reorder the array to reorder the buttons. Override labels via
-the second argument. Wire each to `login(undefined, id)`.
+Returns `{ id, label }[]` — one per login method the mounted
+`RenownWalletProvider`'s adapters offer, deduped, in descriptor-array order —
+reading each descriptor's eager metadata only (no wallet libraries load).
+Reorder the array you pass the provider to reorder the buttons. Override labels
+via the argument. Wire each to `login(undefined, id)`.
+
+The descriptors come from the provider, not from a prop or context, so a login UI
+mounted **outside** the provider's subtree still gets the full list — Connect
+renders its login modal as a sibling of the app. Empty when no provider is
+mounted, which is the redirect-only case.
 
 ### Next.js
 

--- a/packages/reactor-browser/README.md
+++ b/packages/reactor-browser/README.md
@@ -549,6 +549,13 @@ const ADAPTERS = [
 </RenownProvider>;
 ```
 
+**One chain per app.** `chainId` (default `1`) is the chain credentials are issued
+on, and it is part of the user's DID (`did:pkh:eip155:<chainId>:<address>`), so the
+same wallet on another chain is a different user. Sign-in from a wallet on a
+different chain is rejected, so if you set `chainId`, pass matching `chains` to the
+wallet adapters — that is what makes the wallet UI prompt a network switch rather
+than failing at the end of the flow.
+
 **Install only the peers of the adapters you import.** Importing
 `@renown/sdk/wallet/rainbow` is what makes RainbowKit a build requirement; an app
 that only imports `@renown/sdk/wallet/privy` needs no RainbowKit and no bundler

--- a/packages/reactor-browser/src/renown/login-methods.ts
+++ b/packages/reactor-browser/src/renown/login-methods.ts
@@ -1,5 +1,10 @@
-import { LoginMethod, type WalletAdapterDescriptor } from "@renown/sdk/wallet";
-import { useMemo } from "react";
+import { LoginMethod } from "@renown/sdk/wallet";
+import { useMemo, useSyncExternalStore } from "react";
+import {
+  getServerWalletDescriptors,
+  getWalletDescriptors,
+  subscribeWalletDescriptors,
+} from "./wallet-registry.js";
 
 export interface RenownLoginMethod {
   id: LoginMethod;
@@ -13,16 +18,19 @@ const DEFAULT_METHOD_LABELS: Partial<Record<LoginMethod, string>> = {
   [LoginMethod.APPLE]: "Continue with Apple",
 };
 
-/** Derive the offered login methods from wallet adapter descriptors, for building a login UI. Reads each descriptor's eager metadata only — no wallet libraries load. Buttons follow the descriptor array order, deduped. Wire each to `useRenownAuth().login(undefined, id)`. Labels are overridable. See the reactor-browser README + Academy Renown auth guide. */
+/** The login methods the mounted {@link RenownWalletProvider}'s adapters offer, for building a login UI. Reads each descriptor's eager metadata only — no wallet libraries load. Buttons follow the provider's descriptor array order, deduped; empty when no provider is mounted (redirect-only). Wire each to `useRenownAuth().login(undefined, id)`. Labels are overridable. See the reactor-browser README + Academy Renown auth guide. */
 export function useRenownLoginMethods(
-  adapters: WalletAdapterDescriptor[] | undefined,
   labels?: Partial<Record<LoginMethod, string>>,
 ): RenownLoginMethod[] {
+  const descriptors = useSyncExternalStore(
+    subscribeWalletDescriptors,
+    getWalletDescriptors,
+    getServerWalletDescriptors,
+  );
   return useMemo(() => {
-    if (!adapters) return [];
     const seen = new Set<LoginMethod>();
     const methods: RenownLoginMethod[] = [];
-    for (const { meta } of adapters) {
+    for (const { meta } of descriptors) {
       for (const id of meta.supportedMethods) {
         if (seen.has(id)) continue;
         seen.add(id);
@@ -33,5 +41,5 @@ export function useRenownLoginMethods(
       }
     }
     return methods;
-  }, [adapters, labels]);
+  }, [descriptors, labels]);
 }

--- a/packages/reactor-browser/src/renown/provider.tsx
+++ b/packages/reactor-browser/src/renown/provider.tsx
@@ -27,6 +27,8 @@ export interface RenownProviderProps {
   theme?: WalletTheme;
   /** Re-check the restored credential against the source (default "always"). */
   revalidate?: "always" | "never";
+  /** Chain id credentials are issued on (default 1). Keep the adapters' chains in step: it is part of the user's DID, so a wallet on another chain is rejected. */
+  chainId?: number;
   /** Server-resolved session (SSR); its presence seeds from the cookie + enables cookie sync. Omit for client-only (seed = localStorage). */
   session?: { user?: User } | null;
   /** Endpoint for the session-cookie sync (SSR). Default /api/renown/session. */
@@ -66,6 +68,7 @@ export function RenownProvider({
   adapters,
   theme,
   revalidate,
+  chainId,
   session,
   sessionEndpoint,
   onError,
@@ -102,6 +105,7 @@ export function RenownProvider({
         url={url}
         switchboardUrl={switchboardUrl}
         revalidate={revalidate}
+        chainId={chainId}
         onError={onError}
       />
       <RenownInitialUserProvider initialAuth={seed}>

--- a/packages/reactor-browser/src/renown/use-renown-init.ts
+++ b/packages/reactor-browser/src/renown/use-renown-init.ts
@@ -13,6 +13,8 @@ export interface RenownInitOptions {
   switchboardUrl?: string;
   /** Re-check the restored credential against the source (default "always"). */
   revalidate?: "always" | "never";
+  /** Chain id credentials are issued on (default 1). It is part of the user's DID, so sign-in from a wallet on another chain is rejected. */
+  chainId?: number;
 }
 
 async function initRenown(
@@ -21,6 +23,7 @@ async function initRenown(
   url: string | undefined,
   switchboardUrl: string | undefined,
   revalidate: "always" | "never",
+  chainId: number | undefined,
 ): Promise<IRenown> {
   addRenownEventHandler();
   setRenown(loading);
@@ -30,6 +33,7 @@ async function initRenown(
     baseUrl: url,
     switchboardUrl,
     revalidate,
+    chainId,
   });
   // Browser build() fires a non-blocking credential revalidate (when enabled)
   // plus a profile refresh; init stays optimistic either way.
@@ -60,6 +64,7 @@ export function useRenownInit({
   url,
   switchboardUrl,
   revalidate = "always",
+  chainId,
 }: RenownInitOptions): Promise<IRenown> {
   // Stable promise returned every render; resolved later by the init effect.
   const promiseRef = useRef<PromiseWithResolvers<IRenown> | null>(null);
@@ -73,7 +78,7 @@ export function useRenownInit({
     if (initRef.current) return;
     initRef.current = true;
 
-    initRenown(appName, namespace, url, switchboardUrl, revalidate)
+    initRenown(appName, namespace, url, switchboardUrl, revalidate, chainId)
       .then(promiseRef.current!.resolve)
       .catch(promiseRef.current!.reject);
   }, []);

--- a/packages/reactor-browser/src/renown/wallet-provider.tsx
+++ b/packages/reactor-browser/src/renown/wallet-provider.tsx
@@ -22,6 +22,7 @@ import {
   failWalletActivation,
   setActiveWalletController,
   setWalletActivator,
+  setWalletDescriptors,
   whenWalletControllerReady,
 } from "./wallet-registry.js";
 import { useCompleteRedirectSignIn } from "./use-complete-redirect-sign-in.js";
@@ -110,6 +111,26 @@ export function RenownWalletProvider({
 }: RenownWalletProviderProps) {
   const [descriptors] = useState(() => adaptersConfig);
   const user = useUser();
+  // The snapshot above means a caller who rebuilds the array every render loses
+  // every value after the first; say so instead of leaving it to the JSDoc.
+  useEffect(() => {
+    // `process` is not guaranteed to exist in a browser bundle, so probe it.
+    if (
+      typeof process !== "undefined" &&
+      process.env?.NODE_ENV === "production"
+    )
+      return;
+    if (adaptersConfig === descriptors) return;
+    console.error(
+      "RenownWalletProvider: the `adapters` array changed identity after mount, and the new value was ignored. Build it once at module scope (or memoize it) — see the @powerhousedao/reactor-browser README.",
+    );
+  }, [adaptersConfig, descriptors]);
+  // Published for useRenownLoginMethods, which a login UI can call from outside
+  // this provider's subtree.
+  useEffect(() => {
+    setWalletDescriptors(descriptors);
+    return () => setWalletDescriptors(undefined);
+  }, [descriptors]);
   // Eager metadata: enough to detect a redirect return and list login methods
   // without loading any wallet library.
   const metas = useMemo(

--- a/packages/reactor-browser/src/renown/wallet-provider.tsx
+++ b/packages/reactor-browser/src/renown/wallet-provider.tsx
@@ -111,10 +111,9 @@ export function RenownWalletProvider({
 }: RenownWalletProviderProps) {
   const [descriptors] = useState(() => adaptersConfig);
   const user = useUser();
-  // The snapshot above means a caller who rebuilds the array every render loses
-  // every value after the first; say so instead of leaving it to the JSDoc.
+  // The snapshot above drops every array after the first; say so in dev.
   useEffect(() => {
-    // `process` is not guaranteed to exist in a browser bundle, so probe it.
+    // `process` need not exist in a browser bundle.
     if (
       typeof process !== "undefined" &&
       process.env?.NODE_ENV === "production"
@@ -125,8 +124,7 @@ export function RenownWalletProvider({
       "RenownWalletProvider: the `adapters` array changed identity after mount, and the new value was ignored. Build it once at module scope (or memoize it) — see the @powerhousedao/reactor-browser README.",
     );
   }, [adaptersConfig, descriptors]);
-  // Published for useRenownLoginMethods, which a login UI can call from outside
-  // this provider's subtree.
+  // For useRenownLoginMethods, callable from outside this subtree.
   useEffect(() => {
     setWalletDescriptors(descriptors);
     return () => setWalletDescriptors(undefined);

--- a/packages/reactor-browser/src/renown/wallet-registry.ts
+++ b/packages/reactor-browser/src/renown/wallet-registry.ts
@@ -1,4 +1,7 @@
-import type { WalletController } from "@renown/sdk/wallet";
+import type {
+  WalletAdapterDescriptor,
+  WalletController,
+} from "@renown/sdk/wallet";
 
 // Module-level registry for the active wallet controller. Connect mounts the
 // configured adapter Providers and registers the controller for useRenownAuth.
@@ -53,4 +56,62 @@ export function whenWalletControllerReady(): Promise<WalletController> {
   return new Promise((resolve, reject) =>
     controllerWaiters.push({ resolve, reject }),
   );
+}
+
+// Descriptors the mounted provider snapshotted. A registry rather than context
+// because a login UI is not always inside the provider tree (see the controller).
+const NO_DESCRIPTORS: readonly WalletAdapterDescriptor[] = Object.freeze([]);
+
+interface DescriptorStore {
+  descriptors: readonly WalletAdapterDescriptor[];
+  listeners: Set<() => void>;
+}
+
+// Keyed in the global symbol registry, not a module-level `let`, so duplicate
+// copies of this package (separately-bundled consumer, plugin) share one store.
+const DESCRIPTOR_STORE = Symbol.for(
+  "@powerhousedao/reactor-browser:renown-wallet-descriptors",
+);
+
+// `globalThis` exists on the server too, and SSR never reads this store (see
+// getServerWalletDescriptors), so no state crosses requests.
+function descriptorStore(): DescriptorStore {
+  const host = globalThis as unknown as Record<
+    symbol,
+    DescriptorStore | undefined
+  >;
+  return (host[DESCRIPTOR_STORE] ??= {
+    descriptors: NO_DESCRIPTORS,
+    listeners: new Set(),
+  });
+}
+
+export function setWalletDescriptors(
+  descriptors: readonly WalletAdapterDescriptor[] | undefined,
+): void {
+  const store = descriptorStore();
+  const next = descriptors ?? NO_DESCRIPTORS;
+  if (next === store.descriptors) return;
+  // Each copy of this module has its own empty sentinel; treat them as equal so
+  // an unmount in one copy does not churn subscribers in another.
+  if (next.length === 0 && store.descriptors.length === 0) return;
+  store.descriptors = next;
+  store.listeners.forEach((listener) => listener());
+}
+
+// Identity-stable while unchanged, so useSyncExternalStore does not loop.
+export function getWalletDescriptors(): readonly WalletAdapterDescriptor[] {
+  return descriptorStore().descriptors;
+}
+
+// No provider is mounted during a server render; a constant keeps the hydration
+// snapshot stable until the client subscribes.
+export function getServerWalletDescriptors(): readonly WalletAdapterDescriptor[] {
+  return NO_DESCRIPTORS;
+}
+
+export function subscribeWalletDescriptors(listener: () => void): () => void {
+  const { listeners } = descriptorStore();
+  listeners.add(listener);
+  return () => listeners.delete(listener);
 }

--- a/packages/reactor-browser/src/renown/wallet-registry.ts
+++ b/packages/reactor-browser/src/renown/wallet-registry.ts
@@ -67,14 +67,14 @@ interface DescriptorStore {
   listeners: Set<() => void>;
 }
 
-// Keyed in the global symbol registry, not a module-level `let`, so duplicate
-// copies of this package (separately-bundled consumer, plugin) share one store.
+// In the global symbol registry, not a module-level `let`, so duplicate copies
+// of this package share one store.
 const DESCRIPTOR_STORE = Symbol.for(
   "@powerhousedao/reactor-browser:renown-wallet-descriptors",
 );
 
-// `globalThis` exists on the server too, and SSR never reads this store (see
-// getServerWalletDescriptors), so no state crosses requests.
+// Safe on the server: `globalThis` exists there and SSR reads the constant
+// below instead, so nothing crosses requests.
 function descriptorStore(): DescriptorStore {
   const host = globalThis as unknown as Record<
     symbol,
@@ -92,8 +92,7 @@ export function setWalletDescriptors(
   const store = descriptorStore();
   const next = descriptors ?? NO_DESCRIPTORS;
   if (next === store.descriptors) return;
-  // Each copy of this module has its own empty sentinel; treat them as equal so
-  // an unmount in one copy does not churn subscribers in another.
+  // Copies of this module have distinct empty sentinels; treat them as equal.
   if (next.length === 0 && store.descriptors.length === 0) return;
   store.descriptors = next;
   store.listeners.forEach((listener) => listener());

--- a/packages/reactor-browser/test/renown/login-methods.test.tsx
+++ b/packages/reactor-browser/test/renown/login-methods.test.tsx
@@ -14,8 +14,7 @@ function descriptor(
   } as unknown as WalletAdapterDescriptor;
 }
 
-// A login UI is not always inside RenownWalletProvider (Connect renders its login
-// modal as a sibling of the app), so the hook reads the registry, not context.
+// Deliberately not wrapped in a provider: the hook reads the registry.
 function Probe() {
   const methods = useRenownLoginMethods();
   return (

--- a/packages/reactor-browser/test/renown/login-methods.test.tsx
+++ b/packages/reactor-browser/test/renown/login-methods.test.tsx
@@ -1,0 +1,88 @@
+import type { WalletAdapterDescriptor } from "@renown/sdk/wallet";
+import { afterEach, describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { useRenownLoginMethods } from "../../src/renown/login-methods.js";
+import { setWalletDescriptors } from "../../src/renown/wallet-registry.js";
+
+function descriptor(
+  id: string,
+  supportedMethods: string[],
+): WalletAdapterDescriptor {
+  return {
+    meta: { id, redirectReturnParams: [], supportedMethods },
+    load: () => Promise.reject(new Error("not loaded in this test")),
+  } as unknown as WalletAdapterDescriptor;
+}
+
+// A login UI is not always inside RenownWalletProvider (Connect renders its login
+// modal as a sibling of the app), so the hook reads the registry, not context.
+function Probe() {
+  const methods = useRenownLoginMethods();
+  return (
+    <span data-testid="methods">{methods.map((m) => m.id).join(",")}</span>
+  );
+}
+
+function LabelledProbe() {
+  const methods = useRenownLoginMethods({ wallet: "Use my wallet" });
+  return (
+    <span data-testid="labels">{methods.map((m) => m.label).join("|")}</span>
+  );
+}
+
+afterEach(() => {
+  setWalletDescriptors(undefined);
+});
+
+describe("useRenownLoginMethods", () => {
+  it("is empty when no provider has published descriptors", async () => {
+    const screen = render(<Probe />);
+    await expect.element(screen.getByTestId("methods")).toHaveTextContent("");
+  });
+
+  it("reads descriptors published by a provider elsewhere in the app", async () => {
+    setWalletDescriptors([descriptor("rainbow", ["wallet"])]);
+    const screen = render(<Probe />);
+    await expect
+      .element(screen.getByTestId("methods"))
+      .toHaveTextContent("wallet");
+  });
+
+  it("follows descriptor order and dedupes shared methods", async () => {
+    setWalletDescriptors([
+      descriptor("privy", ["google", "email"]),
+      descriptor("rainbow", ["wallet", "google"]),
+    ]);
+    const screen = render(<Probe />);
+    await expect
+      .element(screen.getByTestId("methods"))
+      .toHaveTextContent("google,email,wallet");
+  });
+
+  it("re-renders when a provider mounts after the login UI", async () => {
+    const screen = render(<Probe />);
+    await expect.element(screen.getByTestId("methods")).toHaveTextContent("");
+    setWalletDescriptors([descriptor("privy", ["google"])]);
+    await expect
+      .element(screen.getByTestId("methods"))
+      .toHaveTextContent("google");
+  });
+
+  it("clears when the provider unmounts", async () => {
+    setWalletDescriptors([descriptor("privy", ["google"])]);
+    const screen = render(<Probe />);
+    await expect
+      .element(screen.getByTestId("methods"))
+      .toHaveTextContent("google");
+    setWalletDescriptors(undefined);
+    await expect.element(screen.getByTestId("methods")).toHaveTextContent("");
+  });
+
+  it("applies overridden labels", async () => {
+    setWalletDescriptors([descriptor("rainbow", ["wallet"])]);
+    const screen = render(<LabelledProbe />);
+    await expect
+      .element(screen.getByTestId("labels"))
+      .toHaveTextContent("Use my wallet");
+  });
+});

--- a/packages/renown/README.md
+++ b/packages/renown/README.md
@@ -136,6 +136,11 @@ controller with `connect(method?)`, `disconnect()`, and `getSession()`.
 `connect()` resolves a `WalletSession` (`{ address, chainId, signTypedData }`);
 pass it to `renown.signIn(session)` to write + log in the credential in-page.
 
+Both adapters honour `mode` and `accentColor`. `accentColorForeground` is
+RainbowKit-only — Privy derives its own contrast. Privy accepts hex only, so an
+accent it cannot convert to hex (a named or `hsl()` color) is dropped rather than
+forwarded; `rgb()`, which is what resolving a CSS token yields, converts fine.
+
 **Login methods.** Rainbow supports `wallet`; Privy supports `wallet`, `google`,
 `apple`, `email` (default `["google", "email"]`). Each adapter's config accepts
 only the methods it can drive, so a typo is a compile error. Social/email flows

--- a/packages/renown/README.md
+++ b/packages/renown/README.md
@@ -146,6 +146,12 @@ sign-in completes in-page — no full-page redirect.
 `appId` (and optional `clientId`), and RainbowKit's `walletConnectProjectId`.
 Never put a Privy **App Secret** in browser config — it is server-only.
 
+`walletConnectProjectId` is optional, but treat it as required in practice: without
+it the rainbow adapter offers only an installed browser wallet and the Safe App
+iframe. Every other RainbowKit wallet connects over WalletConnect — `rainbowWallet`
+always when its extension is absent, `metaMaskWallet` on desktop without the
+extension — so those are omitted rather than offered and failing on the relay.
+
 ## Node.js
 
 For server-side usage, import from `@renown/sdk/node`.

--- a/packages/renown/README.md
+++ b/packages/renown/README.md
@@ -28,6 +28,16 @@ const renown = await new RenownBuilder("my-app")
 - `withCrypto(crypto)` — Pre-built crypto instance
 - `withKeyPairStorage(storage)` — Key pair storage (crypto is built from this)
 - `withProfileFetcher(fetcher)` — Custom profile enrichment strategy
+- `withChainId(chainId)` — Chain credentials are issued on (default `1`)
+
+**The chain id is part of the user's identity.** The issuer DID is
+`did:pkh:eip155:<chainId>:<address>`, so the same wallet on a different chain is a
+different user. `signIn` therefore rejects a wallet session whose chain differs
+from this one, and the bearer token is scoped to it too. When you pass a
+pre-built crypto via `withCrypto()`, give it the same chain
+(`RenownCryptoBuilder().withChainId(...)`) — the builder warns if the two
+disagree. Keep the wallet adapters' `chains` in step, so the wallet UI prompts a
+network switch instead of the user reaching a rejection at the end of the flow.
 
 ## Renown Instance
 
@@ -156,6 +166,12 @@ it the rainbow adapter offers only an installed browser wallet and the Safe App
 iframe. Every other RainbowKit wallet connects over WalletConnect — `rainbowWallet`
 always when its extension is absent, `metaMaskWallet` on desktop without the
 extension — so those are omitted rather than offered and failing on the relay.
+
+The rainbow adapter's `chains` (from `wagmi/chains`) defaults to Ethereum mainnet
+alone, matching the chain credentials are issued on. Widen it only alongside
+`withChainId`: a wallet on a chain outside the list has to switch networks to sign
+in, and one that signs on a chain Renown does not issue on is rejected. The
+adapter warns at config time if `chains` cannot produce the issuing chain.
 
 ## Node.js
 

--- a/packages/renown/src/common.ts
+++ b/packages/renown/src/common.ts
@@ -1,5 +1,6 @@
 import {
   CREDENTIAL_TYPES,
+  DEFAULT_RENOWN_CHAIN_ID,
   DEFAULT_RENOWN_NETWORK_ID,
   DEFAULT_RENOWN_URL,
 } from "./constants.js";
@@ -40,6 +41,7 @@ export class Renown implements IRenown {
   #signer: ISigner;
   #profileFetcher?: ProfileFetcher;
   #switchboard?: SwitchboardClient;
+  #chainId: number;
   #status: LoginStatus = "initial";
 
   constructor(
@@ -50,6 +52,7 @@ export class Renown implements IRenown {
     baseUrl = DEFAULT_RENOWN_URL,
     profileFetcher?: ProfileFetcher,
     switchboard?: SwitchboardClient,
+    chainId = Number(DEFAULT_RENOWN_CHAIN_ID),
   ) {
     this.#store = store;
     this.#eventEmitter = eventEmitter;
@@ -58,6 +61,7 @@ export class Renown implements IRenown {
     this.#appName = appName;
     this.#profileFetcher = profileFetcher;
     this.#switchboard = switchboard;
+    this.#chainId = chainId;
     const restoredUser = this.user;
     this.#signer = new RenownCryptoSigner(crypto, this.#appName, restoredUser);
 
@@ -74,6 +78,11 @@ export class Renown implements IRenown {
 
   get baseUrl() {
     return this.#baseUrl;
+  }
+
+  /** Chain id this app issues credentials on; a session from another chain is rejected by {@link signIn}. */
+  get chainId() {
+    return this.#chainId;
   }
 
   get user() {
@@ -153,6 +162,14 @@ export class Renown implements IRenown {
       userImage,
       expiresInDays,
     } = params;
+
+    // The chain id goes into the issuer DID and the EIP-712 domain, so signing on
+    // another chain would mint a second identity for the same wallet.
+    if (chainId !== this.#chainId) {
+      throw new Error(
+        `Renown signIn: wallet is on chain ${chainId}, but this app issues credentials on chain ${this.#chainId}. Switch networks and retry — signing here would create a separate identity for the same address.`,
+      );
+    }
 
     this.#updateStatus("checking");
     try {

--- a/packages/renown/src/crypto/renown-crypto-builder.ts
+++ b/packages/renown/src/crypto/renown-crypto-builder.ts
@@ -10,6 +10,7 @@ import {
 export class RenownCryptoBuilder {
   private keyPairStorage?: JsonWebKeyPairStorage;
   private subtleCrypto?: SubtleCrypto;
+  private chainId?: number;
 
   withKeyPairStorage(storage: JsonWebKeyPairStorage): this {
     this.keyPairStorage = storage;
@@ -18,6 +19,13 @@ export class RenownCryptoBuilder {
 
   withSubtleCrypto(crypto: SubtleCrypto): this {
     this.subtleCrypto = crypto;
+    return this;
+  }
+
+  // Scopes the bearer token to a chain (default 1). Match the Renown instance
+  // issuing credentials, or the token and the credential disagree.
+  withChainId(chainId: number): this {
+    this.chainId = chainId;
     return this;
   }
 
@@ -35,7 +43,13 @@ export class RenownCryptoBuilder {
     );
     const did = await parseDid(keyPair);
 
-    return new RenownCrypto(this.keyPairStorage, subtleCrypto, keyPair, did);
+    return new RenownCrypto(
+      this.keyPairStorage,
+      subtleCrypto,
+      keyPair,
+      did,
+      this.chainId,
+    );
   }
 
   async #initializeKeyPair(

--- a/packages/renown/src/crypto/renown-crypto.ts
+++ b/packages/renown/src/crypto/renown-crypto.ts
@@ -1,11 +1,12 @@
 import { fromString, toString } from "uint8arrays";
+import {
+  DEFAULT_RENOWN_CHAIN_ID,
+  DEFAULT_RENOWN_NETWORK_ID,
+} from "../constants.js";
 import type { CreateBearerTokenOptions, Issuer } from "../types.js";
 import { createAuthBearerToken } from "../utils.js";
 import type { DID, IRenownCrypto, JsonWebKeyPairStorage } from "./types.js";
 import { ECDSA_ALGORITHM, ECDSA_SIGN_ALGORITHM } from "./utils.js";
-
-const RENOWN_NETWORK_ID = "eip155";
-const RENOWN_CHAIN_ID = 1;
 
 export class RenownCrypto implements IRenownCrypto {
   #subtleCrypto: SubtleCrypto;
@@ -13,6 +14,8 @@ export class RenownCrypto implements IRenownCrypto {
   #keyPairStorage: JsonWebKeyPairStorage;
 
   readonly did: DID;
+  /** Chain id the bearer token is scoped to; keep it equal to the issuing Renown instance's. */
+  readonly chainId: number;
 
   static algorithm = ECDSA_ALGORITHM;
   static signAlgorithm = ECDSA_SIGN_ALGORITHM;
@@ -22,11 +25,13 @@ export class RenownCrypto implements IRenownCrypto {
     crypto: SubtleCrypto,
     keyPair: CryptoKeyPair,
     did: DID,
+    chainId = Number(DEFAULT_RENOWN_CHAIN_ID),
   ) {
     this.#keyPairStorage = keyPairStorage;
     this.#subtleCrypto = crypto;
     this.#keyPair = keyPair;
     this.did = did;
+    this.chainId = chainId;
   }
 
   get publicKey() {
@@ -38,8 +43,8 @@ export class RenownCrypto implements IRenownCrypto {
     options?: CreateBearerTokenOptions,
   ): Promise<string> {
     return await createAuthBearerToken(
-      Number(RENOWN_CHAIN_ID),
-      RENOWN_NETWORK_ID,
+      this.chainId,
+      DEFAULT_RENOWN_NETWORK_ID,
       address || this.did,
       this.issuer,
       options,

--- a/packages/renown/src/crypto/types.ts
+++ b/packages/renown/src/crypto/types.ts
@@ -15,6 +15,8 @@ export type DID = `did:${string}`;
 
 export interface IRenownCrypto {
   did: DID;
+  /** Chain the bearer token is scoped to. Optional so an external implementation still satisfies this; the builder warns when it differs from the issuing chain. */
+  chainId?: number;
   publicKey: CryptoKey;
   removeDid(): Promise<void>;
   sign: (data: Uint8Array) => Promise<Uint8Array>;

--- a/packages/renown/src/init.browser.ts
+++ b/packages/renown/src/init.browser.ts
@@ -30,6 +30,8 @@ export interface BrowserRenownBuilderOptions {
   keyDbName?: string;
   /** Re-check a stored credential on build (default "always"). */
   revalidate?: "always" | "never";
+  /** Chain id credentials are issued on (default 1). It is part of the issuer DID, so `signIn` rejects a session from another chain. */
+  chainId?: number;
 }
 
 /**
@@ -53,6 +55,9 @@ export class RenownBuilder extends BaseRenownBuilder {
     }
     if (options.switchboardUrl) {
       this.withSwitchboardUrl(options.switchboardUrl);
+    }
+    if (options.chainId !== undefined) {
+      this.withChainId(options.chainId);
     }
   }
 

--- a/packages/renown/src/renown-builder.ts
+++ b/packages/renown/src/renown-builder.ts
@@ -21,6 +21,8 @@ export interface RenownBuilderOptions {
   baseUrl?: string;
   switchboardUrl?: string;
   profileFetcher?: ProfileFetcher;
+  /** Chain id credentials are issued on (default 1). The issuer DID embeds it, so `signIn` rejects a wallet session from another chain. */
+  chainId?: number;
 }
 
 /**
@@ -37,6 +39,7 @@ export class BaseRenownBuilder {
   #baseUrl?: string;
   #switchboardUrl?: string;
   #profileFetcher?: ProfileFetcher;
+  #chainId?: number;
 
   /**
    * @param appName - Application name used for signing context
@@ -98,6 +101,13 @@ export class BaseRenownBuilder {
     return this;
   }
 
+  // Set the chain id credentials are issued on (default 1). It is part of the
+  // issuer DID, so signIn rejects a wallet session from a different chain.
+  withChainId(chainId: number): this {
+    this.#chainId = chainId;
+    return this;
+  }
+
   /**
    * Set a profile fetcher strategy for enriching user data after login.
    * The fetcher receives the authenticated user and the base URL,
@@ -152,6 +162,7 @@ export class BaseRenownBuilder {
       baseUrl,
       profileFetcher,
       switchboard,
+      this.#chainId,
     );
 
     // A stored user is loaded as-is for an instant, offline-safe start; callers
@@ -185,6 +196,9 @@ export class BaseRenownBuilder {
     }
     if (options.profileFetcher) {
       builder.withProfileFetcher(options.profileFetcher);
+    }
+    if (options.chainId !== undefined) {
+      builder.withChainId(options.chainId);
     }
 
     return builder;

--- a/packages/renown/src/renown-builder.ts
+++ b/packages/renown/src/renown-builder.ts
@@ -1,5 +1,5 @@
 import { Renown, RenownMemoryStorage } from "./common.js";
-import { DEFAULT_RENOWN_URL } from "./constants.js";
+import { DEFAULT_RENOWN_CHAIN_ID, DEFAULT_RENOWN_URL } from "./constants.js";
 import { RenownCryptoBuilder } from "./crypto/renown-crypto-builder.js";
 import type { IRenownCrypto, JsonWebKeyPairStorage } from "./crypto/types.js";
 import { resolveSwitchboardEndpoint } from "./discovery.js";
@@ -131,11 +131,21 @@ export class BaseRenownBuilder {
       );
     }
 
+    const chainId = this.#chainId ?? Number(DEFAULT_RENOWN_CHAIN_ID);
     const crypto =
       this.#crypto ??
       (await new RenownCryptoBuilder()
         .withKeyPairStorage(this.#keyPairStorage!)
+        .withChainId(chainId)
         .build());
+
+    // A crypto supplied via withCrypto() carries its own chain; the bearer token
+    // it mints would then disagree with the credentials issued here.
+    if (crypto.chainId !== undefined && crypto.chainId !== chainId) {
+      console.warn(
+        `Renown: the supplied crypto signs bearer tokens for chain ${crypto.chainId}, but credentials are issued on chain ${chainId}.`,
+      );
+    }
 
     const storage = this.#storage ?? new RenownMemoryStorage();
     const eventEmitter = this.#eventEmitter ?? new MemoryEventEmitter();
@@ -162,7 +172,7 @@ export class BaseRenownBuilder {
       baseUrl,
       profileFetcher,
       switchboard,
-      this.#chainId,
+      chainId,
     );
 
     // A stored user is loaded as-is for an instant, offline-safe start; callers

--- a/packages/renown/src/wallet/privy/provider.tsx
+++ b/packages/renown/src/wallet/privy/provider.tsx
@@ -3,6 +3,7 @@ import { PrivyProvider, type PrivyClientConfig } from "@privy-io/react-auth";
 import { normalizeWalletTheme, type WalletTheme } from "../types.js";
 import type { PrivyCore } from "./adapter.js";
 import { PrivyAdapterBridge } from "./bridge.js";
+import { toPrivyAccentColor } from "./theme.js";
 
 interface PrivyProviderConfig {
   appId: string;
@@ -22,12 +23,14 @@ export function createPrivyProvider(
     children: ReactNode;
     theme?: WalletTheme;
   }) {
-    const { mode } = normalizeWalletTheme(theme);
+    const { mode, accentColor } = normalizeWalletTheme(theme);
+    const accent = toPrivyAccentColor(accentColor);
     // Memoize so a new config object per render doesn't rebuild PrivyProvider's
     // context and cascade re-renders into descendants.
     const privyConfig = useMemo<PrivyClientConfig>(
       () => ({
-        appearance: { theme: mode },
+        // Privy generates its own light/dark variants from the accent.
+        appearance: { theme: mode, ...(accent ? { accentColor: accent } : {}) },
         embeddedWallets: {
           ethereum: { createOnLogin: "users-without-wallets" as const },
           showWalletUIs: false,
@@ -39,7 +42,7 @@ export function createPrivyProvider(
           walletConnect: { enabled: false },
         },
       }),
-      [mode],
+      [mode, accent],
     );
 
     return (

--- a/packages/renown/src/wallet/privy/theme.ts
+++ b/packages/renown/src/wallet/privy/theme.ts
@@ -1,0 +1,19 @@
+const HEX = /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+const RGB = /^rgba?\(\s*(-?[\d.]+)[\s,]+(-?[\d.]+)[\s,]+(-?[\d.]+)/i;
+
+function channel(value: string): string {
+  const byte = Math.round(Number(value));
+  return Math.min(255, Math.max(0, byte)).toString(16).padStart(2, "0");
+}
+
+/** Convert a host theme accent color to the hex Privy's `appearance` requires, or `undefined` if it is not expressible. Hosts resolve CSS tokens through `getComputedStyle`, which yields `rgb(...)`, so plain pass-through would be rejected. Alpha is dropped: Privy derives its own variants. */
+export function toPrivyAccentColor(
+  color: string | undefined,
+): `#${string}` | undefined {
+  if (!color) return undefined;
+  const value = color.trim();
+  if (HEX.test(value)) return value as `#${string}`;
+  const rgb = RGB.exec(value);
+  if (!rgb) return undefined;
+  return `#${channel(rgb[1])}${channel(rgb[2])}${channel(rgb[3])}`;
+}

--- a/packages/renown/src/wallet/rainbow/config.ts
+++ b/packages/renown/src/wallet/rainbow/config.ts
@@ -4,15 +4,9 @@ import {
   safeWallet as rainbowSafeWallet,
 } from "@rainbow-me/rainbowkit/wallets";
 import { http, type Config } from "wagmi";
-import {
-  arbitrum,
-  base,
-  mainnet,
-  optimism,
-  polygon,
-  sepolia,
-} from "wagmi/chains";
-import type { PHRenownRainbowAdapterConfig } from "./meta.js";
+import { mainnet } from "wagmi/chains";
+import { DEFAULT_RENOWN_CHAIN_ID } from "../../constants.js";
+import type { PHRenownChain, PHRenownRainbowAdapterConfig } from "./meta.js";
 
 // RainbowKit ships types via an exports map with no "types" condition, so
 // type-aware lint sees them as error-typed; assert the shapes we rely on.
@@ -32,10 +26,25 @@ const getDefaultConfig = rainbowGetDefaultConfig as (params: {
 const injectedWallet = rainbowInjectedWallet as WalletCreator;
 const safeWallet = rainbowSafeWallet as WalletCreator;
 
-/** The wallets that work with no WalletConnect project id. Composed explicitly rather than subtracted from `getDefaultWallets()`: RainbowKit's other defaults fall back to WalletConnect themselves — `rainbowWallet` whenever its extension is absent, `metaMaskWallet` on desktop without the extension — so removing only the WalletConnect entry still leaves buttons that fail on the relay. `injectedWallet` and `safeWallet` are the two that never reach it. */
+/** The wallets that work with no WalletConnect project id. Composed rather than subtracted from `getDefaultWallets()`, whose other entries fall back to WalletConnect themselves, so dropping just its entry still leaves buttons that cannot connect. */
 export function walletsWithoutWalletConnect(): WalletGroup[] {
   return [{ groupName: "Installed", wallets: [injectedWallet, safeWallet] }];
 }
+
+// Matches DEFAULT_RENOWN_CHAIN_ID: the issuer DID embeds the chain the wallet
+// signs on, so offering others would let one wallet mint several identities.
+const DEFAULT_CHAINS: readonly [PHRenownChain, ...PHRenownChain[]] = [mainnet];
+
+// Keyed by id rather than by chain, which would import them. A chain that is not
+// listed falls back to the RPC in its own definition.
+const INFURA_SUBDOMAINS: Record<number, string> = {
+  1: "mainnet",
+  11155111: "sepolia",
+  137: "polygon-mainnet",
+  10: "optimism-mainnet",
+  42161: "arbitrum-mainnet",
+  8453: "base-mainnet",
+};
 
 // Build the wagmi + RainbowKit config from operator-provided project ids.
 // Ported from renown/utils/wagmi.ts (env vars replaced by config fields).
@@ -44,8 +53,17 @@ export function buildWagmiConfig(config: PHRenownRainbowAdapterConfig): Config {
     walletConnectProjectId,
     infuraProjectId,
     appName = "Renown",
+    chains = DEFAULT_CHAINS,
     ssr,
   } = config;
+
+  // renown.signIn() rejects a session from any other chain, so say so here
+  // rather than at the end of a login the user cannot complete.
+  if (!chains.some((chain) => chain.id === Number(DEFAULT_RENOWN_CHAIN_ID))) {
+    console.warn(
+      `renown rainbow adapter: none of the configured chains is ${DEFAULT_RENOWN_CHAIN_ID}, the chain credentials are issued on — sign-in will be rejected unless the Renown chain id is configured to match.`,
+    );
+  }
 
   if (!walletConnectProjectId) {
     console.warn(
@@ -53,15 +71,17 @@ export function buildWagmiConfig(config: PHRenownRainbowAdapterConfig): Config {
     );
   }
 
-  const infuraUrl = (subdomain: string) =>
-    infuraProjectId
+  const infuraUrl = (chainId: number) => {
+    const subdomain = INFURA_SUBDOMAINS[chainId];
+    return infuraProjectId && subdomain
       ? `https://${subdomain}.infura.io/v3/${infuraProjectId}`
       : undefined;
+  };
 
   return getDefaultConfig({
     appName,
     projectId: walletConnectProjectId || "MISSING_WALLET_CONNECT_PROJECT_ID",
-    chains: [mainnet, sepolia, polygon, optimism, arbitrum, base],
+    chains: chains as readonly [unknown, ...unknown[]],
     // On SSR hosts wagmi's Hydrate defers reconnect to an effect; without it that
     // runs during render, which setState-in-render warns via RainbowKit's modal.
     ssr,
@@ -70,13 +90,8 @@ export function buildWagmiConfig(config: PHRenownRainbowAdapterConfig): Config {
     ...(walletConnectProjectId
       ? {}
       : { wallets: walletsWithoutWalletConnect() }),
-    transports: {
-      [mainnet.id]: http(infuraUrl("mainnet")),
-      [sepolia.id]: http(infuraUrl("sepolia")),
-      [polygon.id]: http(infuraUrl("polygon-mainnet")),
-      [optimism.id]: http(infuraUrl("optimism-mainnet")),
-      [arbitrum.id]: http(infuraUrl("arbitrum-mainnet")),
-      [base.id]: http(infuraUrl("base-mainnet")),
-    },
+    transports: Object.fromEntries(
+      chains.map((chain) => [chain.id, http(infuraUrl(chain.id))]),
+    ),
   });
 }

--- a/packages/renown/src/wallet/rainbow/config.ts
+++ b/packages/renown/src/wallet/rainbow/config.ts
@@ -1,7 +1,8 @@
+import { getDefaultConfig as rainbowGetDefaultConfig } from "@rainbow-me/rainbowkit";
 import {
-  getDefaultConfig as rainbowGetDefaultConfig,
-  getDefaultWallets as rainbowGetDefaultWallets,
-} from "@rainbow-me/rainbowkit";
+  injectedWallet as rainbowInjectedWallet,
+  safeWallet as rainbowSafeWallet,
+} from "@rainbow-me/rainbowkit/wallets";
 import { http, type Config } from "wagmi";
 import {
   arbitrum,
@@ -15,8 +16,11 @@ import type { PHRenownRainbowAdapterConfig } from "./meta.js";
 
 // RainbowKit ships types via an exports map with no "types" condition, so
 // type-aware lint sees them as error-typed; assert the shapes we rely on.
-type WalletCreator = { name?: string };
-type WalletGroup = { groupName: string; wallets: WalletCreator[] };
+type WalletCreator = () => unknown;
+interface WalletGroup {
+  groupName: string;
+  wallets: WalletCreator[];
+}
 const getDefaultConfig = rainbowGetDefaultConfig as (params: {
   appName: string;
   projectId: string;
@@ -25,19 +29,12 @@ const getDefaultConfig = rainbowGetDefaultConfig as (params: {
   transports: Record<number, unknown>;
   ssr?: boolean;
 }) => Config;
-const getDefaultWallets = rainbowGetDefaultWallets as () => {
-  wallets: WalletGroup[];
-};
+const injectedWallet = rainbowInjectedWallet as WalletCreator;
+const safeWallet = rainbowSafeWallet as WalletCreator;
 
-// RainbowKit's default wallet list minus the WalletConnect option, used when no
-// project id is set (WalletConnect can't work without one; injected wallets do).
-function walletsWithoutWalletConnect(): WalletGroup[] {
-  return getDefaultWallets()
-    .wallets.map((group) => ({
-      ...group,
-      wallets: group.wallets.filter((w) => w.name !== "walletConnectWallet"),
-    }))
-    .filter((group) => group.wallets.length > 0);
+/** The wallets that work with no WalletConnect project id. Composed explicitly rather than subtracted from `getDefaultWallets()`: RainbowKit's other defaults fall back to WalletConnect themselves — `rainbowWallet` whenever its extension is absent, `metaMaskWallet` on desktop without the extension — so removing only the WalletConnect entry still leaves buttons that fail on the relay. `injectedWallet` and `safeWallet` are the two that never reach it. */
+export function walletsWithoutWalletConnect(): WalletGroup[] {
+  return [{ groupName: "Installed", wallets: [injectedWallet, safeWallet] }];
 }
 
 // Build the wagmi + RainbowKit config from operator-provided project ids.
@@ -51,8 +48,8 @@ export function buildWagmiConfig(config: PHRenownRainbowAdapterConfig): Config {
   } = config;
 
   if (!walletConnectProjectId) {
-    console.debug(
-      "renown rainbow adapter: walletConnectProjectId is not set — hiding the WalletConnect option; only injected/browser wallets are offered.",
+    console.warn(
+      "renown rainbow adapter: walletConnectProjectId is not set — only an installed browser wallet (or a Safe App iframe) can sign in. Every other RainbowKit wallet connects over WalletConnect, which needs a project id.",
     );
   }
 
@@ -68,8 +65,8 @@ export function buildWagmiConfig(config: PHRenownRainbowAdapterConfig): Config {
     // On SSR hosts wagmi's Hydrate defers reconnect to an effect; without it that
     // runs during render, which setState-in-render warns via RainbowKit's modal.
     ssr,
-    // Omit `wallets` to keep RainbowKit's default set when a project id exists;
-    // otherwise drop only the WalletConnect option from that default set.
+    // Omit `wallets` to keep RainbowKit's default set (which needs the project
+    // id) when one exists; otherwise offer only the WalletConnect-free wallets.
     ...(walletConnectProjectId
       ? {}
       : { wallets: walletsWithoutWalletConnect() }),

--- a/packages/renown/src/wallet/rainbow/index.ts
+++ b/packages/renown/src/wallet/rainbow/index.ts
@@ -16,4 +16,4 @@ export function rainbowAdapter(
 }
 
 export { RAINBOW_METHODS, rainbowAdapterMeta } from "./meta.js";
-export type { PHRenownRainbowAdapterConfig } from "./meta.js";
+export type { PHRenownChain, PHRenownRainbowAdapterConfig } from "./meta.js";

--- a/packages/renown/src/wallet/rainbow/meta.ts
+++ b/packages/renown/src/wallet/rainbow/meta.ts
@@ -1,5 +1,12 @@
 import { LoginMethod, type WalletAdapterMeta } from "../types.js";
 
+// Any `wagmi/chains` export satisfies this. Declared here so the module stays
+// free of wallet-peer imports, type ones included.
+export interface PHRenownChain {
+  id: number;
+  name: string;
+}
+
 // Config slice this adapter consumes; operators pass the same shape from
 // powerhouse.config.json. No `methods`: this adapter only does wallet login.
 export interface PHRenownRainbowAdapterConfig {
@@ -8,6 +15,9 @@ export interface PHRenownRainbowAdapterConfig {
   walletConnectProjectId?: string;
   infuraProjectId?: string;
   appName?: string;
+  // From `wagmi/chains`; defaults to mainnet alone, as each one adds bundle
+  // weight. A wallet on a chain outside this list must switch to sign in.
+  chains?: readonly [PHRenownChain, ...PHRenownChain[]];
   // Opt-in for server-rendered hosts (e.g. Next.js) so wagmi defers its hydrate
   // reconnect to an effect instead of running it during render.
   ssr?: boolean;

--- a/packages/renown/src/wallet/rainbow/meta.ts
+++ b/packages/renown/src/wallet/rainbow/meta.ts
@@ -3,8 +3,8 @@ import { LoginMethod, type WalletAdapterMeta } from "../types.js";
 // Config slice this adapter consumes; operators pass the same shape from
 // powerhouse.config.json. No `methods`: this adapter only does wallet login.
 export interface PHRenownRainbowAdapterConfig {
-  // Optional: when unset the WalletConnect option is hidden; injected/browser
-  // wallets (MetaMask, etc.) still work. See buildWagmiConfig.
+  // Optional, but without it only an installed browser wallet (or a Safe App
+  // iframe) can sign in — every other wallet needs it. See buildWagmiConfig.
   walletConnectProjectId?: string;
   infuraProjectId?: string;
   appName?: string;

--- a/packages/renown/test/auth.test.ts
+++ b/packages/renown/test/auth.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from "vitest";
 import { MemoryKeyStorage, RenownCryptoBuilder } from "../src/crypto/index.js";
 import { verifyAuthBearerToken } from "../src/utils.js";
 
+async function tokenChainId(crypto: {
+  getBearerToken: (address: string) => Promise<string>;
+}): Promise<number | undefined> {
+  const verified = await verifyAuthBearerToken(
+    await crypto.getBearerToken("0x123"),
+  );
+  if (!verified) throw new Error("bearer token did not verify");
+  return verified.verifiableCredential.credentialSubject.chainId;
+}
+
 describe("auth", () => {
   it("should reject an invalid token", async () => {
     const verified = await verifyAuthBearerToken("invalid-token");
@@ -24,5 +34,23 @@ describe("auth", () => {
     const token = await renownCrypto.getBearerToken("0x123");
     const tampered = await verifyAuthBearerToken(token + "invalid");
     expect(tampered).toBeFalsy();
+  });
+
+  it("defaults the token's chain to 1", async () => {
+    const renownCrypto = await new RenownCryptoBuilder()
+      .withKeyPairStorage(new MemoryKeyStorage())
+      .build();
+    expect(renownCrypto.chainId).toBe(1);
+    expect(await tokenChainId(renownCrypto)).toBe(1);
+  });
+
+  // The token used to be pinned to chain 1 regardless of the issuing chain.
+  it("scopes the token to the configured chain", async () => {
+    const renownCrypto = await new RenownCryptoBuilder()
+      .withKeyPairStorage(new MemoryKeyStorage())
+      .withChainId(137)
+      .build();
+    expect(renownCrypto.chainId).toBe(137);
+    expect(await tokenChainId(renownCrypto)).toBe(137);
   });
 });

--- a/packages/renown/test/signin.test.ts
+++ b/packages/renown/test/signin.test.ts
@@ -42,7 +42,7 @@ function mockReactor() {
   return calls;
 }
 
-async function makeRenown(withSwitchboard = true) {
+async function makeRenown(withSwitchboard = true, chainId?: number) {
   const crypto = await new RenownCryptoBuilder()
     .withKeyPairStorage(new MemoryKeyStorage())
     .build();
@@ -54,6 +54,7 @@ async function makeRenown(withSwitchboard = true) {
     "https://renown.test",
     undefined,
     withSwitchboard ? new SwitchboardClient(SB) : undefined,
+    chainId,
   );
 }
 
@@ -101,5 +102,46 @@ describe("Renown.signIn", () => {
       }),
     ).rejects.toThrow(/switchboard/i);
     expect(renown.status).not.toBe("authorized");
+  });
+
+  // The chain id lands in the issuer DID, so accepting any chain would let one
+  // wallet hold several identities.
+  it("rejects a session from a chain it does not issue on", async () => {
+    const calls = mockReactor();
+    const renown = await makeRenown();
+
+    await expect(
+      renown.signIn({
+        address: ACCOUNT.address,
+        chainId: 137,
+        signTypedData: sign,
+      }),
+    ).rejects.toThrow(/chain 137.*chain 1/);
+    expect(renown.status).not.toBe("authorized");
+    // Rejected before anything was written.
+    expect(calls).toEqual([]);
+  });
+
+  it("issues on a configured non-default chain", async () => {
+    mockReactor();
+    const renown = await makeRenown(true, 137);
+    expect(renown.chainId).toBe(137);
+
+    const user = await renown.signIn({
+      address: ACCOUNT.address,
+      chainId: 137,
+      signTypedData: sign,
+    });
+
+    expect(user.did).toBe(
+      `did:pkh:eip155:137:${ACCOUNT.address.toLowerCase()}`,
+    );
+    await expect(
+      renown.signIn({
+        address: ACCOUNT.address,
+        chainId: 1,
+        signTypedData: sign,
+      }),
+    ).rejects.toThrow(/chain 1.*chain 137/);
   });
 });

--- a/packages/renown/test/wallet/privy-theme.test.ts
+++ b/packages/renown/test/wallet/privy-theme.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { toPrivyAccentColor } from "../../src/wallet/privy/theme.js";
+
+describe("toPrivyAccentColor", () => {
+  it("passes hex through", () => {
+    expect(toPrivyAccentColor("#0084ff")).toBe("#0084ff");
+    expect(toPrivyAccentColor("#08f")).toBe("#08f");
+    expect(toPrivyAccentColor("  #0084FF  ")).toBe("#0084FF");
+  });
+
+  // What a host actually supplies: getComputedStyle normalizes to rgb().
+  it("converts the rgb() a resolved CSS token yields", () => {
+    expect(toPrivyAccentColor("rgb(0, 132, 255)")).toBe("#0084ff");
+    expect(toPrivyAccentColor("rgb(255 255 255)")).toBe("#ffffff");
+  });
+
+  it("drops alpha, which Privy derives itself", () => {
+    expect(toPrivyAccentColor("rgba(0, 132, 255, 0.5)")).toBe("#0084ff");
+  });
+
+  it("clamps and rounds out-of-range channels", () => {
+    expect(toPrivyAccentColor("rgb(-20, 132.6, 300)")).toBe("#0085ff");
+  });
+
+  // Privy rejects anything non-hex, so an unconvertible color must be omitted
+  // rather than forwarded.
+  it("returns undefined when it cannot produce hex", () => {
+    expect(toPrivyAccentColor(undefined)).toBeUndefined();
+    expect(toPrivyAccentColor("")).toBeUndefined();
+    expect(toPrivyAccentColor("rebeccapurple")).toBeUndefined();
+    expect(toPrivyAccentColor("var(--primary)")).toBeUndefined();
+    expect(toPrivyAccentColor("hsl(210 100% 50%)")).toBeUndefined();
+  });
+});

--- a/packages/renown/test/wallet/rainbow-config.test.ts
+++ b/packages/renown/test/wallet/rainbow-config.test.ts
@@ -1,5 +1,7 @@
 import { getDefaultWallets as rainbowGetDefaultWallets } from "@rainbow-me/rainbowkit";
 import { describe, expect, it } from "vitest";
+import { base, mainnet, polygon } from "wagmi/chains";
+import { buildWagmiConfig } from "../../src/wallet/rainbow/config.js";
 import { walletsWithoutWalletConnect } from "../../src/wallet/rainbow/config.js";
 
 // RainbowKit's exports map has no "types" condition, so type-aware lint sees its
@@ -18,7 +20,7 @@ function ids(groups: { wallets: unknown[] }[]): (string | undefined)[] {
   );
 }
 
-/** All reach WalletConnect, so none work without a project id: `walletConnect` directly, `rainbow` whenever its extension is absent, `metaMask` on desktop without the extension. */
+// All reach WalletConnect, so none can work without a project id.
 const NEEDS_WALLET_CONNECT = ["walletConnect", "rainbow", "metaMask"];
 
 describe("walletsWithoutWalletConnect", () => {
@@ -33,8 +35,7 @@ describe("walletsWithoutWalletConnect", () => {
     }
   });
 
-  // Pins why the list is built by hand: RainbowKit's defaults are full of wallets
-  // that fall back to WalletConnect, so subtracting one entry is not enough.
+  // Pins why the list is built by hand rather than filtered.
   it("is not just RainbowKit's defaults minus WalletConnect", () => {
     const defaults = ids(getDefaultWallets().wallets);
     expect(defaults).toContain("walletConnect");
@@ -42,5 +43,36 @@ describe("walletsWithoutWalletConnect", () => {
       NEEDS_WALLET_CONNECT.includes(id ?? ""),
     );
     expect(dependent.length).toBeGreaterThan(1);
+  });
+});
+
+describe("buildWagmiConfig chains", () => {
+  // The narrow default is a bundle-size decision, so pin it.
+  it("defaults to Ethereum mainnet alone", () => {
+    const config = buildWagmiConfig({ walletConnectProjectId: "test" });
+    expect(config.chains.map((chain) => chain.id)).toEqual([mainnet.id]);
+  });
+
+  it("uses the chains it is given, in order", () => {
+    const config = buildWagmiConfig({
+      walletConnectProjectId: "test",
+      chains: [polygon, mainnet, base],
+    });
+    expect(config.chains.map((chain) => chain.id)).toEqual([
+      polygon.id,
+      mainnet.id,
+      base.id,
+    ]);
+  });
+
+  it("builds one transport per configured chain", () => {
+    const config = buildWagmiConfig({
+      walletConnectProjectId: "test",
+      chains: [mainnet, polygon],
+    });
+    expect(Object.keys(config._internal.transports).map(Number)).toEqual([
+      mainnet.id,
+      polygon.id,
+    ]);
   });
 });

--- a/packages/renown/test/wallet/rainbow-config.test.ts
+++ b/packages/renown/test/wallet/rainbow-config.test.ts
@@ -1,0 +1,46 @@
+import { getDefaultWallets as rainbowGetDefaultWallets } from "@rainbow-me/rainbowkit";
+import { describe, expect, it } from "vitest";
+import { walletsWithoutWalletConnect } from "../../src/wallet/rainbow/config.js";
+
+// RainbowKit's exports map has no "types" condition, so type-aware lint sees its
+// exports as error-typed; assert the shapes we read.
+type Probe = (params: { projectId: string }) => { id?: string } | undefined;
+const getDefaultWallets = rainbowGetDefaultWallets as () => {
+  wallets: { wallets: unknown[] }[];
+};
+
+// A wallet creator returns a descriptor carrying a stable string `id`.
+function ids(groups: { wallets: unknown[] }[]): (string | undefined)[] {
+  return groups.flatMap((group) =>
+    group.wallets.map(
+      (create) => (create as Probe)({ projectId: "probe" })?.id,
+    ),
+  );
+}
+
+/** All reach WalletConnect, so none work without a project id: `walletConnect` directly, `rainbow` whenever its extension is absent, `metaMask` on desktop without the extension. */
+const NEEDS_WALLET_CONNECT = ["walletConnect", "rainbow", "metaMask"];
+
+describe("walletsWithoutWalletConnect", () => {
+  it("offers only the wallets that never reach WalletConnect", () => {
+    expect(ids(walletsWithoutWalletConnect())).toEqual(["injected", "safe"]);
+  });
+
+  it("excludes every WalletConnect-dependent wallet", () => {
+    const offered = ids(walletsWithoutWalletConnect());
+    for (const id of NEEDS_WALLET_CONNECT) {
+      expect(offered).not.toContain(id);
+    }
+  });
+
+  // Pins why the list is built by hand: RainbowKit's defaults are full of wallets
+  // that fall back to WalletConnect, so subtracting one entry is not enough.
+  it("is not just RainbowKit's defaults minus WalletConnect", () => {
+    const defaults = ids(getDefaultWallets().wallets);
+    expect(defaults).toContain("walletConnect");
+    const dependent = defaults.filter((id) =>
+      NEEDS_WALLET_CONNECT.includes(id ?? ""),
+    );
+    expect(dependent.length).toBeGreaterThan(1);
+  });
+});

--- a/test/test-fusion/.env.local.example
+++ b/test/test-fusion/.env.local.example
@@ -1,0 +1,19 @@
+# Copy to .env.local and fill in. All are optional and all ship to the
+# browser (NEXT_PUBLIC_), so use ids scoped to this test app.
+
+# WalletConnect Cloud project id — https://dashboard.reown.com
+# Without it RainbowKit only offers wallets that never touch the WalletConnect
+# relay (an installed browser wallet, or a Safe App iframe).
+NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
+
+# Infura project id — https://developer.metamask.io
+# Without it each chain uses the public RPC from its wagmi/chains definition.
+NEXT_PUBLIC_INFURA_PROJECT_ID=
+
+# Privy app id + client id — https://dashboard.privy.io
+# Without the app id the privy adapter is dropped, so no social/email login.
+NEXT_PUBLIC_PRIVY_APP_ID=
+NEXT_PUBLIC_PRIVY_CLIENT_ID=
+
+# Set to 1 to swap in the headless mock signer (local dev / e2e).
+NEXT_PUBLIC_RENOWN_MOCK=

--- a/test/test-fusion/.gitignore
+++ b/test/test-fusion/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel

--- a/test/test-fusion/src/components/renown-login.tsx
+++ b/test/test-fusion/src/components/renown-login.tsx
@@ -5,7 +5,6 @@ import {
   useRenownLoginMethods,
 } from "@powerhousedao/reactor-browser/renown";
 import { LoginMethod } from "@renown/sdk/wallet";
-import { WALLET_ADAPTERS } from "@/lib/wallet-adapters";
 
 export function RenownLogin() {
   const {
@@ -18,7 +17,7 @@ export function RenownLogin() {
     error,
     logout,
   } = useRenownAuth();
-  const methods = useRenownLoginMethods(WALLET_ADAPTERS);
+  const methods = useRenownLoginMethods();
 
   if (user) {
     return (

--- a/test/test-fusion/src/lib/wallet-adapters.ts
+++ b/test/test-fusion/src/lib/wallet-adapters.ts
@@ -2,16 +2,33 @@ import type { WalletAdapterDescriptor } from "@renown/sdk/wallet";
 import { mockAdapter } from "@renown/sdk/wallet/mock";
 import { privyAdapter } from "@renown/sdk/wallet/privy";
 import { rainbowAdapter } from "@renown/sdk/wallet/rainbow";
+import { RENOWN_APP_NAME } from "./renown";
+
+// Unlike the rainbow ids, Privy's app id has no degraded mode: the adapter
+// can't initialise without one, so it is left out entirely when unset.
+const PRIVY_APP_ID = process.env.NEXT_PUBLIC_PRIVY_APP_ID;
 
 /** Wallet adapters for in-page sign-in; importing one is what makes its peer deps a build requirement, while the wallet library itself still loads lazily on the first login click. Module scope, so RenownWalletProvider snapshots a stable array. NEXT_PUBLIC_RENOWN_MOCK=1 swaps in the headless mock adapter (e2e/dev). */
 export const WALLET_ADAPTERS: WalletAdapterDescriptor[] =
   process.env.NEXT_PUBLIC_RENOWN_MOCK === "1"
     ? [mockAdapter({ methods: ["wallet", "google", "email"] })]
     : [
-        rainbowAdapter({ ssr: true }),
-        privyAdapter({
-          appId: "cmruc4ldh02wr0cjxhpdfjbso",
-          clientId: "client-WY6bMp7uwaPvuL4wFm5b7Xj7x5wEFhGTLA4k8rwahyZbd",
-          methods: ["google", "email"],
+        rainbowAdapter({
+          ssr: true,
+          appName: RENOWN_APP_NAME,
+          // Both optional (see .env.local.example): without the WalletConnect id
+          // only an installed wallet can sign in, without Infura chains use public RPCs.
+          walletConnectProjectId:
+            process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID,
+          infuraProjectId: process.env.NEXT_PUBLIC_INFURA_PROJECT_ID,
         }),
+        ...(PRIVY_APP_ID
+          ? [
+              privyAdapter({
+                appId: PRIVY_APP_ID,
+                clientId: process.env.NEXT_PUBLIC_PRIVY_CLIENT_ID,
+                methods: ["google", "email"],
+              }),
+            ]
+          : []),
       ];


### PR DESCRIPTION
Follow-ups on #2891, from reviewing the merged branch. Four independent concerns.

---

## 1. Wallets that cannot work were offered without a WalletConnect project id

With no `walletConnectProjectId`, the rainbow adapter took RainbowKit's default wallet
list and removed the WalletConnect entry. That was wrong twice.

**The removal never happened in a built app.** It filtered on
`w.name !== "walletConnectWallet"`, but those entries are wallet **creator functions**, so
that reads `Function.prototype.name` — which every minifier renames. Bundling the shipped
dist with and without `--minify`:

```
MINIFIED    names: ["lEi","cEi","NTr","DTr","uEi"]                    survivors: 5 of 5
UNMINIFIED  names: ["safeWallet","rainbowWallet","base32","metaMaskWallet","walletConnectWallet"]
                                                                      survivors: 4 of 5
```

So WalletConnect stayed offered with `projectId: "MISSING_WALLET_CONNECT_PROJECT_ID"` and
the relay answered `code: 3000` (Project not found). Works in dev, broken in prod. The name
is unreliable even unminified — RainbowKit's own dist ships the Base entry as `base3`.

**Removing that one entry was never sufficient anyway.** RainbowKit's other defaults reach
WalletConnect themselves and fail identically:

| default wallet | falls back to WalletConnect when |
| --- | --- |
| `rainbowWallet` | `!isRainbowInjected` — whenever the extension is absent |
| `metaMaskWallet` | `!isMetaMaskInjected && !isMobile()` — desktop without the extension |

**Fix — compose the list instead of subtracting from it.** Without a project id we offer
`injectedWallet` and `safeWallet`, the two that never reach WalletConnect
(`getInjectedConnector` and wagmi's `safe()`). Nothing introspects a function name or an id
any more, so the minification failure mode is **gone rather than guarded**. With a project
id, `wallets` stays omitted and RainbowKit's defaults apply unchanged.

The placeholder project id stays: `getWalletConnectConnector` throws on a falsy one and
RainbowKit reaches it while building connectors.

> **Reference identity does not work here**, in case that looks like the obvious fix.
> `dist/index.js` and `dist/wallets/walletConnectors/index.js` are separate bundles that
> each inline their own copy of every creator, so **zero** of the five default entries match
> any of the 76 exports from `@rainbow-me/rainbowkit/wallets`.

Also promotes the accompanying `console.debug` — invisible at default log levels, and
describing something that had not happened — to a `console.warn`, and corrects the docs that
claimed MetaMask still worked without a project id.

## 2. `useRenownLoginMethods` reads the mounted provider

It took the descriptor array separately from `RenownWalletProvider`, which snapshots its own
copy on mount and exposed it nowhere. Keeping them in agreement was a JSDoc obligation each
call site honoured independently, and Connect had **three** call sites each deriving a fresh
array from `getRuntimeConfig()` via its own `useMemo` — so the hook never saw the array the
provider mounted. A disagreement shows or hides a login button.

The provider now publishes its snapshot to `wallet-registry.ts`; the hook reads it through
`useSyncExternalStore`. Connect's three derivations collapse to one.

**A registry rather than context**, which is the part worth reviewing. Connect renders
`ModalsContainer` — and so `LoginModal`, its primary login UI — as a sibling of `<App />` in
`app-loader.tsx`, while `RenownWalletProvider` lives inside `<App />`. A context-based hook
would have given the login modal **zero buttons**. The active wallet controller is already a
module registry for exactly this reason.

**Duplicate-instance and SSR safe.** The store hangs off `globalThis` under a `Symbol.for`
key rather than a module-level `let`, so duplicate copies of this package — a
separately-bundled consumer or plugin — share one store instead of each seeing its own empty
one. No `typeof window` guard needed: `globalThis` exists on the server, and
`getServerWalletDescriptors` returns a constant, so a server render never reads the mutable
store and no state crosses requests. (The controller registry still has the module-level
weakness; converting it has promise/waiter semantics to think through.)

Also enforces the snapshot contract instead of only documenting it. `useState(() => adapters)`
silently ignores every later array, so a consumer inlining `adapters={[rainbowAdapter({...})]}`
in JSX gets something that appears to work with no feedback. A dev-only identity check now
reports it, guarded with `typeof process !== "undefined"` since this is the first
`process.env` read in reactor-browser and a browser bundle need not define it.

### Breaking

`useRenownLoginMethods(adapters, labels?)` → `useRenownLoginMethods(labels?)`.

```diff
-const methods = useRenownLoginMethods(adapters);
+const methods = useRenownLoginMethods();
```

Empty when no provider is mounted (the redirect-only case), matching what the old
`if (!adapters) return []` did for `undefined`. Callers updated: Connect (2), test-fusion (1).

## 3. One wallet could hold several identities

The issuer DID embeds the chain id — `did:pkh:eip155:${chainId}:${address}` — and that id
came from `WalletSession.chainId`, i.e. whichever network the wallet happened to be on
(`rainbow/factory.ts` reads `account.chainId`; privy parses the wallet's CAIP-2 id).
`session.ts` passed it through unchecked. **So signing in on Polygon made you a different
user** — different DID, different credentials, different grants — than on mainnet.

It never surfaced because the EIP-712 domain is derived from the same value, so signatures
always verified. Nothing compared the two.

Three sources of truth disagreed:

| source | was | now |
| --- | --- | --- |
| wallet's live network | became the DID + EIP-712 domain | validated against the issuing chain |
| `renownChainId` config | plumbed CLI arg → `useRenownChainId`, value read **nowhere** | `RenownProvider`/builder option that Renown actually uses |
| `crypto/renown-crypto.ts` | hardcoded `1` for the bearer token | the configured chain |

Renown now owns the chain it issues on (`chainId`, default 1, settable via the builder,
`RenownProvider`, and `RenownInitOptions`), and `signIn` **rejects** a session from any other
chain before writing anything. `RenownCrypto` takes the same chain for its bearer token, and
`RenownBuilder` warns when a crypto supplied through `withCrypto()` disagrees.

Relabelling the domain instead would not work: wallets validate `eth_signTypedData_v4`'s
domain chain id against the active chain, so the active chain is what has to be constrained.
Hence the rainbow adapter's `chains` now defaults to that same chain, and warns when a
configured list cannot produce it — a narrow list is what makes RainbowKit prompt a network
switch, rather than letting the user reach a rejection at the end of the flow.

> **The narrowed chain list is a correctness measure, not a size one.** Dropping five chains
> moved **~19 bytes gzip**. My initial ~14 KB estimate was wrong: measured in isolation,
> `optimism`/`base` pull viem's op-stack code, but in the real bundle that code is present
> regardless. See the bundle note below.

## 4. Privy honours the host accent color

The privy adapter mapped only the theme `mode`, so its modal kept Privy's default accent
while rainbow picked up the host's — two login routes, two accents.

`appearance.accentColor` takes `HexColor` only, and hosts resolve a CSS token through
`getComputedStyle`, which returns `rgb(...)`, so passing the value straight through is
rejected. Converts hex and `rgb()`/`rgba()` (alpha dropped — Privy derives its own variants)
and omits anything else, since a named or `hsl()` color has no hex form without a DOM.
`accentColorForeground` stays rainbow-only; Privy computes its own contrast.

---

## Bundle note, since the chain change invites the question

Worth recording because it corrects two wrong numbers of mine. Measured with Rollup/Vite
(esbuild cross-checked); "marginal" treats react, react-dom, `@tanstack/*` and `@noble/*` as
already in the host graph.

| eager first-click chunk | isolated gzip | marginal gzip |
| --- | --- | --- |
| rainbow factory | 212 KB | **180 KB** |
| privy factory | 562 KB | **536 KB** |

- An earlier 1.36 MB figure was ~6× too pessimistic: `esbuild --bundle --outfile` inlines
  every dynamic-import subgraph, and RainbowKit has 77 of them.
- The stray chain definitions were an **esbuild chunking artifact**, not a real cost — Rollup
  tree-shakes `viem/chains` to the one definition used. Hence the ~19 bytes.
- **Privy is ~3× rainbow's weight** and largely outside our control: its default entry
  statically pulls WalletConnect, Coinbase SDK, `@solana/*`, zod v3 and a duplicated `ox`,
  and `disableAllExternalWallets` is runtime config — it saves a handshake, not a byte.

Not pursued here: deduping `ox` (lockfile-only, est. 10–15 KB gz), replacing
`getDefaultConfig` with `connectorsForWallets` + `createConfig` (−7.9 KB gz eager, lazy
artifacts 162→75 chunks), and giving the no-WalletConnect path its own RainbowKit-free chunk
(−167 KB gz, but loses the modal, wallet detection, ENS and QR). All Rollup/Vite numbers —
**Turbopack is unverified**, and if it chunks like esbuild then aliasing `wagmi/chains` is
worth ~72 KB gz.

## Also in this PR

`test/test-fusion` reads its wallet adapter ids from `NEXT_PUBLIC_*` instead of literals in
source (the privy app id and client id were hardcoded), documented in a new
`.env.local.example`. Rainbow always loads since it degrades without either id; privy is
dropped from the array entirely when no app id is set, because it cannot initialise without
one.

## Verification

Run after a full `pnpm build` at the repo root (exit 0), which matters — without it
`document-model`/`reactor` project references are unbuilt and 19 reactor-browser files plus 1
Connect file fail to resolve, masking the real result.

- Root `pnpm build`: clean. `tsc --build` across renown / reactor-browser / connect: clean.
- `@renown/sdk`: **139/139** tests (12 files).
- `@powerhousedao/reactor-browser`: **295/295** (36 files), including 6 new `login-methods`
  cases: out-of-tree read, provider-mounts-late, unmount, label overrides.
- `apps/connect`: **167/167** (18 files). `test/test-fusion`: `tsc` + lint clean.
- Lint: 0 errors across all three (pre-existing warnings only).

New tests worth noting: `signIn` rejecting a foreign chain **and writing nothing**; issuing
on a configured non-default chain; the bearer token following the configured chain;
`walletsWithoutWalletConnect` offering exactly `["injected", "safe"]` and pinning that
RainbowKit's defaults contain more than one WalletConnect-dependent wallet, so a future
"just filter `getDefaultWallets()`" simplification fails.

**Caveat:** the reactor-browser browser-mode suite is flaky. One intermediate run reported 4
failures (`act(...)` noise in `document-cache`); repeated runs are green at 295/295. It
reproduces without these changes and I did not chase it.

Not done: no manual browser run against a real WalletConnect-less deployment, and no
Turbopack chunking check.
