### PR TITLE
fix(reactor-browser): let useDocumentSafe observe the initial fetch settling

### DIFF
--- a/packages/reactor-browser/src/hooks/document-cache.ts
+++ b/packages/reactor-browser/src/hooks/document-cache.ts
@@ -1,5 +1,11 @@
 import type { PHDocument } from "@powerhousedao/shared/document-model";
-import { use, useCallback, useSyncExternalStore } from "react";
+import {
+  use,
+  useCallback,
+  useEffect,
+  useReducer,
+  useSyncExternalStore,
+} from "react";
 import { readPromiseState } from "../document-cache.js";
 import type { IDocumentCache } from "../types/documents.js";
 import type { SetPHGlobalValue, UsePHGlobalValue } from "../types/global.js";
@@ -89,6 +95,31 @@ export function useDocumentSafe(id: string | null | undefined) {
     (cb) => (id && documentCache ? documentCache.subscribe(id, cb) : () => {}),
     () => (id ? documentCache?.get(id) : undefined),
   );
+
+  // The cache notifies subscribers only when a document CHANGES (its stored
+  // promise is replaced); the INITIAL fetch settles without a notification,
+  // and since the snapshot above is the promise itself - same identity before
+  // and after settling - nothing re-renders this hook past "pending" on a
+  // page that is otherwise quiet. Watch the pending promise and bump local
+  // state when it settles, so the state below is re-read. The promise is
+  // captured at render time: if it settles before the effect runs, `.then`
+  // still fires the bump on the next microtask, so the race loses nothing.
+  // `useDocument` needs none of this - React itself resumes a component
+  // suspended on `use(promise)`.
+  const [, bumpOnSettle] = useReducer((count: number) => count + 1, 0);
+  const pendingPromise =
+    promise && readPromiseState(promise).status === "pending" ? promise : null;
+  useEffect(() => {
+    if (!pendingPromise) return;
+    let active = true;
+    const settled = () => {
+      if (active) bumpOnSettle();
+    };
+    pendingPromise.then(settled, settled);
+    return () => {
+      active = false;
+    };
+  }, [pendingPromise]);
 
   if (!promise || !documentCache || !id) {
     return {

--- a/packages/reactor-browser/test/use-document-safe.test.tsx
+++ b/packages/reactor-browser/test/use-document-safe.test.tsx
@@ -1,0 +1,143 @@
+import type { PHDocument } from "@powerhousedao/shared/document-model";
+import { StrictMode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { DocumentCache } from "../src/document-cache.js";
+import { ensurePHEventHandlers } from "../src/graphql-client/graphql-reactor-provider.js";
+import {
+  setDocumentCache,
+  useDocumentSafe,
+} from "../src/hooks/document-cache.js";
+import type { IReactorBrowserClient } from "../src/types/reactor-browser-client.js";
+
+/**
+ * Regression suite for the initial-resolution gap: the cache notifies
+ * subscribers only when a stored promise is REPLACED (a document change),
+ * never when the INITIAL fetch settles - and the hook's snapshot is the
+ * promise itself, whose identity does not change on settling. Without the
+ * settle watcher inside `useDocumentSafe`, a page with no other render
+ * activity stays "pending" forever. (Surfaced by pfnur's statement detail
+ * page, whose only state was this hook.)
+ */
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const testDocument = {
+  header: { id: "doc-1", name: "My Doc" },
+} as unknown as PHDocument;
+
+/** A cache over a client stub whose only job is serving the given fetch. */
+function makeCache(get: (id: string) => Promise<PHDocument>) {
+  const client = {
+    get,
+    subscribe: () => () => undefined,
+  } as unknown as IReactorBrowserClient;
+  return new DocumentCache(client);
+}
+
+function Probe({ id }: { id: string }) {
+  const state = useDocumentSafe(id);
+  return (
+    <div>
+      <span data-testid="status">{state.status}</span>
+      <span data-testid="name">{state.data?.header.name ?? ""}</span>
+      <span data-testid="error">
+        {state.error instanceof Error ? state.error.message : ""}
+      </span>
+    </div>
+  );
+}
+
+function textOf(screen: ReturnType<typeof render>, testId: string) {
+  return (
+    screen.container.querySelector(`[data-testid=${testId}]`)?.textContent ?? ""
+  );
+}
+
+describe("useDocumentSafe", () => {
+  beforeEach(() => {
+    window.ph = {};
+    delete window.__phEventHandlersRegistered;
+    ensurePHEventHandlers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.ph = {};
+    delete window.__phEventHandlersRegistered;
+  });
+
+  it("leaves pending on its own once the initial fetch resolves", async () => {
+    const { promise, resolve } = deferred<PHDocument>();
+    setDocumentCache(makeCache(() => promise));
+
+    const screen = render(
+      <StrictMode>
+        <Probe id="doc-1" />
+      </StrictMode>,
+    );
+    expect(textOf(screen, "status")).toBe("pending");
+
+    // No cache notification happens here - the settle watcher alone must
+    // move the hook forward.
+    resolve(testDocument);
+    await vi.waitFor(() => {
+      expect(textOf(screen, "status")).toBe("success");
+    });
+    expect(textOf(screen, "name")).toBe("My Doc");
+  });
+
+  it("reports the error once the initial fetch rejects", async () => {
+    // `addPromiseState` deliberately re-throws the rejection to keep it
+    // observable; swallow the resulting unhandled-rejection event so it does
+    // not fail the run.
+    const swallow = (event: PromiseRejectionEvent) => {
+      event.preventDefault();
+    };
+    window.addEventListener("unhandledrejection", swallow);
+    try {
+      const { promise, reject } = deferred<PHDocument>();
+      setDocumentCache(makeCache(() => promise));
+
+      const screen = render(
+        <StrictMode>
+          <Probe id="doc-404" />
+        </StrictMode>,
+      );
+      expect(textOf(screen, "status")).toBe("pending");
+
+      reject(new Error("Document not found"));
+      await vi.waitFor(() => {
+        expect(textOf(screen, "status")).toBe("error");
+      });
+      expect(textOf(screen, "error")).toBe("Document not found");
+    } finally {
+      window.removeEventListener("unhandledrejection", swallow);
+    }
+  });
+
+  it("wins the race when the promise settles before the watcher attaches", async () => {
+    // An already-resolved promise: by the time the effect runs, the status is
+    // no longer pending. The render-time capture still attaches `.then`, so
+    // the bump fires on the next microtask instead of being skipped.
+    setDocumentCache(makeCache(() => Promise.resolve(testDocument)));
+
+    const screen = render(
+      <StrictMode>
+        <Probe id="doc-1" />
+      </StrictMode>,
+    );
+    await vi.waitFor(() => {
+      expect(textOf(screen, "status")).toBe("success");
+    });
+    expect(textOf(screen, "name")).toBe("My Doc");
+  });
+});


### PR DESCRIPTION
## What

`useDocumentSafe` now watches the pending document promise and re-reads its state when it settles, instead of waiting for a cache notification that never comes for the initial fetch.

## Why

`DocumentCache` notifies subscribers only when a stored promise is REPLACED (a document change event). The initial fetch settles without any notification — and the hook's `useSyncExternalStore` snapshot is the promise itself, whose identity doesn't change on settling, so React sees an unchanged snapshot and never re-renders. On a page with no other render activity the hook reports `pending` forever. Connect masks this with unrelated re-renders; it surfaced in a fusion app (pfnur's statement detail page) whose only state was this hook — the page hung on its loading skeleton indefinitely.

## How

The pending promise is captured at render time and a settle watcher bumps a local `useReducer` counter. Capture-at-render makes the settled-before-effect race safe: attaching `.then` to an already-settled promise still fires on the next microtask. `useDocument` needs none of this — React itself resumes a component suspended on `use(promise)`.

## Verification

- New regression suite `test/use-document-safe.test.tsx` (initial resolve, initial reject, settle-before-effect race) — red-green verified: all three fail without the fix.
- reactor-browser unit tests: 470/470.
- Repo `tsc --build`, eslint and prettier clean.