### PR TITLE
feat(reactor-browser): export useDocumentOperations from the graphql-client entry

### DIFF
--- a/packages/reactor-browser/src/graphql-client/entry.ts
+++ b/packages/reactor-browser/src/graphql-client/entry.ts
@@ -44,5 +44,7 @@ export {
   useDocumentModelModuleById,
   useDocumentModelModules,
 } from "../hooks/document-model-modules.js";
+export { useDocumentOperations } from "../hooks/document-operations.js";
+export type { DocumentOperationsState } from "../hooks/document-operations.js";
 export { setReactorClient, useReactorClient } from "../hooks/reactor.js";
 export type { IReactorBrowserClient } from "../types/reactor-browser-client.js";

--- a/packages/reactor-browser/src/hooks/document-operations.ts
+++ b/packages/reactor-browser/src/hooks/document-operations.ts
@@ -9,7 +9,8 @@ type InternalState = {
   error: Error | undefined;
 };
 
-type DocumentOperationsState = InternalState & {
+/** What `useDocumentOperations` returns; exported so consumers can name it. */
+export type DocumentOperationsState = InternalState & {
   refetch: () => void;
 };
 

--- a/test/test-fusion/e2e/document-models.spec.ts
+++ b/test/test-fusion/e2e/document-models.spec.ts
@@ -34,6 +34,20 @@ test("registers the app's document models and drives the flow through them", asy
     "from the generated module",
   ]);
 
+  // The operation log round-tripped through the same client: the
+  // entry-exported useDocumentOperations sees the operation the dispatch
+  // appended. No exact total - creation semantics may add operations of
+  // their own - just that the log is non-empty once ADD_TODO landed.
+  await expect
+    .poll(
+      async () => {
+        const text = await page.getByTestId("operations-count").textContent();
+        return Number(/\d+/.exec(text ?? "")?.[0] ?? "0");
+      },
+      { timeout: 15_000 },
+    )
+    .toBeGreaterThan(0);
+
   // The module-built document and the typed action both round-tripped without
   // a reducer or transport error.
   await expect(page.getByTestId("dispatch-error")).toHaveCount(0);

--- a/test/test-fusion/src/components/todo-demo.tsx
+++ b/test/test-fusion/src/components/todo-demo.tsx
@@ -5,11 +5,12 @@ import {
   useDocument,
   useDocumentModelModuleById,
   useDocumentModelModules,
+  useDocumentOperations,
   useReactorClient,
 } from "@powerhousedao/reactor-browser/graphql-client";
 import { generateId, type PHDocument } from "document-model";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import {
   readTodos,
   TODO_DOCUMENT_TYPE,
@@ -114,6 +115,16 @@ function TodoList({ documentId }: { documentId: string }) {
   const [error, setError] = useState<string>();
   const todos = readTodos(document);
 
+  // The operation log through the same client the document came from - the
+  // primitive a fusion app derives a history view from. Refetching keyed on
+  // the document's last-modified stamp keeps it in step with every update the
+  // cache sees, including ones pushed over the realtime subscription.
+  const { globalOperations, refetch } = useDocumentOperations(documentId);
+  const lastModified = document?.header.lastModifiedAtUtcIso;
+  useEffect(() => {
+    if (lastModified) refetch();
+  }, [lastModified, refetch]);
+
   function add() {
     const trimmed = title.trim();
     if (!trimmed || !todoModule) return;
@@ -166,6 +177,12 @@ function TodoList({ documentId }: { documentId: string }) {
           </li>
         ))}
       </ul>
+      <p
+        className="font-mono text-xs text-foreground/50"
+        data-testid="operations-count"
+      >
+        {globalOperations.length} operations
+      </p>
     </section>
   );
 }


### PR DESCRIPTION
## What

Re-exports the existing `useDocumentOperations` hook (and its `DocumentOperationsState` result type) from the browser-safe entry `@powerhousedao/reactor-browser/graphql-client`.

## Why

Fusion apps need the document operation log to derive history views client-side. The generic hook already ships with the package and works with the light client (it reads the `window.ph.reactorClient` slot the provider fills), but it was unreachable from the browser-safe entry - and light apps must not import from the package root.

## How it's proven

- The browser-entry guard test (`browser-entry.node.test.ts`) walks the entry's transitive import graph and passes unchanged - the new export pulls in no node-only code.
- The test-fusion demo renders an operations badge from `useDocumentOperations`, refetched whenever the document advances (keyed on `header.lastModifiedAtUtcIso`), asserted in e2e after ADD_TODO.

## Verification

- reactor-browser unit tests: 467/467
- Repo typecheck (`tsc --build`): clean
- test-fusion e2e: 9/9
- vetra e2e: 24 passed / 4 skipped (baseline)