### PR TITLE
fix(codegen): stop overwriting hand-written reducers and generate processors that actually run

### DIFF
--- a/clis/ph-cli/src/commands/generate-app.ts
+++ b/clis/ph-cli/src/commands/generate-app.ts
@@ -1,6 +1,5 @@
 import { debugArgs } from "@powerhousedao/shared/clis/args";
 import {
-  array,
   boolean,
   command,
   flag,
@@ -10,6 +9,7 @@ import {
   string,
 } from "cmd-ts";
 import { Directory, File } from "cmd-ts/dist/cjs/batteries/fs.js";
+import { CommaSeparatedStrings } from "../utils/comma-separated.js";
 
 export const generateAppCmd = command({
   name: "app",
@@ -22,10 +22,11 @@ export const generateAppCmd = command({
       description: "The name of the drive app to generate",
     }),
     allowedDocumentTypes: multioption({
-      type: optional(array(string)),
+      type: optional(CommaSeparatedStrings),
       long: "document-types",
       short: "t",
-      description: "The document types allowed by the new app",
+      description:
+        "The document types allowed by the new app (repeatable or comma-separated)",
     }),
     document: option({
       type: optional(File),

--- a/clis/ph-cli/src/commands/generate-processor.ts
+++ b/clis/ph-cli/src/commands/generate-processor.ts
@@ -2,7 +2,6 @@ import { debugArgs } from "@powerhousedao/shared/clis/args";
 import { PROCESSOR_APPS } from "@powerhousedao/shared/processors";
 import type { Type } from "cmd-ts";
 import {
-  array,
   command,
   flag,
   multioption,
@@ -12,9 +11,14 @@ import {
   string,
 } from "cmd-ts";
 import { Directory, File } from "cmd-ts/dist/cjs/batteries/fs.js";
+import {
+  CommaSeparatedStrings,
+  splitCommaSeparated,
+} from "../utils/comma-separated.js";
 
 const ProcessorAppType: Type<string[], ("connect" | "switchboard")[]> = {
-  from(processorApps) {
+  from(rawProcessorApps) {
+    const processorApps = splitCommaSeparated(rawProcessorApps);
     if (processorApps.length === 0) {
       throw new Error(
         `No arguments provided for processor apps. Must be "connect" and/or "switchboard"`,
@@ -54,10 +58,11 @@ export const generateProcessorCmd = command({
       defaultValueIsSerializable: true,
     }),
     documentTypes: multioption({
-      type: array(string),
+      type: CommaSeparatedStrings,
       long: "document-types",
       short: "t",
-      description: "The document types the processor will run on",
+      description:
+        "The document types the processor will run on (repeatable or comma-separated)",
       defaultValue: () => [],
       defaultValueIsSerializable: true,
     }),

--- a/clis/ph-cli/src/utils/comma-separated.ts
+++ b/clis/ph-cli/src/utils/comma-separated.ts
@@ -1,0 +1,15 @@
+import type { Type } from "cmd-ts";
+
+/** Splits comma-separated values so `-t "a,b"` means the same as `-t a -t b`
+ * instead of yielding the single value `"a,b"`, which matches nothing. */
+export function splitCommaSeparated(values: string[]): string[] {
+  return values
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+/** `multioption` type accepting repeated and/or comma-separated values. */
+export const CommaSeparatedStrings: Type<string[], string[]> = {
+  from: (values) => Promise.resolve(splitCommaSeparated(values)),
+};

--- a/clis/ph-cli/test/comma-separated.test.ts
+++ b/clis/ph-cli/test/comma-separated.test.ts
@@ -1,0 +1,41 @@
+// `multioption` hands `from` the raw values it collected, so a single
+// `--document-types "a,b"` arrives as one string that has to be split.
+
+import { describe, expect, it } from "vitest";
+import {
+  CommaSeparatedStrings,
+  splitCommaSeparated,
+} from "../src/utils/comma-separated.js";
+
+describe("splitCommaSeparated", () => {
+  it("splits a comma-separated value into one entry per item", () => {
+    expect(
+      splitCommaSeparated(["pfnur/rto-company,pfnur/toll-statement"]),
+    ).toEqual(["pfnur/rto-company", "pfnur/toll-statement"]);
+  });
+
+  it("leaves repeated options untouched", () => {
+    expect(splitCommaSeparated(["a/one", "b/two"])).toEqual(["a/one", "b/two"]);
+  });
+
+  it("trims whitespace and drops empty entries", () => {
+    expect(splitCommaSeparated([" a/one , ,b/two,"])).toEqual([
+      "a/one",
+      "b/two",
+    ]);
+    expect(splitCommaSeparated([])).toEqual([]);
+  });
+});
+
+describe("CommaSeparatedStrings", () => {
+  it("parses both comma-separated and repeated values", async () => {
+    await expect(CommaSeparatedStrings.from(["a,b"])).resolves.toEqual([
+      "a",
+      "b",
+    ]);
+    await expect(CommaSeparatedStrings.from(["a", "b"])).resolves.toEqual([
+      "a",
+      "b",
+    ]);
+  });
+});

--- a/packages/codegen/src/templates/index.mts
+++ b/packages/codegen/src/templates/index.mts
@@ -83,4 +83,5 @@ export * from "./processors/relational-db/index.js";
 export * from "./processors/relational-db/migrations.js";
 export * from "./processors/relational-db/processor.js";
 export * from "./processors/relational-db/schema.js";
+export * from "./processors/utils.js";
 export * from "./subgraphs/index.js";

--- a/packages/codegen/src/templates/processors/analytics/factory.ts
+++ b/packages/codegen/src/templates/processors/analytics/factory.ts
@@ -1,5 +1,5 @@
 import { ts } from "@tmpl/core";
-import { getDocumentType } from "../utils.js";
+import { renderProcessorFilter } from "../utils.js";
 
 export const analyticsFactoryTemplate = (v: {
   pascalCaseName: string;
@@ -20,12 +20,12 @@ export const ${v.camelCaseName}FactoryBuilder: ProcessorFactoryBuilder = (module
   return [
     {
       processor: new ${v.pascalCaseName}(module.analyticsStore),
-      filter: {
+      // An omitted field matches every value. Only \`documentId\` honours "*".
+      filter: ${renderProcessorFilter({
         branch: ["main"],
         documentId: ["*"],
-        scope: ["*"],
-        documentType: [${getDocumentType(v.documentTypes)}],
-      },
+        documentType: v.documentTypes,
+      })},
     },
   ];
 }

--- a/packages/codegen/src/templates/processors/relational-db/factory.ts
+++ b/packages/codegen/src/templates/processors/relational-db/factory.ts
@@ -37,6 +37,11 @@ export const ${v.camelCaseName}FactoryBuilder: ProcessorFactoryBuilder = (module
 
   // Create the processor
   const processor = new ${v.pascalCaseName}(namespace, filter, store);
+
+  // Run the processor's migrations. Nothing in the runtime calls this, so
+  // without it the first write hits a database with no tables.
+  await processor.initAndUpgrade();
+
   return [
     {
       processor,

--- a/packages/codegen/src/templates/processors/relational-db/factory.ts
+++ b/packages/codegen/src/templates/processors/relational-db/factory.ts
@@ -1,5 +1,5 @@
 import { ts } from "@tmpl/core";
-import { getDocumentType } from "../utils.js";
+import { renderProcessorFilter } from "../utils.js";
 
 export const relationalDbFactoryTemplate = (v: {
   camelCaseName: string;
@@ -26,13 +26,14 @@ export const ${v.camelCaseName}FactoryBuilder: ProcessorFactoryBuilder = (module
     namespace,
   );
 
-  // Create a filter for the processor
-  const filter: ProcessorFilter = {
+  // Create a filter for the processor. An omitted field matches every value.
+  // Only \`documentId\` honours "*", so "*" elsewhere would match nothing.
+  const filter: ProcessorFilter = ${renderProcessorFilter({
     branch: ["main"],
     documentId: ["*"],
-    documentType: [${getDocumentType(v.documentTypes)}],
+    documentType: v.documentTypes,
     scope: ["global"],
-  };
+  })};
 
   // Create the processor
   const processor = new ${v.pascalCaseName}(namespace, filter, store);

--- a/packages/codegen/src/templates/processors/utils.ts
+++ b/packages/codegen/src/templates/processors/utils.ts
@@ -1,4 +1,39 @@
-export function getDocumentType(documentTypes: string[]) {
-  if (!documentTypes.length) return `"*"`;
-  return documentTypes.map((type) => `"${type}"`).join(", ");
+/** Fields of a generated processor's `ProcessorFilter`, in emission order. */
+export type ProcessorFilterFields = {
+  branch?: string[];
+  documentId?: string[];
+  documentType?: string[];
+  scope?: string[];
+};
+
+const FILTER_FIELD_ORDER = [
+  "branch",
+  "documentId",
+  "documentType",
+  "scope",
+] as const satisfies readonly (keyof ProcessorFilterFields)[];
+
+/** Splits, trims and compacts one filter field, so `-t a -t b` and
+ * `-t "a,b"` mean the same thing instead of the latter yielding one value. */
+export function parseFilterValues(values: string[] | undefined): string[] {
+  return (values ?? [])
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+/** Renders a generated factory's `ProcessorFilter`, omitting empty fields:
+ * only `documentId` honours `"*"`, so `["*"]` elsewhere matches nothing. */
+export function renderProcessorFilter(fields: ProcessorFilterFields): string {
+  const properties = FILTER_FIELD_ORDER.map(
+    (name) => [name, parseFilterValues(fields[name])] as const,
+  )
+    .filter(([, values]) => values.length > 0)
+    .map(
+      ([name, values]) =>
+        `  ${name}: [${values.map((value) => `"${value}"`).join(", ")}],`,
+    );
+
+  if (properties.length === 0) return "{}";
+  return `{\n${properties.join("\n")}\n}`;
 }

--- a/packages/codegen/src/utils/source-files.ts
+++ b/packages/codegen/src/utils/source-files.ts
@@ -1,5 +1,6 @@
 import path from "path";
-import type { Project } from "ts-morph";
+import type { Project, SourceFile } from "ts-morph";
+import { FileSystemRefreshResult } from "ts-morph";
 
 /** Gets a SourceFile by name in a ts-morph Project, or creates a new one
  * if none with that path exists.
@@ -16,15 +17,28 @@ import type { Project } from "ts-morph";
  * Reading the file in when it is on disk but not yet loaded mirrors what
  * `DirectoryManager.createSourceFile` already does. Files that codegen fully
  * owns are unaffected: they call `replaceWithText` immediately afterwards.
+ *
+ * The rule has to hold on the cache-hit path too, which is the other half of
+ * the same data loss. `ph vetra` builds one Project per process and reuses it
+ * for every codegen run, and nothing ever refreshes it, so a SourceFile loaded
+ * by an earlier run keeps the text it had then: codegen scaffolds a reducer
+ * with TODO stubs, the user writes the real body on disk, and the next run in
+ * that session still sees the stubs and writes them back on `project.save()`.
+ * A fresh process (`ph generate`) never hit this — the cache miss forced a read
+ * from disk. Refreshing a cached SourceFile before handing it out makes the
+ * long-lived Project behave like a fresh one. Only cached files are refreshed;
+ * `addSourceFileAtPathIfExists` has just read disk, so refreshing that again
+ * would be I/O for a guaranteed `NoChange`.
  */
 export function getOrCreateSourceFile(project: Project, filePath: string) {
   const dirName = path.dirname(filePath);
   if (!project.getDirectory(dirName)) {
     project.createDirectory(dirName);
   }
-  const sourceFile =
-    project.getSourceFile(filePath) ??
-    project.addSourceFileAtPathIfExists(filePath);
+  const cachedSourceFile = project.getSourceFile(filePath);
+  const sourceFile = cachedSourceFile
+    ? refreshCachedSourceFile(cachedSourceFile)
+    : project.addSourceFileAtPathIfExists(filePath);
   if (!sourceFile) {
     // `overwrite: false` so that a future regression here fails loudly instead
     // of quietly truncating a file: reaching this line now means the path is
@@ -41,6 +55,16 @@ export function getOrCreateSourceFile(project: Project, filePath: string) {
     alreadyExists: true,
     sourceFile,
   };
+}
+
+/** Re-reads a cached SourceFile from disk, `undefined` once it is gone from
+ * disk (ts-morph forgets it then, so the caller re-creates it). */
+function refreshCachedSourceFile(sourceFile: SourceFile) {
+  // Pending in-memory edits belong to the run in progress; disk is only the
+  // authority while the loaded copy matches what codegen last wrote out.
+  if (!sourceFile.isSaved()) return sourceFile;
+  const result = sourceFile.refreshFromFileSystemSync();
+  return result === FileSystemRefreshResult.Deleted ? undefined : sourceFile;
 }
 
 /** Gets a Directory by name in a ts-morph Project, or creates a new one

--- a/packages/shared/processors/drive-analytics/index.ts
+++ b/packages/shared/processors/drive-analytics/index.ts
@@ -7,13 +7,14 @@ import { DriveAnalyticsProcessor } from "./drive-processor.js";
 export const processorFactory =
   (module: { analyticsStore: IAnalyticsStore }) =>
   (driveHeader: PHDocumentHeader): ProcessorRecord[] => {
+    // Omitted filter fields match every value. Only `documentId` honours "*",
+    // so "*" in `scope`/`documentType`/`branch` would match nothing at all.
     return [
       {
         processor: new DriveAnalyticsProcessor(module.analyticsStore),
         filter: {
           branch: ["main"],
           documentId: ["*"],
-          scope: ["*"],
           documentType: ["powerhouse/document-drive"],
         },
       },
@@ -22,8 +23,6 @@ export const processorFactory =
         filter: {
           branch: ["main"],
           documentId: ["*"],
-          scope: ["*"],
-          documentType: ["*"],
         },
       },
     ];

--- a/test/codegen/tests/generate-processor.test.ts
+++ b/test/codegen/tests/generate-processor.test.ts
@@ -300,6 +300,121 @@ describe("generate processor", () => {
       });
     });
   });
+  describe("processor filters", () => {
+    // `matchesFilter` only honours "*" for documentId, so a wildcard in any
+    // other field is a filter that matches nothing.
+    const WILDCARD_FIELD = /(?:documentType|scope|branch):\s*\[[^\]]*"\*"/;
+
+    function readFactory(outDir: string, processorDirName: string) {
+      return readFile(
+        join(outDir, "processors", processorDirName, "factory.ts"),
+        "utf-8",
+      );
+    }
+
+    it("should split a comma separated document types value into one entry per type", async () => {
+      const documentTypes = ["pfnur/rto-company,pfnur/toll-statement"];
+      const outDir = await runProcessorTests({
+        outDirName: "filter-comma-separated-document-types",
+        inputs: [
+          {
+            processorName: "relational-comma-separated",
+            processorType: "relationalDb",
+            documentTypes,
+            processorApps: ["switchboard"],
+          },
+          {
+            processorName: "analytics-comma-separated",
+            processorType: "analytics",
+            documentTypes,
+            processorApps: ["switchboard"],
+          },
+        ],
+      });
+
+      for (const dirName of [
+        "relational-comma-separated",
+        "analytics-comma-separated",
+      ]) {
+        const factory = await readFactory(outDir, dirName);
+        expect(factory).toContain(
+          `documentType: ["pfnur/rto-company", "pfnur/toll-statement"],`,
+        );
+        expect(factory).not.toContain(
+          `["pfnur/rto-company,pfnur/toll-statement"]`,
+        );
+      }
+    });
+
+    it("should omit filter fields with no values instead of emitting a wildcard", async () => {
+      const outDir = await runProcessorTests({
+        outDirName: "filter-without-document-types",
+        inputs: [
+          {
+            processorName: "relational-no-document-types",
+            processorType: "relationalDb",
+            documentTypes: [],
+            processorApps: ["switchboard"],
+          },
+          {
+            processorName: "analytics-no-document-types",
+            processorType: "analytics",
+            documentTypes: [],
+            processorApps: ["switchboard"],
+          },
+        ],
+      });
+
+      for (const dirName of [
+        "relational-no-document-types",
+        "analytics-no-document-types",
+      ]) {
+        const factory = await readFactory(outDir, dirName);
+        expect(factory).not.toMatch(WILDCARD_FIELD);
+        expect(factory).not.toContain("documentType");
+        // documentId is the one field for which the wildcard is honoured
+        expect(factory).toContain(`documentId: ["*"],`);
+      }
+
+      // the analytics factory used to pin `scope` to a wildcard, which meant it
+      // could never receive an operation
+      const analyticsFactory = await readFactory(
+        outDir,
+        "analytics-no-document-types",
+      );
+      expect(analyticsFactory).not.toContain("scope");
+    });
+
+    it("should not emit a wildcard filter field when document types are given", async () => {
+      const outDir = await runProcessorTests({
+        outDirName: "filter-with-document-types",
+        inputs: [
+          {
+            processorName: "relational-with-document-types",
+            processorType: "relationalDb",
+            documentTypes: ["billing-statement"],
+            processorApps: ["switchboard"],
+          },
+          {
+            processorName: "analytics-with-document-types",
+            processorType: "analytics",
+            documentTypes: ["billing-statement"],
+            processorApps: ["switchboard"],
+          },
+        ],
+      });
+
+      for (const dirName of [
+        "relational-with-document-types",
+        "analytics-with-document-types",
+      ]) {
+        const factory = await readFactory(outDir, dirName);
+        expect(factory).not.toMatch(WILDCARD_FIELD);
+        expect(factory).toContain(`documentType: ["billing-statement"],`);
+      }
+    });
+  });
+
   // A customized processor's files are only on disk on a fresh project — the
   // case skipAddingFilesFromTsConfig regresses, overwriting user code.
   it("should not overwrite a customized processor on a fresh project", async () => {

--- a/test/codegen/tests/generate-processor.test.ts
+++ b/test/codegen/tests/generate-processor.test.ts
@@ -13,7 +13,9 @@ import {
 import type {
   IProcessor,
   IProcessorHostModule,
+  IRelationalDbProcessor,
   ProcessorApps,
+  ProcessorFactoryBuilder,
   ProcessorRecord,
 } from "@powerhousedao/shared/processors";
 import { afterEach, describe, expect, it } from "bun:test";
@@ -413,6 +415,64 @@ describe("generate processor", () => {
         expect(factory).toContain(`documentType: ["billing-statement"],`);
       }
     });
+  });
+
+  it("should run the generated relational db processor's migrations before returning it", async () => {
+    const outDir = join(parentOutDir, "relational-db-init-and-upgrade");
+    await cpForce(NEW_PROJECT, outDir);
+    const project = buildTsMorphProject(outDir);
+    await generateProcessor(
+      {
+        processorName: "relational-init-and-upgrade",
+        processorType: "relationalDb",
+        documentTypes: ["powerhouse/document-drive"],
+        processorApps: ["switchboard"],
+      },
+      project,
+    );
+    await project.save();
+
+    const factoryPath = join(
+      outDir,
+      "processors",
+      "relational-init-and-upgrade",
+      "factory.ts",
+    );
+    expect(await readFile(factoryPath, "utf-8")).toContain(
+      "await processor.initAndUpgrade();",
+    );
+
+    const { pgLite, relationalDb } = await getDb();
+    const { store } = await createAnalyticsStore({ pgLite });
+    const hostModule: IProcessorHostModule = {
+      processorApp: "switchboard",
+      analyticsStore: store,
+      relationalDb,
+      dispatch: {
+        execute: () => Promise.resolve({ id: "mock", status: "mock" }),
+      },
+      getReadModel: () => {
+        throw new Error("No read models in test");
+      },
+    };
+
+    const { relationalInitAndUpgradeFactoryBuilder: factoryBuilder } =
+      (await import(factoryPath)) as {
+        relationalInitAndUpgradeFactoryBuilder: ProcessorFactoryBuilder;
+      };
+    const factory = await factoryBuilder(hostModule);
+    const records = await factory(
+      { id: "init-and-upgrade-drive" } as PHDocumentHeader,
+      "switchboard",
+    );
+
+    // The scaffolded migration creates the `todo` table. Nothing in the runtime
+    // calls initAndUpgrade(), so this query only succeeds if the factory did.
+    const processor = records[0]!.processor as IRelationalDbProcessor<{
+      todo: { task: string; status: boolean | null };
+    }>;
+    const rows = await processor.query.selectFrom("todo").selectAll().execute();
+    expect(rows).toEqual([]);
   });
 
   // A customized processor's files are only on disk on a fresh project — the

--- a/test/codegen/tests/processor-filter.test.ts
+++ b/test/codegen/tests/processor-filter.test.ts
@@ -1,0 +1,57 @@
+import {
+  parseFilterValues,
+  renderProcessorFilter,
+} from "@powerhousedao/codegen/templates";
+import { describe, expect, it } from "bun:test";
+
+describe("parseFilterValues", () => {
+  it("splits a comma-separated value into one entry per document type", () => {
+    expect(
+      parseFilterValues(["pfnur/rto-company,pfnur/toll-statement"]),
+    ).toEqual(["pfnur/rto-company", "pfnur/toll-statement"]);
+  });
+
+  it("treats a repeated option the same as a comma-separated one", () => {
+    expect(parseFilterValues(["a/one", "b/two"])).toEqual(["a/one", "b/two"]);
+    expect(parseFilterValues(["a/one,b/two"])).toEqual(["a/one", "b/two"]);
+  });
+
+  it("trims whitespace and drops empty entries", () => {
+    expect(parseFilterValues([" a/one , , b/two,"])).toEqual([
+      "a/one",
+      "b/two",
+    ]);
+  });
+
+  it("returns an empty list for no values", () => {
+    expect(parseFilterValues([])).toEqual([]);
+    expect(parseFilterValues(undefined)).toEqual([]);
+    expect(parseFilterValues([""])).toEqual([]);
+  });
+});
+
+describe("renderProcessorFilter", () => {
+  it("omits empty fields instead of emitting a wildcard that matches nothing", () => {
+    const filter = renderProcessorFilter({
+      branch: ["main"],
+      documentId: ["*"],
+      documentType: [],
+      scope: [],
+    });
+
+    expect(filter).toContain(`branch: ["main"],`);
+    expect(filter).toContain(`documentId: ["*"],`);
+    expect(filter).not.toContain("documentType");
+    expect(filter).not.toContain("scope");
+  });
+
+  it("renders an empty object when every field is empty", () => {
+    expect(renderProcessorFilter({})).toBe("{}");
+  });
+
+  it("renders a comma-separated document type list as separate entries", () => {
+    expect(renderProcessorFilter({ documentType: ["a/one,b/two"] })).toContain(
+      `documentType: ["a/one", "b/two"],`,
+    );
+  });
+});

--- a/test/codegen/tests/source-files.test.ts
+++ b/test/codegen/tests/source-files.test.ts
@@ -1,0 +1,118 @@
+import {
+  DEFAULT_PROJECT_OPTIONS,
+  getOrCreateSourceFile,
+} from "@powerhousedao/codegen/utils";
+import { afterEach, describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Project } from "ts-morph";
+
+const SCAFFOLDED_STUB = `export const testDocBarOperations = {
+  fooOperation(state, action) {
+    // TODO: implement fooOperation reducer
+    throw new Error("Reducer for 'fooOperation' not implemented.");
+  },
+};
+`;
+
+const HAND_WRITTEN = `export const testDocBarOperations = {
+  fooOperation(state, action) {
+    state.foo = action.input.foo;
+  },
+};
+`;
+
+const tmpDirs: string[] = [];
+
+function makeTmpDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "codegen-source-files-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tmpDirs.length) {
+    fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+/** `ph vetra` keeps one Project for the whole process, so the tests below reuse
+ * one instance — a fresh Project per run never goes stale and would pass unfixed. */
+function buildLongLivedProject() {
+  return new Project(DEFAULT_PROJECT_OPTIONS);
+}
+
+/** Stands in for one `ph vetra` codegen run: scaffold the reducer file and flush
+ * it, leaving the SourceFile cached on the long-lived Project. */
+function scaffoldAndSave(project: Project, filePath: string) {
+  const { alreadyExists, sourceFile } = getOrCreateSourceFile(
+    project,
+    filePath,
+  );
+  expect(alreadyExists).toBe(false);
+  sourceFile.replaceWithText(SCAFFOLDED_STUB);
+  project.saveSync();
+  expect(fs.readFileSync(filePath, "utf8")).toBe(SCAFFOLDED_STUB);
+}
+
+describe("getOrCreateSourceFile", () => {
+  it("picks up edits made on disk after the file was cached", () => {
+    const dir = makeTmpDir();
+    const filePath = path.join(dir, "reducers", "bar.ts");
+    const project = buildLongLivedProject();
+
+    scaffoldAndSave(project, filePath);
+
+    // The user replaces the TODO stub with a real reducer body, out of band.
+    fs.writeFileSync(filePath, HAND_WRITTEN);
+
+    const { alreadyExists, sourceFile } = getOrCreateSourceFile(
+      project,
+      filePath,
+    );
+
+    expect(alreadyExists).toBe(true);
+    expect(sourceFile.getFullText()).toBe(HAND_WRITTEN);
+
+    // The whole point: the next flush must not put the stub back.
+    project.saveSync();
+    expect(fs.readFileSync(filePath, "utf8")).toBe(HAND_WRITTEN);
+  });
+
+  it("treats a cached file deleted on disk as absent", () => {
+    const dir = makeTmpDir();
+    const filePath = path.join(dir, "reducers", "bar.ts");
+    const project = buildLongLivedProject();
+
+    scaffoldAndSave(project, filePath);
+
+    fs.rmSync(filePath);
+
+    const { alreadyExists, sourceFile } = getOrCreateSourceFile(
+      project,
+      filePath,
+    );
+
+    // Absent, so builders re-scaffold rather than resurrect text that is gone.
+    expect(alreadyExists).toBe(false);
+    expect(sourceFile.getFullText()).toBe("");
+  });
+
+  it("keeps unflushed in-memory work within a single run", () => {
+    const dir = makeTmpDir();
+    const filePath = path.join(dir, "reducers", "bar.ts");
+    const project = buildLongLivedProject();
+
+    const first = getOrCreateSourceFile(project, filePath);
+    expect(first.alreadyExists).toBe(false);
+    first.sourceFile.replaceWithText(SCAFFOLDED_STUB);
+
+    // Same run, before any save: the in-memory copy is the newest state there
+    // is, so refreshing from disk must not discard it.
+    const second = getOrCreateSourceFile(project, filePath);
+
+    expect(second.alreadyExists).toBe(true);
+    expect(second.sourceFile.getFullText()).toBe(SCAFFOLDED_STUB);
+  });
+});


### PR DESCRIPTION
Four independent codegen bugs, each of which silently destroys or disables user
work. The first was the original subject of this PR; the processor fixes were
added on top.

1. [Cached ts-morph source files were never refreshed from disk](#1--hand-written-reducers-reverted-to-todo-stubs) — hand-written reducers reverted to TODO stubs.
2. [A comma-separated `--document-types` value was emitted as one array element](#2--a-comma-separated---document-types-value-was-not-split) — the generated processor could never match a document.
3. [Filters emitted `["*"]`, which matches nothing](#3--filters-emitted--which-matches-nothing) — every generated analytics processor was dead.
4. [`initAndUpgrade()` was never called](#4--initandupgrade-was-never-called) — generated relational-db processors never ran their migrations.

---

# 1 — Hand-written reducers reverted to TODO stubs

## Symptom

Hand-written reducer bodies silently revert to `// TODO: implement ... reducer`
stubs while `ph vetra` is running. The user implements
`document-models/<name>/v<n>/src/reducers/<module>.ts`, edits the document model
again (or touches any other codegen-triggering document), and the next codegen
run writes the original scaffolded stub back over the implementation. Confirmed
data loss.

## Mechanism

`getOrCreateSourceFile` resolved the file as:

```ts
const sourceFile =
  project.getSourceFile(filePath) ??
  project.addSourceFileAtPathIfExists(filePath);
```

The ts-morph cache was consulted **before** disk, so `alreadyExists` could mean
"loaded earlier in this process" rather than "on disk" — which is not what that
function's own doc comment promises.

`packages/vetra/processors/codegen/factory.ts` builds **one** ts-morph `Project`
per `ph vetra` process and reuses it for every codegen run ("Use one instance of
ts-morph project, which handles race conditions"), and nothing anywhere called
`refreshFromFileSystem`. So:

1. Run #1 scaffolds the reducer file with TODO stubs and caches that `SourceFile`.
2. The user writes the real bodies on disk. ts-morph never notices.
3. Any later run in the **same** vetra session hits the stale cache, sees the
   stub text, and the scaffold-once-then-amend builders find nothing missing —
   then `project.save()` flushes the stale stubs over the user's file.

A fresh process (`ph generate ...`) was unaffected: cache miss →
`addSourceFileAtPathIfExists` reads current disk → the builders correctly append
only what is missing.

This **completes #2889** ("fix(codegen): stop overwriting hand-written files and
fix custom-scalar mocks"), which fixed the fresh-process half of exactly this
data-loss class and left the cache-hit path open.

## The fix

`packages/codegen/src/utils/source-files.ts` — on the cache-hit branch, refresh
from disk before returning, so "exists" keeps meaning *on disk*:

- Only **cached** files are refreshed. `addSourceFileAtPathIfExists` has just
  read disk, so refreshing it again would be I/O for a guaranteed `NoChange`.
- Only files with **no pending in-memory edits** (`isSaved()`) are refreshed. A
  dirty `SourceFile` is work the run in progress has not flushed yet; refreshing
  would discard it and trade one data loss for another.
- A file that was loaded but has since been **deleted on disk** refreshes to
  `FileSystemRefreshResult.Deleted` (ts-morph `forget()`s it). That is treated as
  absent, so we fall through to creating an empty `SourceFile` and codegen
  re-scaffolds, rather than resurrecting text that no longer exists anywhere.
- `overwrite: false` and the existing explanatory comments are preserved; the doc
  comment is extended to cover the cache-hit case.

`getOrCreateSourceFile` is the single entry point used by the builders for
reducers, tests, subgraphs, editors, processors, apps and the
`gen`/`src`/`root`/`upgrades` dirs (~70 call sites across
`packages/codegen/src/file-builders/**`), so the one fix covers all of them.

## Regression test

`test/codegen/tests/source-files.test.ts`, alongside the existing codegen suite
(`bun test`, run by `pnpm test:codegen`). It reproduces the actual bug rather
than a proxy for it: scaffold + `saveSync` through `getOrCreateSourceFile`,
mutate the file on disk out-of-band with plain `node:fs`, then call
`getOrCreateSourceFile` again on the **same** `Project`. Reusing one `Project` is
the whole point — with a fresh `Project` per run the cache never goes stale and
the test would pass unfixed.

Three cases: on-disk edit is picked up (and a subsequent `saveSync` does not put
the stub back), a cached file deleted on disk is reported absent, and unflushed
in-memory work within a single run survives.

Verified both ways against a build of the package: **2 of the 3 fail on
`origin/main`** (the first shows the TODO stub handed back in place of the
hand-written body, the second reports `alreadyExists: true` for a deleted file)
and **all 3 pass with the fix**.

---

# Background for the processor fixes: what a `ProcessorFilter` actually matches

`ProcessorFilter` (`packages/shared/processors/types.ts`) is
`{ documentType?, scope?, branch?, documentId? }`, and its own doc comment says:

> When a field is undefined or empty, it matches all values for that field.

`matchesFilter` (`packages/reactor/src/processors/utils.ts`) implements that with
an exact `.includes()` check for `documentType`, `scope` and `branch`, and
honours a `"*"` wildcard for **`documentId` only**:

```ts
if (filter.scope && filter.scope.length > 0) {
  if (!filter.scope.includes(op.context.scope)) return false;   // no wildcard
}
...
if (filter.documentId && filter.documentId.length > 0) {
  const hasWildcard = filter.documentId.includes("*");           // wildcard
  if (!hasWildcard && !filter.documentId.includes(op.context.documentId)) return false;
}
```

Two consequences drive fixes 2 and 3:

- `scope: ["*"]` is a **non-empty** array holding the literal string `"*"`. No
  operation has the scope `"*"`, so the filter matches **nothing**. Same for
  `documentType` and `branch`. "Match all" must be spelled as an omitted or
  empty field.
- `documentType: ["a/b,c/d"]` is one document type whose name contains a comma.
  No document has that type, so again the filter matches nothing.

Both failure modes are silent: the processor is registered, gets a cursor row,
reports `active`, and simply never receives an operation.

`matchesFilter` is deliberately **not** changed to honour `"*"` in the other
fields — that is a wider behavioural change affecting every existing filter and
does not belong here.

---

# 2 — A comma-separated `--document-types` value was not split

## Symptom

```
ph-cli generate processor --name company-aggregates --type relationalDb \
  --document-types "pfnur/rto-company,pfnur/toll-statement" --apps switchboard
```

generated

```ts
documentType: ["pfnur/rto-company,pfnur/toll-statement"],
```

— one array element with a comma inside it. Reproduced in a consuming project.

## Mechanism

cmd-ts `multioption` hands its `from` the raw values it collected, so a single
`--document-types "a,b"` arrives as the one-element array `["a,b"]`; only a
repeated `-t a -t b` produced two entries. The value was passed through codegen
untouched and quoted straight into the template.

`--apps` had the same shape: `--apps "connect,switchboard"` failed
`ProcessorAppType` validation outright (loud, at least). `generate app
--document-types` was affected too.

## The fix

- `packages/codegen/src/templates/processors/utils.ts` — `parseFilterValues`
  splits on commas, trims and drops empties. This is the choke point every
  generated filter goes through, whichever front end produced the list (CLI,
  a `powerhouse/processor` spec document, or `getProcessorMetadata`).
- `clis/ph-cli/src/utils/comma-separated.ts` — a `multioption` type that does the
  same, wired into `generate processor --document-types` / `--apps` and
  `generate app --document-types`, so the parsed args are correct too and
  `--apps "connect,switchboard"` now works.

---

# 3 — Filters emitted `["*"]`, which matches nothing

Per the background section above, these were all filters that could never match:

- `packages/codegen/src/templates/processors/analytics/factory.ts` hard-coded
  `scope: ["*"]`, so **every generated analytics processor could never receive an
  operation**, regardless of its document types.
- `packages/codegen/src/templates/processors/utils.ts` emitted
  `documentType: ["*"]` when no document types were supplied — i.e. the
  "run on everything" case was precisely the one that ran on nothing.

## The fix

`renderProcessorFilter` renders the filter object literal and **omits** any field
with no values, which is the documented way to match all. `documentId: ["*"]` is
kept as-is — that wildcard is genuinely honoured. The generated factories now
carry a comment saying so, so the wildcard is not reintroduced by hand.

## Also fixed: `packages/shared/processors/drive-analytics/index.ts` (not codegen)

Shipped, hand-written code with the same bug: `scope: ["*"]` on both records plus
`documentType: ["*"]` on the document processor, so **both** drive-analytics
processors were dead. Called out separately here because it is not codegen and
its blast radius is different: nothing in this repo registers that factory, and
for consumers that do, these processors currently receive nothing — so enabling
them cannot regress behaviour that works today. Left in this PR rather than split
out because it is the same one-line class of bug and is easier to review beside
the template fix than on its own.

---

# 4 — `initAndUpgrade()` was never called

`initAndUpgrade()` is declared on `IRelationalDbProcessor`, declared `abstract` on
`RelationalDbProcessor`, and implemented by the relational-db codegen template —
and **grep finds no caller anywhere in the monorepo**. A generated processor
therefore never creates its tables; the first write throws, `ProcessorManager`
catches it, and the processor is marked permanently `errored` (recoverable only
through `retry()`). Vetra's own read model works around this by calling `up(db)`
by hand inside its factory
(`packages/vetra/processors/vetra-read-model/factory.ts`).

## The fix, and why this one

The generated factory now awaits `processor.initAndUpgrade()` before returning
the record — codegen-only, and exactly what Vetra already does by hand.

The alternative was to have `ProcessorManager` call it when it instantiates a
processor, which would additionally fix every **already generated** processor.
Not chosen here:

- The factory already owns namespace creation (`createNamespace`), so migrations
  belong next to it; the manager would have to type-test for a relational-db
  processor to know whether to call it at all.
- A failure inside the factory already flows through the manager's existing
  factory error handling. Adding the call in the manager needs new handling to
  make sure a failed migration doesn't silently leave a processor `active` but
  broken, or freeze it without a diagnostic.

The runtime call remains worth doing separately for pre-existing processors; it
is noted rather than done.

---

# Tests

- `test/codegen/tests/source-files.test.ts` — the cache-refresh cases described
  in section 1.
- `test/codegen/tests/processor-filter.test.ts` — unit tests for
  `parseFilterValues` / `renderProcessorFilter`: comma splitting, trimming,
  empty-field omission.
- `test/codegen/tests/generate-processor.test.ts` — assertions on actually
  generated factories: a two-type `--document-types` value yields
  `documentType: ["pfnur/rto-company", "pfnur/toll-statement"]`; no generated
  filter contains `["*"]` for `documentType`/`scope`/`branch` (with or without
  document types) while `documentId: ["*"]` is kept; and a generated relational-db
  factory is imported, invoked against a PGlite-backed relational db, and its
  `todo` table queried — which only succeeds if `initAndUpgrade()` ran.

All four new processor tests were confirmed to **fail** against the unfixed
templates and pass with the fix.

Also `clis/ph-cli/test/comma-separated.test.ts` for the CLI option type. Note
that ph-cli's vitest project is not part of `pnpm test:ci`, so that file runs
under the root `pnpm vitest` / locally rather than in the PR check — which is why
the load-bearing assertions live in `test/codegen`, run by `pnpm test:codegen` in
the Codegen Tests workflow.

## Checks run

- `pnpm --filter=@powerhousedao/codegen build` — clean.
- `packages/codegen`: `pnpm tsc` clean; `pnpm lint` 0 errors (12 pre-existing
  `no-unnecessary-condition` warnings in `features.ts` / `graphql.ts` /
  `validation.ts`, none in changed files).
- `clis/ph-cli`: `pnpm tsc` and `pnpm lint` clean. `packages/shared` typechecks.
- `tsc --build test/codegen` — clean.
- `pnpm test:codegen` equivalent (full `bun test --preload ./setup.ts`):
  **105 pass, 0 fail** across 16 files. Run with bun **1.3.8**, the version CI
  pins; the locally installed bun 1.3.14 cannot run this suite at all for an
  unrelated pre-existing reason (CJS `cmd-ts` requiring ESM-only chalk 5).
- End-to-end: generated a `relationalDb` processor into a throwaway project with
  `documentTypes: ["pfnur/rto-company,pfnur/toll-statement"]` and inspected the
  emitted factory — two-element `documentType`, no `["*"]`, `initAndUpgrade()`
  awaited.

# Known related limitations, deliberately out of scope

- `packages/codegen/src/file-builders/document-model/src-dir.ts` has:

  ```ts
  for (const name of operationsInterfaceTypeProperties) {
    if (operationsInterfaceObject.getProperty(name)) continue;
    ...
  }
  ```

  An operation's `reducer` field from the document-model document is therefore
  never propagated into an already-scaffolded method — reducer code set via
  `SET_OPERATION_REDUCER` only lands the first time the method is created. That
  is arguably the intended "never touch an existing method" guarantee and is a
  separate decision, so it is untouched here.

- `getProcessorMetadata` (`packages/codegen/src/utils/get-processor-metadata.ts`)
  reads document types out of a generated factory with
  `getStringArrayPropertyElements(factory, "documentTypes")`, but the emitted
  property is `documentType` (singular). So `ph generate processor --dir` /
  `--all` always round-trips an **empty** document-type list. It is latent today
  because an existing `factory.ts` is never rewritten, and fixing it is a
  behaviour change to regeneration, so it is left alone.

- `matchesFilter` is not changed to honour `"*"` for
  `documentType`/`scope`/`branch`.

# Notes

- The repo does not use changesets (no `.changeset/`, no mention in
  `package.json` or `RELEASE.md`; versioning goes through `releases/release.ts`),
  so no changeset file was added.
