### PR TITLE
feat(reactor-browser): sign action batches in the GraphQL light client

### DIFF
--- a/packages/reactor-browser/src/graphql-client/graphql-reactor-client.ts
+++ b/packages/reactor-browser/src/graphql-client/graphql-reactor-client.ts
@@ -8,8 +8,17 @@ import type {
   SearchFilter,
   ViewFilter,
 } from "@powerhousedao/reactor";
-import type { ISigner } from "@powerhousedao/shared/document-model";
-import type { Action, Operation, PHDocument } from "document-model";
+import type {
+  ISigner,
+  PHDocumentState,
+} from "@powerhousedao/shared/document-model";
+import { normalizeDocumentModelVersion } from "@powerhousedao/shared/document-model";
+import type {
+  Action,
+  DocumentModelModule,
+  Operation,
+  PHDocument,
+} from "document-model";
 import { logger } from "document-model";
 import type { Variables } from "graphql-request";
 import { createClient } from "../graphql/client.js";
@@ -38,7 +47,8 @@ import {
   type MutateDocumentWithOperationsResult,
   type MutateDocumentWithOperationsVariables,
 } from "./operations.js";
-import { signStampedAction, stampAction } from "./signing.js";
+import { prepareSignedActions } from "./signing.js";
+import { resolveDocumentModelModule } from "./static-package-manager.js";
 import {
   describeGraphQLDocument,
   SubgraphSdkRegistry,
@@ -94,6 +104,30 @@ export type GraphQLReactorClientOptions = {
    * only emits the changes it made itself.
    */
   realtime?: boolean;
+
+  /**
+   * The document model modules used to sign a batch of two or more actions.
+   *
+   * Signing action N+1 needs the state action N leaves behind, and only the
+   * document's own reducer can predict it - so a batch is signable only when
+   * the module matching the document's type AND its exact
+   * `state.document.version` is here. One action needs no prediction and is
+   * signed without any of this.
+   *
+   * Read once, when the client is built. Below `GraphQLReactorProvider` this
+   * is its `documentModels` prop; a client constructed directly passes its own.
+   */
+  documentModels?: readonly DocumentModelModule<any>[];
+
+  /**
+   * Signs the actions this client pushes, instead of the logged-in Renown user.
+   *
+   * Left out - the normal case - the signer is resolved per push from
+   * `window.ph.renown`, so a page signs as whoever is logged in and pushes
+   * unsigned when nobody is. Set it where there is no Renown to read: tests,
+   * scripts, and integration suites that must sign deterministically.
+   */
+  signer?: ISigner;
 };
 
 /** Paging defaults, matching the reactor's own client. */
@@ -131,6 +165,8 @@ export class GraphQLReactorClient implements IReactorBrowserClient {
   private readonly listeners: ChangeListener[] = [];
   private readonly tokenProvider: BearerTokenProvider;
   private readonly subscriptionsUrl: string | undefined;
+  private readonly documentModels: readonly DocumentModelModule<any>[];
+  private readonly signer: ISigner | undefined;
   private stopRealtime: (() => void) | undefined;
   private realtimeStarted = false;
   private realtimeGeneration = 0;
@@ -138,6 +174,10 @@ export class GraphQLReactorClient implements IReactorBrowserClient {
 
   constructor(options: GraphQLReactorClientOptions) {
     this.tokenProvider = options.tokenProvider ?? ambientRenownTokenProvider;
+    // Copied, not held: the caller's array must not be able to change which
+    // reducer a later batch is signed with.
+    this.documentModels = [...(options.documentModels ?? [])];
+    this.signer = options.signer;
     this.subscriptionsUrl =
       options.realtime === false
         ? undefined
@@ -262,7 +302,13 @@ export class GraphQLReactorClient implements IReactorBrowserClient {
     signal?: AbortSignal,
   ): Promise<TDocument> {
     const document = await this.get(documentIdentifier, { branch }, signal);
-    const preparedActions = await prepareActionsForPush(actions, document);
+    const preparedActions = await prepareActionsForPush(
+      actions,
+      document,
+      this.documentModels,
+      this.signer,
+      signal,
+    );
 
     const variables: MutateDocumentWithOperationsVariables = {
       documentIdentifier,
@@ -669,28 +715,54 @@ function propagationModeInput(
 /**
  * Stamps and signs the actions about to be pushed.
  *
- * Signing needs the state the action applies to, so only a single action can be
- * signed per call: the second action of a batch applies to a state this client
- * cannot compute without running the reducer. Batches are pushed unsigned.
+ * With no signer the actions go out exactly as given, batch or not - this
+ * client does not require signatures. With one, every action is signed:
+ * {@link prepareSignedActions} predicts the chain a batch will produce by
+ * running the document's own reducer between signatures, which is why a batch
+ * needs the module matching the document's type and exact version.
+ *
+ * A batch that cannot be predicted - no matching module, mixed scopes, an
+ * action needing history - throws here, before the mutation. Sending it
+ * unsigned instead would silently drop the signatures the caller asked for.
  */
 async function prepareActionsForPush(
   actions: Action[],
   document: PHDocument,
+  documentModels: readonly DocumentModelModule<any>[],
+  explicitSigner: ISigner | undefined,
+  signal?: AbortSignal,
 ): Promise<Action[]> {
-  const signer = resolveAmbientSigner();
+  const signer = explicitSigner ?? resolveAmbientSigner();
   if (!signer || actions.length === 0) {
     return actions;
   }
 
-  if (actions.length > 1) {
-    logger.warn(
-      "GraphQLReactorClient: pushing a multi-action batch unsigned, only single actions can be signed",
-    );
-    return actions;
-  }
+  // Only a batch needs the reducer, and it needs the EXACT one the document was
+  // written with - the same rule the server applies in `SimpleJobExecutor`.
+  const module =
+    actions.length > 1
+      ? resolveDocumentModelModule(
+          documentModels,
+          document.header.documentType,
+          documentModelVersion(document),
+        )
+      : undefined;
 
-  const stamped = stampAction(actions[0], document);
-  return [await signStampedAction(stamped, signer)];
+  return prepareSignedActions(actions, document, signer, module, signal);
+}
+
+/**
+ * The document-model version the document's actions must be reduced with.
+ *
+ * `state` arrives as JSON over GraphQL, so its `document` scope is only as
+ * reliable as the server that sent it - one written before that scope existed
+ * carries no version at all. `normalizeDocumentModelVersion` maps that, and 0,
+ * to 1: the same rule `SimpleJobExecutor` applies before asking the registry
+ * for a module, so client and server cannot resolve different reducers.
+ */
+function documentModelVersion(document: PHDocument): number {
+  const documentScope = document.state.document as PHDocumentState | undefined;
+  return normalizeDocumentModelVersion(documentScope?.version);
 }
 
 /** Resolves the signer of the logged-in user, if there is one. */

--- a/packages/reactor-browser/src/graphql-client/graphql-reactor-provider.tsx
+++ b/packages/reactor-browser/src/graphql-client/graphql-reactor-provider.tsx
@@ -99,8 +99,16 @@ export type GraphQLReactorProviderProps = {
    * resolution happens before tree-shaking, so a root import drags processor
    * (server-side) code into the browser bundle and can break the build.
    *
+   * They are also what lets the client SIGN a batch of two or more actions:
+   * signing the second action needs the state the first one leaves behind, and
+   * only the document's own reducer can predict it, so a batch is signable only
+   * while the module matching the document's type and exact version is here.
+   * Single actions are signed without any of this.
+   *
    * Optional on purpose: a light app may equally ship NO modules and let the
    * Switchboard own the model entirely - both modes are supported.
+   *
+   * Like `url`, this is read once, when the client is built.
    */
   documentModels?: readonly DocumentModelModule<any>[];
 
@@ -115,9 +123,11 @@ export type GraphQLReactorProviderProps = {
  *
  * It fills the document slots, plus `window.ph.vetraPackageManager` when
  * `documentModels` is given (a fixed {@link StaticPackageManager}, which makes
- * the document-model hooks work). `window.ph.reactorClientModule` always stays
- * empty, so full-reactor surfaces (drives, jobs, editor auto-discovery) find
- * nothing - an app below this provider renders components it imports itself.
+ * the document-model hooks work). The same modules go to the client itself, so
+ * a dispatch of two or more actions is signed rather than refused.
+ * `window.ph.reactorClientModule` always stays empty, so full-reactor surfaces
+ * (drives, jobs, editor auto-discovery) find nothing - an app below this
+ * provider renders components it imports itself.
  *
  * The client is built on the client only: on the server the slots stay empty
  * and the hooks report their normal loading states. The props are read once,
@@ -144,6 +154,7 @@ export function GraphQLReactorProvider({
           tokenProvider,
           subscriptionsUrl,
           realtime,
+          documentModels,
         }),
   );
 

--- a/packages/reactor-browser/src/graphql-client/signing.ts
+++ b/packages/reactor-browser/src/graphql-client/signing.ts
@@ -1,6 +1,8 @@
 import type {
   Action,
+  DocumentModelModule,
   ISigner,
+  Operation,
   PHDocument,
 } from "@powerhousedao/shared/document-model";
 import { hashDocumentStateForScope } from "@powerhousedao/shared/document-model";
@@ -14,9 +16,17 @@ import { hashDocumentStateForScope } from "@powerhousedao/shared/document-model"
  * `prevOpIndex` is the index of that last operation: revisions count
  * operations and indices are zero based, so an empty scope stamps `-1`, which
  * matches what the remote controller records.
+ *
+ * `revision` overrides the scope revision the index is derived from. Only a
+ * batch needs it - {@link prepareSignedActions} stamps action N at the revision
+ * the N actions before it will have produced, which the document itself does
+ * not know yet. `prevOpHash` always comes from the supplied document's state.
  */
-export function stampAction(action: Action, document: PHDocument): Action {
-  const revision = document.header.revision[action.scope] ?? 0;
+export function stampAction(
+  action: Action,
+  document: PHDocument,
+  revision = document.header.revision[action.scope] ?? 0,
+): Action {
   return {
     ...action,
     context: {
@@ -36,6 +46,7 @@ export function stampAction(action: Action, document: PHDocument): Action {
 export async function signStampedAction(
   action: Action,
   signer: ISigner,
+  signal?: AbortSignal,
 ): Promise<Action> {
   const actionSigner = action.context?.signer;
   const user = actionSigner?.user ?? signer.user;
@@ -46,7 +57,7 @@ export async function signStampedAction(
     );
   }
 
-  const signature = await signer.signAction(action);
+  const signature = await signer.signAction(action, signal);
   return {
     ...action,
     context: {
@@ -58,4 +69,187 @@ export async function signStampedAction(
       },
     },
   };
+}
+
+/**
+ * Actions a snapshot batch cannot predict the next state for.
+ *
+ * `UNDO`, `REDO` and `PRUNE` rewrite history the light read path never fetched
+ * (and the reducer appends no operation for them); `NOOP` is only ever produced
+ * by an undo chain; the document-scope actions run through the reactor's
+ * document-action handler rather than a document-model reducer
+ * (`DOCUMENT_SCOPE_ACTIONS` in packages/reactor/src/executor/util.ts) and
+ * `UPGRADE_DOCUMENT` changes which reducer applies mid-batch.
+ */
+const unsupportedBatchActions: ReadonlySet<string> = new Set([
+  "UNDO",
+  "REDO",
+  "PRUNE",
+  "NOOP",
+  "CREATE_DOCUMENT",
+  "DELETE_DOCUMENT",
+  "UPGRADE_DOCUMENT",
+  "ADD_RELATIONSHIP",
+  "REMOVE_RELATIONSHIP",
+  "UPDATE_RELATIONSHIP",
+]);
+
+/**
+ * The base-reducer protocol version to predict with when the snapshot's header
+ * carries none.
+ *
+ * `baseReducer` reads `baseReducerVersion(document.header)` for every action and
+ * throws when the header has no `protocolVersions` - and a header built by
+ * {@link phDocumentFromGetDocument} never has one, because the GraphQL
+ * `PHDocument` type does not expose it. The version only selects between the v1
+ * and v2 UNDO/NOOP branches, and every action reaching the prediction loop is an
+ * ordinary append-only one, so it cannot change the predicted state here; it is
+ * passed purely so the lookup does not throw.
+ */
+const predictionProtocolVersion = 2;
+
+/**
+ * Stamps and signs a batch of actions against one document snapshot, so every
+ * action carries the head its predecessor will leave behind.
+ *
+ * The server executes the array in order, each action against the state the one
+ * before it produced. The snapshot the light client reads has correct state and
+ * per-scope revisions but NO operation history (see `adapter.ts`), so the chain
+ * is predicted here: reduce action N over the working document to get the state
+ * action N+1 hashes, and carry a virtual revision alongside it. The revision has
+ * to be tracked separately because the reducer derives operation indices from
+ * the last stored operation, and with an empty history that counts from zero
+ * rather than from the document's real revision.
+ *
+ * A single action needs no prediction and therefore no `module`, which keeps
+ * today's callers working unchanged. Two or more require the document's exact
+ * reducer, one shared scope (the reactor rejects mixed-scope jobs) and only
+ * append-only actions. Anything else rejects: a batch that cannot be predicted
+ * must fail before the mutation, never be downgraded to unsigned.
+ */
+export async function prepareSignedActions(
+  actions: readonly Action[],
+  snapshot: PHDocument,
+  signer: ISigner,
+  module?: DocumentModelModule<any>,
+  signal?: AbortSignal,
+): Promise<Action[]> {
+  if (actions.length === 0) {
+    return [];
+  }
+
+  if (actions.length === 1) {
+    return [
+      await signStampedAction(
+        stampAction(actions[0], snapshot),
+        signer,
+        signal,
+      ),
+    ];
+  }
+
+  const scope = sharedScope(actions);
+  assertSupportedBatch(actions);
+
+  if (!module) {
+    throw new Error(
+      `cannot sign ${actions.length} actions: no document model module for ${snapshot.header.documentType} was supplied, so the batch state cannot be predicted`,
+    );
+  }
+
+  // A working copy: the reducer never writes to its input, but the scope's
+  // operation list is read back below, so it must exist even for a scope the
+  // snapshot's `revisionsList` did not mention.
+  let working: PHDocument = {
+    ...snapshot,
+    operations: {
+      ...snapshot.operations,
+      [scope]: [...(snapshot.operations[scope] ?? [])],
+    },
+  };
+  let revision = snapshot.header.revision[scope] ?? 0;
+
+  const signed: Action[] = [];
+  for (const [index, action] of actions.entries()) {
+    throwIfAborted(signal, index);
+
+    const stamped = stampAction(action, working, revision);
+    const signedAction = await signStampedAction(stamped, signer, signal);
+    signed.push(signedAction);
+
+    // The last action's state is never hashed by anything, but reducing it
+    // anyway is what proves the whole batch is applicable before it is sent.
+    const before = scopeOperationCount(working, scope);
+    let next: PHDocument;
+    try {
+      next = module.reducer(working, signedAction, undefined, {
+        protocolVersion:
+          working.header.protocolVersions?.["base-reducer"] ??
+          predictionProtocolVersion,
+      });
+    } catch (error) {
+      throw new Error(
+        `cannot sign action ${index} (${action.type}): the ${snapshot.header.documentType} reducer rejected it, so the rest of the batch cannot be predicted`,
+        { cause: error },
+      );
+    }
+
+    const after = scopeOperationCount(next, scope);
+    if (after !== before + 1) {
+      throw new Error(
+        `cannot sign action ${index} (${action.type}): the reducer appended ${after - before} operations to ${scope}, expected exactly 1`,
+      );
+    }
+
+    working = next;
+    // Deliberately not `next.operations[scope].at(-1).index`: those indices
+    // count from the snapshot's empty history, not from the document's head.
+    revision += 1;
+  }
+
+  return signed;
+}
+
+/**
+ * How many operations a scope holds.
+ *
+ * The index signature types the array as always present, but a module's reducer
+ * is arbitrary code: one that hands back a document without the scope should
+ * produce the actionable error above, not a `TypeError` on `.length`.
+ */
+function scopeOperationCount(document: PHDocument, scope: string): number {
+  const operations: Record<string, Operation[] | undefined> =
+    document.operations;
+  return operations[scope]?.length ?? 0;
+}
+
+/** The one scope a reactor job may span (`getSharedActionScope`). */
+function sharedScope(actions: readonly Action[]): string {
+  const scope = actions[0].scope;
+  const mixed = actions.find((action) => action.scope !== scope);
+  if (mixed) {
+    throw new Error(
+      `cannot sign a batch spanning scopes "${scope}" and "${mixed.scope}": every action in one request must share a scope`,
+    );
+  }
+  return scope;
+}
+
+function assertSupportedBatch(actions: readonly Action[]): void {
+  const unsupported = actions.find((action) =>
+    unsupportedBatchActions.has(action.type),
+  );
+  if (unsupported) {
+    throw new Error(
+      `cannot sign a batch containing ${unsupported.type}: it needs operation history or an alternate executor path, so send it as a single action`,
+    );
+  }
+}
+
+function throwIfAborted(signal: AbortSignal | undefined, index: number): void {
+  if (signal?.aborted) {
+    throw new Error(`signing aborted before action ${index}`, {
+      cause: signal.reason as unknown,
+    });
+  }
 }

--- a/packages/reactor-browser/src/graphql-client/static-package-manager.ts
+++ b/packages/reactor-browser/src/graphql-client/static-package-manager.ts
@@ -38,23 +38,12 @@ export class StaticPackageManager implements IPackageManager {
    * version wins, with `version ?? 1` as each module's default.
    */
   load(documentType: string): Promise<DocumentModelSource> {
-    let latestModule: DocumentModelModule<any> | undefined;
-    let latestVersion = -1;
-    for (const pkg of this.packages) {
-      for (const module of pkg.documentModels) {
-        if (module.documentModel.global.id !== documentType) {
-          continue;
-        }
-        const moduleVersion = module.version ?? 1;
-        if (moduleVersion > latestVersion) {
-          latestVersion = moduleVersion;
-          latestModule = module;
-        }
-      }
+    const modules = this.packages.flatMap((pkg) => pkg.documentModels);
+    try {
+      return Promise.resolve(resolveDocumentModelModule(modules, documentType));
+    } catch (error) {
+      return Promise.reject(error as Error);
     }
-    return latestModule
-      ? Promise.resolve(latestModule)
-      : Promise.reject(new Error(`Unknown document type: ${documentType}`));
   }
 
   subscribe(_handler: IPackagesListener): IPackageListerUnsubscribe {
@@ -96,6 +85,66 @@ export class StaticPackageManager implements IPackageManager {
   ): void {
     throw staticPackageManagerError("addLocalPackage");
   }
+}
+
+/**
+ * Resolves one document-model module out of a flat module list, with the same
+ * rule the reactor registry uses (`IDocumentModelRegistry.getModule`, at
+ * packages/reactor/src/registry/implementation.ts): with a `version`, only an
+ * EXACT `version ?? 1` match resolves; without one, the LATEST version wins.
+ *
+ * Signing an existing document needs the exact rule. A document carries the
+ * model version it was written with in `state.document.version`, and its
+ * reducer is the only one whose operations that document's history can accept -
+ * so "latest" is correct only when no version is asked for.
+ *
+ * Pure and dependency-free on purpose: this is reachable from the browser
+ * entry, so it must not pull the reactor registry in as a value.
+ */
+export function resolveDocumentModelModule(
+  modules: readonly DocumentModelModule<any>[],
+  documentType: string,
+  version?: number,
+): DocumentModelModule<any> {
+  let latestModule: DocumentModelModule<any> | undefined;
+  let latestVersion = -1;
+
+  for (const module of modules) {
+    if (module.documentModel.global.id !== documentType) {
+      continue;
+    }
+    const moduleVersion = module.version ?? 1;
+    if (version !== undefined && moduleVersion === version) {
+      return module;
+    }
+    if (moduleVersion > latestVersion) {
+      latestVersion = moduleVersion;
+      latestModule = module;
+    }
+  }
+
+  if (version === undefined && latestModule) {
+    return latestModule;
+  }
+
+  throw new Error(
+    version === undefined
+      ? `Unknown document type: ${documentType}`
+      : `Unknown document model version: ${documentType} v${version}` +
+          (latestModule
+            ? ` (available: ${availableVersions(modules, documentType).join(", ")})`
+            : " (no module for this document type)"),
+  );
+}
+
+function availableVersions(
+  modules: readonly DocumentModelModule<any>[],
+  documentType: string,
+): number[] {
+  return modules
+    .filter((module) => module.documentModel.global.id === documentType)
+    .map((module) => module.version ?? 1)
+    .sort((a, b) => a - b);
 }
 
 function staticPackageManagerError(member: string): Error {

--- a/packages/reactor-browser/test/graphql-client/graphql-reactor-client.write.test.ts
+++ b/packages/reactor-browser/test/graphql-client/graphql-reactor-client.write.test.ts
@@ -4,16 +4,23 @@ import type {
   ISigner,
   Signature,
 } from "@powerhousedao/shared/document-model";
-import { hashDocumentStateForScope } from "@powerhousedao/shared/document-model";
+import type { PHBaseState } from "@powerhousedao/shared/document-model";
+import {
+  createReducer,
+  hashDocumentStateForScope,
+} from "@powerhousedao/shared/document-model";
 import type { IRenown } from "@renown/sdk";
-import { logger } from "document-model";
+import type { DocumentModelModule, PHDocument } from "document-model";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GetDocumentQuery } from "../../src/graphql/gen/schema.js";
 import type {
   ReactorGraphQLClient,
   RunDocumentOptions,
 } from "../../src/graphql/types.js";
-import { GraphQLReactorClient } from "../../src/graphql-client/graphql-reactor-client.js";
+import {
+  GraphQLReactorClient,
+  type GraphQLReactorClientOptions,
+} from "../../src/graphql-client/graphql-reactor-client.js";
 import type {
   MutateDocumentWithOperationsResult,
   MutateDocumentWithOperationsVariables,
@@ -105,10 +112,14 @@ function createMockSdk(overrides: Partial<MockSdk> = {}): MockSdk {
   };
 }
 
-function createClientWith(sdk: MockSdk): GraphQLReactorClient {
+function createClientWith(
+  sdk: MockSdk,
+  options: Partial<GraphQLReactorClientOptions> = {},
+): GraphQLReactorClient {
   return new GraphQLReactorClient({
     url: "http://localhost:4001/graphql",
     graphqlClient: sdk as unknown as ReactorGraphQLClient,
+    ...options,
   });
 }
 
@@ -156,6 +167,74 @@ afterEach(() => {
   window.ph = {};
   vi.restoreAllMocks();
 });
+
+/** The shape the test module's reducer writes to, i.e. `documentPayload.state`. */
+type TestState = PHBaseState & { global: { name: string } };
+
+// A real base reducer over a trivial state reducer: batch signing is only
+// meaningful against a reducer that actually appends operations and moves the
+// state the next signature hashes.
+function createTestModule(
+  version: number | undefined,
+  transform: (name: string) => string = (name) => name,
+): DocumentModelModule<any> {
+  return {
+    version,
+    reducer: createReducer<TestState>((draft, reduced) => {
+      if (reduced.type === "SET_TEST_NAME") {
+        draft.global.name = transform((reduced.input as { name: string }).name);
+      }
+    }),
+    actions: {},
+    utils: {},
+    documentModel: { global: { id: "powerhouse/test" }, local: {} },
+  } as unknown as DocumentModelModule<any>;
+}
+
+function batchAction(id: string, name: string): Action {
+  return {
+    id,
+    type: "SET_TEST_NAME",
+    timestampUtcMs: "1700000007000",
+    input: { name },
+    scope: "global",
+  };
+}
+
+const batch: Action[] = [
+  batchAction("action-1", "first"),
+  batchAction("action-2", "second"),
+  batchAction("action-3", "third"),
+];
+
+/** The snapshot the client builds out of `documentPayload`, for hand-folding. */
+function snapshotForFold(): PHDocument {
+  return {
+    header: {
+      id: "doc-1",
+      revision: { global: 7, document: 1 },
+    },
+    state,
+    initialState: state,
+    operations: { global: [], document: [] },
+    clipboard: [],
+  } as unknown as PHDocument;
+}
+
+function foldScopeHashes(
+  module: DocumentModelModule<any>,
+  actions: readonly Action[],
+): string[] {
+  let document = snapshotForFold();
+  const hashes: string[] = [];
+  for (const folded of actions) {
+    hashes.push(hashDocumentStateForScope(document, "global"));
+    document = module.reducer(document as never, folded, undefined, {
+      protocolVersion: 2,
+    }) as unknown as PHDocument;
+  }
+  return hashes;
+}
 
 describe("GraphQLReactorClient.execute", () => {
   it("fetches the document before pushing and narrows the returned operations", async () => {
@@ -283,20 +362,234 @@ describe("GraphQLReactorClient.execute", () => {
     );
   });
 
-  it("pushes multi-action batches unsigned and warns", async () => {
-    const { signAction } = installSigner();
-    const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+  it("pushes a multi-action batch unsigned when there is no signer", async () => {
     const sdk = createMockSdk();
 
+    // No signer, no signatures to protect - and therefore no models needed.
     await createClientWith(sdk).execute("doc-1", "main", [
       action,
       secondAction,
     ]);
 
-    expect(signAction).not.toHaveBeenCalled();
     expect(runDocumentVariables(sdk).actions).toEqual([action, secondAction]);
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(String(warn.mock.calls[0][0])).toContain("unsigned");
+  });
+
+  it("signs every action of a batch in one mutation", async () => {
+    const { signAction } = installSigner();
+    const sdk = createMockSdk();
+    const module = createTestModule(1);
+
+    await createClientWith(sdk, { documentModels: [module] }).execute(
+      "doc-1",
+      "main",
+      batch,
+    );
+
+    expect(sdk.RunDocument).toHaveBeenCalledTimes(1);
+    expect(signAction).toHaveBeenCalledTimes(3);
+    const pushed = runDocumentVariables(sdk).actions as Action[];
+    expect(pushed.map((a) => a.id)).toEqual([
+      "action-1",
+      "action-2",
+      "action-3",
+    ]);
+    for (const pushedAction of pushed) {
+      expect(pushedAction.context?.signer?.signatures).toEqual([signature]);
+    }
+  });
+
+  it("chains the batch onto the document's own head", async () => {
+    installSigner();
+    const sdk = createMockSdk();
+    const module = createTestModule(1);
+
+    await createClientWith(sdk, { documentModels: [module] }).execute(
+      "doc-1",
+      "main",
+      batch,
+    );
+
+    const pushed = runDocumentVariables(sdk).actions as Action[];
+    // The document is at global revision 7, so the batch continues from index 6.
+    expect(pushed.map((a) => a.context?.prevOpIndex)).toEqual([6, 7, 8]);
+    expect(pushed.map((a) => a.context?.prevOpHash)).toEqual(
+      foldScopeHashes(module, batch),
+    );
+  });
+
+  it("signs a batch with the module matching the document's exact version", async () => {
+    installSigner();
+    const sdk = createMockSdk({
+      GetDocument: vi.fn().mockResolvedValue({
+        document: {
+          ...documentPayload.document!,
+          document: {
+            ...documentPayload.document!.document,
+            state: { ...state, document: { version: 2 } },
+          },
+        },
+      }),
+    });
+    // v1 and v2 write different state, so the hash chain says which one ran.
+    const v1 = createTestModule(1);
+    const v2 = createTestModule(2, (name) => name.toUpperCase());
+
+    await createClientWith(sdk, { documentModels: [v1, v2] }).execute(
+      "doc-1",
+      "main",
+      batch,
+    );
+
+    const pushed = runDocumentVariables(sdk).actions as Action[];
+    expect(pushed.map((a) => a.context?.prevOpHash)).toEqual(
+      foldScopeHashes(v2, batch),
+    );
+    expect(pushed.map((a) => a.context?.prevOpHash)).not.toEqual(
+      foldScopeHashes(v1, batch),
+    );
+  });
+
+  it("treats an unversioned document as version 1", async () => {
+    installSigner();
+    const sdk = createMockSdk();
+    // `documentPayload` carries no `state.document`, which is what a document
+    // written before versioning looks like.
+    const v1 = createTestModule(1);
+    const v2 = createTestModule(2, (name) => name.toUpperCase());
+
+    await createClientWith(sdk, { documentModels: [v2, v1] }).execute(
+      "doc-1",
+      "main",
+      batch,
+    );
+
+    const pushed = runDocumentVariables(sdk).actions as Action[];
+    expect(pushed.map((a) => a.context?.prevOpHash)).toEqual(
+      foldScopeHashes(v1, batch),
+    );
+  });
+
+  it("forwards the abort signal to the signer", async () => {
+    const { signAction } = installSigner();
+    const sdk = createMockSdk();
+    const controller = new AbortController();
+
+    await createClientWith(sdk, {
+      documentModels: [createTestModule(1)],
+    }).execute("doc-1", "main", batch, controller.signal);
+
+    for (const call of signAction.mock.calls) {
+      expect(call[1]).toBe(controller.signal);
+    }
+  });
+
+  it("does not mutate the actions it was given", async () => {
+    installSigner();
+    const sdk = createMockSdk();
+    const before = JSON.stringify(batch);
+
+    await createClientWith(sdk, {
+      documentModels: [createTestModule(1)],
+    }).execute("doc-1", "main", batch);
+
+    expect(JSON.stringify(batch)).toBe(before);
+  });
+
+  it("refuses a batch when no models were given, instead of sending it unsigned", async () => {
+    installSigner();
+    const sdk = createMockSdk();
+
+    await expect(
+      createClientWith(sdk).execute("doc-1", "main", batch),
+    ).rejects.toThrow("Unknown document model version: powerhouse/test v1");
+    expect(sdk.RunDocument).not.toHaveBeenCalled();
+  });
+
+  it("refuses a batch when the document's exact version is missing", async () => {
+    installSigner();
+    const sdk = createMockSdk({
+      GetDocument: vi.fn().mockResolvedValue({
+        document: {
+          ...documentPayload.document!,
+          document: {
+            ...documentPayload.document!.document,
+            state: { ...state, document: { version: 3 } },
+          },
+        },
+      }),
+    });
+
+    await expect(
+      createClientWith(sdk, {
+        documentModels: [createTestModule(1), createTestModule(2)],
+      }).execute("doc-1", "main", batch),
+    ).rejects.toThrow("Unknown document model version: powerhouse/test v3");
+    expect(sdk.RunDocument).not.toHaveBeenCalled();
+  });
+
+  it("refuses a batch of actions in different scopes", async () => {
+    installSigner();
+    const sdk = createMockSdk();
+
+    await expect(
+      createClientWith(sdk, {
+        documentModels: [createTestModule(1)],
+      }).execute("doc-1", "main", [
+        batch[0],
+        { ...batch[1], scope: "document" },
+      ]),
+    ).rejects.toThrow('spanning scopes "global" and "document"');
+    expect(sdk.RunDocument).not.toHaveBeenCalled();
+  });
+
+  it("signs a single action without any document models", async () => {
+    const { signAction } = installSigner();
+    const sdk = createMockSdk();
+
+    await createClientWith(sdk).execute("doc-1", "main", [action]);
+
+    expect(signAction).toHaveBeenCalledTimes(1);
+    const pushed = runDocumentVariables(sdk).actions[0] as Action;
+    expect(pushed.context?.signer?.signatures).toEqual([signature]);
+  });
+
+  it("signs with an explicitly supplied signer instead of renown", async () => {
+    const explicitSign = vi.fn().mockResolvedValue(signature);
+    const explicitSigner = {
+      user: { address: "0x9", networkId: "eip155", chainId: 1 },
+      app: { name: "explicit-app", key: "explicit-key" },
+      signAction: explicitSign,
+    } as unknown as ISigner;
+    const { signAction: ambientSign } = installSigner();
+    const sdk = createMockSdk();
+
+    await createClientWith(sdk, {
+      signer: explicitSigner,
+      documentModels: [createTestModule(1)],
+    }).execute("doc-1", "main", batch);
+
+    expect(explicitSign).toHaveBeenCalledTimes(3);
+    expect(ambientSign).not.toHaveBeenCalled();
+    const pushed = runDocumentVariables(sdk).actions as Action[];
+    expect(pushed[0].context?.signer?.app).toEqual(explicitSigner.app);
+  });
+
+  it("signs with an explicit signer when nobody is logged in", async () => {
+    const explicitSign = vi.fn().mockResolvedValue(signature);
+    const explicitSigner = {
+      user: { address: "0x9", networkId: "eip155", chainId: 1 },
+      app: { name: "explicit-app", key: "explicit-key" },
+      signAction: explicitSign,
+    } as unknown as ISigner;
+    const sdk = createMockSdk();
+
+    await createClientWith(sdk, { signer: explicitSigner }).execute(
+      "doc-1",
+      "main",
+      [action],
+    );
+
+    expect(explicitSign).toHaveBeenCalledTimes(1);
   });
 
   it("does not sign when renown has no logged-in user", async () => {

--- a/packages/reactor-browser/test/graphql-client/provider.test.tsx
+++ b/packages/reactor-browser/test/graphql-client/provider.test.tsx
@@ -1,3 +1,10 @@
+import type {
+  Action,
+  ISigner,
+  PHBaseState,
+  Signature,
+} from "@powerhousedao/shared/document-model";
+import { createReducer } from "@powerhousedao/shared/document-model";
 import type { DocumentModelModule } from "document-model";
 import { StrictMode } from "react";
 import {
@@ -615,5 +622,187 @@ describe("GraphQLReactorProvider version resolution", () => {
 
     await expect.poll(() => probe(screen, "wrap")).toBe("none");
     expect(probe(screen, "version")).toBe("v1");
+  });
+});
+
+// The whole point of the `documentModels` prop on the write side: the client
+// built by the provider must be able to sign a BATCH, which needs the reducer
+// of the document's exact version. Everything here goes over the same `fetch`
+// seam the read tests use.
+const signingDocumentFields = {
+  ...documentFields,
+  state: { global: { name: "hello" }, local: {}, document: { version: 1 } },
+};
+
+/** Answers reads AND the write mutation, recording the mutation bodies. */
+function stubSigningSwitchboard(): Record<string, unknown>[] {
+  const mutations: Record<string, unknown>[] = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+    const body = JSON.parse(
+      typeof init?.body === "string" ? init.body : "{}",
+    ) as {
+      query?: string;
+      variables?: Record<string, unknown>;
+    };
+    const isMutation = Boolean(body.query?.includes("mutation MutateDocument"));
+    if (isMutation) {
+      mutations.push(body.variables ?? {});
+    }
+    const data = isMutation
+      ? {
+          mutateDocument: {
+            ...signingDocumentFields,
+            revisionsList: [{ scope: "global", revision: 9 }],
+            operations: { items: [] },
+          },
+        }
+      : { document: { document: signingDocumentFields } };
+    return Promise.resolve(
+      new Response(JSON.stringify({ data }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  });
+  return mutations;
+}
+
+const signature: Signature = [
+  "1700000007",
+  "did:key:test",
+  "action-hash",
+  "prev-hash",
+  "0xdeadbeef",
+];
+
+/** Logs a user in, the way the light client reads one: off `window.ph.renown`. */
+function installAmbientSigner() {
+  const signAction = vi.fn().mockResolvedValue(signature);
+  const signer = {
+    user: { address: "0x1", networkId: "eip155", chainId: 1 },
+    app: { name: "test-app", key: "app-key" },
+    signAction,
+  } as unknown as ISigner;
+  window.ph = {
+    ...window.ph,
+    // `getBearerToken` is what the ambient token provider calls on every
+    // request; a logged-in renown always has it.
+    renown: {
+      user: signer.user,
+      signer,
+      getBearerToken: vi.fn().mockResolvedValue("test-token"),
+    } as never,
+  };
+  return signAction;
+}
+
+/** The shape the test module's reducer writes to. */
+type TestState = PHBaseState & { global: { name: string } };
+
+// A real base reducer: signing a batch means running it between signatures.
+const signableModule = {
+  version: 1,
+  reducer: createReducer<TestState>((draft, reduced) => {
+    if (reduced.type === "SET_TEST_NAME") {
+      draft.global.name = (reduced.input as { name: string }).name;
+    }
+  }),
+  actions: {},
+  utils: {},
+  documentModel: { global: { id: "powerhouse/test" }, local: {} },
+} as unknown as DocumentModelModule;
+
+const signableBatch: Action[] = [
+  {
+    id: "action-1",
+    type: "SET_TEST_NAME",
+    timestampUtcMs: "1700000007000",
+    input: { name: "first" },
+    scope: "global",
+  },
+  {
+    id: "action-2",
+    type: "SET_TEST_NAME",
+    timestampUtcMs: "1700000008000",
+    input: { name: "second" },
+    scope: "global",
+  },
+];
+
+describe("GraphQLReactorProvider signed batches", () => {
+  beforeEach(() => {
+    resetPHGlobals();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetPHGlobals();
+  });
+
+  it("signs a batch dispatched through the published client", async () => {
+    const signAction = installAmbientSigner();
+    const mutations = stubSigningSwitchboard();
+
+    render(
+      <GraphQLReactorProvider
+        url={url}
+        realtime={false}
+        documentModels={[signableModule]}
+      >
+        <span />
+      </GraphQLReactorProvider>,
+    );
+
+    await window.ph!.reactorClient!.execute("doc-1", "main", signableBatch);
+
+    expect(mutations).toHaveLength(1);
+    expect(signAction).toHaveBeenCalledTimes(2);
+    const pushed = (mutations[0] as { actions: Action[] }).actions;
+    expect(pushed.map((a) => a.id)).toEqual(["action-1", "action-2"]);
+    expect(pushed.map((a) => a.context?.signer?.signatures)).toEqual([
+      [signature],
+      [signature],
+    ]);
+    // The document is at global revision 7, so the batch continues from 6.
+    expect(pushed.map((a) => a.context?.prevOpIndex)).toEqual([6, 7]);
+    expect(pushed[1].context?.prevOpHash).not.toBe(
+      pushed[0].context?.prevOpHash,
+    );
+  });
+
+  it("refuses the batch when the provider was given no models", async () => {
+    const signAction = installAmbientSigner();
+    const mutations = stubSigningSwitchboard();
+
+    render(
+      <GraphQLReactorProvider url={url} realtime={false}>
+        <span />
+      </GraphQLReactorProvider>,
+    );
+
+    await expect(
+      window.ph!.reactorClient!.execute("doc-1", "main", signableBatch),
+    ).rejects.toThrow("Unknown document model version: powerhouse/test v1");
+    expect(mutations).toHaveLength(0);
+    expect(signAction).not.toHaveBeenCalled();
+  });
+
+  it("still reads and pushes unsigned without models and without a user", async () => {
+    const mutations = stubSigningSwitchboard();
+
+    render(
+      <GraphQLReactorProvider url={url} realtime={false}>
+        <span />
+      </GraphQLReactorProvider>,
+    );
+
+    const document = await window.ph!.reactorClient!.get("doc-1");
+    expect(document.header.revision).toEqual({ global: 7 });
+
+    await window.ph!.reactorClient!.execute("doc-1", "main", signableBatch);
+
+    expect(mutations).toHaveLength(1);
+    const pushed = (mutations[0] as { actions: Action[] }).actions;
+    expect(pushed).toEqual(signableBatch);
   });
 });

--- a/packages/reactor-browser/test/graphql-client/signing.test.ts
+++ b/packages/reactor-browser/test/graphql-client/signing.test.ts
@@ -4,9 +4,17 @@ import type {
   PHDocument,
   Signature,
 } from "@powerhousedao/shared/document-model";
-import { hashDocumentStateForScope } from "@powerhousedao/shared/document-model";
+import {
+  addModule,
+  hashDocumentStateForScope,
+  setModelDescription,
+  setModelName,
+  setModuleName,
+} from "@powerhousedao/shared/document-model";
+import { documentModelDocumentModelModule } from "document-model";
 import { describe, expect, it, vi } from "vitest";
 import {
+  prepareSignedActions,
   signStampedAction,
   stampAction,
 } from "../../src/graphql-client/signing.js";
@@ -151,5 +159,336 @@ describe("signStampedAction", () => {
       "no user or app identity",
     );
     expect(signer.signAction).not.toHaveBeenCalled();
+  });
+});
+
+// A batch is predicted with the REAL built-in document-model reducer: a fake one
+// would hide exactly what this helper exists to get right - the state the server
+// will hash, and the fact that the reducer's own indices count from an empty
+// history rather than from the document's head.
+function createSnapshot(revision: Record<string, number>): PHDocument {
+  const document = documentModelDocumentModelModule.utils.createDocument();
+  const snapshot = {
+    header: { ...document.header, revision },
+    state: document.state,
+    initialState: document.state,
+    // What `phDocumentFromGetDocument` produces: the scopes are known, the
+    // history is not.
+    operations: { global: [], local: [] },
+    clipboard: [],
+  } as unknown as PHDocument;
+  // The GraphQL `PHDocument` type carries no protocol versions, so a real light
+  // snapshot never has them either.
+  delete (snapshot.header as { protocolVersions?: unknown }).protocolVersions;
+  return snapshot;
+}
+
+/** Folds the same reducer by hand, to check the chain against something else. */
+function foldScopeHashes(
+  snapshot: PHDocument,
+  batch: readonly Action[],
+): string[] {
+  let document = snapshot;
+  const hashes: string[] = [];
+  for (const action of batch) {
+    hashes.push(hashDocumentStateForScope(document, "global"));
+    document = documentModelDocumentModelModule.reducer(
+      document as never,
+      action,
+      undefined,
+      { protocolVersion: 2 },
+    ) as unknown as PHDocument;
+  }
+  return hashes;
+}
+
+const batch: Action[] = [
+  setModelName({ name: "Invoice" }),
+  setModelDescription({ description: "An invoice" }),
+  addModule({ id: "module-1", name: "core" }),
+];
+
+describe("prepareSignedActions", () => {
+  it("signs nothing for an empty batch", async () => {
+    await expect(
+      prepareSignedActions([], createSnapshot({ global: 5 }), createSigner()),
+    ).resolves.toEqual([]);
+  });
+
+  it("signs a single action without needing a document model", async () => {
+    const signer = createSigner();
+    const snapshot = createSnapshot({ global: 7 });
+
+    const [signed] = await prepareSignedActions([action], snapshot, signer);
+
+    expect(signed.context?.prevOpIndex).toBe(6);
+    expect(signed.context?.prevOpHash).toBe(
+      hashDocumentStateForScope(snapshot, "global"),
+    );
+    expect(signed.context?.signer?.signatures).toEqual([signature]);
+  });
+
+  it("chains prevOpHash across the batch from a history-free snapshot", async () => {
+    const snapshot = createSnapshot({ global: 5 });
+
+    const signed = await prepareSignedActions(
+      batch,
+      snapshot,
+      createSigner(),
+      documentModelDocumentModelModule,
+    );
+
+    expect(signed.map((a) => a.context?.prevOpHash)).toEqual(
+      foldScopeHashes(snapshot, batch),
+    );
+  });
+
+  it("counts prevOpIndex from the document's revision, not the reducer's", async () => {
+    const snapshot = createSnapshot({ global: 5 });
+
+    const signed = await prepareSignedActions(
+      batch,
+      snapshot,
+      createSigner(),
+      documentModelDocumentModelModule,
+    );
+
+    // The simulated operations are indexed 0, 1, 2 because the snapshot has no
+    // history; the remote chain continues from revision 5.
+    expect(signed.map((a) => a.context?.prevOpIndex)).toEqual([4, 5, 6]);
+  });
+
+  it("starts a fresh scope at -1", async () => {
+    const signed = await prepareSignedActions(
+      batch,
+      createSnapshot({ global: 0 }),
+      createSigner(),
+      documentModelDocumentModelModule,
+    );
+
+    expect(signed.map((a) => a.context?.prevOpIndex)).toEqual([-1, 0, 1]);
+  });
+
+  it("signs every action in the batch, in order", async () => {
+    const signer = createSigner();
+
+    const signed = await prepareSignedActions(
+      batch,
+      createSnapshot({ global: 5 }),
+      signer,
+      documentModelDocumentModelModule,
+    );
+
+    expect(signer.signAction).toHaveBeenCalledTimes(3);
+    expect(signed.map((a) => a.type)).toEqual(batch.map((a) => a.type));
+    for (const signedAction of signed) {
+      expect(signedAction.context?.signer?.signatures).toEqual([signature]);
+    }
+  });
+
+  it("signs each action already stamped with its own place in the chain", async () => {
+    const signer = createSigner();
+    const snapshot = createSnapshot({ global: 5 });
+
+    const signed = await prepareSignedActions(
+      batch,
+      snapshot,
+      signer,
+      documentModelDocumentModelModule,
+    );
+
+    const signedArguments = vi
+      .mocked(signer.signAction)
+      .mock.calls.map(([signedAction]) => signedAction);
+    expect(signedArguments.map((a) => a.context?.prevOpHash)).toEqual(
+      signed.map((a) => a.context?.prevOpHash),
+    );
+    expect(signedArguments.map((a) => a.context?.prevOpIndex)).toEqual([
+      4, 5, 6,
+    ]);
+  });
+
+  it("mutates neither the snapshot nor the actions it is given", async () => {
+    const snapshot = createSnapshot({ global: 5 });
+    const before = JSON.stringify(snapshot);
+    const actionsBefore = JSON.stringify(batch);
+
+    await prepareSignedActions(
+      batch,
+      snapshot,
+      createSigner(),
+      documentModelDocumentModelModule,
+    );
+
+    expect(JSON.stringify(snapshot)).toBe(before);
+    expect(JSON.stringify(batch)).toBe(actionsBefore);
+  });
+
+  it("passes the abort signal to every signer call", async () => {
+    const signer = createSigner();
+    const controller = new AbortController();
+
+    await prepareSignedActions(
+      batch,
+      createSnapshot({ global: 5 }),
+      signer,
+      documentModelDocumentModelModule,
+      controller.signal,
+    );
+
+    for (const call of vi.mocked(signer.signAction).mock.calls) {
+      expect(call[1]).toBe(controller.signal);
+    }
+  });
+
+  it("stops before signing anything once aborted", async () => {
+    const signer = createSigner();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      prepareSignedActions(
+        batch,
+        createSnapshot({ global: 5 }),
+        signer,
+        documentModelDocumentModelModule,
+        controller.signal,
+      ),
+    ).rejects.toThrow("signing aborted before action 0");
+    expect(signer.signAction).not.toHaveBeenCalled();
+  });
+
+  it("rejects a batch with no document model instead of sending it unsigned", async () => {
+    await expect(
+      prepareSignedActions(
+        batch,
+        createSnapshot({ global: 5 }),
+        createSigner(),
+      ),
+    ).rejects.toThrow("no document model module for powerhouse/document-model");
+  });
+
+  it("rejects a batch spanning more than one scope", async () => {
+    const mixed = [batch[0], { ...batch[1], scope: "local" }];
+
+    await expect(
+      prepareSignedActions(
+        mixed,
+        createSnapshot({ global: 5 }),
+        createSigner(),
+        documentModelDocumentModelModule,
+      ),
+    ).rejects.toThrow('spanning scopes "global" and "local"');
+  });
+
+  it.each([
+    "UNDO",
+    "REDO",
+    "PRUNE",
+    "NOOP",
+    "CREATE_DOCUMENT",
+    "DELETE_DOCUMENT",
+    "UPGRADE_DOCUMENT",
+    "ADD_RELATIONSHIP",
+    "REMOVE_RELATIONSHIP",
+    "UPDATE_RELATIONSHIP",
+  ])("rejects a batch containing %s", async (type) => {
+    const withUnsupported = [batch[0], { ...batch[1], type }];
+
+    await expect(
+      prepareSignedActions(
+        withUnsupported,
+        createSnapshot({ global: 5 }),
+        createSigner(),
+        documentModelDocumentModelModule,
+      ),
+    ).rejects.toThrow(`cannot sign a batch containing ${type}`);
+  });
+
+  it("rejects the batch when the reducer throws", async () => {
+    // The real reducer records a bad action as a failed operation rather than
+    // throwing (see the test below), so the throwing case needs a stub. It is
+    // only ever the escape hatch: a reducer that cannot run at all leaves the
+    // rest of the batch unpredictable.
+    const throwing = {
+      ...documentModelDocumentModelModule,
+      reducer: () => {
+        throw new Error("boom");
+      },
+    } as unknown as typeof documentModelDocumentModelModule;
+
+    await expect(
+      prepareSignedActions(
+        batch,
+        createSnapshot({ global: 5 }),
+        createSigner(),
+        throwing,
+      ),
+    ).rejects.toThrow(
+      "cannot sign action 0 (SET_MODEL_NAME): the powerhouse/document-model reducer rejected it",
+    );
+  });
+
+  it("rejects the batch when a reducer call appends no operation", async () => {
+    // The revision chain is only sound while one action means one operation, so
+    // a reducer that quietly swallows an action must not be signed around.
+    const swallowing = {
+      ...documentModelDocumentModelModule,
+      reducer: (document: PHDocument) => document,
+    } as unknown as typeof documentModelDocumentModelModule;
+
+    await expect(
+      prepareSignedActions(
+        batch,
+        createSnapshot({ global: 5 }),
+        createSigner(),
+        swallowing,
+      ),
+    ).rejects.toThrow("appended 0 operations to global, expected exactly 1");
+  });
+
+  it("records a schema-invalid action as a failed operation, not a throw", async () => {
+    // ADD_MODULE validates its input inside the state reducer, which baseReducer
+    // catches - so this is the recorded-failure path, and the chain survives it.
+    const malformed: Action = { ...batch[2], input: { id: undefined } };
+    const snapshot = createSnapshot({ global: 5 });
+
+    const signed = await prepareSignedActions(
+      [batch[0], malformed, batch[1]],
+      snapshot,
+      createSigner(),
+      documentModelDocumentModelModule,
+    );
+
+    expect(signed.map((a) => a.context?.prevOpIndex)).toEqual([4, 5, 6]);
+    expect(signed.map((a) => a.context?.prevOpHash)).toEqual(
+      foldScopeHashes(snapshot, [batch[0], malformed, batch[1]]),
+    );
+  });
+
+  it("keeps chaining when the reducer records a failed operation", async () => {
+    // `setModuleName` for a module that does not exist leaves the state alone
+    // but still appends one operation carrying the error, and the server does
+    // the same - so the next action hashes the unchanged state at the next
+    // revision, and the batch is still signable.
+    const withFailure = [
+      batch[0],
+      setModuleName({ id: "missing", name: "nope" }),
+      batch[1],
+    ];
+    const snapshot = createSnapshot({ global: 5 });
+
+    const signed = await prepareSignedActions(
+      withFailure,
+      snapshot,
+      createSigner(),
+      documentModelDocumentModelModule,
+    );
+
+    expect(signed.map((a) => a.context?.prevOpIndex)).toEqual([4, 5, 6]);
+    expect(signed[2].context?.prevOpHash).toBe(signed[1].context?.prevOpHash);
+    expect(signed.map((a) => a.context?.prevOpHash)).toEqual(
+      foldScopeHashes(snapshot, withFailure),
+    );
   });
 });

--- a/packages/reactor-browser/test/graphql-client/static-package-manager.node.test.ts
+++ b/packages/reactor-browser/test/graphql-client/static-package-manager.node.test.ts
@@ -6,6 +6,7 @@ import {
 import { describe, expect, it } from "vitest";
 import {
   packageFromDocumentModels,
+  resolveDocumentModelModule,
   StaticPackageManager,
 } from "../../src/graphql-client/static-package-manager.js";
 
@@ -109,6 +110,57 @@ describe("StaticPackageManager", () => {
     expect(manager.getPackageSource("some-package")).toBeNull();
     expect(manager.getPackageVersion("some-package")).toBeUndefined();
     expect(manager.getRegistryPackages()).toEqual([]);
+  });
+});
+
+describe("resolveDocumentModelModule", () => {
+  const modules = [todoV1, todoV2, unversioned];
+
+  it("returns the EXACT version when one is asked for", () => {
+    expect(resolveDocumentModelModule(modules, "test/todo", 1)).toBe(todoV1);
+    expect(resolveDocumentModelModule(modules, "test/todo", 2)).toBe(todoV2);
+  });
+
+  it("treats an absent module version as 1 when matching exactly", () => {
+    expect(resolveDocumentModelModule(modules, "test/legacy", 1)).toBe(
+      unversioned,
+    );
+  });
+
+  it("returns the LATEST version when none is asked for", () => {
+    expect(resolveDocumentModelModule(modules, "test/todo")).toBe(todoV2);
+  });
+
+  it("never falls back to another version when an exact one is missing", () => {
+    // The whole point of the exact rule: v3 is absent, so this must throw
+    // rather than silently sign with the v2 reducer.
+    expect(() => resolveDocumentModelModule(modules, "test/todo", 3)).toThrow(
+      "Unknown document model version: test/todo v3",
+    );
+  });
+
+  it("names the versions it does have when the exact one is missing", () => {
+    expect(() => resolveDocumentModelModule(modules, "test/todo", 3)).toThrow(
+      "available: 1, 2",
+    );
+  });
+
+  it("reports an unknown type for a versioned lookup too", () => {
+    expect(() =>
+      resolveDocumentModelModule(modules, "test/unknown", 1),
+    ).toThrow("Unknown document model version: test/unknown v1");
+  });
+
+  it("reports an unknown type for an unversioned lookup", () => {
+    expect(() => resolveDocumentModelModule(modules, "test/unknown")).toThrow(
+      "Unknown document type: test/unknown",
+    );
+  });
+
+  it("resolves nothing from an empty module list", () => {
+    expect(() => resolveDocumentModelModule([], "test/todo")).toThrow(
+      "Unknown document type: test/todo",
+    );
   });
 });
 

--- a/test/switchboard/src/graphql-reactor-client.test.ts
+++ b/test/switchboard/src/graphql-reactor-client.test.ts
@@ -1,0 +1,174 @@
+import { createClient } from "@powerhousedao/reactor-browser";
+import { GraphQLReactorClient } from "@powerhousedao/reactor-browser/graphql-client";
+import type { Action, PHDocument } from "@powerhousedao/shared/document-model";
+import {
+  setModelDescription,
+  setModelName,
+  setName,
+} from "@powerhousedao/shared/document-model";
+import {
+  MemoryKeyStorage,
+  RenownCryptoBuilder,
+  RenownCryptoSigner,
+} from "@renown/sdk/node";
+import { documentModelDocumentModelModule } from "document-model";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const SWITCHBOARD_URL =
+  process.env.SWITCHBOARD_URL ?? "http://localhost:4001/graphql";
+
+const DRIVE_ID = process.env.SWITCHBOARD_DRIVE_ID ?? "powerhouse";
+
+const client = createClient(SWITCHBOARD_URL);
+
+/** Track created document IDs for cleanup. */
+const createdDocumentIds: string[] = [];
+
+const testUser = {
+  address: "0x9aDdcBbaA28F7eB5f75E023F7C1Fcb13C9DFD8F7",
+  networkId: "eip155",
+  chainId: 1,
+};
+
+/**
+ * Counts the `MutateDocumentWithOperations` requests made while `run` executes,
+ * without replacing the real transport: the spy delegates to the original
+ * `fetch` and is put back in a `finally`.
+ */
+async function countMutations<T>(
+  run: () => Promise<T>,
+): Promise<{ result: T; requests: Record<string, unknown>[] }> {
+  const requests: Record<string, unknown>[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    if (typeof init?.body === "string") {
+      const body = JSON.parse(init.body) as {
+        query?: string;
+        variables?: Record<string, unknown>;
+      };
+      if (body.query?.includes("mutation MutateDocumentWithOperations")) {
+        requests.push(body.variables ?? {});
+      }
+    }
+    return originalFetch(input, init);
+  };
+  try {
+    return { result: await run(), requests };
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+describe("GraphQLReactorClient signed batches e2e", () => {
+  let signer: RenownCryptoSigner;
+
+  beforeAll(async () => {
+    const renownCrypto = await new RenownCryptoBuilder()
+      .withKeyPairStorage(new MemoryKeyStorage())
+      .build();
+    signer = new RenownCryptoSigner(renownCrypto, "e2e-test", testUser);
+  });
+
+  afterAll(async () => {
+    for (const id of createdDocumentIds) {
+      try {
+        await client.DeleteDocument({ identifier: id });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it("sends three sequentially signed actions in one mutation", async () => {
+    const created = await client.CreateEmptyDocument({
+      documentType: "powerhouse/document-model",
+      parentIdentifier: DRIVE_ID,
+    });
+    const documentId = created.createEmptyDocument.id;
+    createdDocumentIds.push(documentId);
+
+    const reactorClient = new GraphQLReactorClient({
+      url: SWITCHBOARD_URL,
+      realtime: false,
+      documentModels: [documentModelDocumentModelModule],
+      signer,
+    });
+
+    // The revision the batch has to chain onto, read the same way the client
+    // reads it.
+    const before = await reactorClient.get<PHDocument>(documentId, {
+      branch: "main",
+    });
+    const startRevision = before.header.revision.global;
+
+    const actions: Action[] = [
+      setName({ name: "Signed Batch Document" }),
+      setModelName({ name: "SignedBatchModel" }),
+      setModelDescription({ description: "Written as one signed batch" }),
+    ];
+
+    const { requests } = await countMutations(() =>
+      reactorClient.execute(documentId, "main", actions),
+    );
+
+    // One request, carrying all three actions.
+    expect(requests).toHaveLength(1);
+    const pushed = requests[0].actions as Action[];
+    expect(pushed.map((a) => a.type)).toEqual([
+      "SET_NAME",
+      "SET_MODEL_NAME",
+      "SET_MODEL_DESCRIPTION",
+    ]);
+
+    // Every action individually signed, and chained onto the document's head.
+    for (const pushedAction of pushed) {
+      expect(pushedAction.context?.signer?.user).toEqual(testUser);
+      expect(pushedAction.context?.signer?.signatures).toHaveLength(1);
+    }
+    expect(pushed.map((a) => a.context?.prevOpIndex)).toEqual([
+      startRevision - 1,
+      startRevision,
+      startRevision + 1,
+    ]);
+
+    // What the server actually stored: the same three operations, in order,
+    // each carrying the signature it was signed with. Read back through the
+    // light client's own paged read, i.e. the way an app would.
+    const operations = await reactorClient.getOperations(
+      documentId,
+      { branch: "main", scopes: ["global"] },
+      undefined,
+      { cursor: "0", limit: 100 },
+    );
+    const storedBatch = operations.results.slice(-3);
+    expect(storedBatch.map((operation) => operation.action.type)).toEqual([
+      "SET_NAME",
+      "SET_MODEL_NAME",
+      "SET_MODEL_DESCRIPTION",
+    ]);
+    for (const operation of storedBatch) {
+      expect(operation.error).toBeFalsy();
+      expect(operation.action.context?.signer?.signatures).toHaveLength(1);
+    }
+
+    // The chain the client predicted is the chain the server produced: each
+    // action's prevOpHash is the hash the previous operation resulted in.
+    expect(pushed[1].context?.prevOpHash).toBe(storedBatch[0].hash);
+    expect(pushed[2].context?.prevOpHash).toBe(storedBatch[1].hash);
+
+    const after = await reactorClient.get<PHDocument>(documentId, {
+      branch: "main",
+    });
+    expect(after.header.name).toBe("Signed Batch Document");
+    // `PHDocument` types only the base scopes; the model's own global state is
+    // whatever its reducer writes.
+    const globalState = (
+      after.state as unknown as {
+        global: { name: string; description: string };
+      }
+    ).global;
+    expect(globalState.name).toBe("SignedBatchModel");
+    expect(globalState.description).toBe("Written as one signed batch");
+    expect(after.header.revision.global).toBe(startRevision + 3);
+  });
+});

--- a/test/switchboard/src/graphql-reactor-client.test.ts
+++ b/test/switchboard/src/graphql-reactor-client.test.ts
@@ -1,11 +1,16 @@
 import { createClient } from "@powerhousedao/reactor-browser";
 import { GraphQLReactorClient } from "@powerhousedao/reactor-browser/graphql-client";
-import type { Action, PHDocument } from "@powerhousedao/shared/document-model";
+import type {
+  Action,
+  PHDocument,
+  Signature,
+} from "@powerhousedao/shared/document-model";
 import {
   setModelDescription,
   setModelName,
   setName,
 } from "@powerhousedao/shared/document-model";
+import { createSignatureVerifier } from "@renown/sdk/crypto";
 import {
   MemoryKeyStorage,
   RenownCryptoBuilder,
@@ -59,6 +64,25 @@ async function countMutations<T>(
   }
 }
 
+/**
+ * The action hash a signature commits to, as `RenownCryptoSigner.hashAction`
+ * computes it. Recomputed here from the operation the SERVER stored, so the
+ * assertion below proves the signature covers that exact action rather than
+ * whatever the client happened to hold.
+ */
+async function hashAction(action: Action): Promise<string> {
+  const payload = [
+    action.scope,
+    action.type,
+    JSON.stringify(action.input),
+  ].join("");
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(payload),
+  );
+  return Buffer.from(digest).toString("base64");
+}
+
 describe("GraphQLReactorClient signed batches e2e", () => {
   let signer: RenownCryptoSigner;
 
@@ -99,7 +123,11 @@ describe("GraphQLReactorClient signed batches e2e", () => {
     const before = await reactorClient.get<PHDocument>(documentId, {
       branch: "main",
     });
-    const startRevision = before.header.revision.global;
+    // The header types every scope as present; a freshly created document has
+    // no `global` revision at all until its first operation lands.
+    const revisions: Record<string, number | undefined> =
+      before.header.revision;
+    const startRevision = revisions.global ?? 0;
 
     const actions: Action[] = [
       setName({ name: "Signed Batch Document" }),
@@ -155,6 +183,60 @@ describe("GraphQLReactorClient signed batches e2e", () => {
     // action's prevOpHash is the hash the previous operation resulted in.
     expect(pushed[1].context?.prevOpHash).toBe(storedBatch[0].hash);
     expect(pushed[2].context?.prevOpHash).toBe(storedBatch[1].hash);
+
+    // And the signatures the server stored hold up cryptographically. The
+    // Switchboard does not verify them itself - nothing in the monorepo wires
+    // `withSignatureVerifier` - so this runs the real Renown verifier over what
+    // came back, which is what proves the batch is signed CORRECTLY and not
+    // merely signed.
+    const verify = createSignatureVerifier(true);
+    for (const operation of storedBatch) {
+      const signer = operation.action.context?.signer;
+      expect(signer).toBeDefined();
+      await expect(verify(operation, signer!.app.key)).resolves.toBe(true);
+    }
+
+    // Guard against a vacuous check: one flipped byte and the same verifier
+    // must say no.
+    const [head] = storedBatch;
+    const headSigner = head.action.context!.signer!;
+    const [timestamp, did, actionHash, prevOpHash, signatureHex] =
+      headSigner.signatures[0];
+    const tampered = {
+      ...head,
+      action: {
+        ...head.action,
+        context: {
+          signer: {
+            ...headSigner,
+            signatures: [
+              [
+                timestamp,
+                did,
+                actionHash,
+                prevOpHash,
+                `${signatureHex.slice(0, -1)}${signatureHex.endsWith("0") ? "1" : "0"}`,
+              ] as Signature,
+            ],
+          },
+        },
+      },
+    };
+    await expect(verify(tampered, headSigner.app.key)).resolves.toBe(false);
+
+    // What each signature actually committed to: this action, at this point in
+    // the chain. Without correct sequential stamping the third signature would
+    // attest to the first action's state hash while sitting at revision+2.
+    for (const [offset, operation] of storedBatch.entries()) {
+      const [, , signedActionHash, signedPrevOpHash] =
+        operation.action.context!.signer!.signatures[0];
+      expect(signedActionHash).toBe(await hashAction(operation.action));
+      expect(signedPrevOpHash).toBe(
+        offset === 0
+          ? (pushed[0].context?.prevOpHash as string)
+          : storedBatch[offset - 1].hash,
+      );
+    }
 
     const after = await reactorClient.get<PHDocument>(documentId, {
       branch: "main",


### PR DESCRIPTION
## Summary

The GraphQL light client signed only a single action. With an ambient signer and a batch it warned and pushed the whole batch **unsigned**. It now signs every action of a same-scope batch and sends them in the one existing mutation — no schema, resolver, or executor change.

The light read path fetches state and per-scope revisions but **no operation history**, so the chain is predicted client-side: each action is stamped at a virtual revision, signed, then reduced with the document's own reducer to get the state the next signature hashes. The virtual revision is tracked separately because the reducer derives operation indices from the last stored operation, which counts from zero on a history-free snapshot.

## Changes

- `static-package-manager.ts` — new pure `resolveDocumentModelModule(modules, type, version?)`: exact match when a version is given, latest when not. `StaticPackageManager.load` delegates to it.
- `signing.ts` — new `prepareSignedActions`; `stampAction` takes an optional explicit revision, `signStampedAction` takes an `AbortSignal`.
- `graphql-reactor-client.ts` — new `documentModels` and `signer` options; the module is resolved with `normalizeDocumentModelVersion`, the same rule `SimpleJobExecutor` applies, so client and server cannot pick different reducers.
- `graphql-reactor-provider.tsx` — its existing `documentModels` prop now also reaches the client constructor.

A batch that cannot be predicted — no matching module version, mixed scopes, or an action needing history (`UNDO`/`REDO`/`PRUNE`/`NOOP`, document-scope actions) — fails before the mutation instead of downgrading to unsigned. Single actions still sign without any models, and unsigned pushes are unchanged.

