### PR TITLE
fix(vetra-e2e): keep the upgrade-repro diagnostic out of the default suite

### DIFF
--- a/test/vetra-e2e/playwright.config.ts
+++ b/test/vetra-e2e/playwright.config.ts
@@ -79,7 +79,11 @@ export default defineConfig({
   projects: [
     {
       name: "vetra-dev",
-      testIgnore: /runtime-config-preview\.spec\.ts/,
+      // upgrade-repro is a diagnostic harness with its own configs
+      // (playwright.repro.config.ts / playwright.repro-external.config.ts);
+      // its setup expects a project-specific vetra drive that does not exist
+      // under this suite's fixture, so it can never pass here.
+      testIgnore: /runtime-config-preview\.spec\.ts|upgrade-repro\.spec\.ts/,
       use: { ...devices["Desktop Chrome"], baseURL: CONNECT_URL },
     },
     ...(workerMode ? [] : [previewProject]),


### PR DESCRIPTION
## Summary

Both Vetra E2E legs have been red on main since the upgrade-repro spec landed: the default playwright config globs every spec in `tests/`, so the diagnostic harness got swept into the CI suite. Its setup authors a document model through a project-specific vetra drive that does not exist under this suite's fixture, so it fails during setup (`Document not found: vetra-…`) on every run and retry, in both legs — the "Update document" bug it exists to reproduce is never even reached.

This adds the spec to the default config's `testIgnore`. Its two dedicated configs (`playwright.repro.config.ts`, `playwright.repro-external.config.ts`) remain the intentional way to run it — where it is green against a real `ph vetra --watch` project following the upgrade fixes.

Open question for the repro's author: whether a fixture-compatible variant should eventually join the default suite as a permanent regression test.

## Test plan

- `playwright test --list` (default config): 0 `upgrade-repro` matches, the other 28 tests intact.
- `playwright test --list --config playwright.repro.config.ts`: still finds the repro spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)