### PR TITLE
fix(reactor-browser): take document models only, not whole packages

### DIFF
--- a/apps/academy/docs/academy/04-Reference/08-ReactorBrowserClient/02-ApiReference.md
+++ b/apps/academy/docs/academy/04-Reference/08-ReactorBrowserClient/02-ApiReference.md
@@ -116,8 +116,7 @@ those pages with no realtime at all and nothing logged.
 | `subscriptionsUrl`  | `string`                             | derived from `url`        | The websocket endpoint.                                                                   |
 | `realtime`          | `boolean`                            | `true`                    | Whether server-pushed changes reach subscribers.                                          |
 | `attachmentService` | `PHGlobal["attachmentService"]`      | none                      | Published into the slot the editors read.                                                 |
-| `packages`          | `readonly DocumentModelLib[]`        | none                      | The app's packages (real manifest, models, editors) — makes model and editor hooks work.  |
-| `documentModels`    | `readonly DocumentModelModule[]`     | none                      | Sugar for hand-picked modules; wrapped into one synthetic package after `packages`.       |
+| `documentModels`    | `readonly DocumentModelModule[]`     | none                      | The app's generated modules, published so the document-model hooks work.                  |
 | `children`          | `ReactNode`                          | required                  |                                                                                           |
 
 On mount the provider registers the `window.ph` event handlers once per page,
@@ -127,24 +126,23 @@ client, and leaves the slots populated, matching how Connect never unsets them.
 
 The props are read once, in the `useState` initialiser. Changing `url` or
 `tokenProvider` afterwards does not rebuild the client; remount the provider if
-the endpoint has to change. `attachmentService`, `packages` and
-`documentModels` are the exceptions: each is published from its own effect, so
-passing them later does not throw away every open document.
+the endpoint has to change. `attachmentService` and `documentModels` are the
+exceptions: each is published from its own effect, so passing them later does
+not throw away every open document.
 
-`packages` takes real `DocumentModelLib`s, assembled from a generated package's
-**subpath exports** (`my-models/document-models`, `my-models/editors`,
-`my-models/manifest`) — never from the package root, whose entry also exports
-`processorFactory` and would drag processor (server-side) code into the browser
-bundle. They publish through a fixed `StaticPackageManager` into the same
-`window.ph.vetraPackageManager` slot Connect fills, which makes the
-document-model hooks AND the editor hooks work below the provider. Array order
-is precedence (same-type collisions and the fallback editor resolve to the
-earlier package). `useDocumentModelModuleById(type, version?)` resolves the
-LATEST version when `version` is omitted — the registry's own semantics — and
-pins an exact one when given. Passing no packages is equally supported: actions
-are plain data and the Switchboard runs the reducer either way. Editor
-discovery is not a rendering guarantee: document hooks work in a light app,
-drive APIs do not exist.
+`documentModels` takes the app's generated modules, imported from the package's
+`document-models` **subpath** — never from the package root, whose entry also
+exports `processorFactory` and would drag processor (server-side) code into the
+browser bundle. They publish through a fixed `StaticPackageManager` into the
+same `window.ph.vetraPackageManager` slot Connect fills, which makes
+`useDocumentModelModules` and `useDocumentModelModuleById` work below the
+provider. `useDocumentModelModuleById(type, version?)` resolves the LATEST
+version when `version` is omitted — the registry's own semantics — and pins an
+exact one when given. Passing no modules is equally supported: actions are
+plain data and the Switchboard runs the reducer either way. Deliberately
+modules only, no editors: editors read the selected document through Connect's
+drive/node selection and are not portable to light apps yet — import an
+editor's React components directly if you need them.
 
 ## Hooks
 

--- a/apps/academy/llms-full.txt
+++ b/apps/academy/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-07-30T18:45:20.434Z
+> Generated: 2026-07-31T14:47:55.021Z
 > Total Documents: 109
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -14683,8 +14683,7 @@ those pages with no realtime at all and nothing logged.
 | `subscriptionsUrl`  | `string`                             | derived from `url`        | The websocket endpoint.                                                                   |
 | `realtime`          | `boolean`                            | `true`                    | Whether server-pushed changes reach subscribers.                                          |
 | `attachmentService` | `PHGlobal["attachmentService"]`      | none                      | Published into the slot the editors read.                                                 |
-| `packages`          | `readonly DocumentModelLib[]`        | none                      | The app's packages (real manifest, models, editors) — makes model and editor hooks work.  |
-| `documentModels`    | `readonly DocumentModelModule[]`     | none                      | Sugar for hand-picked modules; wrapped into one synthetic package after `packages`.       |
+| `documentModels`    | `readonly DocumentModelModule[]`     | none                      | The app's generated modules, published so the document-model hooks work.                  |
 | `children`          | `ReactNode`                          | required                  |                                                                                           |
 
 On mount the provider registers the `window.ph` event handlers once per page,
@@ -14694,24 +14693,23 @@ client, and leaves the slots populated, matching how Connect never unsets them.
 
 The props are read once, in the `useState` initialiser. Changing `url` or
 `tokenProvider` afterwards does not rebuild the client; remount the provider if
-the endpoint has to change. `attachmentService`, `packages` and
-`documentModels` are the exceptions: each is published from its own effect, so
-passing them later does not throw away every open document.
+the endpoint has to change. `attachmentService` and `documentModels` are the
+exceptions: each is published from its own effect, so passing them later does
+not throw away every open document.
 
-`packages` takes real `DocumentModelLib`s, assembled from a generated package's
-**subpath exports** (`my-models/document-models`, `my-models/editors`,
-`my-models/manifest`) — never from the package root, whose entry also exports
-`processorFactory` and would drag processor (server-side) code into the browser
-bundle. They publish through a fixed `StaticPackageManager` into the same
-`window.ph.vetraPackageManager` slot Connect fills, which makes the
-document-model hooks AND the editor hooks work below the provider. Array order
-is precedence (same-type collisions and the fallback editor resolve to the
-earlier package). `useDocumentModelModuleById(type, version?)` resolves the
-LATEST version when `version` is omitted — the registry's own semantics — and
-pins an exact one when given. Passing no packages is equally supported: actions
-are plain data and the Switchboard runs the reducer either way. Editor
-discovery is not a rendering guarantee: document hooks work in a light app,
-drive APIs do not exist.
+`documentModels` takes the app's generated modules, imported from the package's
+`document-models` **subpath** — never from the package root, whose entry also
+exports `processorFactory` and would drag processor (server-side) code into the
+browser bundle. They publish through a fixed `StaticPackageManager` into the
+same `window.ph.vetraPackageManager` slot Connect fills, which makes
+`useDocumentModelModules` and `useDocumentModelModuleById` work below the
+provider. `useDocumentModelModuleById(type, version?)` resolves the LATEST
+version when `version` is omitted — the registry's own semantics — and pins an
+exact one when given. Passing no modules is equally supported: actions are
+plain data and the Switchboard runs the reducer either way. Deliberately
+modules only, no editors: editors read the selected document through Connect's
+drive/node selection and are not portable to light apps yet — import an
+editor's React components directly if you need them.
 
 ## Hooks
 

--- a/apps/academy/static/llms-full.txt
+++ b/apps/academy/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-07-30T18:45:20.434Z
+> Generated: 2026-07-31T14:47:55.021Z
 > Total Documents: 109
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -14683,8 +14683,7 @@ those pages with no realtime at all and nothing logged.
 | `subscriptionsUrl`  | `string`                             | derived from `url`        | The websocket endpoint.                                                                   |
 | `realtime`          | `boolean`                            | `true`                    | Whether server-pushed changes reach subscribers.                                          |
 | `attachmentService` | `PHGlobal["attachmentService"]`      | none                      | Published into the slot the editors read.                                                 |
-| `packages`          | `readonly DocumentModelLib[]`        | none                      | The app's packages (real manifest, models, editors) — makes model and editor hooks work.  |
-| `documentModels`    | `readonly DocumentModelModule[]`     | none                      | Sugar for hand-picked modules; wrapped into one synthetic package after `packages`.       |
+| `documentModels`    | `readonly DocumentModelModule[]`     | none                      | The app's generated modules, published so the document-model hooks work.                  |
 | `children`          | `ReactNode`                          | required                  |                                                                                           |
 
 On mount the provider registers the `window.ph` event handlers once per page,
@@ -14694,24 +14693,23 @@ client, and leaves the slots populated, matching how Connect never unsets them.
 
 The props are read once, in the `useState` initialiser. Changing `url` or
 `tokenProvider` afterwards does not rebuild the client; remount the provider if
-the endpoint has to change. `attachmentService`, `packages` and
-`documentModels` are the exceptions: each is published from its own effect, so
-passing them later does not throw away every open document.
+the endpoint has to change. `attachmentService` and `documentModels` are the
+exceptions: each is published from its own effect, so passing them later does
+not throw away every open document.
 
-`packages` takes real `DocumentModelLib`s, assembled from a generated package's
-**subpath exports** (`my-models/document-models`, `my-models/editors`,
-`my-models/manifest`) — never from the package root, whose entry also exports
-`processorFactory` and would drag processor (server-side) code into the browser
-bundle. They publish through a fixed `StaticPackageManager` into the same
-`window.ph.vetraPackageManager` slot Connect fills, which makes the
-document-model hooks AND the editor hooks work below the provider. Array order
-is precedence (same-type collisions and the fallback editor resolve to the
-earlier package). `useDocumentModelModuleById(type, version?)` resolves the
-LATEST version when `version` is omitted — the registry's own semantics — and
-pins an exact one when given. Passing no packages is equally supported: actions
-are plain data and the Switchboard runs the reducer either way. Editor
-discovery is not a rendering guarantee: document hooks work in a light app,
-drive APIs do not exist.
+`documentModels` takes the app's generated modules, imported from the package's
+`document-models` **subpath** — never from the package root, whose entry also
+exports `processorFactory` and would drag processor (server-side) code into the
+browser bundle. They publish through a fixed `StaticPackageManager` into the
+same `window.ph.vetraPackageManager` slot Connect fills, which makes
+`useDocumentModelModules` and `useDocumentModelModuleById` work below the
+provider. `useDocumentModelModuleById(type, version?)` resolves the LATEST
+version when `version` is omitted — the registry's own semantics — and pins an
+exact one when given. Passing no modules is equally supported: actions are
+plain data and the Switchboard runs the reducer either way. Deliberately
+modules only, no editors: editors read the selected document through Connect's
+drive/node selection and are not portable to light apps yet — import an
+editor's React components directly if you need them.
 
 ## Hooks
 

--- a/packages/reactor-browser/src/graphql-client/README.md
+++ b/packages/reactor-browser/src/graphql-client/README.md
@@ -39,69 +39,50 @@ uses the same document hooks Connect uses.
 | `subscriptionsUrl`  | derived from `url`        | The websocket endpoint, `http` -> `ws` plus `/subscriptions`.                             |
 | `realtime`          | `true`                    | Whether server-pushed changes reach subscribers.                                          |
 | `attachmentService` | none                      | The attachment service, published into the slot the editors read.                         |
-| `packages`          | none                      | The app's packages, as real `DocumentModelLib`s — makes the model AND editor hooks work.  |
-| `documentModels`    | none                      | Sugar for hand-picked modules without package artifacts (see below).                      |
+| `documentModels`    | none                      | The app's document model modules, published so the model hooks work (below).              |
 
 The props are read once, when the client is built. Changing `url` afterwards
 does not rebuild the client; remount the provider (or key it on the URL) if the
 endpoint has to change at runtime.
 
-### Packages and document models
+### Document models
 
-A light app has two equally supported modes. It can ship **no** packages and let
+A light app has two equally supported modes. It can ship **no** modules and let
 the Switchboard own the model entirely — actions are plain data, and the server
-runs the reducer. Or it can pass the real package it imports itself, assembled
-from the package's **subpath exports**:
+runs the reducer. Or it can pass the generated modules it imports itself, from
+the package's `document-models` **subpath**:
 
 ```tsx
-import { TodoV2 } from "my-models/document-models";
-import { TodoEditor } from "my-models/editors";
-import manifest from "my-models/manifest";
+import { TodoV1, TodoV2 } from "my-models/document-models";
 
-<GraphQLReactorProvider url={url} packages={[{ manifest, documentModels: [TodoV2], editors: [TodoEditor] }]}>
+<GraphQLReactorProvider url={url} documentModels={[TodoV1, TodoV2]}>
 ```
 
-Import from the subpaths, **never from the package root**. The root entry also
-exports the package's `processorFactory`, and module resolution happens before
-tree-shaking — a root import drags processor (server-side) code into the
-browser bundle and can break the build outright, named imports or not.
+Import from the `document-models` subpath, **never from the package root**. The
+root entry also exports the package's `processorFactory`, and module resolution
+happens before tree-shaking — a root import drags processor (server-side) code
+into the browser bundle and can break the build outright, named imports or not.
 
-`packages` publishes a fixed `StaticPackageManager` into the same
-`window.ph.vetraPackageManager` slot Connect fills, which makes the
-document-model hooks (`useDocumentModelModules`, `useDocumentModelModuleById`,
-`useVetraPackages`) AND the editor hooks (`useEditorModules`,
-`useEditorModulesForDocumentType`, `useFallbackEditorModule`, …) work below the
-provider. The manager is static: it never installs, updates or removes
-packages, and its mutating members throw.
-
-For several packages, pass several entries — a small per-package file avoids
-import aliasing:
-
-```ts
-// lib/todo-package.ts
-import { TodoV2 } from "my-models/document-models";
-import { TodoEditor } from "my-models/editors";
-import manifest from "my-models/manifest";
-export const todoPackage = { manifest, documentModels: [TodoV2], editors: [TodoEditor] };
-```
-
-**Array order is precedence.** Hooks merge packages in order: when two packages
-ship the same document type at the same version the earlier package wins, and
-`useFallbackEditorModule` picks the first matching editor in array order.
+`documentModels` publishes a fixed `StaticPackageManager` (one synthetic
+package, built by `packageFromDocumentModels`) into the same
+`window.ph.vetraPackageManager` slot Connect fills, which makes
+`useDocumentModelModules` and `useDocumentModelModuleById` work below the
+provider — typed action creators, `utils.createDocument()` for
+`client.create`, and model metadata for the UI. The manager is static: it never
+installs, updates or removes packages, and its mutating members throw.
 
 **Versions resolve like the registry.** `useDocumentModelModuleById(type)`
 returns the LATEST version of the type — the same choice the reactor makes when
 a document is created — and `useDocumentModelModuleById(type, version)` pins an
-exact one. A versioned package registers all of its versions.
+exact one. Pass every version your package ships (as above) and the hooks pick
+the right one.
 
-**Editor discovery is not a rendering guarantee.** The editor hooks find the
-modules; whether an editor runs in a light app depends on what its component
-touches — document hooks work, drive APIs do not exist here.
-
-`documentModels` remains as sugar for hand-picked modules without package
-artifacts, wrapped via `packageFromDocumentModels` into one synthetic package
-appended after `packages`. Prefer `packages` when you have the real package —
-it also carries the editors.
+**Modules only — not whole packages, and no editors.** Editors are not portable
+outside Connect yet: they read the selected document through Connect's
+drive/node selection (`useSelectedDocument`), which a light app deliberately
+does not have, and bundling them inflates the app for components that cannot
+run. Until editors take their document via props, a light app that wants an
+editor-like UI imports the React components directly.
 
 Server-side there is no client: the provider builds one only in the browser, so
 the slots stay empty during SSR and the hooks report their normal loading

--- a/packages/reactor-browser/src/graphql-client/entry.ts
+++ b/packages/reactor-browser/src/graphql-client/entry.ts
@@ -45,8 +45,4 @@ export {
   useDocumentModelModules,
 } from "../hooks/document-model-modules.js";
 export { setReactorClient, useReactorClient } from "../hooks/reactor.js";
-export {
-  setVetraPackageManager,
-  useVetraPackages,
-} from "../hooks/vetra-packages.js";
 export type { IReactorBrowserClient } from "../types/reactor-browser-client.js";

--- a/packages/reactor-browser/src/graphql-client/graphql-reactor-provider.tsx
+++ b/packages/reactor-browser/src/graphql-client/graphql-reactor-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { DocumentModelLib, DocumentModelModule } from "document-model";
+import type { DocumentModelModule } from "document-model";
 import { type ReactNode, useEffect, useState } from "react";
 import { DocumentCache } from "../document-cache.js";
 import { addPHEventHandlers } from "../hooks/add-ph-event-handlers.js";
@@ -76,37 +76,31 @@ export type GraphQLReactorProviderProps = {
   attachmentService?: PHGlobal["attachmentService"];
 
   /**
-   * The packages the app works with, as real `DocumentModelLib`s built from
-   * each package's SUBPATH exports:
+   * The document model modules the app works with, imported from its generated
+   * package's `document-models` SUBPATH:
    *
    * ```tsx
-   * import { TodoV2 } from "my-models/document-models";
-   * import { TodoEditor } from "my-models/editors";
-   * import manifest from "my-models/manifest";
-   * <GraphQLReactorProvider url={url} packages={[{ manifest, documentModels: [TodoV2], editors: [TodoEditor] }]}>
+   * import { TodoV1, TodoV2 } from "my-models/document-models";
+   * <GraphQLReactorProvider url={url} documentModels={[TodoV1, TodoV2]}>
    * ```
    *
-   * Published through a {@link StaticPackageManager} into the same
-   * `window.ph.vetraPackageManager` slot Connect fills, so the document-model
-   * hooks AND the editor hooks (`useEditorModules` and friends) work below
-   * this provider. Array order is precedence: hooks merge packages in order,
-   * and same-type collisions resolve to the earlier package.
+   * Wrapped via {@link packageFromDocumentModels} and published through a
+   * {@link StaticPackageManager} into the same `window.ph.vetraPackageManager`
+   * slot Connect fills, so `useDocumentModelModules` and
+   * `useDocumentModelModuleById` work below this provider.
    *
-   * Import from the subpaths, never from the package ROOT: the root entry also
-   * exports the package's `processorFactory`, and module resolution happens
-   * before tree-shaking, so a root import drags processor (server-side) code
-   * into the browser bundle and can break the build outright.
+   * Modules only, deliberately - not whole packages. Editors are not portable
+   * outside Connect yet (they read the selected document from Connect's
+   * drive/node selection) and would inflate the bundle; a light app that needs
+   * an editor imports the React component directly.
    *
-   * Optional on purpose: a light app may equally ship NO packages and let the
+   * Import from the `document-models` subpath, never from the package ROOT:
+   * the root entry also exports the package's `processorFactory`, and module
+   * resolution happens before tree-shaking, so a root import drags processor
+   * (server-side) code into the browser bundle and can break the build.
+   *
+   * Optional on purpose: a light app may equally ship NO modules and let the
    * Switchboard own the model entirely - both modes are supported.
-   */
-  packages?: readonly DocumentModelLib<any>[];
-
-  /**
-   * Sugar for hand-picked modules without package artifacts, wrapped via
-   * {@link packageFromDocumentModels} into one synthetic package (appended
-   * AFTER `packages` in precedence). Prefer `packages` when you have the real
-   * package - it also carries the editors.
    */
   documentModels?: readonly DocumentModelModule<any>[];
 
@@ -139,7 +133,6 @@ export function GraphQLReactorProvider({
   subscriptionsUrl,
   realtime,
   attachmentService,
-  packages,
   documentModels,
   children,
 }: GraphQLReactorProviderProps) {
@@ -185,23 +178,19 @@ export function GraphQLReactorProvider({
   }, [attachmentService]);
 
   // Its own effect for the same reason as the attachment service above: the
-  // packages must not rebuild the client and its cache. The slot stays
+  // modules must not rebuild the client and its cache. The slot stays
   // populated on unmount, matching the other slots. setVetraPackageManager's
   // reactor side effects no-op here - there is no reactorClientModule to
   // register modules on.
   useEffect(() => {
-    const libs = [
-      ...(packages ?? []),
-      ...(documentModels && documentModels.length > 0
-        ? [packageFromDocumentModels(documentModels)]
-        : []),
-    ];
-    if (libs.length === 0) {
+    if (!documentModels || documentModels.length === 0) {
       return;
     }
     ensurePHEventHandlers();
-    setVetraPackageManager(new StaticPackageManager(libs));
-  }, [packages, documentModels]);
+    setVetraPackageManager(
+      new StaticPackageManager([packageFromDocumentModels(documentModels)]),
+    );
+  }, [documentModels]);
 
   return <>{children}</>;
 }

--- a/packages/reactor-browser/test/graphql-client/provider.test.tsx
+++ b/packages/reactor-browser/test/graphql-client/provider.test.tsx
@@ -1,8 +1,4 @@
-import type {
-  DocumentModelLib,
-  DocumentModelModule,
-  EditorModule,
-} from "document-model";
+import type { DocumentModelModule } from "document-model";
 import { StrictMode } from "react";
 import {
   afterEach,
@@ -21,10 +17,6 @@ import {
   useDocumentModelModuleById,
   useDocumentModelModules,
 } from "../../src/hooks/document-model-modules.js";
-import {
-  useEditorModules,
-  useFallbackEditorModule,
-} from "../../src/hooks/editor-modules.js";
 import {
   ensurePHEventHandlers,
   GraphQLReactorProvider,
@@ -565,28 +557,9 @@ describe("GraphQLReactorProvider documentModels", () => {
   });
 });
 
-// Real-lib fixtures for the `packages` prop: two packages, two versions of the
-// same type spread across them, and one editor each for the same type.
-function makeEditor(id: string): EditorModule {
-  return {
-    Component: () => null,
-    documentTypes: ["test/todo"],
-    config: { id, name: id },
-  };
-}
-
-const editorA = makeEditor("editor-a");
-const editorB = makeEditor("editor-b");
-const libA: DocumentModelLib = {
-  manifest: { name: "package-a" },
-  documentModels: [makeModule("test/todo", 1)],
-  editors: [editorA],
-};
-const libB: DocumentModelLib = {
-  manifest: { name: "package-b" },
-  documentModels: [makeModule("test/todo", 2)],
-  editors: [editorB],
-};
+// Two versions of the same type: the module hook must resolve them the way the
+// registry does - latest by default, exact when pinned.
+const todoV1 = makeModule("test/todo", 1);
 
 function VersionProbe({ version }: { version?: number }) {
   const module = useDocumentModelModuleById("test/todo", version);
@@ -595,22 +568,11 @@ function VersionProbe({ version }: { version?: number }) {
   );
 }
 
-function EditorsProbe() {
-  const editors = useEditorModules();
-  const fallback = useFallbackEditorModule("test/todo");
-  return (
-    <span data-testid="editors">
-      {(editors ?? []).map((module) => module.config.id).join(",")}|
-      {fallback?.config.id ?? "none"}
-    </span>
-  );
-}
-
 function probe(screen: { container: HTMLElement }, testId: string) {
   return screen.container.querySelector(`[data-testid=${testId}]`)?.textContent;
 }
 
-describe("GraphQLReactorProvider packages", () => {
+describe("GraphQLReactorProvider version resolution", () => {
   beforeEach(() => {
     window.ph = {};
     delete window.__phEventHandlersRegistered;
@@ -622,35 +584,18 @@ describe("GraphQLReactorProvider packages", () => {
     delete window.__phEventHandlersRegistered;
   });
 
-  it("publishes the given packages exactly as given, in order", () => {
-    render(
-      <GraphQLReactorProvider
-        url={url}
-        realtime={false}
-        packages={[libA, libB]}
-      >
-        <span />
-      </GraphQLReactorProvider>,
-    );
-
-    const manager = window.ph?.vetraPackageManager;
-    expect(manager).toBeInstanceOf(StaticPackageManager);
-    expect(manager?.packages[0]).toBe(libA);
-    expect(manager?.packages[1]).toBe(libB);
-  });
-
-  it("resolves the module hook to the LATEST version across packages", async () => {
+  it("resolves the module hook to the LATEST version", async () => {
     const screen = render(
       <GraphQLReactorProvider
         url={url}
         realtime={false}
-        packages={[libA, libB]}
+        documentModels={[todoV1, todoModule]}
       >
         <VersionProbe />
       </GraphQLReactorProvider>,
     );
 
-    // libA (v1) comes first, but latest wins - the registry's semantics.
+    // v1 comes first in the array, but latest wins - the registry's semantics.
     await expect.poll(() => probe(screen, "version")).toBe("v2");
   });
 
@@ -659,7 +604,7 @@ describe("GraphQLReactorProvider packages", () => {
       <GraphQLReactorProvider
         url={url}
         realtime={false}
-        packages={[libA, libB]}
+        documentModels={[todoV1, todoModule]}
       >
         <VersionProbe version={1} />
         <span data-testid="wrap">
@@ -670,39 +615,5 @@ describe("GraphQLReactorProvider packages", () => {
 
     await expect.poll(() => probe(screen, "wrap")).toBe("none");
     expect(probe(screen, "version")).toBe("v1");
-  });
-
-  it("makes the editor hooks work, honoring package order for the fallback", async () => {
-    const screen = render(
-      <GraphQLReactorProvider
-        url={url}
-        realtime={false}
-        packages={[libA, libB]}
-      >
-        <EditorsProbe />
-      </GraphQLReactorProvider>,
-    );
-
-    await expect
-      .poll(() => probe(screen, "editors"))
-      .toBe("editor-a,editor-b|editor-a");
-  });
-
-  it("appends the documentModels sugar AFTER the real packages", () => {
-    render(
-      <GraphQLReactorProvider
-        url={url}
-        realtime={false}
-        packages={[libA]}
-        documentModels={[makeModule("test/extra", 1)]}
-      >
-        <span />
-      </GraphQLReactorProvider>,
-    );
-
-    const manager = window.ph?.vetraPackageManager;
-    expect(manager?.packages).toHaveLength(2);
-    expect(manager?.packages[0]).toBe(libA);
-    expect(manager?.packages[1].manifest.name).toBe("graphql-reactor-provider");
   });
 });

--- a/test/test-fusion/e2e/document-models.spec.ts
+++ b/test/test-fusion/e2e/document-models.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-// The packages chain end to end: the page passes the REAL generated package
-// (manifest, both todo versions, editors) to `GraphQLReactorProvider`, a
-// StaticPackageManager publishes it into the `window.ph.vetraPackageManager`
-// slot, `useDocumentModelModuleById` resolves the LATEST version (registry
+// The documentModels chain end to end: the page passes the REAL generated todo
+// modules (both versions) to `GraphQLReactorProvider`, a StaticPackageManager
+// publishes them into the `window.ph.vetraPackageManager` slot,
+// `useDocumentModelModuleById` resolves the LATEST version (registry
 // semantics), and the module's own `utils.createDocument` and typed action
 // creators drive the same anonymous flow the switchboard accepts.
 

--- a/test/test-fusion/src/app/documents/page.tsx
+++ b/test/test-fusion/src/app/documents/page.tsx
@@ -5,16 +5,19 @@ import { Suspense } from "react";
 import { ExtensibilityProbe } from "@/components/extensibility-probe";
 import { TodoDemo } from "@/components/todo-demo";
 import { SWITCHBOARD_URL } from "@/lib/renown";
-import { todoPackage } from "@/lib/todo-document";
+import { todoDocumentModels } from "@/lib/todo-document";
 
 // One provider is the whole integration: it publishes a GraphQLReactorClient
 // and a DocumentCache into the `window.ph` slots the reactor-browser hooks
-// read, and `packages` additionally publishes the app's own generated package
-// (real manifest, models and editors) so the document-model and editor hooks
-// work. Everything below it uses the hooks Connect uses.
+// read, and `documentModels` additionally publishes the app's own generated
+// modules so the document-model hooks work. Everything below it uses the hooks
+// Connect uses.
 export default function DocumentsPage() {
   return (
-    <GraphQLReactorProvider url={SWITCHBOARD_URL} packages={[todoPackage]}>
+    <GraphQLReactorProvider
+      url={SWITCHBOARD_URL}
+      documentModels={todoDocumentModels}
+    >
       <Suspense fallback={null}>
         <TodoDemo />
         <ExtensibilityProbe />

--- a/test/test-fusion/src/lib/todo-document.ts
+++ b/test/test-fusion/src/lib/todo-document.ts
@@ -2,34 +2,29 @@ import {
   TodoV1,
   TodoV2,
 } from "@powerhousedao/versioned-documents/document-models";
-import { todoUpgradeManifest } from "@powerhousedao/versioned-documents/document-models/todo";
-import { TodoEditor } from "@powerhousedao/versioned-documents/editors";
-import manifestJson from "@powerhousedao/versioned-documents/manifest";
-import type { DocumentModelLib, Manifest, PHDocument } from "document-model";
+import type { DocumentModelModule, PHDocument } from "document-model";
 
-// The real generated package - the same code the local switchboard loads from
-// `test/versioned-documents` - assembled from the package's SUBPATH exports and
-// handed to `GraphQLReactorProvider` via `packages`.
+// The real generated todo modules - the same code the local switchboard loads
+// from `test/versioned-documents` - imported from the package's
+// `document-models` SUBPATH and handed to `GraphQLReactorProvider` via
+// `documentModels`. Both versions register, and the module hooks resolve the
+// latest, exactly like the reactor's registry does.
 //
-// Subpaths on purpose, never the package ROOT: the root entry also exports
-// `processorFactory`, and module resolution happens before tree-shaking, so
-// importing anything from the root drags the processor graph (switchboard-side
-// code) into the browser bundle and breaks the build.
-//
-// This is what makes the document-model hooks AND the editor hooks work below
-// the provider. (A light app may equally ship no packages at all and let the
-// switchboard own the model - both modes are supported.)
-//
-// DocumentModelLib<any>: the package carries BOTH todo versions, whose
-// concrete state generics differ - the same variance escape the provider prop
-// uses.
+// Modules only, deliberately: editors are not portable outside Connect yet
+// (they read the selected document from Connect's drive/node selection) and
+// would inflate the bundle - a light app that needs an editor imports the
+// React component directly. And never import from the package ROOT: its entry
+// also exports `processorFactory`, and module resolution happens before
+// tree-shaking, so a root import drags server-side processor code into the
+// browser bundle.
+// DocumentModelModule<any>: the two versions' concrete state generics differ -
+// the same variance escape the provider prop uses. The annotation also keeps
+// the exported type portable (TS2883).
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const todoPackage: DocumentModelLib<any> = {
-  manifest: manifestJson as Manifest,
-  documentModels: [TodoV1, TodoV2],
-  editors: [TodoEditor],
-  upgradeManifests: [todoUpgradeManifest],
-};
+export const todoDocumentModels: readonly DocumentModelModule<any>[] = [
+  TodoV1,
+  TodoV2,
+];
 
 export const TODO_DOCUMENT_TYPE: string = TodoV2.documentModel.global.id;
 


### PR DESCRIPTION
## Summary

Follow-up to #2893, per review feedback: the light client's provider should take **document models only**, not whole packages with editors. Editors are not portable outside Connect yet — they read the selected document through Connect's drive/node selection (`useSelectedDocument`), which a light app deliberately does not have — and bundling them inflates the app for components that cannot run. Until editors take their document via props, light apps import editor React components directly.

- The `packages` prop is removed; `documentModels` (modules only, #2893's original API) is the way to publish models, wrapped by `packageFromDocumentModels` and published through the unchanged `StaticPackageManager`.
- The `useVetraPackages`/`setVetraPackageManager` re-exports leave the browser entry; its surface is the two document-model hooks.
- Version-aware resolution is untouched: `useDocumentModelModuleById(type, version?)` still resolves the latest version like the registry, now covered through `documentModels` carrying both todo versions.
- The test-fusion demo imports the two todo modules from the `document-models` subpath only (no editors/manifest/upgrade-manifest imports); README and Academy are rewritten accordingly, keeping the never-import-the-package-root warning.

## Tests

- reactor-browser: tsc, build, 467 unit tests (version-resolution cases rewired through `documentModels`), eslint 0 errors, prettier clean
- test-fusion: tsc/eslint/prettier clean; Playwright e2e 9/9 against a local Switchboard (both todo versions register, the flow runs on v2 via latest-wins)
- Connect tsc clean; academy build; repo-wide `tsc --build` clean