### PR TITLE
feat(reactor): auth-scope stage 6 — conditions (authConditions)

### DIFF
--- a/docs/specs/auth-scope.md
+++ b/docs/specs/auth-scope.md
@@ -745,7 +745,7 @@ Conflicting auth operations are the deliberate exception, and they do not conver
 
 **Stage 5: the groups projection (`authGroups`).** Ship the `PHGroup` model, derive group queries from the grant list, add group streams to the read-set and the append condition, maintain the group-reference relation so sync carries referenced groups and re-evaluation finds dependent documents (see Synchronization), and re-evaluate dependents in their own jobs. Group principals begin to match only here. Until conditions ship, a group's own policy is limited to `address` and `anyone` principals, since `match` never applies. Exit: a group-gated operation syncs to a replica that does not hold the group document and fails closed there until the group's history arrives, after which both replicas agree; and a membership removal denies later operations on every document that references the group.
 
-**Stage 6: conditions (`authConditions`).** The `where` and `match` evaluators turn on. Conditional grants begin to apply only here.
+**Stage 6: conditions (`authConditions`).** The `where` and `match` evaluators turn on. Conditional grants begin to apply only here — for `execute` requests. The read surface does not yet supply a condition context (or a groups map), so a `read` grant that uses `where`, `match`, or `{ group }` still never applies; that lands with the read-path work described under Reads.
 
 Registering decision models beyond auth is out of scope. The types are model-agnostic, so that work is registration, not new semantics.
 

--- a/packages/document-model/test/document-model/auth-conditions.test.ts
+++ b/packages/document-model/test/document-model/auth-conditions.test.ts
@@ -1,0 +1,353 @@
+import type {
+  AuthRequest,
+  Condition,
+  ConditionContext,
+  Grant,
+  PHAuthState,
+} from "@powerhousedao/shared/document-model";
+import {
+  evaluate,
+  evaluateCondition,
+} from "@powerhousedao/shared/document-model";
+
+const execGlobal: AuthRequest = {
+  verb: "execute",
+  scope: "global",
+  operation: "SET_STATUS",
+};
+
+const ctx = (scopeState: unknown, actionInput?: unknown): ConditionContext => ({
+  scopeState,
+  actionInput,
+});
+
+function evalCond(
+  condition: Condition,
+  options: {
+    scopeState?: unknown;
+    actionInput?: unknown;
+    address?: string;
+    request?: AuthRequest;
+  } = {},
+): boolean {
+  return evaluateCondition(
+    condition,
+    { address: options.address },
+    options.request ?? execGlobal,
+    ctx(options.scopeState, options.actionInput),
+  );
+}
+
+describe("operand resolution", () => {
+  it("resolves doc paths against the executing scope's state only", () => {
+    const condition: Condition = {
+      eq: [{ attr: "doc.global.status" }, { lit: "OPEN" }],
+    };
+    expect(evalCond(condition, { scopeState: { status: "OPEN" } })).toBe(true);
+    expect(evalCond(condition, { scopeState: { status: "CLOSED" } })).toBe(
+      false,
+    );
+    // A path naming another scope never resolves.
+    expect(
+      evalCond(
+        { eq: [{ attr: "doc.local.status" }, { lit: "OPEN" }] },
+        { scopeState: { status: "OPEN" } },
+      ),
+    ).toBe(false);
+  });
+
+  it("resolves subject and action.input paths", () => {
+    expect(
+      evalCond(
+        { eq: [{ attr: "subject.address" }, { lit: "0xabc" }] },
+        { address: "0xabc" },
+      ),
+    ).toBe(true);
+    expect(
+      evalCond(
+        { eq: [{ attr: "action.input.newStatus" }, { lit: "APPROVED" }] },
+        { actionInput: { newStatus: "APPROVED" } },
+      ),
+    ).toBe(true);
+  });
+
+  it("yields undefined for missing paths, objects, and arrays: comparisons are false", () => {
+    expect(
+      evalCond(
+        { eq: [{ attr: "doc.global.missing" }, { lit: "x" }] },
+        { scopeState: {} },
+      ),
+    ).toBe(false);
+    // resolves to an object
+    expect(
+      evalCond(
+        { eq: [{ attr: "doc.global.nested" }, { lit: "x" }] },
+        { scopeState: { nested: { a: 1 } } },
+      ),
+    ).toBe(false);
+    // resolves to an array
+    expect(
+      evalCond(
+        { eq: [{ attr: "doc.global.list" }, { lit: "x" }] },
+        { scopeState: { list: [1] } },
+      ),
+    ).toBe(false);
+    // ne with an unresolved side is also false, not true
+    expect(
+      evalCond(
+        { ne: [{ attr: "doc.global.missing" }, { lit: "x" }] },
+        { scopeState: {} },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not traverse through arrays or scalars", () => {
+    expect(
+      evalCond(
+        { eq: [{ attr: "doc.global.list.0" }, { lit: 1 }] },
+        { scopeState: { list: [1] } },
+      ),
+    ).toBe(false);
+    expect(
+      evalCond(
+        { eq: [{ attr: "doc.global.status.length" }, { lit: 4 }] },
+        { scopeState: { status: "OPEN" } },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("operators", () => {
+  const state = { count: 5, name: "beta", flag: true, empty: null };
+
+  it("eq and ne compare strictly within a type", () => {
+    expect(evalCond({ eq: [{ lit: 1 }, { lit: 1 }] })).toBe(true);
+    expect(evalCond({ eq: [{ lit: 1 }, { lit: "1" }] })).toBe(false);
+    expect(evalCond({ eq: [{ lit: null }, { lit: null }] })).toBe(true);
+    expect(evalCond({ ne: [{ lit: 1 }, { lit: 2 }] })).toBe(true);
+    expect(evalCond({ ne: [{ lit: true }, { lit: true }] })).toBe(false);
+  });
+
+  it("orders numbers numerically and strings by code point", () => {
+    expect(evalCond({ lt: [{ lit: 2 }, { lit: 10 }] })).toBe(true);
+    expect(evalCond({ gte: [{ lit: 2 }, { lit: 2 }] })).toBe(true);
+    expect(evalCond({ lt: [{ lit: "10" }, { lit: "2" }] })).toBe(true);
+    // An astral code point sorts above a high BMP code unit.
+    expect(evalCond({ lt: [{ lit: "｡" }, { lit: "\u{1F600}" }] })).toBe(true);
+    // Mixed types never order.
+    expect(evalCond({ lt: [{ lit: 1 }, { lit: "2" }] })).toBe(false);
+    expect(evalCond({ gt: [{ lit: 1 }, { lit: "0" }] })).toBe(false);
+    expect(evalCond({ lte: [{ lit: true }, { lit: true }] })).toBe(false);
+  });
+
+  it("in and notIn test list membership", () => {
+    const status: Condition = {
+      in: [{ attr: "doc.global.name" }, [{ lit: "alpha" }, { lit: "beta" }]],
+    };
+    expect(evalCond(status, { scopeState: state })).toBe(true);
+    expect(
+      evalCond(
+        { notIn: [{ attr: "doc.global.name" }, [{ lit: "alpha" }]] },
+        { scopeState: state },
+      ),
+    ).toBe(true);
+    // An unresolved left side makes both false.
+    expect(
+      evalCond(
+        { in: [{ attr: "doc.global.missing" }, [{ lit: "x" }]] },
+        { scopeState: state },
+      ),
+    ).toBe(false);
+    expect(
+      evalCond(
+        { notIn: [{ attr: "doc.global.missing" }, [{ lit: "x" }]] },
+        { scopeState: state },
+      ),
+    ).toBe(false);
+  });
+
+  it("exists tests presence explicitly", () => {
+    expect(
+      evalCond({ exists: { attr: "doc.global.count" } }, { scopeState: state }),
+    ).toBe(true);
+    expect(
+      evalCond(
+        { exists: { attr: "doc.global.missing" } },
+        { scopeState: state },
+      ),
+    ).toBe(false);
+    // null is a present value
+    expect(
+      evalCond({ exists: { attr: "doc.global.empty" } }, { scopeState: state }),
+    ).toBe(true);
+  });
+
+  it("combines with and, or, not", () => {
+    const gated: Condition = {
+      and: [
+        { eq: [{ attr: "doc.global.flag" }, { lit: true }] },
+        {
+          or: [
+            { gt: [{ attr: "doc.global.count" }, { lit: 3 }] },
+            { eq: [{ attr: "doc.global.name" }, { lit: "nope" }] },
+          ],
+        },
+      ],
+    };
+    expect(evalCond(gated, { scopeState: state })).toBe(true);
+    expect(evalCond({ not: gated } as Condition, { scopeState: state })).toBe(
+      false,
+    );
+    // Empty and/or have their identity values.
+    expect(evalCond({ and: [] })).toBe(true);
+    expect(evalCond({ or: [] })).toBe(false);
+  });
+});
+
+describe("totality", () => {
+  it("is false for malformed conditions, even under not", () => {
+    expect(evalCond({} as never)).toBe(false);
+    expect(evalCond({ eq: [{ lit: 1 }] } as never)).toBe(false);
+    expect(evalCond({ frob: [] } as never)).toBe(false);
+    expect(evalCond(null as never)).toBe(false);
+    // A malformed child poisons `not` rather than widening it.
+    expect(evalCond({ not: { frob: [] } } as never)).toBe(false);
+    expect(evalCond({ not: null } as never)).toBe(false);
+    expect(evalCond({ and: [{ frob: [] }] } as never)).toBe(false);
+  });
+
+  it("never resolves non-finite numbers from state", () => {
+    expect(
+      evalCond(
+        { eq: [{ attr: "doc.global.n" }, { attr: "doc.global.n" }] },
+        { scopeState: { n: Number.NaN } },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("conditions in the grant stack", () => {
+  const whereOpen: Grant = {
+    id: "g-while-open",
+    description: "execute while open",
+    effect: "allow",
+    principal: { anyone: true },
+    capability: { can: "execute", scope: "global" },
+    where: {
+      notIn: [
+        { attr: "doc.global.status" },
+        [{ lit: "APPROVED" }, { lit: "REJECTED" }],
+      ],
+    },
+  };
+
+  const matchOwner: Grant = {
+    id: "g-owner",
+    description: "the rto reads their own statement",
+    effect: "allow",
+    principal: {
+      match: {
+        eq: [{ attr: "subject.address" }, { attr: "doc.global.rtoAddress" }],
+      },
+    },
+    capability: { can: "execute", scope: "global" },
+  };
+
+  function policy(...grants: Grant[]): PHAuthState {
+    return { version: 1, grants };
+  }
+
+  it("a where clause gates the grant on the executing scope's state", () => {
+    const auth = policy(whereOpen);
+    expect(
+      evaluate(auth, {}, execGlobal, {}, ctx({ status: "PROCESSING" }))
+        .decision,
+    ).toBe("allow");
+    expect(
+      evaluate(auth, {}, execGlobal, {}, ctx({ status: "APPROVED" })).decision,
+    ).toBe("deny");
+  });
+
+  it("a conditional grant never applies without a condition context", () => {
+    const auth = policy(whereOpen);
+    expect(evaluate(auth, {}, execGlobal, {}).decision).toBe("deny");
+    expect(evaluate(auth, {}, execGlobal).decision).toBe("deny");
+  });
+
+  it("a match principal relates the subject to the document", () => {
+    const auth = policy(matchOwner);
+    const state = { rtoAddress: "0xOwner" };
+    expect(
+      evaluate(auth, { address: "0xOwner" }, execGlobal, {}, ctx(state))
+        .decision,
+    ).toBe("allow");
+    expect(
+      evaluate(auth, { address: "0xOther" }, execGlobal, {}, ctx(state))
+        .decision,
+    ).toBe("deny");
+    // No context: the match principal never applies.
+    expect(
+      evaluate(auth, { address: "0xOwner" }, execGlobal, {}).decision,
+    ).toBe("deny");
+  });
+
+  it("a conditional deny can freeze a terminal document", () => {
+    const auth = policy(
+      {
+        id: "g-open",
+        description: "anyone executes",
+        effect: "allow",
+        principal: { anyone: true },
+        capability: { can: "execute", scope: "global" },
+      },
+      {
+        id: "g-freeze",
+        description: "frozen once terminal",
+        effect: "deny",
+        principal: { anyone: true },
+        capability: {
+          can: "execute",
+          scope: "global",
+          operation: ["SET_STATUS"],
+        },
+        where: {
+          in: [{ attr: "doc.global.status" }, [{ lit: "APPROVED" }]],
+        },
+      },
+    );
+
+    expect(
+      evaluate(auth, {}, execGlobal, {}, ctx({ status: "OPEN" })).decision,
+    ).toBe("allow");
+    const frozen = evaluate(
+      auth,
+      {},
+      execGlobal,
+      {},
+      ctx({ status: "APPROVED" }),
+    );
+    expect(frozen).toEqual({
+      decision: "deny",
+      refusal: "denied-by-grant",
+      grantId: "g-freeze",
+    });
+  });
+
+  it("action input paths gate on what is being attempted", () => {
+    const auth = policy({
+      id: "g-input",
+      description: "only small increments",
+      effect: "allow",
+      principal: { anyone: true },
+      capability: { can: "execute", scope: "global" },
+      where: { lte: [{ attr: "action.input.amount" }, { lit: 10 }] },
+    });
+
+    expect(
+      evaluate(auth, {}, execGlobal, {}, ctx({}, { amount: 5 })).decision,
+    ).toBe("allow");
+    expect(
+      evaluate(auth, {}, execGlobal, {}, ctx({}, { amount: 50 })).decision,
+    ).toBe("deny");
+  });
+});

--- a/packages/document-model/test/document-model/auth-conditions.test.ts
+++ b/packages/document-model/test/document-model/auth-conditions.test.ts
@@ -224,6 +224,40 @@ describe("totality", () => {
       ),
     ).toBe(false);
   });
+
+  it("a malformed operand poisons its condition, even under not", () => {
+    expect(evalCond({ not: { exists: { frob: 1 } } } as never)).toBe(false);
+    expect(
+      evalCond({ not: { eq: [{ frob: 1 }, { lit: "x" }] } } as never),
+    ).toBe(false);
+    expect(
+      evalCond({ not: { in: [{ lit: "x" }, [{ frob: 1 }]] } } as never),
+    ).toBe(false);
+    expect(
+      evalCond({ not: { eq: [{ lit: {} }, { lit: "x" }] } } as never),
+    ).toBe(false);
+  });
+
+  it("reads own properties only: prototype members never resolve", () => {
+    expect(
+      evalCond(
+        { exists: { attr: "doc.global.toString" } },
+        { scopeState: { status: "OPEN" } },
+      ),
+    ).toBe(false);
+    expect(
+      evalCond(
+        { exists: { attr: "doc.global.__proto__" } },
+        { scopeState: { status: "OPEN" } },
+      ),
+    ).toBe(false);
+    expect(
+      evalCond(
+        { eq: [{ attr: "doc.global.constructor.name" }, { lit: "Object" }] },
+        { scopeState: { status: "OPEN" } },
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("conditions in the grant stack", () => {

--- a/packages/reactor/src/core/feature-flags.ts
+++ b/packages/reactor/src/core/feature-flags.ts
@@ -15,6 +15,7 @@ export const FLAG_PREREQUISITES: Record<
   documentDecisions: [],
   authEnforcement: ["documentDecisions"],
   authGroups: ["authEnforcement"],
+  authConditions: ["authGroups"],
 };
 
 /**

--- a/packages/reactor/src/decision/auth-decision-model.ts
+++ b/packages/reactor/src/decision/auth-decision-model.ts
@@ -3,6 +3,7 @@ import type {
   AuthRefusal,
   AuthRequest,
   AuthSubject,
+  ConditionContext,
   Operation,
   PHAuthState,
   PHDocument,
@@ -20,6 +21,7 @@ import {
   groupDocumentType,
   groupMembershipActionTypes,
   mentionedGroupIds,
+  normalizeDocumentModelVersion,
   referencedGroupIds,
 } from "@powerhousedao/shared/document-model";
 import type { IDocumentModelRegistry } from "../registry/interfaces.js";
@@ -56,13 +58,14 @@ function decideAuthModel(
   subject: AuthSubject,
   request: AuthRequest,
   groups?: AuthGroups,
+  conditions?: ConditionContext,
 ): Evaluation {
   // A read has no position, so deletion does not gate it.
   if (request.verb === "execute" && model.document.isDeleted) {
     return { decision: "deny", reason: DOCUMENT_DELETED_REASON };
   }
 
-  const evaluation = evaluate(model.auth, subject, request, groups);
+  const evaluation = evaluate(model.auth, subject, request, groups, conditions);
   if (evaluation.decision === "allow") {
     return { decision: "allow" };
   }
@@ -150,12 +153,83 @@ function applyGroupOperation(
 }
 
 /**
+ * Folds one evaluated-scope operation with the reducer registered for the
+ * document's own type, at the document's stamped version. A reactor without
+ * that module folds nothing, so conditions read the base state and an
+ * unresolvable reducer never widens access.
+ */
+function applyModelOperation(
+  registry: IDocumentModelRegistry,
+  document: PHDocument,
+  operation: Operation,
+): PHDocument {
+  let reducer: (document: PHDocument, action: unknown) => PHDocument;
+  try {
+    const version = normalizeDocumentModelVersion(
+      (document.state as { document?: { version?: number } }).document?.version,
+    );
+    const module = registry.getModule(
+      document.header.documentType,
+      version,
+    ) as {
+      reducer: (document: PHDocument, action: unknown) => PHDocument;
+    };
+    reducer = module.reducer;
+  } catch {
+    return document;
+  }
+  return reducer(document, operation.action);
+}
+
+/**
  * The auth model extended with a derived groups projection: the streams it
  * reads are the group documents the folded grant list names, so adding a
  * grant that names a new group pulls that group's stream into the read-set.
  * Group queries pin the main branch, because a group's member list lives on
  * its main branch no matter which branch the referencing document is on.
  */
+function groupsProjection(
+  registry: IDocumentModelRegistry,
+): Projection<AuthGroupsDecisionModel> {
+  return {
+    decidingActions: [...groupMembershipActionTypes],
+
+    apply: (document, operation) =>
+      applyGroupOperation(registry, document, operation),
+
+    query: (model) =>
+      referencedGroupIds(model.auth?.grants ?? []).map((id) => ({
+        documentId: id,
+        branch: "main",
+        scope: "global",
+      })),
+
+    // A positional walk reads the union of groups the auth range ever
+    // names, because a grant referenced at one position folds membership
+    // there even if a later operation removes it.
+    queryOverHistory: (reads) => {
+      const ids: string[] = [];
+      for (const read of reads) {
+        if (read.name !== "auth") {
+          continue;
+        }
+        for (const operation of read.operations) {
+          for (const id of mentionedGroupIds(operation.action)) {
+            if (!ids.includes(id)) {
+              ids.push(id);
+            }
+          }
+        }
+      }
+      return ids.map((id) => ({
+        documentId: id,
+        branch: "main",
+        scope: "global",
+      }));
+    },
+  };
+}
+
 export function authGroupsDecisionModel(
   registry: IDocumentModelRegistry,
 ): (target: DecisionTarget) => DecisionModel<AuthGroupsDecisionModel> {
@@ -163,44 +237,7 @@ export function authGroupsDecisionModel(
     projections: {
       document: documentProjection(target),
       auth: authProjection(target),
-
-      groups: {
-        decidingActions: [...groupMembershipActionTypes],
-
-        apply: (document, operation) =>
-          applyGroupOperation(registry, document, operation),
-
-        query: (model) =>
-          referencedGroupIds(model.auth?.grants ?? []).map((id) => ({
-            documentId: id,
-            branch: "main",
-            scope: "global",
-          })),
-
-        // A positional walk reads the union of groups the auth range ever
-        // names, because a grant referenced at one position folds membership
-        // there even if a later operation removes it.
-        queryOverHistory: (reads) => {
-          const ids: string[] = [];
-          for (const read of reads) {
-            if (read.name !== "auth") {
-              continue;
-            }
-            for (const operation of read.operations) {
-              for (const id of mentionedGroupIds(operation.action)) {
-                if (!ids.includes(id)) {
-                  ids.push(id);
-                }
-              }
-            }
-          }
-          return ids.map((id) => ({
-            documentId: id,
-            branch: "main",
-            scope: "global",
-          }));
-        },
-      },
+      groups: groupsProjection(registry),
     },
 
     evaluatesScope() {
@@ -209,6 +246,39 @@ export function authGroupsDecisionModel(
 
     decide(model, subject, request): Evaluation {
       return decideAuthModel(model, subject, request, model.groups);
+    },
+  });
+}
+
+/**
+ * The groups model with conditions live: decide hands the executing scope's
+ * state and the action input through to the evaluator, so `where` clauses
+ * and { match } principals apply. The model folds the evaluated scope during
+ * a positional walk, so a condition reads the state as it stood at each
+ * operation's position.
+ */
+export function authConditionsDecisionModel(
+  registry: IDocumentModelRegistry,
+): (target: DecisionTarget) => DecisionModel<AuthGroupsDecisionModel> {
+  return (target) => ({
+    projections: {
+      document: documentProjection(target),
+      auth: authProjection(target),
+      groups: groupsProjection(registry),
+    },
+
+    foldEvaluatedScope: (document, operation) =>
+      applyModelOperation(registry, document, operation),
+
+    evaluatesScope() {
+      return true;
+    },
+
+    decide(model, subject, request, ctx): Evaluation {
+      return decideAuthModel(model, subject, request, model.groups, {
+        scopeState: ctx.scopeState,
+        actionInput: ctx.actionInput,
+      });
     },
   });
 }

--- a/packages/reactor/src/decision/evaluation.ts
+++ b/packages/reactor/src/decision/evaluation.ts
@@ -197,9 +197,50 @@ export async function evaluateByPosition<M>(
     });
   }
 
-  if (writtenProjection === undefined) {
-    // No projection reads this scope, so these take a position without
-    // contributing state to any of them.
+  // Whether the evaluated scope's state is walked, and under which key. A
+  // projection-read scope folds through its projection; otherwise a model
+  // that reads the executing scope (conditions) folds the full effective
+  // stream itself, and a model that does not lets the evaluated operations
+  // take positions without contributing state.
+  let evaluatedStateKey: string | undefined;
+  if (writtenProjection !== undefined) {
+    evaluatedStateKey = streamKey(writtenProjection.query);
+  } else if (definition.foldEvaluatedScope !== undefined) {
+    const query: StreamQuery = {
+      documentId: target.documentId,
+      scope,
+      branch: target.branch,
+    };
+    // Every effective operation moves state, so this read is unfiltered.
+    const storedOperations = (
+      await operationStore.getSince(
+        query.documentId,
+        query.scope,
+        query.branch,
+        -1,
+        undefined,
+        undefined,
+        signal,
+      )
+    ).results.filter((operation) => !evaluating.has(operation.id));
+
+    const before = await writeCache.getState(
+      query.documentId,
+      query.scope,
+      query.branch,
+      -1,
+      signal,
+    );
+
+    evaluatedStateKey = streamKey(query);
+    walked.push({
+      streamKey: evaluatedStateKey,
+      scope,
+      document: before,
+      operations: [...storedOperations, ...operations],
+      apply: definition.foldEvaluatedScope,
+    });
+  } else {
     walked.push({
       streamKey: EVALUATED_ONLY,
       scope,
@@ -274,6 +315,17 @@ export async function evaluateByPosition<M>(
       continue;
     }
 
+    // The executing scope's state as the walk reached this operation, for
+    // conditions that read it. Undefined when the model does not fold it.
+    const evaluatedDocument =
+      evaluatedStateKey === undefined
+        ? undefined
+        : position.states.get(evaluatedStateKey);
+    const scopeState =
+      evaluatedDocument === undefined
+        ? undefined
+        : (evaluatedDocument.state as Record<string, unknown>)[scope];
+
     const evaluation = definition.decide(
       modelAt<M>(
         readSet,
@@ -287,7 +339,7 @@ export async function evaluateByPosition<M>(
         scope: position.operation.action.scope,
         operation: position.operation.action.type,
       },
-      { scopeState: undefined },
+      { scopeState, actionInput: position.operation.action.input },
     );
 
     const denied = evaluation.decision === "deny";

--- a/packages/reactor/src/decision/registered-model.ts
+++ b/packages/reactor/src/decision/registered-model.ts
@@ -7,6 +7,7 @@ import type { ReactorFeatureFlags } from "../executor/types.js";
 import type { IDocumentModelRegistry } from "../registry/interfaces.js";
 import type { AppendCondition } from "../storage/interfaces.js";
 import {
+  authConditionsDecisionModel,
   authDecisionModel,
   authGroupsDecisionModel,
 } from "./auth-decision-model.js";
@@ -33,8 +34,22 @@ export type AdmissionDecision = {
 };
 
 /**
+ * What decideAtHead resolves a condition context from: the action's input,
+ * with the executing scope's state read at the head. Supplied only while
+ * authConditions is on.
+ */
+export type AdmissionConditions = {
+  actionInput?: unknown;
+};
+
+/**
  * Builds the model at the stream heads and decides one request against it. The
  * append condition it returns is the read-set the store enforces at write time.
+ *
+ * With `conditions` supplied, the executing scope's state is read at the head
+ * for `doc.<scope>.*` paths. That read carries no append-condition entry of
+ * its own: the written stream's expected-revision check already refuses a
+ * write whose scope grew between the read and the append.
  */
 export async function decideAtHead(
   model: RegisteredDecisionModel,
@@ -43,12 +58,26 @@ export async function decideAtHead(
   subject: AuthSubject,
   request: AuthRequest,
   signal?: AbortSignal,
+  conditions?: AdmissionConditions,
 ): Promise<AdmissionDecision> {
   const built = await buildDecisionModel(cache, model, target, signal);
 
+  let scopeState: unknown;
+  if (conditions !== undefined) {
+    const document = await cache.getState(
+      target.documentId,
+      request.scope,
+      target.branch,
+      undefined,
+      signal,
+    );
+    scopeState = (document.state as Record<string, unknown>)[request.scope];
+  }
+
   return {
     evaluation: model(target).decide(built.model, subject, request, {
-      scopeState: undefined,
+      scopeState,
+      actionInput: conditions?.actionInput,
     }),
     appendCondition: built.appendCondition,
     documentVersion: built.model.document.version,
@@ -66,6 +95,9 @@ export function selectDecisionModel(
   flags: ReactorFeatureFlags,
   registry: IDocumentModelRegistry,
 ): RegisteredDecisionModel {
+  if (flags.authConditions) {
+    return authConditionsDecisionModel(registry);
+  }
   if (flags.authGroups) {
     return authGroupsDecisionModel(registry);
   }

--- a/packages/reactor/src/decision/types.ts
+++ b/packages/reactor/src/decision/types.ts
@@ -41,9 +41,15 @@ export type DecisionStores = {
   operationStore: IOperationStore;
 };
 
-/** The executing scope's own state, for conditions that read it. */
+/**
+ * What a decision's conditions may read beyond the projections: the executing
+ * scope's own state and the attempted action's input. Populated only while
+ * authConditions is on; otherwise both stay undefined and conditional grants
+ * never apply.
+ */
 export type DecisionContext = {
   scopeState: unknown;
+  actionInput?: unknown;
 };
 
 /** A statically-queried stream's operations, named after its projection. */
@@ -102,6 +108,18 @@ export type ReadStream = {
 /** Projections plus a decision function over the built model. */
 export type DecisionModel<M> = {
   projections: { [K in keyof M]: Projection<M> };
+
+  /**
+   * Present when decide reads the executing scope's state through the
+   * decision context. A positional walk then folds the evaluated stream with
+   * this, from its base state through every effective operation, so
+   * conditions read the state as it stood at each operation's position
+   * rather than at the head.
+   */
+  foldEvaluatedScope?: (
+    document: PHDocument,
+    operation: Operation,
+  ) => PHDocument;
 
   /**
    * Whether or not this model decides about operations in a given scope. That

--- a/packages/reactor/src/executor/document-action-handler.ts
+++ b/packages/reactor/src/executor/document-action-handler.ts
@@ -173,6 +173,9 @@ export class DocumentActionHandler {
         },
         { verb: "execute", scope: action.scope, operation: action.type },
         signal,
+        this.featureFlags.authConditions
+          ? { actionInput: action.input }
+          : undefined,
       );
     } catch (error) {
       return buildErrorResult(

--- a/packages/reactor/src/executor/simple-job-executor.ts
+++ b/packages/reactor/src/executor/simple-job-executor.ts
@@ -145,6 +145,7 @@ export class SimpleJobExecutor implements IJobExecutor {
       documentDecisions: config.featureFlags?.documentDecisions ?? false,
       authEnforcement: config.featureFlags?.authEnforcement ?? false,
       authGroups: config.featureFlags?.authGroups ?? false,
+      authConditions: config.featureFlags?.authConditions ?? false,
     };
     // The builder validates too, but a pooled worker is constructed directly
     // from the flags that crossed the boundary.

--- a/packages/reactor/src/executor/simple-job-executor.ts
+++ b/packages/reactor/src/executor/simple-job-executor.ts
@@ -545,6 +545,9 @@ export class SimpleJobExecutor implements IJobExecutor {
           },
           { verb: "execute", scope: action.scope, operation: action.type },
           signal,
+          this.featureFlags.authConditions
+            ? { actionInput: action.input }
+            : undefined,
         );
       } catch (error) {
         return buildErrorResult(

--- a/packages/reactor/src/executor/types.ts
+++ b/packages/reactor/src/executor/types.ts
@@ -129,6 +129,12 @@ export type ReactorFeatureFlags = {
    * derived projections. Requires authEnforcement.
    */
   authGroups: boolean;
+
+  /**
+   * Evaluate `where` clauses and { match } principals against the executing
+   * scope's state, the subject, and the action input. Requires authGroups.
+   */
+  authConditions: boolean;
 };
 
 /**

--- a/packages/reactor/test/core/feature-flags.test.ts
+++ b/packages/reactor/test/core/feature-flags.test.ts
@@ -22,6 +22,7 @@ describe("feature flag validation", () => {
     authEnforcement: ["documentDecisions"],
     authGroups: ["authEnforcement"],
     authConditions: ["authGroups"],
+    hypotheticalLaterStage: ["authConditions"],
   };
 
   it("accepts a flag whose prerequisites are all on", () => {
@@ -59,8 +60,11 @@ describe("feature flag validation", () => {
 
   it("rejects a name this reactor does not know", () => {
     expect(() =>
-      validateFeatureFlags({ authConditions: true }, FLAG_PREREQUISITES),
-    ).toThrow(/Unrecognized reactor feature flag: authConditions/);
+      validateFeatureFlags(
+        { hypotheticalLaterStage: true },
+        FLAG_PREREQUISITES,
+      ),
+    ).toThrow(/Unrecognized reactor feature flag: hypotheticalLaterStage/);
   });
 
   it("declares only the flags that are implemented", () => {
@@ -68,6 +72,7 @@ describe("feature flag validation", () => {
       "documentDecisions",
       "authEnforcement",
       "authGroups",
+      "authConditions",
     ]);
   });
 
@@ -78,11 +83,30 @@ describe("feature flag validation", () => {
         driveDocumentModelModule as never,
       ])
       .withExecutorConfig({
-        featureFlags: { authConditions: true } as never,
+        featureFlags: { hypotheticalLaterStage: true } as never,
       });
 
     await expect(builder.build()).rejects.toThrow(
-      /Unrecognized reactor feature flag: authConditions/,
+      /Unrecognized reactor feature flag: hypotheticalLaterStage/,
+    );
+  });
+
+  it("rejects authConditions without authGroups from the builder", async () => {
+    const builder = new ReactorBuilder()
+      .withDocumentModelSources([
+        documentModelDocumentModelModule as never,
+        driveDocumentModelModule as never,
+      ])
+      .withExecutorConfig({
+        featureFlags: {
+          documentDecisions: true,
+          authEnforcement: true,
+          authConditions: true,
+        },
+      });
+
+    await expect(builder.build()).rejects.toThrow(
+      /authConditions requires authGroups/,
     );
   });
 

--- a/packages/reactor/test/decision/conditions.integration.test.ts
+++ b/packages/reactor/test/decision/conditions.integration.test.ts
@@ -1,0 +1,241 @@
+import { driveDocumentModelModule } from "@powerhousedao/shared/document-drive";
+import type {
+  Action,
+  Grant,
+  Operation,
+} from "@powerhousedao/shared/document-model";
+import {
+  addModule,
+  garbageCollect,
+  initializeAuth,
+  setModelName,
+  sortOperations,
+} from "@powerhousedao/shared/document-model";
+import { documentModelDocumentModelModule } from "document-model";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ReactorBuilder } from "../../src/core/reactor-builder.js";
+import type { IReactor } from "../../src/core/types.js";
+import { JobStatus } from "../../src/shared/types.js";
+import { createDocModelDocument } from "../factories.js";
+
+const ADMIN = "0xAdmin";
+const WRITER = "0xWriter";
+
+function signedBy<T extends Action>(action: T, address: string): T {
+  return {
+    ...action,
+    context: {
+      signer: {
+        user: { address, networkId: "", chainId: 0 },
+        app: { name: "test", key: "" },
+        signatures: [],
+      },
+    },
+  };
+}
+
+const adminGrant: Grant = {
+  id: "g-admin",
+  description: "admin executes everything",
+  effect: "allow",
+  principal: { address: ADMIN },
+  capability: { can: "execute", scope: "*" },
+};
+
+// Anyone may write the global scope only while the model name is unset.
+const whileUnnamed: Grant = {
+  id: "g-while-unnamed",
+  description: "open until named",
+  effect: "allow",
+  principal: { anyone: true },
+  capability: { can: "execute", scope: "global" },
+  where: { eq: [{ attr: "doc.global.name" }, { lit: "" }] },
+};
+
+describe("conditions end to end", () => {
+  let reactor: IReactor;
+
+  async function build(authConditions: boolean): Promise<IReactor> {
+    return new ReactorBuilder()
+      .withDocumentModelSources([
+        documentModelDocumentModelModule as never,
+        driveDocumentModelModule as never,
+      ])
+      .withExecutorConfig({
+        featureFlags: {
+          documentDecisions: true,
+          authEnforcement: true,
+          authGroups: true,
+          authConditions,
+        },
+      })
+      .build();
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    reactor?.kill();
+    vi.useRealTimers();
+  });
+
+  async function settle(jobId: string): Promise<string | undefined> {
+    await vi.waitUntil(async () => {
+      const status = await reactor.getJobStatus(jobId);
+      return (
+        status.status === JobStatus.FAILED ||
+        status.status === JobStatus.READ_READY
+      );
+    });
+    const status = await reactor.getJobStatus(jobId);
+    return status.status === JobStatus.FAILED
+      ? (status.error?.message ?? "job failed")
+      : undefined;
+  }
+
+  async function appliedGlobal(
+    documentId: string,
+  ): Promise<Array<{ type: string; denied: boolean }>> {
+    const result = await reactor.getOperations(documentId, {
+      branch: "main",
+      scopes: ["global"],
+    });
+    const stored = (result as Record<string, { results: Operation[] }>).global
+      .results;
+    return garbageCollect(sortOperations([...stored])).map((operation) => ({
+      type: operation.action.type,
+      denied: operation.deniedReason !== undefined,
+    }));
+  }
+
+  async function createGatedDocument(id: string): Promise<string> {
+    const document = createDocModelDocument({ id });
+    const error = await settle((await reactor.create(document)).id);
+    expect(error).toBeUndefined();
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:01.000Z"));
+    const authError = await settle(
+      (
+        await reactor.execute(document.header.id, "main", [
+          initializeAuth({ version: 1, grants: [adminGrant, whileUnnamed] }),
+        ])
+      ).id,
+    );
+    expect(authError).toBeUndefined();
+    return document.header.id;
+  }
+
+  it("a where clause gates admission on the executing scope's state", async () => {
+    reactor = await build(true);
+    const docId = await createGatedDocument("conditions-doc");
+
+    // Open while the name is unset.
+    vi.setSystemTime(new Date("2026-01-01T00:00:02.000Z"));
+    expect(
+      await settle(
+        (
+          await reactor.execute(docId, "main", [
+            signedBy(addModule({ id: "m1", name: "m1" }), WRITER),
+          ])
+        ).id,
+      ),
+    ).toBeUndefined();
+
+    // The admin names the model, which closes the conditional grant.
+    vi.setSystemTime(new Date("2026-01-01T00:00:03.000Z"));
+    expect(
+      await settle(
+        (
+          await reactor.execute(docId, "main", [
+            signedBy(setModelName({ name: "locked" }), ADMIN),
+          ])
+        ).id,
+      ),
+    ).toBeUndefined();
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:04.000Z"));
+    const refusal = await settle(
+      (
+        await reactor.execute(docId, "main", [
+          signedBy(addModule({ id: "m2", name: "m2" }), WRITER),
+        ])
+      ).id,
+    );
+    expect(refusal).toMatch(/denied|Authorization/i);
+
+    // The admin's own writes are unaffected.
+    vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
+    expect(
+      await settle(
+        (
+          await reactor.execute(docId, "main", [
+            signedBy(addModule({ id: "m3", name: "m3" }), ADMIN),
+          ])
+        ).id,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("a backdated state change re-judges later operations at their positions", async () => {
+    reactor = await build(true);
+    const docId = await createGatedDocument("conditions-positional");
+
+    // Admitted while the name is unset.
+    vi.setSystemTime(new Date("2026-01-01T00:00:03.000Z"));
+    expect(
+      await settle(
+        (
+          await reactor.execute(docId, "main", [
+            signedBy(addModule({ id: "m1", name: "m1" }), WRITER),
+          ])
+        ).id,
+      ),
+    ).toBeUndefined();
+    expect(await appliedGlobal(docId)).toEqual([
+      { type: "ADD_MODULE", denied: false },
+    ]);
+
+    // The admin names the model with a timestamp before the writer's
+    // operation, so at the writer's position the grant no longer holds.
+    vi.setSystemTime(new Date("2026-01-01T00:00:02.000Z"));
+    expect(
+      await settle(
+        (
+          await reactor.execute(docId, "main", [
+            signedBy(setModelName({ name: "locked" }), ADMIN),
+          ])
+        ).id,
+      ),
+    ).toBeUndefined();
+
+    await vi.waitUntil(
+      async () =>
+        (await appliedGlobal(docId)).some((operation) => operation.denied),
+      { timeout: 10_000 },
+    );
+
+    expect(await appliedGlobal(docId)).toEqual([
+      { type: "SET_MODEL_NAME", denied: false },
+      { type: "ADD_MODULE", denied: true },
+    ]);
+  });
+
+  it("conditional grants never apply while the flag is off", async () => {
+    reactor = await build(false);
+    const docId = await createGatedDocument("conditions-off");
+
+    // The name is unset, but the conditional grant does not apply: deny.
+    vi.setSystemTime(new Date("2026-01-01T00:00:02.000Z"));
+    const refusal = await settle(
+      (
+        await reactor.execute(docId, "main", [
+          signedBy(addModule({ id: "m1", name: "m1" }), WRITER),
+        ])
+      ).id,
+    );
+    expect(refusal).toMatch(/denied|Authorization/i);
+  });
+});

--- a/packages/reactor/test/executor/document-action-handler/unit.test.ts
+++ b/packages/reactor/test/executor/document-action-handler/unit.test.ts
@@ -84,6 +84,7 @@ function createHarness(
     documentDecisions: false,
     authEnforcement: false,
     authGroups: false,
+    authConditions: false,
   };
   const registry = createTestRegistry();
   const handler = new DocumentActionHandler(
@@ -528,6 +529,7 @@ describe("DocumentActionHandler", () => {
         documentDecisions: true,
         authEnforcement: true,
         authGroups: false,
+        authConditions: false,
       };
       const harness = createHarness(sourceDoc);
       const registry = createTestRegistry();

--- a/packages/shared/document-model/auth-v1.ts
+++ b/packages/shared/document-model/auth-v1.ts
@@ -500,6 +500,15 @@ export function assertAuthAdministrationRetained(
 type ConditionValue = string | number | boolean | null;
 
 /**
+ * An operand whose shape validation would have rejected. Distinguished from
+ * an unresolved path so a structurally malformed operand poisons its whole
+ * condition to false rather than reading as "absent", which `not` would
+ * otherwise widen to true.
+ */
+const INVALID_OPERAND = Symbol("invalid-operand");
+type ResolvedOperand = ConditionValue | undefined | typeof INVALID_OPERAND;
+
+/**
  * Narrows to the values conditions compare. An object, array, or non-finite
  * number resolves to undefined, and every comparison involving undefined is
  * false.
@@ -521,24 +530,35 @@ function asConditionValue(value: unknown): ConditionValue | undefined {
 /**
  * Resolves one operand. Attr roots: `subject.*`, `doc.<scope>.*` where the
  * scope must be the executing scope (validation already rejects any other,
- * but resolution stays total), and `action.input.*`.
+ * but resolution stays total), and `action.input.*`. Path steps read own
+ * properties only, so prototype members can never influence a verdict.
  */
 function resolveOperand(
   operand: unknown,
   subject: AuthSubject,
   request: AuthRequest,
   conditions: ConditionContext,
-): ConditionValue | undefined {
+): ResolvedOperand {
   if (!isPlainValue(operand)) {
-    return undefined;
+    return INVALID_OPERAND;
   }
-  if ("lit" in operand) {
-    return asConditionValue(operand.lit);
+  const keys = Object.keys(operand);
+  if (keys.length !== 1) {
+    return INVALID_OPERAND;
   }
 
+  if (keys[0] === "lit") {
+    const value = asConditionValue(operand.lit);
+    // A lit holds a plain finite value by validation; anything else is shape.
+    return value === undefined ? INVALID_OPERAND : value;
+  }
+
+  if (keys[0] !== "attr") {
+    return INVALID_OPERAND;
+  }
   const attr = operand.attr;
   if (typeof attr !== "string" || attr.length === 0) {
-    return undefined;
+    return INVALID_OPERAND;
   }
   const path = attr.split(".");
 
@@ -561,7 +581,7 @@ function resolveOperand(
   }
 
   for (const segment of rest) {
-    if (!isPlainValue(value)) {
+    if (!isPlainValue(value) || !Object.hasOwn(value, segment)) {
       return undefined;
     }
     value = value[segment];
@@ -602,9 +622,10 @@ function compareValues(
 
 /**
  * Tri-state evaluation: undefined marks a structurally invalid node, which
- * poisons the whole tree to false at the top. That is distinct from an
- * operand that fails to resolve, which is a valid comparison that is false.
- * The distinction keeps `not` from widening over malformed input.
+ * poisons the whole tree to false at the top — and a structurally malformed
+ * operand poisons its condition the same way. Both are distinct from an
+ * operand whose path fails to resolve, which is a valid comparison that is
+ * false. The distinction keeps `not` from widening over malformed input.
  */
 function evaluateNode(
   node: unknown,
@@ -634,6 +655,9 @@ function evaluateNode(
       }
       const left = resolveOperand(body[0], subject, request, conditions);
       const right = resolveOperand(body[1], subject, request, conditions);
+      if (left === INVALID_OPERAND || right === INVALID_OPERAND) {
+        return undefined;
+      }
       if (left === undefined || right === undefined) {
         return false;
       }
@@ -669,20 +693,29 @@ function evaluateNode(
         return undefined;
       }
       const left = resolveOperand(body[0], subject, request, conditions);
+      if (left === INVALID_OPERAND) {
+        return undefined;
+      }
+      const elements = body[1].map((element) =>
+        resolveOperand(element, subject, request, conditions),
+      );
+      if (elements.some((value) => value === INVALID_OPERAND)) {
+        return undefined;
+      }
       if (left === undefined) {
         return false;
       }
-      const found = body[1].some((element) => {
-        const value = resolveOperand(element, subject, request, conditions);
-        return value !== undefined && value === left;
-      });
+      const found = elements.some(
+        (value) => value !== undefined && value === left,
+      );
       return kind === "in" ? found : !found;
     }
     case "exists": {
-      if (!isPlainValue(body)) {
+      const value = resolveOperand(body, subject, request, conditions);
+      if (value === INVALID_OPERAND) {
         return undefined;
       }
-      return resolveOperand(body, subject, request, conditions) !== undefined;
+      return value !== undefined;
     }
     case "and":
     case "or": {

--- a/packages/shared/document-model/auth-v1.ts
+++ b/packages/shared/document-model/auth-v1.ts
@@ -7,11 +7,13 @@ import type {
   AuthEvaluation,
   AuthRequest,
   AuthSubject,
+  ConditionContext,
 } from "./auth.js";
 import { groupDocumentType } from "./document-type.js";
 import type {
   AuthGroups,
   Capability,
+  Condition,
   Grant,
   PHGroupState,
   Principal,
@@ -492,6 +494,239 @@ export function assertAuthAdministrationRetained(
   }
 }
 
+// --- Condition evaluation (version 1) -------------------------------------
+
+/** A resolved operand value; undefined marks a path that did not resolve. */
+type ConditionValue = string | number | boolean | null;
+
+/**
+ * Narrows to the values conditions compare. An object, array, or non-finite
+ * number resolves to undefined, and every comparison involving undefined is
+ * false.
+ */
+function asConditionValue(value: unknown): ConditionValue | undefined {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return undefined;
+}
+
+/**
+ * Resolves one operand. Attr roots: `subject.*`, `doc.<scope>.*` where the
+ * scope must be the executing scope (validation already rejects any other,
+ * but resolution stays total), and `action.input.*`.
+ */
+function resolveOperand(
+  operand: unknown,
+  subject: AuthSubject,
+  request: AuthRequest,
+  conditions: ConditionContext,
+): ConditionValue | undefined {
+  if (!isPlainValue(operand)) {
+    return undefined;
+  }
+  if ("lit" in operand) {
+    return asConditionValue(operand.lit);
+  }
+
+  const attr = operand.attr;
+  if (typeof attr !== "string" || attr.length === 0) {
+    return undefined;
+  }
+  const path = attr.split(".");
+
+  let value: unknown;
+  let rest: string[];
+  if (path[0] === "subject") {
+    value = subject;
+    rest = path.slice(1);
+  } else if (path[0] === "doc") {
+    if (path[1] !== request.scope) {
+      return undefined;
+    }
+    value = conditions.scopeState;
+    rest = path.slice(2);
+  } else if (path[0] === "action" && path[1] === "input") {
+    value = conditions.actionInput;
+    rest = path.slice(2);
+  } else {
+    return undefined;
+  }
+
+  for (const segment of rest) {
+    if (!isPlainValue(value)) {
+      return undefined;
+    }
+    value = value[segment];
+  }
+  return asConditionValue(value);
+}
+
+/**
+ * Total order within one type: numbers numerically, strings by code point.
+ * Everything else, including mixed types, does not order.
+ */
+function compareValues(
+  left: ConditionValue,
+  right: ConditionValue,
+): number | undefined {
+  if (typeof left === "number" && typeof right === "number") {
+    return left < right ? -1 : left > right ? 1 : 0;
+  }
+  if (typeof left === "string" && typeof right === "string") {
+    const leftPoints = Array.from(left);
+    const rightPoints = Array.from(right);
+    const shared = Math.min(leftPoints.length, rightPoints.length);
+    for (let i = 0; i < shared; i++) {
+      const a = leftPoints[i].codePointAt(0) ?? 0;
+      const b = rightPoints[i].codePointAt(0) ?? 0;
+      if (a !== b) {
+        return a < b ? -1 : 1;
+      }
+    }
+    return leftPoints.length === rightPoints.length
+      ? 0
+      : leftPoints.length < rightPoints.length
+        ? -1
+        : 1;
+  }
+  return undefined;
+}
+
+/**
+ * Tri-state evaluation: undefined marks a structurally invalid node, which
+ * poisons the whole tree to false at the top. That is distinct from an
+ * operand that fails to resolve, which is a valid comparison that is false.
+ * The distinction keeps `not` from widening over malformed input.
+ */
+function evaluateNode(
+  node: unknown,
+  subject: AuthSubject,
+  request: AuthRequest,
+  conditions: ConditionContext,
+): boolean | undefined {
+  if (!isPlainValue(node)) {
+    return undefined;
+  }
+  const keys = Object.keys(node);
+  if (keys.length !== 1) {
+    return undefined;
+  }
+  const kind = keys[0];
+  const body = node[kind];
+
+  switch (kind) {
+    case "eq":
+    case "ne":
+    case "lt":
+    case "lte":
+    case "gt":
+    case "gte": {
+      if (!Array.isArray(body) || body.length !== 2) {
+        return undefined;
+      }
+      const left = resolveOperand(body[0], subject, request, conditions);
+      const right = resolveOperand(body[1], subject, request, conditions);
+      if (left === undefined || right === undefined) {
+        return false;
+      }
+      if (kind === "eq") {
+        return left === right;
+      }
+      if (kind === "ne") {
+        return left !== right;
+      }
+      const order = compareValues(left, right);
+      if (order === undefined) {
+        return false;
+      }
+      switch (kind) {
+        case "lt":
+          return order < 0;
+        case "lte":
+          return order <= 0;
+        case "gt":
+          return order > 0;
+        case "gte":
+          return order >= 0;
+      }
+      return undefined;
+    }
+    case "in":
+    case "notIn": {
+      if (
+        !Array.isArray(body) ||
+        body.length !== 2 ||
+        !Array.isArray(body[1])
+      ) {
+        return undefined;
+      }
+      const left = resolveOperand(body[0], subject, request, conditions);
+      if (left === undefined) {
+        return false;
+      }
+      const found = body[1].some((element) => {
+        const value = resolveOperand(element, subject, request, conditions);
+        return value !== undefined && value === left;
+      });
+      return kind === "in" ? found : !found;
+    }
+    case "exists": {
+      if (!isPlainValue(body)) {
+        return undefined;
+      }
+      return resolveOperand(body, subject, request, conditions) !== undefined;
+    }
+    case "and":
+    case "or": {
+      if (!Array.isArray(body)) {
+        return undefined;
+      }
+      let result = kind === "and";
+      for (const child of body) {
+        const value = evaluateNode(child, subject, request, conditions);
+        if (value === undefined) {
+          return undefined;
+        }
+        if (kind === "and") {
+          result = result && value;
+        } else {
+          result = result || value;
+        }
+      }
+      return result;
+    }
+    case "not": {
+      const value = evaluateNode(body, subject, request, conditions);
+      return value === undefined ? undefined : !value;
+    }
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Evaluates a version-1 condition. Deterministic, total, and pure: any input
+ * shape yields a boolean and never throws, and a malformed condition is
+ * false. These are consensus semantics, versioned by `PHAuthState.version`;
+ * changing them requires a new version.
+ */
+export function evaluateCondition(
+  condition: Condition,
+  subject: AuthSubject,
+  request: AuthRequest,
+  conditions: ConditionContext,
+): boolean {
+  return evaluateNode(condition, subject, request, conditions) === true;
+}
+
 function capabilityCovers(
   capability: Capability,
   request: AuthRequest,
@@ -519,7 +754,9 @@ function capabilityCovers(
 function principalMatches(
   principal: Principal,
   subject: AuthSubject,
+  request: AuthRequest,
   groups?: AuthGroups,
+  conditions?: ConditionContext,
 ): boolean {
   if ("anyone" in principal) {
     return true;
@@ -546,7 +783,13 @@ function principalMatches(
     const address = subject.address.toLowerCase();
     return group.members.some((member) => member.toLowerCase() === address);
   }
-  // { match } is not evaluated yet: conditions are deferred.
+  if ("match" in principal) {
+    // Matches only when a condition context is supplied (authConditions on).
+    if (conditions === undefined) {
+      return false;
+    }
+    return evaluateCondition(principal.match, subject, request, conditions);
+  }
   return false;
 }
 
@@ -567,24 +810,31 @@ export function referencedGroupIds(grants: Grant[]): string[] {
 /**
  * Evaluates a v1 grant stack: default deny, last applicable grant wins, and
  * reports which grant decided it. Group principals match only against a
- * supplied groups map; match principals and `where` conditions are not
- * evaluated yet, so a grant that uses one never applies.
+ * supplied groups map, and `where` clauses and { match } principals evaluate
+ * only against a supplied condition context; a grant that uses an unsupplied
+ * feature never applies.
  */
 export function evaluateGrantStack(
   grants: Grant[],
   subject: AuthSubject,
   request: AuthRequest,
   groups?: AuthGroups,
+  conditions?: ConditionContext,
 ): AuthEvaluation {
   let applicable: Grant | undefined;
   for (const grant of grants) {
-    // `where` is not evaluated yet; a conditional grant never applies.
     if (grant.where !== undefined) {
-      continue;
+      // With no condition context a conditional grant never applies.
+      if (conditions === undefined) {
+        continue;
+      }
+      if (!evaluateCondition(grant.where, subject, request, conditions)) {
+        continue;
+      }
     }
     if (
       capabilityCovers(grant.capability, request) &&
-      principalMatches(grant.principal, subject, groups)
+      principalMatches(grant.principal, subject, request, groups, conditions)
     ) {
       applicable = grant;
     }
@@ -612,6 +862,8 @@ export function evaluateGrants(
   subject: AuthSubject,
   request: AuthRequest,
   groups?: AuthGroups,
+  conditions?: ConditionContext,
 ): AuthDecision {
-  return evaluateGrantStack(grants, subject, request, groups).decision;
+  return evaluateGrantStack(grants, subject, request, groups, conditions)
+    .decision;
 }

--- a/packages/shared/document-model/auth.ts
+++ b/packages/shared/document-model/auth.ts
@@ -478,6 +478,18 @@ export type AuthSubject = {
   key?: string;
 };
 
+/**
+ * What condition attr paths resolve against, beyond the subject. Supplied
+ * only while authConditions enforcement is on: with no context a grant
+ * carrying `where` or a { match } principal never applies.
+ */
+export type ConditionContext = {
+  /** The executing scope's own state, for `doc.<scope>.*` paths. */
+  scopeState: unknown;
+  /** The action's input, for `action.input.*` paths. Absent for reads. */
+  actionInput?: unknown;
+};
+
 export type AuthDecision = "allow" | "deny";
 
 /** Why the policy refused a request. */
@@ -505,12 +517,15 @@ export type AuthEvaluation =
  *
  * Group principals match only against a supplied groups map (the groups
  * projection, present when authGroups is on); with no map they never apply.
+ * `where` clauses and { match } principals likewise evaluate only against a
+ * supplied condition context (present when authConditions is on).
  */
 export function evaluate(
   auth: PHAuthState | undefined,
   subject: AuthSubject,
   request: AuthRequest,
   groups?: AuthGroups,
+  conditions?: ConditionContext,
 ): AuthEvaluation {
   if (!auth || !auth.version) {
     return { decision: "allow" };
@@ -531,7 +546,7 @@ export function evaluate(
     return { decision: "deny", refusal: "version-unsupported" };
   }
 
-  return evaluateGrantStack(auth.grants, subject, request, groups);
+  return evaluateGrantStack(auth.grants, subject, request, groups, conditions);
 }
 
 /**
@@ -543,8 +558,9 @@ export function decide(
   subject: AuthSubject,
   request: AuthRequest,
   groups?: AuthGroups,
+  conditions?: ConditionContext,
 ): AuthDecision {
-  return evaluate(auth, subject, request, groups).decision;
+  return evaluate(auth, subject, request, groups, conditions).decision;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements stage 6 of `docs/specs/auth-scope.md` — the last enforcement flag. `where` clauses and `{ match }` principals now evaluate, gated by `authConditions` (requires `authGroups`, default off).

- **The condition evaluator** (`@powerhousedao/shared`): judges the v1 condition language — deterministic, total, and pure, so any input shape yields a boolean and never throws. Attr paths resolve `subject.*`, `doc.<scope>.*` for the executing scope only, and `action.input.*`; a path that does not resolve (or resolves to an object, array, or non-finite number) yields undefined, and every comparison involving undefined is false — including `ne` and `notIn`, so absence never widens access. Numbers order numerically, strings by code point. Structural invalidity is tracked separately from an unresolved operand, so a malformed condition under `not` poisons to false instead of negating to true. The grant stack takes an optional `ConditionContext` mirroring the groups-map pattern: no context (flag off) means conditional grants never apply.
- **State at position**: at admission, `decideAtHead` reads the executing scope at the head when a condition context is requested (deliberately with no append-condition entry of its own — the written stream's expected-revision check already refuses a write whose scope grew between read and append). At replay, a model that reads the executing scope declares `foldEvaluatedScope`, and the positional walk folds the evaluated stream from its base state through every effective operation with the reducer registered for the document's own type at its stamped version. A condition therefore reads the state as it stood at each operation's position: a backdated state change re-judges the operations after it, on every replica, exactly as membership changes and deletions already do.
- **Flag bookkeeping**: `authConditions` joins `FLAG_PREREQUISITES`; the unrecognized-flag tests move to a hypothetical later stage now that the table matches the spec's full cascade.

## Test plan

- 16 new evaluator tests in document-model: every operator, totality over malformed input, the spec's worked examples (`notIn` status gates, the RTO `match` on `doc.global.rtoAddress`, `action.input` gates); document-model 128/128.
- Integration tests in reactor prove the three behaviors end to end: a `where` clause closing at admission when an admin changes the gating state, a **backdated** state change flipping an already-accepted operation to denied via the walk fold, and a flag-off build leaving conditional grants inert.
- Full reactor suite green (2505+), decision+core 191/191 re-verified after merging main; `tsc` and lint clean across shared, document-model, reactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Known limitation

Conditions (and group principals) apply to `execute` requests only for now: the read surface evaluates grants with no condition context or groups map, so a `read` grant using `where`, `match`, or `{ group }` still never applies. That lands with the read-path cluster (group serving, deletion-boundary reads, `replayDocument` denied-op handling).
