### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -93,16 +93,13 @@ jobs:
           git config user.name "Github Actions Bot"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # pnpm v11 stopped reading npm_config_* env vars (including the
-      # NPM_CONFIG_USERCONFIG that actions/setup-node writes), so the temp
-      # .npmrc with the auth token reference is invisible to `pnpm publish`.
-      # Write the token to ~/.npmrc directly so pnpm picks it up by default.
-      - name: Configure npm auth for pnpm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
-          echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
+      # No npm token: publishing uses trusted publishing (OIDC). Every
+      # released package has this workflow registered as its trusted
+      # publisher on npmjs.com; `pnpm publish` exchanges the id-token
+      # (permissions.id-token: write) for a short-lived credential.
+      # New packages must be published once with a token, then registered
+      # via `npm trust github <pkg> --file release-branch.yml
+      # --repo powerhouse-inc/powerhouse --allow-publish`.
 
       # sentry-cli is installed before Run release: release.ts shells out
       # to `sentry-cli sourcemaps inject` between build and publish.
@@ -114,7 +111,6 @@ jobs:
         id: run-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
           PNPM_CONFIG_PROVENANCE: "true"
         run: |
           pnpm run run-release -- \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -347,10 +347,21 @@ A failure in any of those steps posts to Discord via the `DISCORD_FAILURES` webh
 
 > For production releases, after this section runs green, post the Discord message from Production [Step 5](#step-5--announce-in-coredev-releases) to `#coredev-releases`. This is **not** the same channel as the failure webhook.
 
+## npm authentication
+
+Publishing uses [trusted publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC) — no npm token is configured in CI. Each released package has `release-branch.yml` in `powerhouse-inc/powerhouse` registered as its trusted publisher on npmjs.com, and provenance attestations are generated automatically.
+
+**Adding a new package to the release?** Trusted publishing can't create a package that doesn't exist on the registry yet. Publish it once manually (or with a token), then register the trusted publisher:
+
+```bash
+npm trust github <pkg> --file release-branch.yml --repo powerhouse-inc/powerhouse --allow-publish
+```
+
 ## Troubleshooting
 
 - **"Cannot do a prerelease on production"** — you triggered the workflow on `release/production/*` with `release_mode=prerelease`. Use `patch`.
 - **"Branch ... is invalid" / "must start with release/" / "invalid tag"** — branch name doesn't match `main`, `release/staging/<label>`, or `release/production/<label>`.
+- **npm publish fails with 404/permission error for one package** — its trusted publisher config on npmjs.com is missing or doesn't match (`npm trust list <pkg>` to inspect). See [npm authentication](#npm-authentication).
 - **"No version changes detected — skipping release"** — Nx didn't find new commits worth releasing on this branch since the last tag. Confirm there are real commits since the last release tag.
 - **Mixed versions across packages after `npx nx release version`** — a workspace is missing from the `projects` glob in `releases/release.ts` (currently: `packages/*`, `packages/analytics-engine/*`, `clis/*`, `apps/*`). Either add it there or hand-edit the missing `package.json` to the same baseline before committing.
 - **Wrong base version published** — you ran a fresh staging or production cut without setting the baseline you needed. The npm version is now burned; cut a new line one prerelease number higher and move on.


### PR DESCRIPTION
Switches the release pipeline from a long-lived npm token to [trusted publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC).

## What changed
- `release-branch.yml`: drop the `~/.npmrc` token write and `NODE_AUTH_TOKEN` — `pnpm publish` now exchanges the workflow's OIDC id-token for a short-lived credential (`permissions.id-token: write` was already set). Provenance is generated automatically under trusted publishing.
- `RELEASE.md`: document the OIDC setup and the new-package caveat (a package must exist on the registry before it can be registered via `npm trust`).

## Already done on npmjs.com
All 30 published packages have this workflow registered as their trusted publisher (`npm trust github <pkg> --file release-branch.yml --repo powerhouse-inc/powerhouse --allow-publish`), verified with `npm trust list`.

## After merge
1. Trigger a manual dev release on `main` (`release_mode=prerelease`) to prove the OIDC path.
2. Revoke `NPM_ACCESS_TOKEN` (only the deprecated `manual-release.yml` still references it).