### PR TITLE
feat(reactor-api): add execute and executeAsync, deprecating the untyped pair

### DIFF
--- a/apps/switchboard-lb/test/integration/mixed-load.js
+++ b/apps/switchboard-lb/test/integration/mixed-load.js
@@ -49,8 +49,11 @@ const CREATE_DOCUMENT_MUTATION = `
 `;
 
 const MUTATE_DOCUMENT_MUTATION = `
-  mutation MutateDocument($documentIdentifier: String!, $actions: [JSONObject!]!) {
-    mutateDocument(documentIdentifier: $documentIdentifier, actions: $actions) {
+  mutation MutateDocument($documentIdentifier: String!, $actions: [ActionInput!]!) {
+    mutateDocument: execute(
+      documentIdentifier: $documentIdentifier
+      actions: $actions
+    ) {
       id
       revisionsList { scope revision }
     }

--- a/packages/reactor-api/src/graphql/reactor/adapters.ts
+++ b/packages/reactor-api/src/graphql/reactor/adapters.ts
@@ -8,6 +8,8 @@ import {
 import { camelCase } from "change-case";
 import type {
   Action,
+  ActionContext,
+  ActionSigner,
   DocumentModelModule,
   DocumentModelPHState,
   Operation,
@@ -20,6 +22,7 @@ import {
 import { GraphQLError } from "graphql";
 import { MalformedStoredOperationError } from "../errors.js";
 import {
+  type ActionInput,
   type ActionEvaluation as GqlActionEvaluation,
   AuthDecision as GqlAuthDecision,
   type DocumentModelResultPage,
@@ -251,6 +254,74 @@ function withDeserializedSignatures(action: Action): Action {
       },
     },
   };
+}
+
+/**
+ * Converts actions the schema has already coerced into the actions the reactor
+ * applies.
+ *
+ * The one conversion the schema cannot express is the signature: GraphQL
+ * declares `signatures` as a list of strings, not of lists, so each arrives
+ * joined and has to be read back as the tuple verification indexes into.
+ *
+ * Nothing is validated here. `ActionInput` states every field the reactor needs,
+ * so anything that reached this point has them - unlike the untyped path, which
+ * has to check by hand.
+ */
+export function toSubmittableActions(
+  actions: readonly ActionInput[],
+): Action[] {
+  return actions.map((action) => {
+    const context = toSubmittableContext(action.context);
+    const submittable: Action = {
+      id: action.id,
+      type: action.type,
+      timestampUtcMs: action.timestampUtcMs,
+      input: action.input,
+      scope: action.scope,
+    };
+    return context ? { ...submittable, context } : submittable;
+  });
+}
+
+/**
+ * `ReactorSignerInput` leaves `user` and `app` optional where `ActionSigner`
+ * requires them, so an incomplete signer cannot be represented. It is carried
+ * through as it arrived rather than filled in: the signature verifier is what
+ * should refuse it, and inventing either field here would be inventing the part
+ * that says who signed.
+ */
+function toSubmittableContext(
+  context: ActionInput["context"],
+): ActionContext | undefined {
+  if (!context) {
+    return undefined;
+  }
+
+  const submittable: ActionContext = {};
+  const prevOpIndex = fromInputMaybe(context.prevOpIndex);
+  if (prevOpIndex !== undefined) {
+    submittable.prevOpIndex = prevOpIndex;
+  }
+  const prevOpHash = fromInputMaybe(context.prevOpHash);
+  if (prevOpHash !== undefined) {
+    submittable.prevOpHash = prevOpHash;
+  }
+  const nonce = fromInputMaybe(context.nonce);
+  if (nonce !== undefined) {
+    submittable.nonce = nonce;
+  }
+
+  const signer = fromInputMaybe(context.signer);
+  if (signer) {
+    submittable.signer = {
+      user: fromInputMaybe(signer.user),
+      app: fromInputMaybe(signer.app),
+      signatures: signer.signatures.map(deserializeSignature),
+    } as ActionSigner;
+  }
+
+  return Object.keys(submittable).length > 0 ? submittable : undefined;
 }
 
 /**

--- a/packages/reactor-api/src/graphql/reactor/gen/graphql.ts
+++ b/packages/reactor-api/src/graphql/reactor/gen/graphql.ts
@@ -1045,8 +1045,8 @@ export type CreateEmptyDocumentMutation = {
 
 export type MutateDocumentMutationVariables = Exact<{
   documentIdentifier: Scalars["String"]["input"];
-  actions: ReadonlyArray<Scalars["JSONObject"]["input"]>;
-  view?: InputMaybe<ViewFilterInput>;
+  actions: ReadonlyArray<ActionInput>;
+  branch?: InputMaybe<Scalars["String"]["input"]>;
 }>;
 
 export type MutateDocumentMutation = {
@@ -1067,12 +1067,19 @@ export type MutateDocumentMutation = {
 
 export type MutateDocumentAsyncMutationVariables = Exact<{
   documentIdentifier: Scalars["String"]["input"];
-  actions: ReadonlyArray<Scalars["JSONObject"]["input"]>;
-  view?: InputMaybe<ViewFilterInput>;
+  actions: ReadonlyArray<ActionInput>;
+  branch?: InputMaybe<Scalars["String"]["input"]>;
 }>;
 
 export type MutateDocumentAsyncMutation = {
-  readonly mutateDocumentAsync: string;
+  readonly mutateDocumentAsync: {
+    readonly id: string;
+    readonly status: string;
+    readonly result?: NonNullable<unknown> | null | undefined;
+    readonly error?: string | null | undefined;
+    readonly createdAt: string | Date;
+    readonly completedAt?: string | Date | null | undefined;
+  };
 };
 
 export type RenameDocumentMutationVariables = Exact<{
@@ -2802,13 +2809,13 @@ export const CreateEmptyDocumentDocument = gql`
 export const MutateDocumentDocument = gql`
   mutation MutateDocument(
     $documentIdentifier: String!
-    $actions: [JSONObject!]!
-    $view: ViewFilterInput
+    $actions: [ActionInput!]!
+    $branch: String
   ) {
-    mutateDocument(
+    mutateDocument: execute(
       documentIdentifier: $documentIdentifier
       actions: $actions
-      view: $view
+      branch: $branch
     ) {
       ...PHDocumentFields
     }
@@ -2818,14 +2825,21 @@ export const MutateDocumentDocument = gql`
 export const MutateDocumentAsyncDocument = gql`
   mutation MutateDocumentAsync(
     $documentIdentifier: String!
-    $actions: [JSONObject!]!
-    $view: ViewFilterInput
+    $actions: [ActionInput!]!
+    $branch: String
   ) {
-    mutateDocumentAsync(
+    mutateDocumentAsync: executeAsync(
       documentIdentifier: $documentIdentifier
       actions: $actions
-      view: $view
-    )
+      branch: $branch
+    ) {
+      id
+      status
+      result
+      error
+      createdAt
+      completedAt
+    }
   }
 `;
 export const RenameDocumentDocument = gql`

--- a/packages/reactor-api/src/graphql/reactor/gen/graphql.ts
+++ b/packages/reactor-api/src/graphql/reactor/gen/graphql.ts
@@ -234,8 +234,32 @@ export type Mutation = {
   readonly createEmptyDocument: PhDocument;
   readonly deleteDocument: Scalars["Boolean"]["output"];
   readonly deleteDocuments: Scalars["Boolean"]["output"];
+  /**
+   * Applies actions to a document and waits for the result.
+   *
+   * Each action is coerced against `ActionInput`, so one missing a field the wire
+   * declares is refused before any work starts. The id in particular: it is hashed
+   * into the operation id and replay dedupes by it, so an action without one is
+   * stored under an operation id shared by every id-less operation on the same
+   * document, scope and branch.
+   *
+   * Named for `IReactorClient.execute`, which this is the wire form of. `branch`
+   * defaults to `main`.
+   */
+  readonly execute: PhDocument;
+  /**
+   * Submits actions to a document and returns the job that will apply them.
+   *
+   * Coerced exactly as `execute` is, so a malformed action is refused here rather
+   * than surfacing later as a failed job. Returns the job rather than only its id,
+   * so a caller has the status and the creation time it would otherwise have to
+   * ask for; `result` is null until the job produces one.
+   */
+  readonly executeAsync: JobInfo;
   readonly moveRelationship: MoveRelationshipResult;
+  /** @deprecated Use execute. Actions here are untyped, so a malformed one is refused by a hand-written check rather than by the schema, and `view.scopes` is accepted but ignored. */
   readonly mutateDocument: PhDocument;
+  /** @deprecated Use executeAsync, which is typed and returns the job rather than only its id. */
   readonly mutateDocumentAsync: Scalars["String"]["output"];
   readonly pushSyncEnvelopes: Scalars["Boolean"]["output"];
   readonly removeRelationship: PhDocument;
@@ -269,6 +293,18 @@ export type MutationDeleteDocumentArgs = {
 export type MutationDeleteDocumentsArgs = {
   identifiers: ReadonlyArray<Scalars["String"]["input"]>;
   propagate?: InputMaybe<PropagationMode>;
+};
+
+export type MutationExecuteArgs = {
+  actions: ReadonlyArray<ActionInput>;
+  branch?: InputMaybe<Scalars["String"]["input"]>;
+  documentIdentifier: Scalars["String"]["input"];
+};
+
+export type MutationExecuteAsyncArgs = {
+  actions: ReadonlyArray<ActionInput>;
+  branch?: InputMaybe<Scalars["String"]["input"]>;
+  documentIdentifier: Scalars["String"]["input"];
 };
 
 export type MutationMoveRelationshipArgs = {
@@ -1827,6 +1863,18 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationDeleteDocumentsArgs, "identifiers">
+  >;
+  execute?: Resolver<
+    ResolversTypes["PHDocument"],
+    ParentType,
+    ContextType,
+    RequireFields<MutationExecuteArgs, "actions" | "documentIdentifier">
+  >;
+  executeAsync?: Resolver<
+    ResolversTypes["JobInfo"],
+    ParentType,
+    ContextType,
+    RequireFields<MutationExecuteAsyncArgs, "actions" | "documentIdentifier">
   >;
   moveRelationship?: Resolver<
     ResolversTypes["MoveRelationshipResult"],

--- a/packages/reactor-api/src/graphql/reactor/gen/graphql.ts
+++ b/packages/reactor-api/src/graphql/reactor/gen/graphql.ts
@@ -215,7 +215,11 @@ export type JobInfo = {
   readonly createdAt: Scalars["DateTime"]["output"];
   readonly error?: Maybe<Scalars["String"]["output"]>;
   readonly id: Scalars["String"]["output"];
-  readonly result: Scalars["JSONObject"]["output"];
+  /**
+   * What the job produced, once it has produced anything. Null until then, which
+   * is the state every job is in when it is handed back from a submission.
+   */
+  readonly result?: Maybe<Scalars["JSONObject"]["output"]>;
   readonly status: Scalars["String"]["output"];
 };
 
@@ -933,7 +937,7 @@ export type GetJobStatusQuery = {
     | {
         readonly id: string;
         readonly status: string;
-        readonly result: NonNullable<unknown>;
+        readonly result?: NonNullable<unknown> | null | undefined;
         readonly error?: string | null | undefined;
         readonly createdAt: string | Date;
         readonly completedAt?: string | Date | null | undefined;
@@ -1769,7 +1773,11 @@ export type JobInfoResolvers<
   createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
-  result?: Resolver<ResolversTypes["JSONObject"], ParentType, ContextType>;
+  result?: Resolver<
+    Maybe<ResolversTypes["JSONObject"]>,
+    ParentType,
+    ContextType
+  >;
   status?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
 }>;
 

--- a/packages/reactor-api/src/graphql/reactor/operations.graphql
+++ b/packages/reactor-api/src/graphql/reactor/operations.graphql
@@ -244,13 +244,13 @@ mutation CreateEmptyDocument(
 
 mutation MutateDocument(
   $documentIdentifier: String!
-  $actions: [JSONObject!]!
-  $view: ViewFilterInput
+  $actions: [ActionInput!]!
+  $branch: String
 ) {
-  mutateDocument(
+  mutateDocument: execute(
     documentIdentifier: $documentIdentifier
     actions: $actions
-    view: $view
+    branch: $branch
   ) {
     ...PHDocumentFields
   }
@@ -258,14 +258,21 @@ mutation MutateDocument(
 
 mutation MutateDocumentAsync(
   $documentIdentifier: String!
-  $actions: [JSONObject!]!
-  $view: ViewFilterInput
+  $actions: [ActionInput!]!
+  $branch: String
 ) {
-  mutateDocumentAsync(
+  mutateDocumentAsync: executeAsync(
     documentIdentifier: $documentIdentifier
     actions: $actions
-    view: $view
-  )
+    branch: $branch
+  ) {
+    id
+    status
+    result
+    error
+    createdAt
+    completedAt
+  }
 }
 
 mutation RenameDocument(

--- a/packages/reactor-api/src/graphql/reactor/resolvers.ts
+++ b/packages/reactor-api/src/graphql/reactor/resolvers.ts
@@ -61,6 +61,7 @@ import {
   toGqlActionEvaluation,
   toDocumentModelResultPage,
   toGqlJobInfo,
+  toSubmittableActions,
   toGqlPhDocument,
   toMutableArray,
   toOperationResultPage,
@@ -70,6 +71,7 @@ import {
 } from "./adapters.js";
 import type {
   ActionEvaluations as GqlActionEvaluations,
+  ActionInput,
   DocumentModelResultPage,
   JobInfo as GqlJobInfo,
   PropagationMode as GqlPropagationMode,
@@ -730,6 +732,84 @@ export async function createDocumentWithInitialState(
       `Failed to convert created document to GraphQL: ${error instanceof Error ? error.message : "Unknown error"}`,
     );
   }
+}
+
+/** The branch a mutation applies to when the caller names none. */
+const DEFAULT_BRANCH = "main";
+
+/**
+ * Applies actions to a document and waits for the result.
+ *
+ * The wire form of `IReactorClient.execute`, and named for it. Takes the actions
+ * already coerced against `ActionInput`, so the only conversion left is the one
+ * the schema cannot express: a signature travels as one string, and verification
+ * reads it as the tuple it was.
+ */
+export async function execute(
+  reactorClient: IReactorClient,
+  args: {
+    documentIdentifier: string;
+    actions: readonly ActionInput[];
+    branch?: string | null;
+  },
+): Promise<ReturnType<typeof toGqlPhDocument>> {
+  const actions = toSubmittableActions(args.actions);
+  const branch = fromInputMaybe(args.branch) ?? DEFAULT_BRANCH;
+
+  let result: PHDocument;
+  try {
+    result = await reactorClient.execute(
+      args.documentIdentifier,
+      branch,
+      actions,
+    );
+  } catch (error) {
+    throw new GraphQLError(
+      `Failed to execute actions: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+
+  try {
+    return toGqlPhDocument(result);
+  } catch (error) {
+    throw new GraphQLError(
+      `Failed to convert executed document to GraphQL: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+}
+
+/**
+ * Submits actions to a document and returns the job that will apply them.
+ *
+ * Returns the job rather than only its id, matching
+ * `IReactorClient.executeAsync`. A job handed back from a submission has no
+ * result yet, which is why `JobInfo.result` is nullable.
+ */
+export async function executeAsync(
+  reactorClient: IReactorClient,
+  args: {
+    documentIdentifier: string;
+    actions: readonly ActionInput[];
+    branch?: string | null;
+  },
+): Promise<GqlJobInfo> {
+  const actions = toSubmittableActions(args.actions);
+  const branch = fromInputMaybe(args.branch) ?? DEFAULT_BRANCH;
+
+  let job: JobInfo;
+  try {
+    job = await reactorClient.executeAsync(
+      args.documentIdentifier,
+      branch,
+      actions,
+    );
+  } catch (error) {
+    throw new GraphQLError(
+      `Failed to submit actions: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+
+  return toGqlJobInfo(job);
 }
 
 export async function mutateDocument(

--- a/packages/reactor-api/src/graphql/reactor/schema.graphql
+++ b/packages/reactor-api/src/graphql/reactor/schema.graphql
@@ -144,7 +144,13 @@ type MoveRelationshipResult {
 type JobInfo {
   id: String!
   status: String!
-  result: JSONObject!
+
+  """
+  What the job produced, once it has produced anything. Null until then, which
+  is the state every job is in when it is handed back from a submission.
+  """
+  result: JSONObject
+
   error: String
   createdAt: DateTime!
   completedAt: DateTime

--- a/packages/reactor-api/src/graphql/reactor/schema.graphql
+++ b/packages/reactor-api/src/graphql/reactor/schema.graphql
@@ -514,12 +514,47 @@ type Mutation {
     parentIdentifier: String
   ): PHDocument!
 
+  """
+  Applies actions to a document and waits for the result.
+
+  Each action is coerced against `ActionInput`, so one missing a field the wire
+  declares is refused before any work starts. The id in particular: it is hashed
+  into the operation id and replay dedupes by it, so an action without one is
+  stored under an operation id shared by every id-less operation on the same
+  document, scope and branch.
+
+  Named for `IReactorClient.execute`, which this is the wire form of. `branch`
+  defaults to `main`.
+  """
+  execute(
+    documentIdentifier: String!
+    actions: [ActionInput!]!
+    branch: String
+  ): PHDocument!
+
+  """
+  Submits actions to a document and returns the job that will apply them.
+
+  Coerced exactly as `execute` is, so a malformed action is refused here rather
+  than surfacing later as a failed job. Returns the job rather than only its id,
+  so a caller has the status and the creation time it would otherwise have to
+  ask for; `result` is null until the job produces one.
+  """
+  executeAsync(
+    documentIdentifier: String!
+    actions: [ActionInput!]!
+    branch: String
+  ): JobInfo!
+
   # Apply actions to a document (synchronous)
   mutateDocument(
     documentIdentifier: String!
     actions: [JSONObject!]!
     view: ViewFilterInput
   ): PHDocument!
+    @deprecated(
+      reason: "Use execute. Actions here are untyped, so a malformed one is refused by a hand-written check rather than by the schema, and `view.scopes` is accepted but ignored."
+    )
 
   # Submit actions to a document (asynchronous)
   mutateDocumentAsync(
@@ -527,6 +562,9 @@ type Mutation {
     actions: [JSONObject!]!
     view: ViewFilterInput
   ): String!
+    @deprecated(
+      reason: "Use executeAsync, which is typed and returns the job rather than only its id."
+    )
 
   # Rename a document
   renameDocument(

--- a/packages/reactor-api/src/graphql/reactor/subgraph.ts
+++ b/packages/reactor-api/src/graphql/reactor/subgraph.ts
@@ -566,6 +566,49 @@ export class ReactorSubgraph extends BaseSubgraph {
         }
       },
 
+      execute: async (_parent, args, ctx: Context) => {
+        this.logger.debug("execute(@args)", args);
+        try {
+          // canMutate combines the write + operation checks per action.
+          const handle = await this.assertCanExecuteOperations(
+            args.documentIdentifier,
+            args.actions,
+            ctx,
+          );
+
+          return await resolvers.execute(this.reactorClient, {
+            ...args,
+            documentIdentifier: handle.fetchIdentifier,
+          });
+        } catch (error) {
+          this.logger.error("Error in execute(@args): @Error", args, error);
+          throw error;
+        }
+      },
+
+      executeAsync: async (_parent, args, ctx: Context) => {
+        this.logger.debug("executeAsync(@args)", args);
+        try {
+          const handle = await this.assertCanExecuteOperations(
+            args.documentIdentifier,
+            args.actions,
+            ctx,
+          );
+
+          return await resolvers.executeAsync(this.reactorClient, {
+            ...args,
+            documentIdentifier: handle.fetchIdentifier,
+          });
+        } catch (error) {
+          this.logger.error(
+            "Error in executeAsync(@args): @Error",
+            args,
+            error,
+          );
+          throw error;
+        }
+      },
+
       mutateDocument: async (_parent, args, ctx: Context) => {
         this.logger.debug("mutateDocument(@args)", args);
         try {

--- a/packages/reactor-api/test/execute-resolvers.test.ts
+++ b/packages/reactor-api/test/execute-resolvers.test.ts
@@ -1,0 +1,243 @@
+import type { IReactorClient, JobInfo } from "@powerhousedao/reactor";
+import type { Action, PHDocument } from "@powerhousedao/shared/document-model";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { GraphQLObjectType } from "graphql";
+import { buildSchema, parse, validate } from "graphql";
+import { describe, expect, it, vi } from "vitest";
+import { execute, executeAsync } from "../src/graphql/reactor/resolvers.js";
+import type { ActionInput } from "../src/graphql/reactor/gen/graphql.js";
+
+const SDL = readFileSync(
+  join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../src/graphql/reactor/schema.graphql",
+  ),
+  "utf8",
+);
+
+const action: ActionInput = {
+  id: "act-1",
+  type: "SET_NAME",
+  timestampUtcMs: "2026-01-01T00:00:00.000Z",
+  input: { name: "x" },
+  scope: "global",
+};
+
+const document = {
+  header: {
+    id: "doc-1",
+    name: "doc",
+    documentType: "powerhouse/document-model",
+    slug: "",
+    revision: { global: 1 },
+    createdAtUtcIso: "2026-01-01T00:00:00.000Z",
+    lastModifiedAtUtcIso: "2026-01-01T00:00:00.000Z",
+  },
+  state: { global: {} },
+} as unknown as PHDocument;
+
+const job: JobInfo = {
+  id: "job-1",
+  status: "PENDING",
+  createdAtUtcIso: "2026-01-01T00:00:00.000Z",
+} as unknown as JobInfo;
+
+/** Captures what the client was asked to do. */
+function recordingClient() {
+  const executeSpy = vi.fn().mockResolvedValue(document);
+  const executeAsyncSpy = vi.fn().mockResolvedValue(job);
+  return {
+    client: {
+      execute: executeSpy,
+      executeAsync: executeAsyncSpy,
+    } as unknown as IReactorClient,
+    executeSpy,
+    executeAsyncSpy,
+  };
+}
+
+const argsOf = (spy: ReturnType<typeof vi.fn>) =>
+  spy.mock.calls[0] as [string, string, Action[]];
+
+describe("execute", () => {
+  it("applies the actions to the document it names", async () => {
+    const { client, executeSpy } = recordingClient();
+
+    const result = await execute(client, {
+      documentIdentifier: "doc-1",
+      actions: [action],
+      branch: "feature",
+    });
+
+    const [identifier, branch, actions] = argsOf(executeSpy);
+    expect(identifier).toBe("doc-1");
+    expect(branch).toBe("feature");
+    expect(actions).toHaveLength(1);
+    expect(actions[0].id).toBe("act-1");
+    expect(result.id).toBe("doc-1");
+  });
+
+  it("applies to main when no branch is named", async () => {
+    const { client, executeSpy } = recordingClient();
+
+    await execute(client, { documentIdentifier: "doc-1", actions: [action] });
+
+    expect(argsOf(executeSpy)[1]).toBe("main");
+  });
+
+  it("treats a null branch as none given", async () => {
+    const { client, executeSpy } = recordingClient();
+
+    await execute(client, {
+      documentIdentifier: "doc-1",
+      actions: [action],
+      branch: null,
+    });
+
+    expect(argsOf(executeSpy)[1]).toBe("main");
+  });
+
+  it("reads a signature back as the tuple verification indexes into", async () => {
+    // The wire carries a signature joined into one string, because GraphQL
+    // declares signatures as a list of strings rather than of lists.
+    const { client, executeSpy } = recordingClient();
+
+    await execute(client, {
+      documentIdentifier: "doc-1",
+      actions: [
+        {
+          ...action,
+          context: {
+            prevOpHash: "deadbeef",
+            prevOpIndex: 3,
+            signer: {
+              user: { address: "0x1", networkId: "eip155", chainId: 1 },
+              app: { name: "Connect", key: "did:key:z6Mk" },
+              signatures: ["ts, key, hash, prev, 0xsig"],
+            },
+          },
+        },
+      ],
+    });
+
+    const submitted = argsOf(executeSpy)[2][0];
+    expect(submitted.context?.signer?.signatures).toEqual([
+      ["ts", "key", "hash", "prev", "0xsig"],
+    ]);
+    expect(submitted.context?.prevOpHash).toBe("deadbeef");
+    expect(submitted.context?.prevOpIndex).toBe(3);
+  });
+
+  it("carries no context for an action that arrived without one", async () => {
+    const { client, executeSpy } = recordingClient();
+
+    await execute(client, { documentIdentifier: "doc-1", actions: [action] });
+
+    expect(argsOf(executeSpy)[2][0]).not.toHaveProperty("context");
+  });
+
+  it("reports a refusal from the reactor as an error", async () => {
+    const client = {
+      execute: vi.fn().mockRejectedValue(new Error("locked by permissions")),
+    } as unknown as IReactorClient;
+
+    await expect(
+      execute(client, { documentIdentifier: "doc-1", actions: [action] }),
+    ).rejects.toThrow("locked by permissions");
+  });
+});
+
+describe("executeAsync", () => {
+  it("returns the job rather than only its id", async () => {
+    const { client, executeAsyncSpy } = recordingClient();
+
+    const submitted = await executeAsync(client, {
+      documentIdentifier: "doc-1",
+      actions: [action],
+    });
+
+    expect(submitted.id).toBe("job-1");
+    expect(submitted.status).toBe("PENDING");
+    // A job is never more resultless than at the moment it is handed back.
+    expect(submitted.result).toBeNull();
+    expect(argsOf(executeAsyncSpy)[1]).toBe("main");
+  });
+});
+
+describe("the mutation surface", () => {
+  const mutation = buildSchema(SDL).getType("Mutation") as GraphQLObjectType;
+
+  it("offers execute and executeAsync", () => {
+    const fields = mutation.getFields();
+    expect(fields.execute).toBeDefined();
+    expect(fields.executeAsync).toBeDefined();
+  });
+
+  it("says execute takes a branch, not a view", () => {
+    // The view's scopes were accepted and ignored on the old field.
+    const args = mutation.getFields().execute.args.map((arg) => arg.name);
+    expect(args).toEqual(["documentIdentifier", "actions", "branch"]);
+  });
+
+  it("points the deprecated fields at their replacements", () => {
+    const fields = mutation.getFields();
+    expect(fields.mutateDocument.deprecationReason).toContain("execute");
+    expect(fields.mutateDocumentAsync.deprecationReason).toContain(
+      "executeAsync",
+    );
+  });
+
+  it("keeps the untyped fields callable", () => {
+    // Deprecation is advisory: a client that has not migrated still works.
+    const fields = mutation.getFields();
+    expect(fields.mutateDocument).toBeDefined();
+    expect(fields.mutateDocumentAsync).toBeDefined();
+  });
+});
+
+describe("what each field will accept", () => {
+  const schema = buildSchema(SDL);
+
+  /** The validation errors a query earns against the real schema. */
+  const errorsFor = (query: string) =>
+    validate(schema, parse(query)).map((error) => error.message);
+
+  const call = (field: string, variableType: string) => `
+    mutation Send($actions: ${variableType}) {
+      ${field}(documentIdentifier: "doc-1", actions: $actions) { id }
+    }
+  `;
+
+  it("lets execute take typed actions", () => {
+    expect(errorsFor(call("execute", "[ActionInput!]!"))).toEqual([]);
+  });
+
+  it("refuses untyped actions on execute", () => {
+    // This is what makes execute a new field rather than a changed one: a
+    // client declaring the old variable type is rejected in validation, whatever
+    // its payload looks like, so the old field has to stay for it.
+    const errors = errorsFor(call("execute", "[JSONObject!]!"));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("[JSONObject!]!");
+    expect(errors[0]).toContain("[ActionInput!]!");
+  });
+
+  it("still lets the deprecated field take untyped actions", () => {
+    expect(errorsFor(call("mutateDocument", "[JSONObject!]!"))).toEqual([]);
+  });
+
+  it("refuses an action with no id given inline to execute", () => {
+    const errors = errorsFor(`
+      mutation Send {
+        execute(
+          documentIdentifier: "doc-1"
+          actions: [{ type: "SET_NAME", scope: "global", input: {}, timestampUtcMs: "t" }]
+        ) { id }
+      }
+    `);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("id");
+  });
+});

--- a/packages/reactor-api/test/job-info-result.schema.test.ts
+++ b/packages/reactor-api/test/job-info-result.schema.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildSchema, graphql } from "graphql";
+import { describe, expect, it } from "vitest";
+import { jobStatus } from "../src/graphql/reactor/resolvers.js";
+import type { IReactorClient } from "@powerhousedao/reactor";
+
+// Executed against the real SDL: what this covers is the schema's own
+// nullability, which a resolver called directly cannot exercise.
+const SDL = readFileSync(
+  join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../src/graphql/reactor/schema.graphql",
+  ),
+  "utf8",
+);
+
+const QUERY = `
+  query Status($jobId: String!) {
+    jobStatus(jobId: $jobId) {
+      id
+      status
+      result
+      error
+      createdAt
+      completedAt
+    }
+  }
+`;
+
+/** A job as the tracker holds one that has not produced anything yet. */
+const pendingJob = {
+  id: "job-1",
+  documentId: "doc-1",
+  status: "PENDING",
+  createdAtUtcIso: "2026-01-01T00:00:00.000Z",
+};
+
+function clientReturning(job: unknown): IReactorClient {
+  return {
+    getJobStatus: () => Promise.resolve(job),
+  } as unknown as IReactorClient;
+}
+
+const ask = (job: unknown) =>
+  graphql({
+    schema: buildSchema(SDL),
+    source: QUERY,
+    variableValues: { jobId: "job-1" },
+    rootValue: {
+      jobStatus: (args: { jobId: string }) =>
+        jobStatus(clientReturning(job), args),
+    },
+  });
+
+describe("asking for a job that has not finished", () => {
+  it("answers, rather than failing on a field it has no value for", async () => {
+    // A job carries no result until it produces one, so a non-null `result`
+    // made every pending job unserveable - the same shape of failure as an
+    // operation the schema cannot represent, one query over.
+    const result = await ask(pendingJob);
+
+    expect(result.errors).toBeUndefined();
+    const data = result.data as {
+      jobStatus: { status: string; result: unknown };
+    };
+    expect(data.jobStatus.status).toBe("PENDING");
+    expect(data.jobStatus.result).toBeNull();
+  });
+
+  it("still carries a result once there is one", async () => {
+    const result = await ask({
+      ...pendingJob,
+      status: "READ_READY",
+      result: { revision: 3 },
+      completedAtUtcIso: "2026-01-01T00:00:01.000Z",
+    });
+
+    expect(result.errors).toBeUndefined();
+    const data = result.data as { jobStatus: { result: unknown } };
+    expect(data.jobStatus.result).toEqual({ revision: 3 });
+  });
+});

--- a/packages/reactor-browser/src/graphql-client/graphql-reactor-client.ts
+++ b/packages/reactor-browser/src/graphql-client/graphql-reactor-client.ts
@@ -318,7 +318,6 @@ export class GraphQLReactorClient implements IReactorBrowserClient {
       // Projected onto the fields the schema declares, so a stamped or signed
       // action does not carry a field the input rejects the whole request for.
       actions: preparedActions.map(toTransportAction),
-      view: { branch },
       sinceRevision: sinceRevisionForActions(document, actions),
       scopes: scopesForActions(actions),
       branch,

--- a/packages/reactor-browser/src/graphql-client/operations.ts
+++ b/packages/reactor-browser/src/graphql-client/operations.ts
@@ -1,9 +1,9 @@
 import { gql } from "graphql-tag";
 import {
   PhDocumentFieldsFragmentDoc,
+  type ActionInput,
   type PhDocumentFieldsFragment,
   type Scalars,
-  type ViewFilterInput,
 } from "../graphql/gen/schema.js";
 import type { RemoteOperation } from "../remote-controller/types.js";
 
@@ -59,23 +59,24 @@ export const ReactorOperationFieldsFragmentDoc = gql`
  * - `scopes` limits the response to the scopes the pushed actions target,
  *   without it the server walks every scope of the document
  *   (`packages/reactor/src/core/reactor.ts` `getOperations`);
- * - `branch` must match the branch the mutation writes to, otherwise the
- *   operations come from `main` (the server's default) while the actions were
- *   applied elsewhere.
+ * - `branch` selects the branch the operations are read from, and is the same
+ *   variable the mutation writes to. It used to be two - the write went through
+ *   a `view`, the filter took its own `branch` - and they had to be kept equal
+ *   by hand or the operations came from `main` while the actions were applied
+ *   elsewhere. One variable cannot disagree with itself.
  */
 export const MutateDocumentWithOperationsDocument = gql`
   mutation MutateDocumentWithOperations(
     $documentIdentifier: String!
-    $actions: [JSONObject!]!
-    $view: ViewFilterInput
+    $actions: [ActionInput!]!
     $sinceRevision: Int
     $scopes: [String!]
     $branch: String
   ) {
-    mutateDocument(
+    mutateDocument: execute(
       documentIdentifier: $documentIdentifier
       actions: $actions
-      view: $view
+      branch: $branch
     ) {
       ...PHDocumentFields
       operations(
@@ -97,8 +98,7 @@ export const MutateDocumentWithOperationsDocument = gql`
 
 export type MutateDocumentWithOperationsVariables = {
   documentIdentifier: Scalars["String"]["input"];
-  actions: ReadonlyArray<Scalars["JSONObject"]["input"]>;
-  view?: ViewFilterInput;
+  actions: ReadonlyArray<ActionInput>;
   sinceRevision?: Scalars["Int"]["input"];
   scopes?: ReadonlyArray<Scalars["String"]["input"]>;
   branch?: Scalars["String"]["input"];

--- a/packages/reactor-browser/src/graphql/gen/schema.ts
+++ b/packages/reactor-browser/src/graphql/gen/schema.ts
@@ -41,12 +41,69 @@ export type Action = {
   readonly type: Scalars["String"]["output"];
 };
 
+/**
+ * One operation an authorization preflight predicts a verdict for.
+ *
+ * `input` is what a conditional grant reads, so a candidate standing for a
+ * filled-in form carries that form's input. Omitting it predicts the verdict an
+ * empty input earns, not the verdict the filled-in form will get.
+ */
+export type ActionCandidateInput = {
+  readonly input?: InputMaybe<Scalars["JSONObject"]["input"]>;
+  readonly scope: Scalars["String"]["input"];
+  readonly type: Scalars["String"]["input"];
+};
+
 export type ActionContext = {
   readonly signer?: Maybe<ReactorSigner>;
 };
 
+/**
+ * An action's context, as a caller submits it.
+ *
+ * Declares every field `ActionContext` carries, because an input object rejects a
+ * field it does not declare: an action stamped with the head it applies to - which
+ * is what a signing client sends - is refused outright if these are missing, and
+ * that refusal is a whole-request one, not a per-field one.
+ *
+ * `prevOpHash` and `prevOpIndex` are the scope head the action was composed
+ * against. They are recorded rather than enforced; a signature is verified from
+ * the params carried in its own tuple, which do not include them.
+ */
 export type ActionContextInput = {
+  /** Covers replay of an operation that would otherwise be a no-op. */
+  readonly nonce?: InputMaybe<Scalars["String"]["input"]>;
+  /** The hash of the state the action applies to. */
+  readonly prevOpHash?: InputMaybe<Scalars["String"]["input"]>;
+  /** The index of the last operation in the scope the action applies to. */
+  readonly prevOpIndex?: InputMaybe<Scalars["Int"]["input"]>;
   readonly signer?: InputMaybe<ReactorSignerInput>;
+};
+
+/**
+ * One candidate's predicted verdict. `reason` carries the refusal a DENY is
+ * recorded with, and is null on an ALLOW.
+ */
+export type ActionEvaluation = {
+  readonly decision: AuthDecision;
+  readonly reason?: Maybe<Scalars["String"]["output"]>;
+};
+
+/**
+ * The predicted verdicts for a set of candidates, in the order they were given,
+ * with the aggregates a caller branches on.
+ *
+ * The aggregates are redundant -- a verdict is binary -- and all four are returned
+ * so a caller reads the one its question is phrased in rather than negating
+ * another. Over no candidates every aggregate is false: nothing is allowed and
+ * nothing is denied.
+ */
+export type ActionEvaluations = {
+  readonly allAllowed: Scalars["Boolean"]["output"];
+  readonly allDenied: Scalars["Boolean"]["output"];
+  readonly anyAllowed: Scalars["Boolean"]["output"];
+  readonly anyDenied: Scalars["Boolean"]["output"];
+  readonly evaluations: ReadonlyArray<ActionEvaluation>;
 };
 
 export type ActionInput = {
@@ -57,6 +114,11 @@ export type ActionInput = {
   readonly timestampUtcMs: Scalars["String"]["input"];
   readonly type: Scalars["String"]["input"];
 };
+
+export enum AuthDecision {
+  Allow = "ALLOW",
+  Deny = "DENY",
+}
 
 export type ChannelMeta = {
   readonly id: Scalars["String"]["output"];
@@ -144,7 +206,11 @@ export type JobInfo = {
   readonly createdAt: Scalars["DateTime"]["output"];
   readonly error?: Maybe<Scalars["String"]["output"]>;
   readonly id: Scalars["String"]["output"];
-  readonly result: Scalars["JSONObject"]["output"];
+  /**
+   * What the job produced, once it has produced anything. Null until then, which
+   * is the state every job is in when it is handed back from a submission.
+   */
+  readonly result?: Maybe<Scalars["JSONObject"]["output"]>;
   readonly status: Scalars["String"]["output"];
 };
 
@@ -159,8 +225,32 @@ export type Mutation = {
   readonly createEmptyDocument: PhDocument;
   readonly deleteDocument: Scalars["Boolean"]["output"];
   readonly deleteDocuments: Scalars["Boolean"]["output"];
+  /**
+   * Applies actions to a document and waits for the result.
+   *
+   * Each action is coerced against `ActionInput`, so one missing a field the wire
+   * declares is refused before any work starts. The id in particular: it is hashed
+   * into the operation id and replay dedupes by it, so an action without one is
+   * stored under an operation id shared by every id-less operation on the same
+   * document, scope and branch.
+   *
+   * Named for `IReactorClient.execute`, which this is the wire form of. `branch`
+   * defaults to `main`.
+   */
+  readonly execute: PhDocument;
+  /**
+   * Submits actions to a document and returns the job that will apply them.
+   *
+   * Coerced exactly as `execute` is, so a malformed action is refused here rather
+   * than surfacing later as a failed job. Returns the job rather than only its id,
+   * so a caller has the status and the creation time it would otherwise have to
+   * ask for; `result` is null until the job produces one.
+   */
+  readonly executeAsync: JobInfo;
   readonly moveRelationship: MoveRelationshipResult;
+  /** @deprecated Use execute. Actions here are untyped, so a malformed one is refused by a hand-written check rather than by the schema, and `view.scopes` is accepted but ignored. */
   readonly mutateDocument: PhDocument;
+  /** @deprecated Use executeAsync, which is typed and returns the job rather than only its id. */
   readonly mutateDocumentAsync: Scalars["String"]["output"];
   readonly pushSyncEnvelopes: Scalars["Boolean"]["output"];
   readonly removeRelationship: PhDocument;
@@ -194,6 +284,18 @@ export type MutationDeleteDocumentArgs = {
 export type MutationDeleteDocumentsArgs = {
   identifiers: ReadonlyArray<Scalars["String"]["input"]>;
   propagate?: InputMaybe<PropagationMode>;
+};
+
+export type MutationExecuteArgs = {
+  actions: ReadonlyArray<ActionInput>;
+  branch?: InputMaybe<Scalars["String"]["input"]>;
+  documentIdentifier: Scalars["String"]["input"];
+};
+
+export type MutationExecuteAsyncArgs = {
+  actions: ReadonlyArray<ActionInput>;
+  branch?: InputMaybe<Scalars["String"]["input"]>;
+  documentIdentifier: Scalars["String"]["input"];
 };
 
 export type MutationMoveRelationshipArgs = {
@@ -340,8 +442,47 @@ export type Query = {
   readonly documentModels: DocumentModelResultPage;
   readonly documentOperations: ReactorOperationResultPage;
   readonly documentOutgoingRelationships: PhDocumentResultPage;
+  /**
+   * Predicts whether the calling subject would be admitted to execute each of a
+   * set of candidate operations, without submitting any of them. A UI asks this to
+   * disable a control rather than offer an action that fails on submit.
+   *
+   * The answer is a prediction, not a promise:
+   *
+   * - Real admission compiles an append condition over everything it read and the
+   *   store enforces it at write time. A preflight reads no future, so a policy
+   *   change landing between this answer and the submit changes the verdict. The
+   *   submit path stays the only authority.
+   * - The verdict is evaluated at the stream heads, so it is correct for a
+   *   candidate about to be submitted. A backdated submission is out of contract;
+   *   the reactor decides that one by position.
+   * - A candidate whose verdict depends on its input has to carry that input, since
+   *   a conditional grant reads it.
+   *
+   * The subject is the authenticated caller and cannot be named in the request:
+   * answering for an arbitrary subject would disclose what a policy grants
+   * somebody else. It carries both the caller's address and the did:key of the app
+   * instance whose token authenticated the request, so a policy naming either
+   * matches the same principal the write path presents.
+   *
+   * Requires the reactor's authEnforcement feature flag. Without it the reactor
+   * holds no decision model, so this fails with extensions.code
+   * AUTH_EVALUATION_UNSUPPORTED rather than guessing.
+   */
+  readonly evaluateActions: ActionEvaluations;
   readonly findDocuments: PhDocumentResultPage;
   readonly jobStatus?: Maybe<JobInfo>;
+  /**
+   * Polls for sync envelopes from a channel.
+   *
+   * An operation stored before the API required an action id cannot be
+   * represented by this schema, and rather than serving a partial response beside
+   * a bare non-null violation, this fails with extensions.code
+   * MALFORMED_STORED_OPERATION naming the operation. That code means the failure
+   * is worth polling through: the document holding the operation needs repairing,
+   * but the channel serves every other document, and a peer that stopped polling
+   * would stop receiving those too.
+   */
   readonly pollSyncEnvelopes: PollSyncEnvelopesResult;
 };
 
@@ -372,6 +513,12 @@ export type QueryDocumentOutgoingRelationshipsArgs = {
   relationshipType: Scalars["String"]["input"];
   sourceIdentifier: Scalars["String"]["input"];
   view?: InputMaybe<ViewFilterInput>;
+};
+
+export type QueryEvaluateActionsArgs = {
+  branch?: InputMaybe<Scalars["String"]["input"]>;
+  candidates: ReadonlyArray<ActionCandidateInput>;
+  documentIdentifier: Scalars["String"]["input"];
 };
 
 export type QueryFindDocumentsArgs = {
@@ -817,13 +964,32 @@ export type GetJobStatusQuery = {
     | {
         readonly id: string;
         readonly status: string;
-        readonly result: NonNullable<unknown>;
+        readonly result?: NonNullable<unknown> | null | undefined;
         readonly error?: string | null | undefined;
         readonly createdAt: string | Date;
         readonly completedAt?: string | Date | null | undefined;
       }
     | null
     | undefined;
+};
+
+export type EvaluateActionsQueryVariables = Exact<{
+  documentIdentifier: Scalars["String"]["input"];
+  branch?: InputMaybe<Scalars["String"]["input"]>;
+  candidates: ReadonlyArray<ActionCandidateInput>;
+}>;
+
+export type EvaluateActionsQuery = {
+  readonly evaluateActions: {
+    readonly allAllowed: boolean;
+    readonly anyAllowed: boolean;
+    readonly allDenied: boolean;
+    readonly anyDenied: boolean;
+    readonly evaluations: ReadonlyArray<{
+      readonly decision: AuthDecision;
+      readonly reason?: string | null | undefined;
+    }>;
+  };
 };
 
 export type CreateDocumentMutationVariables = Exact<{
@@ -870,8 +1036,8 @@ export type CreateEmptyDocumentMutation = {
 
 export type MutateDocumentMutationVariables = Exact<{
   documentIdentifier: Scalars["String"]["input"];
-  actions: ReadonlyArray<Scalars["JSONObject"]["input"]>;
-  view?: InputMaybe<ViewFilterInput>;
+  actions: ReadonlyArray<ActionInput>;
+  branch?: InputMaybe<Scalars["String"]["input"]>;
 }>;
 
 export type MutateDocumentMutation = {
@@ -892,12 +1058,19 @@ export type MutateDocumentMutation = {
 
 export type MutateDocumentAsyncMutationVariables = Exact<{
   documentIdentifier: Scalars["String"]["input"];
-  actions: ReadonlyArray<Scalars["JSONObject"]["input"]>;
-  view?: InputMaybe<ViewFilterInput>;
+  actions: ReadonlyArray<ActionInput>;
+  branch?: InputMaybe<Scalars["String"]["input"]>;
 }>;
 
 export type MutateDocumentAsyncMutation = {
-  readonly mutateDocumentAsync: string;
+  readonly mutateDocumentAsync: {
+    readonly id: string;
+    readonly status: string;
+    readonly result?: NonNullable<unknown> | null | undefined;
+    readonly error?: string | null | undefined;
+    readonly createdAt: string | Date;
+    readonly completedAt?: string | Date | null | undefined;
+  };
 };
 
 export type RenameDocumentMutationVariables = Exact<{
@@ -1402,6 +1575,28 @@ export const GetJobStatusDocument = gql`
     }
   }
 `;
+export const EvaluateActionsDocument = gql`
+  query EvaluateActions(
+    $documentIdentifier: String!
+    $branch: String
+    $candidates: [ActionCandidateInput!]!
+  ) {
+    evaluateActions(
+      documentIdentifier: $documentIdentifier
+      branch: $branch
+      candidates: $candidates
+    ) {
+      evaluations {
+        decision
+        reason
+      }
+      allAllowed
+      anyAllowed
+      allDenied
+      anyDenied
+    }
+  }
+`;
 export const CreateDocumentDocument = gql`
   mutation CreateDocument($document: JSONObject!, $parentIdentifier: String) {
     createDocument(document: $document, parentIdentifier: $parentIdentifier) {
@@ -1427,13 +1622,13 @@ export const CreateEmptyDocumentDocument = gql`
 export const MutateDocumentDocument = gql`
   mutation MutateDocument(
     $documentIdentifier: String!
-    $actions: [JSONObject!]!
-    $view: ViewFilterInput
+    $actions: [ActionInput!]!
+    $branch: String
   ) {
-    mutateDocument(
+    mutateDocument: execute(
       documentIdentifier: $documentIdentifier
       actions: $actions
-      view: $view
+      branch: $branch
     ) {
       ...PHDocumentFields
     }
@@ -1443,14 +1638,21 @@ export const MutateDocumentDocument = gql`
 export const MutateDocumentAsyncDocument = gql`
   mutation MutateDocumentAsync(
     $documentIdentifier: String!
-    $actions: [JSONObject!]!
-    $view: ViewFilterInput
+    $actions: [ActionInput!]!
+    $branch: String
   ) {
-    mutateDocumentAsync(
+    mutateDocumentAsync: executeAsync(
       documentIdentifier: $documentIdentifier
       actions: $actions
-      view: $view
-    )
+      branch: $branch
+    ) {
+      id
+      status
+      result
+      error
+      createdAt
+      completedAt
+    }
   }
 `;
 export const RenameDocumentDocument = gql`
@@ -1832,6 +2034,24 @@ export function getSdk(
             signal,
           }),
         "GetJobStatus",
+        "query",
+        variables,
+      );
+    },
+    EvaluateActions(
+      variables: EvaluateActionsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<EvaluateActionsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<EvaluateActionsQuery>({
+            document: EvaluateActionsDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "EvaluateActions",
         "query",
         variables,
       );

--- a/packages/reactor-browser/src/graphql/mutators.ts
+++ b/packages/reactor-browser/src/graphql/mutators.ts
@@ -1,6 +1,6 @@
 import type { PHDocument } from "document-model";
 import { DEFAULT_DRIVE_ID } from "./constants.js";
-import type { Scalars } from "./gen/schema.js";
+import type { ActionInput } from "./gen/schema.js";
 
 export async function reactorGraphqlCreateDocument<
   TDocument extends PHDocument,
@@ -55,7 +55,7 @@ export async function reactorGraphqlDeleteDocuments(identifiers: string[]) {
 
 export async function reactorGraphqlMutateDocument(
   documentIdentifier: string,
-  ...actions: ReadonlyArray<Scalars["JSONObject"]["input"]>
+  ...actions: ReadonlyArray<ActionInput>
 ) {
   const client = window.ph?.reactorGraphQLClient;
 

--- a/packages/reactor-browser/src/remote-controller/remote-client.ts
+++ b/packages/reactor-browser/src/remote-controller/remote-client.ts
@@ -9,6 +9,7 @@ import type {
   RemoteOperation,
   RemoteOperationResultPage,
 } from "./types.js";
+import type { ActionInput } from "../graphql/gen/schema.js";
 
 /**
  * Thin facade over the GraphQL SDK for remote document operations.
@@ -318,16 +319,22 @@ export class RemoteClient implements IRemoteClient {
     return { operationsByScope };
   }
 
-  /** Push actions to an existing document via MutateDocument. */
+  /**
+   * Push actions to an existing document via MutateDocument.
+   *
+   * Takes the wire shape rather than an in-process `Action`: a signature is a
+   * tuple in one and a string in the other, so the caller projects before it
+   * gets here.
+   */
   async pushActions(
     documentIdentifier: string,
-    actions: ReadonlyArray<NonNullable<unknown>>,
+    actions: ReadonlyArray<ActionInput>,
     branch?: string,
   ): Promise<RemoteDocumentData> {
     const result = await this.client.MutateDocument({
       documentIdentifier,
       actions,
-      view: branch ? { branch } : undefined,
+      branch,
     });
     return result.mutateDocument;
   }

--- a/packages/reactor-browser/src/remote-controller/types.ts
+++ b/packages/reactor-browser/src/remote-controller/types.ts
@@ -6,6 +6,7 @@ import type {
   PHDocument,
   PHDocumentHeader,
 } from "@powerhousedao/shared/document-model";
+import type { ActionInput } from "../graphql/gen/schema.js";
 import type {
   GetDocumentOperationsQuery,
   PhDocumentFieldsFragment,
@@ -151,7 +152,7 @@ export interface IRemoteClient {
 
   pushActions(
     documentIdentifier: string,
-    actions: ReadonlyArray<NonNullable<unknown>>,
+    actions: ReadonlyArray<ActionInput>,
     branch?: string,
   ): Promise<RemoteDocumentData>;
 

--- a/packages/reactor-browser/test/graphql-client/graphql-reactor-client.write.test.ts
+++ b/packages/reactor-browser/test/graphql-client/graphql-reactor-client.write.test.ts
@@ -247,10 +247,11 @@ describe("GraphQLReactorClient.execute", () => {
       undefined,
       undefined,
     );
+    // One `branch`, carrying both the branch written to and the branch the
+    // operations filter reads from; there is no separate `view` to keep in step.
     expect(runDocumentVariables(sdk)).toEqual({
       documentIdentifier: "doc-1",
       actions: [action],
-      view: { branch: "main" },
       sinceRevision: 7,
       scopes: ["global"],
       branch: "main",
@@ -278,9 +279,10 @@ describe("GraphQLReactorClient.execute", () => {
     ]);
 
     // An unbranched operations filter is answered from main, so per-action
-    // reducer errors on any other branch would be invisible.
+    // reducer errors on any other branch would be invisible. One variable now
+    // carries the branch for both the write and the filter, so they cannot
+    // disagree.
     expect(runDocumentVariables(sdk).branch).toBe("feature-x");
-    expect(runDocumentVariables(sdk).view).toEqual({ branch: "feature-x" });
     expect(result.header.branch).toBe("feature-x");
   });
 

--- a/packages/reactor-browser/test/remote-controller/remote-client.test.ts
+++ b/packages/reactor-browser/test/remote-controller/remote-client.test.ts
@@ -182,8 +182,16 @@ describe("RemoteClient", () => {
       const mock = createMockClient();
       const client = new RemoteClient(mock);
 
+      // Carries an id and a timestamp because the mutation's input requires
+      // them; the fixture used to omit both, which is the hole this closes.
       const actions = [
-        { type: "SET_NAME", input: { name: "test" }, scope: "global" },
+        {
+          id: "act-1",
+          type: "SET_NAME",
+          input: { name: "test" },
+          scope: "global",
+          timestampUtcMs: "2026-01-01T00:00:00.000Z",
+        },
       ];
       await client.pushActions("doc-1", actions);
 

--- a/packages/reactor-browser/test/remote-controller/remote-controller.test.ts
+++ b/packages/reactor-browser/test/remote-controller/remote-controller.test.ts
@@ -329,10 +329,10 @@ describe("RemoteDocumentController", () => {
       controller.setName({ name: "Test" });
       await controller.push();
 
+      // Read off the declared input type rather than a hand-written shape: the
+      // mutation takes ActionInput now, so the context fields are typed.
       const mutateCall = vi.mocked(client.MutateDocument).mock.calls[0][0];
-      const actions = mutateCall.actions as Array<{
-        context?: { prevOpHash?: string; prevOpIndex?: number };
-      }>;
+      const actions = mutateCall.actions;
 
       expect(actions).toHaveLength(1);
       expect(actions[0].context).toBeDefined();
@@ -434,18 +434,10 @@ describe("RemoteDocumentController", () => {
 
       // Action should include signer context
       const mutateCall = vi.mocked(client.MutateDocument).mock.calls[0][0];
-      const actions = mutateCall.actions as Array<{
-        context?: {
-          signer?: {
-            user: { address: string };
-            app: { name: string };
-            signatures: unknown[];
-          };
-        };
-      }>;
+      const actions = mutateCall.actions;
       expect(actions[0].context!.signer).toBeDefined();
-      expect(actions[0].context!.signer!.user.address).toBe("0x123");
-      expect(actions[0].context!.signer!.app.name).toBe("test-app");
+      expect(actions[0].context!.signer!.user!.address).toBe("0x123");
+      expect(actions[0].context!.signer!.app!.name).toBe("test-app");
       expect(actions[0].context!.signer!.signatures).toHaveLength(1);
     });
   });

--- a/packages/renown/src/switchboard.ts
+++ b/packages/renown/src/switchboard.ts
@@ -112,9 +112,12 @@ const CREATE_EMPTY_DOCUMENT_MUTATION = /* GraphQL */ `
 const MUTATE_DOCUMENT_MUTATION = /* GraphQL */ `
   mutation MutateDocument(
     $documentIdentifier: String!
-    $actions: [JSONObject!]!
+    $actions: [ActionInput!]!
   ) {
-    mutateDocument(documentIdentifier: $documentIdentifier, actions: $actions) {
+    mutateDocument: execute(
+      documentIdentifier: $documentIdentifier
+      actions: $actions
+    ) {
       id
     }
   }

--- a/packages/shared/document-model/action-transport.ts
+++ b/packages/shared/document-model/action-transport.ts
@@ -24,7 +24,13 @@ export type TransportAction = {
   id: string;
   type: string;
   timestampUtcMs: string;
-  input: unknown;
+  /**
+   * Non-nullable, because the wire declares it so. An action's own type says
+   * `unknown`, which admits the absent input an action creator called without
+   * one produces - {@link toTransportAction} refuses that rather than passing
+   * it on.
+   */
+  input: NonNullable<unknown>;
   scope: string;
   context?: TransportActionContext;
 };
@@ -43,6 +49,15 @@ export type TransportAction = {
  * sends no context at all rather than a context full of nulls.
  */
 export function toTransportAction(action: Action): TransportAction {
+  if (action.input === undefined || action.input === null) {
+    // The wire declares an input, so this would be refused on arrival as a
+    // missing required field, naming the field but not the action. Refused here
+    // instead, where the action is still in hand.
+    throw new Error(
+      `Action ${action.id} (${action.type}) has no input, which the wire requires`,
+    );
+  }
+
   const projected: TransportAction = {
     id: action.id,
     type: action.type,

--- a/test/lb-loadtest/src/run.ts
+++ b/test/lb-loadtest/src/run.ts
@@ -110,8 +110,11 @@ const CREATE_DOCUMENT_MUTATION = `
 `;
 
 const MUTATE_DOCUMENT_MUTATION = `
-  mutation MutateDocument($documentIdentifier: String!, $actions: [JSONObject!]!) {
-    mutateDocument(documentIdentifier: $documentIdentifier, actions: $actions) {
+  mutation MutateDocument($documentIdentifier: String!, $actions: [ActionInput!]!) {
+    mutateDocument: execute(
+      documentIdentifier: $documentIdentifier
+      actions: $actions
+    ) {
       id
       state
       revisionsList { scope revision }
@@ -262,7 +265,9 @@ async function schemaPreflight(lb: LbClient): Promise<void> {
   const queryNames = new Set(
     schema?.queryType?.fields?.map((f) => f.name) ?? [],
   );
-  const missingMutations = ["createDocument", "mutateDocument"].filter(
+  // `execute`, not `mutateDocument`: the preflight has to name the mutation this
+  // run actually sends, or it passes against an image that cannot serve it.
+  const missingMutations = ["createDocument", "execute"].filter(
     (n) => !mutationNames.has(n),
   );
   const missingQueries = ["document"].filter((n) => !queryNames.has(n));

--- a/test/switchboard/src/remote-drive.test.ts
+++ b/test/switchboard/src/remote-drive.test.ts
@@ -20,6 +20,7 @@ import type {
   DocumentModelDocument,
   PHDocument,
 } from "@powerhousedao/shared/document-model";
+import { toTransportAction } from "@powerhousedao/shared/document-model";
 import {
   DocumentModelController,
   documentModelDocumentModelModule,
@@ -57,7 +58,7 @@ async function createDriveOnSwitchboard(name: string): Promise<string> {
   // Set drive name
   await client.MutateDocument({
     documentIdentifier: driveId,
-    actions: [setDriveName({ name })],
+    actions: [setDriveName({ name })].map(toTransportAction),
   });
 
   return driveId;
@@ -176,7 +177,7 @@ describe("Remote drive sync via CONNECT channel", () => {
       actions: [
         setModelName({ name: "SyncedModel" }),
         setModelDescription({ description: "Synced from switchboard" }),
-      ],
+      ].map(toTransportAction),
     });
 
     // 6. Wait for the document to sync to the local reactor
@@ -264,7 +265,9 @@ describe("Remote drive sync via CONNECT channel", () => {
     for (let i = 1; i <= 3; i++) {
       await client.MutateDocument({
         documentIdentifier: documentId,
-        actions: [setModelName({ name: `Iteration-${i}` })],
+        actions: [setModelName({ name: `Iteration-${i}` })].map(
+          toTransportAction,
+        ),
       });
     }
 

--- a/test/test-client/src/client/queries.ts
+++ b/test/test-client/src/client/queries.ts
@@ -34,8 +34,11 @@ export const CREATE_EMPTY_DOCUMENT_MUTATION = `
 `;
 
 export const MUTATE_DOCUMENT_MUTATION = `
-  mutation MutateDocument($documentIdentifier: String!, $actions: [JSONObject!]!) {
-    mutateDocument(documentIdentifier: $documentIdentifier, actions: $actions) {
+  mutation MutateDocument($documentIdentifier: String!, $actions: [ActionInput!]!) {
+    mutateDocument: execute(
+      documentIdentifier: $documentIdentifier
+      actions: $actions
+    ) {
       id
       name
       revisionsList {

--- a/test/test-fusion/e2e/realtime.spec.ts
+++ b/test/test-fusion/e2e/realtime.spec.ts
@@ -12,8 +12,8 @@ import { SWITCHBOARD_URL } from "../playwright.config";
 // re-renders `useDocument`.
 
 const MUTATE_DOCUMENT = `
-  mutation MutateDocument($identifier: String!, $actions: [JSONObject!]!) {
-    mutateDocument(documentIdentifier: $identifier, actions: $actions) {
+  mutation MutateDocument($identifier: String!, $actions: [ActionInput!]!) {
+    mutateDocument: execute(documentIdentifier: $identifier, actions: $actions) {
       id
       revisionsList {
         scope

--- a/test/vetra-e2e/tests/upgrade-repro.spec.ts
+++ b/test/vetra-e2e/tests/upgrade-repro.spec.ts
@@ -331,8 +331,8 @@ test("repro: v1 doc upgrade after v2 release errors", async ({ page }) => {
   // the raw action through the generic reactor mutation instead.
   await gql(
     "r",
-    `mutation ($id: String!, $actions: [JSONObject!]!) {
-       mutateDocument(documentIdentifier: $id, actions: $actions) { id }
+    `mutation ($id: String!, $actions: [ActionInput!]!) {
+       execute(documentIdentifier: $id, actions: $actions) { id }
      }`,
     {
       id: editorDocId,
@@ -398,8 +398,8 @@ test("repro: v1 doc upgrade after v2 release errors", async ({ page }) => {
   note("STEP 4: releasing v2 (RELEASE_NEW_VERSION + new schema)");
   await gql(
     "r",
-    `mutation ($id: String!, $actions: [JSONObject!]!) {
-       mutateDocument(documentIdentifier: $id, actions: $actions) { id }
+    `mutation ($id: String!, $actions: [ActionInput!]!) {
+       execute(documentIdentifier: $id, actions: $actions) { id }
      }`,
     {
       id: modelDocId,


### PR DESCRIPTION
Stacked on #2918 — it depends on three commits there (the completed
`ActionContextInput`, the shared signature codecs, and the server-side
deserialize). Retarget to `main` once that merges.

The GraphQL mutation surface had drifted from the client it is the wire form of,
in three ways at once:

| | `IReactorClient` | GraphQL before |
|---|---|---|
| name | `execute` / `executeAsync` | `mutateDocument` / `mutateDocumentAsync` |
| branch | `branch: string` | a `view` whose `scopes` was read and ignored |
| async return | `Promise<JobInfo>` | `String!`, the job id alone |

Every other mutation in the schema already took a plain `branch`, so the `view`
was the outlier.

**Added, not changed.** Typing the argument in place breaks a client on its
variable declaration alone — `[JSONObject!]!` is not compatible with
`[ActionInput!]!` however well-formed the payload — and no deployment order
spares a browser build somebody already has. So the typed fields are new, the
untyped ones are `@deprecated` beside them, and a client migrates when it is
rebuilt. What the typed argument buys is that an action missing a field the
reactor needs is refused by the schema before any work starts, rather than by a
hand-written check the resolvers have to remember to call.

Every caller in the repo moves onto `execute`, because a deprecation nobody has
migrated off proves nothing. Operation names stay as they are and response keys
are aliased (`mutateDocument: execute(...)`), since reactor-browser dispatches
window events named after the operation and matches those names in two more
places — the field moved, the names around it did not.

Three things fall out:

- **`JobInfo.result` had to become nullable.** It was `JSONObject!`, but a job
  carries no result until it produces one, so asking `jobStatus` about a pending
  job nullified a non-null field and the caller got an error instead of the
  status it asked for. A live bug, uncovered because every existing test calls
  the reactor directly where no schema enforces nullability.
- **`MutateDocumentWithOperations` had two branch variables** — a `view` for the
  write, a `branch` for the operations filter — that had to be kept equal by
  hand or the operations came back from `main` while the actions were applied
  elsewhere. Now one variable, which cannot disagree with itself.
- **The load test's schema preflight** asserted `mutateDocument` exists while
  sending something else. It now names the mutation it actually sends.

Green: root `tsc --build`, reactor 2666, reactor-api 771, reactor-browser 605,
shared 180, renown 155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)