### PR TITLE
fix: group a backfill page by document without reordering its scopes

### DIFF
--- a/docs/updateoutbox-scope-ordering.md
+++ b/docs/updateoutbox-scope-ordering.md
@@ -1,0 +1,319 @@
+# `updateOutbox` orders a document's scopes alphabetically, so `auth` is served before `document`
+
+**Status:** fixed by hoisting the creating run (see
+[What the fix is](#what-the-fix-is-and-what-it-is-not)). Pre-existing on `main`;
+not introduced by the auth-scope work.
+**Symptom:** explained (see [The deadlock](#the-deadlock)) and mitigated by #2918
+(`db6136341`), which bounds it at 30s and raises a dead letter.
+**Reproduces with:** an empty held set, so it is independent of the stage-8 serving gate.
+**Found:** while writing the stage-8 exit test (`packages/reactor-api/test/sync-serving-policy.integration.test.ts`).
+**Repro:** `packages/reactor/test/sync/sync-manager/scope-ordering.test.ts` — 2 of 3
+cases fail without the hoist.
+
+## Summary
+
+When a replica backfills a document it does not yet hold, the outbox emits that
+document's `auth` run before its `document` run and makes the second depend on
+the first. The receiver is therefore asked to apply an auth operation for a
+document it has not created yet.
+
+## Mechanics (verified)
+
+1. The operation index returns rows in global insertion order — `ORDER BY ordinal ASC`
+   (`packages/reactor/src/cache/kysely-operation-index.ts:406`). That order is
+   causally safe by construction: a document's creation is written before
+   anything that follows it.
+
+2. `updateOutbox` then **re-sorts each page** by `(documentId, scope, ordinal)`
+   (`packages/reactor/src/sync/sync-manager.ts:1150-1158`), discarding that
+   order.
+
+3. `scope` is compared as a raw string, so the ordering is lexicographic
+   (`auth < document < global < local`). For any one document the `auth` run
+   sorts ahead of the `document` run that creates it.
+
+4. `emitBatches` chains `dependsOn` per document through `lastJobByDoc`
+   (`sync-manager.ts:1064`, `:1078`, `:1102`), so emission order becomes a hard
+   dependency: the `document` batch depends on the `auth` batch.
+
+5. The sort is per page, so the grouping it buys only holds within a page.
+
+Mechanics 1, 3 and 4 are asserted directly by the repro test.
+
+## The deadlock
+
+Why nothing was dispatched, and why no dead letter was raised. The answer is a
+mutual wait between the sync dependency chain and the executor's deferral path,
+each of which is individually reasonable:
+
+1. The receiver applies the `auth` run first (mechanic 3). Its document does not
+   exist, so the load job is **deferred**. Deferral was silent by design: it
+   emitted no event and moved no job status, so the job sat at `RUNNING`.
+2. A deferred job was released only when a job carrying `CREATE_DOCUMENT` for
+   that document id completed.
+3. That create job is blocked behind the deferred auth job by the inverted
+   `dependsOn` (mechanic 4), so it never runs, so nothing ever releases the hold.
+
+Neither side times out and neither side reports, which is exactly "no runs
+dispatched, no dead letter, indefinitely". Both dead-letter paths
+(`sync-manager.ts:793`, `:816`) are downstream of dispatch and cannot fire.
+
+This is inferred from #2918's `df5bc377d` plus the code paths above; it has not
+yet been demonstrated by a test.
+
+Note the reported status reading is a separate detail:
+`SyncOperationStatus.Unknown` is the constructor state
+(`packages/reactor/src/sync/sync-operation.ts:57`) whose only exit is
+`started()` at transport hand-off, and an inbox item can never be `Unknown`
+because `receive()` calls `transported()`. So whichever list the reactor-api test
+observed was sender-side, which the deadlock above does not by itself explain.
+
+### What #2918 changed
+
+`df5bc377d` bounds the silence: a hold outliving `deferredJobTtlMs` (30s) fails
+the job **through the queue**, which releases anything that declared a dependency
+on it. The deadlock therefore resolves after 30s, the create proceeds, and the
+auth operation fails visibly and must be re-delivered.
+
+That removes the hang, not the defect. Every fresh backfill of a policied
+document still costs a 30s stall and a dead-lettered auth run per document.
+
+## The barrier this violates
+
+Nothing except `dependsOn` orders a document's scopes against each other. The
+queue's sub-queue key is `(documentId, scope, branch)`
+(`packages/reactor/src/queue/queue.ts:158`, invariant documented at `:122-128`),
+so per-scope FIFO is all it guarantees; `queueHint`, fed from `dependsOn`, is the
+only cross-scope mechanism on the inbox path.
+
+That chain is load-bearing, because document-scope operations write **other**
+scopes' rows — three of them:
+
+- `CREATE_DOCUMENT` seeds `header`, `document` and `auth` snapshots
+  (`src/read-models/document-view.ts:158`).
+- `UPGRADE_DOCUMENT` reindexes **every** scope in `resultingState` when the
+  operation vouches for its siblings, via `initialState` or `__migrated`
+  (`document-view.ts:180`). `createDocument` emits a seed upgrade carrying
+  `initialState: document.state` in the same document-scope job as the create
+  (`src/core/reactor.ts:475-485`). A real migration (`fromVersion > 0`) fetches
+  every sibling scope fresh and migrates it
+  (`src/executor/document-action-handler.ts:731-757`).
+- `DELETE_DOCUMENT` updates `DocumentSnapshot` filtered on `documentId` and
+  `branch` with **no scope predicate** (`document-view.ts:117-131`), stamping its
+  index and hash onto every scope's row.
+
+### The barrier only holds within a page
+
+`emitBatches` calls `outbox.add` once per page, and `pushSyncOperations` resolves
+`dependsOn` against a `jobIdToKeys` map built incrementally **within one push
+array** (`src/sync/channels/gql-req-channel.ts:909-929`). A dependency whose job
+was in an earlier push resolves to `undefined` and is **dropped, not stalled**.
+Demonstrated with a 522-op history straddling the 500-row page limit.
+
+So on a multi-page backfill the cross-scope ordering guarantee does not exist at
+all, and the silent divergence the barrier is there to prevent is already
+reachable. The receiver has the machinery for cross-batch dependencies
+(`planKeyToJobUuid` → `externalDeps`, `sync-manager.ts:846-860`) that the
+sender's encoder can never feed. Related: envelope `key`/`dependsOn` are per-push
+array indices (`String(i)`) used verbatim as `jobId`/`jobDependencies`, so
+`planKeyToJobUuid` keys alias across pushes — latent only because the encoder
+drops those dependencies.
+
+## Candidate fixes
+
+1. **Rank scopes causally instead of lexicographically** — `document`, then
+   `auth`, then domain scopes.
+
+   Prototyped green (all 3 repro cases, plus `packages/reactor/test/sync/`,
+   507 tests) and reverted. But it removes the *inversion* without restoring
+   *order*: the sort still groups by scope, so a later `UPGRADE_DOCUMENT` is
+   still delivered ahead of the auth and domain operations it causally follows.
+   With history `document@1, auth@2, global@3, document@4, auth@5, global@6` it
+   emits `document@1, document@4, auth@2, auth@5, global@3, global@6`. Given that
+   an upgrade migrates and reindexes every sibling scope, that is the same hazard
+   class the fix is meant to remove.
+
+   It also hardcodes a precedence table in a comparator — see
+   [Where precedence belongs](#where-precedence-belongs).
+
+2. **Do not chain `dependsOn` across scopes of one document.** Rejected.
+   Since the queue only serializes within a scope, dropping the chain removes the
+   sole ordering between a document's creation and its other scopes.
+
+   The narrowed version — keep `document` as a barrier, relax chaining only
+   between non-document scopes — is also **not worth doing**: the dispatcher
+   refuses to dequeue any job for a document that already has one executing
+   (`isDocumentExecuting`, `queue/queue.ts:270`, `:330`), so execution is already
+   serialized per document across all scopes and the relaxation buys no
+   parallelism at all.
+
+3. **Drop the sort and keep the index's ordinal order.** The only candidate that
+   preserves cross-scope interleaving, and therefore the only one that fixes
+   candidate 1's residual hazard. Costs whatever batching efficiency the sort
+   buys: `batchOperationsByDocument` (`src/sync/utils.ts:141`) only groups
+   contiguous runs, so unsorted input produces more, smaller batches. That cost
+   is measurable and should be measured before choosing.
+
+Current lean: candidate 3, plus fixing the cross-page dependency encoder.
+
+### Where precedence belongs
+
+There is no canonical scope enum; `scope` is an open `string` (Zod `z.string()`,
+`text notNull`, no check constraint). Two homes already encode the distinction —
+`ALWAYS_READABLE_SCOPES` (`src/decision/read-gate.ts:22-32`), copy-pasted twice
+in `reactor-browser` as `NON_DOMAIN_SCOPES`; and the executor's declared
+cross-scope evaluation order, documented as load-bearing and derived from the
+decision model's `staticReadSet` (`src/executor/simple-job-executor.ts:1076-1085`).
+
+A hardcoded table in a sync comparator would be a second source of truth that can
+silently disagree with those. Derive the rank; do not restate it. Note also that
+`comparePositions` (`src/decision/merged-order.ts:44-52`) gives `auth` the
+cross-stream timestamp tie — auth *first* — which is a deliberate spec rule in a
+different context (state derivation, not emission grouping), but means a reader
+already finds two answers to "what is the scope precedence".
+
+Unranked but real: `header` is a scope every operation's snapshot writes. It
+appears to carry no cross-scope causality, but that should be a decision rather
+than a default.
+
+## What the fix is, and what it is not
+
+The fix hoists one run: a page that carries a document's `CREATE_DOCUMENT`
+serves that run before the document's other scopes. Everything else about the
+sort is unchanged, so scopes stay contiguous and a page still batches into one
+entry per (document, scope).
+
+Serving the page in the index's own order instead was tried and rejected on two
+counts.
+
+### It costs a factor of 2.5 in load jobs
+
+Measured against the hub-spoke fixture (410 documents, 7,056 operations, 407 of
+the documents carrying exactly two scopes):
+
+| batching | load jobs | operations per job |
+|---|---|---|
+| by (document, scope) | 817 | 8.6 |
+| by (document, ordinal) | 2,016 | 3.5 |
+
+Convergence time tracked that ratio almost exactly -- 2.47x the jobs for 2.64x
+the wall clock -- so the cost is per-job overhead, not per-operation work. On CI
+that took the 3-spoke leg past its 300s cap and then took Postgres down with it.
+
+### It does not buy the ordering it appears to buy
+
+Delivery order is not what decides the order a document's scopes are applied in.
+`replayDocument` replays `Object.values(operations).flatMap(...)`
+(`shared/document-model/documents.ts:536`) -- scope by scope, with no cross-scope
+sort -- and reduces in that order. Given `global@1000`, `local@2000`,
+`global@3000`, `local@4000`, it applies
+
+```
+global@1000, global@3000, local@2000, local@4000
+```
+
+The one place operations from different streams are ordered by timestamp,
+`mergeByPosition`/`comparePositions` (`reactor/src/decision/merged-order.ts`), is
+reached only from the auth walk (`decision/walk.ts`) and does not feed state
+derivation.
+
+So an `UPGRADE_DOCUMENT` is *not* applied at the position its timestamp implies
+relative to other scopes today, whatever order it is delivered in. If that
+semantics is wanted it belongs in replay -- see adjacent defect 5, which is the
+same missing rank -- and serving in index order neither achieves it nor is
+needed for it.
+
+## The cycle that surfaced while trying the index order
+
+Worth recording because the defect is real and reachable on `main`.
+
+`consolidateSyncOperations` merged **every** SyncOperation sharing a
+`(documentId, scope, branch)`, wherever it sat in the chain. A document whose
+scopes interleave arrives as an alternating chain, each entry depending on the
+one before it:
+
+```
+j1 document  deps []
+j2 auth      deps [j1]
+j3 document  deps [j2]
+j4 auth      deps [j3]
+```
+
+Merging both `document` entries into `j1` and both `auth` entries into `j2`
+leaves `j1 -> [j2]` and `j2 -> [j1]`, which `validateBatchStructure` rejects for
+the whole batch. Merging only contiguous runs keeps the chain linear.
+
+The sort is per page, so this is reachable on `main` too: a document with
+operations in two scopes spanning two backfill pages reaches the outbox
+interleaved without any change to the sort. It needs a multi-page backfill,
+which is why the fixture never hit it.
+
+## Adjacent defects found while investigating
+
+Independent of this bug and of each other. None are needed to fix the ordering.
+
+1. **Re-evaluation writes are discarded.** `reevaluateIfCriteriaMet` returns only
+   `outcome.error` and drops `outcome.operationsWithContext`
+   (`src/executor/simple-job-executor.ts:1214-1215`), so re-appended operations
+   never reach `JOB_WRITE_READY`. The log and sync converge — the outbox is
+   index-driven — but **read models do not**, so projections keep serving
+   pre-revocation state until a restart catch-up. Those re-appends are also
+   absent from `touchedCacheEntries`, so a later rollback leaves
+   post-reevaluation snapshots cached. Security-shaped: a revocation that does
+   not reach reads.
+
+2. **`externalDeps` is unvalidated and can wedge a sub-queue permanently.** It is
+   spread straight into `queueHint` (`src/core/reactor.ts:846-849`) while
+   `validateBatchStructure` only checks `dependsOn` against in-batch keys, and
+   `areDependenciesMet` requires every hint to be in `completedJobs`. A hint
+   naming a job that never enqueues blocks the sub-queue head forever — nothing
+   dispatched, no dead letter. Distinguishing "never existed" from "already
+   completed and forgotten" is the hard half, since `completedJobs` is a `Set`
+   that gets cleared (`queue/queue.ts:450`).
+
+3. **The outbox cursor writer that lacks a clamp.** Two of three cursor writers
+   clamp against unserved/emitted state with docstrings naming the skip hazard;
+   `gql-req-channel.ts:177-195` does a bare `max(getLatestAppliedOrdinal)` →
+   `upsert` with neither. Cross-document parallelism alone lets a higher-ordinal
+   document ack first, so this is a restart-skips-operations risk independent of
+   scope. Not demonstrated end-to-end.
+
+4. **Projection races across scopes.** `ReadModelCoordinator` parallelizes across
+   `(documentId, scope, branch)` keys (`src/read-models/coordinator.ts:18-24`)
+   and the executor's per-document mutex does not extend to the projection stage,
+   so the shared `header` row and the `SlugMapping` upsert
+   (`document-view.ts:186-188`, `:240-257`) already race across a document's
+   scopes. Separately, `BaseReadModel.saveState` sets `ViewState.lastOrdinal` with
+   `set` rather than a max (`src/read-models/base-read-model.ts:161-179`), so
+   parallel chains can walk the watermark backwards.
+
+5. **`replayDocument` orders cross-scope replay by raw `Object.keys`**
+   (`packages/shared/document-model/documents.ts:536`), fed by a `getRevisions()`
+   query with no `ORDER BY` (`src/storage/kysely/store.ts:585-611`). Same missing
+   rank concept, different subsystem. Uninvestigated.
+
+### Not a defect
+
+`failJob` adds a failed job to `completedJobs` "so dependent jobs are unblocked"
+(`queue/queue.ts:506-508`). This looks wrong against the barrier — a failed
+create would let an auth op proceed — but #2918's deferral fix deliberately
+relies on it, and in the backfill case releasing is *correct*: when the deferred
+auth job fails, the create should proceed, not cascade-fail. Release-vs-cascade
+depends on the direction of the causal dependency, which is a design question,
+not a bug to fix.
+
+## Sequencing
+
+1. ~~Merge #2918 as-is~~ — done (`db6136341`), and #2919 (`b6f069fb8`).
+2. Confirm the deadlock with a test, now that #2918 bounds it.
+3. ~~Fix the ordering~~ — done, by hoisting the creating run only. Serving the
+   page in index order was measured (2.47x the load jobs) and shown not to
+   deliver cross-scope ordering anyway, since replay regroups by scope.
+4. Separate PR, if the cross-scope semantics is wanted: order replay across
+   scopes (adjacent defect 5). Batching per document rather than per
+   (document, scope) is the enabler -- it is 410 jobs on the fixture against
+   main's 817.
+5. Separate PR: the `externalDeps` guard (adjacent defect 2).
+6. Separate PR: discarded re-evaluation writes (adjacent defect 1).
+7. Needs a decision before implementation: the cross-page dependency encoder, and
+   whether `dependsOn` should cascade or release on failure.

--- a/docs/updateoutbox-scope-ordering.md
+++ b/docs/updateoutbox-scope-ordering.md
@@ -1,0 +1,240 @@
+# `updateOutbox` orders a document's scopes alphabetically, so `auth` is served before `document`
+
+**Status:** open. Pre-existing on `main`; not introduced by the auth-scope work.
+**Symptom:** explained (see [The deadlock](#the-deadlock)) and mitigated by #2918
+(`db6136341`), which bounds it at 30s and raises a dead letter. The ordering
+defect itself is unfixed.
+**Reproduces with:** an empty held set, so it is independent of the stage-8 serving gate.
+**Found:** while writing the stage-8 exit test (`packages/reactor-api/test/sync-serving-policy.integration.test.ts`).
+**Repro:** `packages/reactor/test/sync/sync-manager/scope-ordering.test.ts` — 2 of 3 cases fail.
+
+## Summary
+
+When a replica backfills a document it does not yet hold, the outbox emits that
+document's `auth` run before its `document` run and makes the second depend on
+the first. The receiver is therefore asked to apply an auth operation for a
+document it has not created yet.
+
+## Mechanics (verified)
+
+1. The operation index returns rows in global insertion order — `ORDER BY ordinal ASC`
+   (`packages/reactor/src/cache/kysely-operation-index.ts:406`). That order is
+   causally safe by construction: a document's creation is written before
+   anything that follows it.
+
+2. `updateOutbox` then **re-sorts each page** by `(documentId, scope, ordinal)`
+   (`packages/reactor/src/sync/sync-manager.ts:1150-1158`), discarding that
+   order.
+
+3. `scope` is compared as a raw string, so the ordering is lexicographic
+   (`auth < document < global < local`). For any one document the `auth` run
+   sorts ahead of the `document` run that creates it.
+
+4. `emitBatches` chains `dependsOn` per document through `lastJobByDoc`
+   (`sync-manager.ts:1064`, `:1078`, `:1102`), so emission order becomes a hard
+   dependency: the `document` batch depends on the `auth` batch.
+
+5. The sort is per page, so the grouping it buys only holds within a page.
+
+Mechanics 1, 3 and 4 are asserted directly by the repro test.
+
+## The deadlock
+
+Why nothing was dispatched, and why no dead letter was raised. The answer is a
+mutual wait between the sync dependency chain and the executor's deferral path,
+each of which is individually reasonable:
+
+1. The receiver applies the `auth` run first (mechanic 3). Its document does not
+   exist, so the load job is **deferred**. Deferral was silent by design: it
+   emitted no event and moved no job status, so the job sat at `RUNNING`.
+2. A deferred job was released only when a job carrying `CREATE_DOCUMENT` for
+   that document id completed.
+3. That create job is blocked behind the deferred auth job by the inverted
+   `dependsOn` (mechanic 4), so it never runs, so nothing ever releases the hold.
+
+Neither side times out and neither side reports, which is exactly "no runs
+dispatched, no dead letter, indefinitely". Both dead-letter paths
+(`sync-manager.ts:793`, `:816`) are downstream of dispatch and cannot fire.
+
+This is inferred from #2918's `df5bc377d` plus the code paths above; it has not
+yet been demonstrated by a test.
+
+Note the reported status reading is a separate detail:
+`SyncOperationStatus.Unknown` is the constructor state
+(`packages/reactor/src/sync/sync-operation.ts:57`) whose only exit is
+`started()` at transport hand-off, and an inbox item can never be `Unknown`
+because `receive()` calls `transported()`. So whichever list the reactor-api test
+observed was sender-side, which the deadlock above does not by itself explain.
+
+### What #2918 changed
+
+`df5bc377d` bounds the silence: a hold outliving `deferredJobTtlMs` (30s) fails
+the job **through the queue**, which releases anything that declared a dependency
+on it. The deadlock therefore resolves after 30s, the create proceeds, and the
+auth operation fails visibly and must be re-delivered.
+
+That removes the hang, not the defect. Every fresh backfill of a policied
+document still costs a 30s stall and a dead-lettered auth run per document.
+
+## The barrier this violates
+
+Nothing except `dependsOn` orders a document's scopes against each other. The
+queue's sub-queue key is `(documentId, scope, branch)`
+(`packages/reactor/src/queue/queue.ts:158`, invariant documented at `:122-128`),
+so per-scope FIFO is all it guarantees; `queueHint`, fed from `dependsOn`, is the
+only cross-scope mechanism on the inbox path.
+
+That chain is load-bearing, because document-scope operations write **other**
+scopes' rows — three of them:
+
+- `CREATE_DOCUMENT` seeds `header`, `document` and `auth` snapshots
+  (`src/read-models/document-view.ts:158`).
+- `UPGRADE_DOCUMENT` reindexes **every** scope in `resultingState` when the
+  operation vouches for its siblings, via `initialState` or `__migrated`
+  (`document-view.ts:180`). `createDocument` emits a seed upgrade carrying
+  `initialState: document.state` in the same document-scope job as the create
+  (`src/core/reactor.ts:475-485`). A real migration (`fromVersion > 0`) fetches
+  every sibling scope fresh and migrates it
+  (`src/executor/document-action-handler.ts:731-757`).
+- `DELETE_DOCUMENT` updates `DocumentSnapshot` filtered on `documentId` and
+  `branch` with **no scope predicate** (`document-view.ts:117-131`), stamping its
+  index and hash onto every scope's row.
+
+### The barrier only holds within a page
+
+`emitBatches` calls `outbox.add` once per page, and `pushSyncOperations` resolves
+`dependsOn` against a `jobIdToKeys` map built incrementally **within one push
+array** (`src/sync/channels/gql-req-channel.ts:909-929`). A dependency whose job
+was in an earlier push resolves to `undefined` and is **dropped, not stalled**.
+Demonstrated with a 522-op history straddling the 500-row page limit.
+
+So on a multi-page backfill the cross-scope ordering guarantee does not exist at
+all, and the silent divergence the barrier is there to prevent is already
+reachable. The receiver has the machinery for cross-batch dependencies
+(`planKeyToJobUuid` → `externalDeps`, `sync-manager.ts:846-860`) that the
+sender's encoder can never feed. Related: envelope `key`/`dependsOn` are per-push
+array indices (`String(i)`) used verbatim as `jobId`/`jobDependencies`, so
+`planKeyToJobUuid` keys alias across pushes — latent only because the encoder
+drops those dependencies.
+
+## Candidate fixes
+
+1. **Rank scopes causally instead of lexicographically** — `document`, then
+   `auth`, then domain scopes.
+
+   Prototyped green (all 3 repro cases, plus `packages/reactor/test/sync/`,
+   507 tests) and reverted. But it removes the *inversion* without restoring
+   *order*: the sort still groups by scope, so a later `UPGRADE_DOCUMENT` is
+   still delivered ahead of the auth and domain operations it causally follows.
+   With history `document@1, auth@2, global@3, document@4, auth@5, global@6` it
+   emits `document@1, document@4, auth@2, auth@5, global@3, global@6`. Given that
+   an upgrade migrates and reindexes every sibling scope, that is the same hazard
+   class the fix is meant to remove.
+
+   It also hardcodes a precedence table in a comparator — see
+   [Where precedence belongs](#where-precedence-belongs).
+
+2. **Do not chain `dependsOn` across scopes of one document.** Rejected.
+   Since the queue only serializes within a scope, dropping the chain removes the
+   sole ordering between a document's creation and its other scopes.
+
+   The narrowed version — keep `document` as a barrier, relax chaining only
+   between non-document scopes — is also **not worth doing**: the dispatcher
+   refuses to dequeue any job for a document that already has one executing
+   (`isDocumentExecuting`, `queue/queue.ts:270`, `:330`), so execution is already
+   serialized per document across all scopes and the relaxation buys no
+   parallelism at all.
+
+3. **Drop the sort and keep the index's ordinal order.** The only candidate that
+   preserves cross-scope interleaving, and therefore the only one that fixes
+   candidate 1's residual hazard. Costs whatever batching efficiency the sort
+   buys: `batchOperationsByDocument` (`src/sync/utils.ts:141`) only groups
+   contiguous runs, so unsorted input produces more, smaller batches. That cost
+   is measurable and should be measured before choosing.
+
+Current lean: candidate 3, plus fixing the cross-page dependency encoder.
+
+### Where precedence belongs
+
+There is no canonical scope enum; `scope` is an open `string` (Zod `z.string()`,
+`text notNull`, no check constraint). Two homes already encode the distinction —
+`ALWAYS_READABLE_SCOPES` (`src/decision/read-gate.ts:22-32`), copy-pasted twice
+in `reactor-browser` as `NON_DOMAIN_SCOPES`; and the executor's declared
+cross-scope evaluation order, documented as load-bearing and derived from the
+decision model's `staticReadSet` (`src/executor/simple-job-executor.ts:1076-1085`).
+
+A hardcoded table in a sync comparator would be a second source of truth that can
+silently disagree with those. Derive the rank; do not restate it. Note also that
+`comparePositions` (`src/decision/merged-order.ts:44-52`) gives `auth` the
+cross-stream timestamp tie — auth *first* — which is a deliberate spec rule in a
+different context (state derivation, not emission grouping), but means a reader
+already finds two answers to "what is the scope precedence".
+
+Unranked but real: `header` is a scope every operation's snapshot writes. It
+appears to carry no cross-scope causality, but that should be a decision rather
+than a default.
+
+## Adjacent defects found while investigating
+
+Independent of this bug and of each other. None are needed to fix the ordering.
+
+1. **Re-evaluation writes are discarded.** `reevaluateIfCriteriaMet` returns only
+   `outcome.error` and drops `outcome.operationsWithContext`
+   (`src/executor/simple-job-executor.ts:1214-1215`), so re-appended operations
+   never reach `JOB_WRITE_READY`. The log and sync converge — the outbox is
+   index-driven — but **read models do not**, so projections keep serving
+   pre-revocation state until a restart catch-up. Those re-appends are also
+   absent from `touchedCacheEntries`, so a later rollback leaves
+   post-reevaluation snapshots cached. Security-shaped: a revocation that does
+   not reach reads.
+
+2. **`externalDeps` is unvalidated and can wedge a sub-queue permanently.** It is
+   spread straight into `queueHint` (`src/core/reactor.ts:846-849`) while
+   `validateBatchStructure` only checks `dependsOn` against in-batch keys, and
+   `areDependenciesMet` requires every hint to be in `completedJobs`. A hint
+   naming a job that never enqueues blocks the sub-queue head forever — nothing
+   dispatched, no dead letter. Distinguishing "never existed" from "already
+   completed and forgotten" is the hard half, since `completedJobs` is a `Set`
+   that gets cleared (`queue/queue.ts:450`).
+
+3. **The outbox cursor writer that lacks a clamp.** Two of three cursor writers
+   clamp against unserved/emitted state with docstrings naming the skip hazard;
+   `gql-req-channel.ts:177-195` does a bare `max(getLatestAppliedOrdinal)` →
+   `upsert` with neither. Cross-document parallelism alone lets a higher-ordinal
+   document ack first, so this is a restart-skips-operations risk independent of
+   scope. Not demonstrated end-to-end.
+
+4. **Projection races across scopes.** `ReadModelCoordinator` parallelizes across
+   `(documentId, scope, branch)` keys (`src/read-models/coordinator.ts:18-24`)
+   and the executor's per-document mutex does not extend to the projection stage,
+   so the shared `header` row and the `SlugMapping` upsert
+   (`document-view.ts:186-188`, `:240-257`) already race across a document's
+   scopes. Separately, `BaseReadModel.saveState` sets `ViewState.lastOrdinal` with
+   `set` rather than a max (`src/read-models/base-read-model.ts:161-179`), so
+   parallel chains can walk the watermark backwards.
+
+5. **`replayDocument` orders cross-scope replay by raw `Object.keys`**
+   (`packages/shared/document-model/documents.ts:536`), fed by a `getRevisions()`
+   query with no `ORDER BY` (`src/storage/kysely/store.ts:585-611`). Same missing
+   rank concept, different subsystem. Uninvestigated.
+
+### Not a defect
+
+`failJob` adds a failed job to `completedJobs` "so dependent jobs are unblocked"
+(`queue/queue.ts:506-508`). This looks wrong against the barrier — a failed
+create would let an auth op proceed — but #2918's deferral fix deliberately
+relies on it, and in the backfill case releasing is *correct*: when the deferred
+auth job fails, the create should proceed, not cascade-fail. Release-vs-cascade
+depends on the direction of the causal dependency, which is a design question,
+not a bug to fix.
+
+## Sequencing
+
+1. ~~Merge #2918 as-is~~ — done (`db6136341`), and #2919 (`b6f069fb8`).
+2. Confirm the deadlock with a test, now that #2918 bounds it.
+3. Fix the ordering (candidate 3, or candidate 1 with a derived rank), measuring
+   the batching cost first.
+4. Separate PR: the `externalDeps` guard (adjacent defect 2).
+5. Separate PR: discarded re-evaluation writes (adjacent defect 1).
+6. Needs a decision before implementation: the cross-page dependency encoder, and
+   whether `dependsOn` should cascade or release on failure.

--- a/packages/reactor/src/sync/sync-manager.ts
+++ b/packages/reactor/src/sync/sync-manager.ts
@@ -1148,11 +1148,39 @@ export class SyncManager implements ISyncManager {
       hasMore = !!page.next;
 
       if (operations.length > 0) {
+        // Which documents this page creates. A creation is always in the
+        // `document` scope (document-action-handler.ts:346), and every other
+        // scope's run for that document needs it to exist first.
+        const created = new Set<string>();
+        for (const entry of operations) {
+          if (entry.operation.action.type === "CREATE_DOCUMENT") {
+            created.add(entry.context.documentId);
+          }
+        }
+
         operations.sort((a, b) => {
           if (a.context.documentId !== b.context.documentId) {
             return a.context.documentId < b.context.documentId ? -1 : 1;
           }
           if (a.context.scope !== b.context.scope) {
+            // Scope is otherwise compared as a raw string, so `auth` sorted
+            // ahead of the `document` run that creates it -- and emitBatches
+            // turns emission order into a dependency through lastJobByDoc, so
+            // the creation was emitted depending on an operation for a
+            // document that did not exist yet. The receiver defers that
+            // operation until a CREATE_DOCUMENT for the id lands, which is the
+            // job queued behind it, and neither side moves.
+            //
+            // Only the creating run is hoisted. Ordering the scopes against
+            // each other generally is a separate question with its own
+            // answers elsewhere (comparePositions gives `auth` a timestamp
+            // tie), and grouping by scope at all is what keeps a page's
+            // batches few -- serving a document's operations in index order
+            // splits it into a batch per scope change.
+            if (created.has(a.context.documentId)) {
+              if (a.context.scope === "document") return -1;
+              if (b.context.scope === "document") return 1;
+            }
             return a.context.scope < b.context.scope ? -1 : 1;
           }
           return a.context.ordinal - b.context.ordinal;

--- a/packages/reactor/src/sync/sync-manager.ts
+++ b/packages/reactor/src/sync/sync-manager.ts
@@ -1148,12 +1148,19 @@ export class SyncManager implements ISyncManager {
       hasMore = !!page.next;
 
       if (operations.length > 0) {
+        // Group a document's operations without reordering them. The index
+        // returns global insertion order, which is causally safe: a document's
+        // creation precedes everything about it, and its auth run precedes the
+        // domain operations it decides. Sorting by scope within a document
+        // discarded that -- it served a document's `auth` run before the
+        // `document` run that creates it, and emitBatches turned emission order
+        // into a dependency, so the creation waited on an operation for a
+        // document that did not exist yet. Grouping by document alone keeps the
+        // batching this sort exists for, since batchOperationsByDocument only
+        // groups contiguous runs.
         operations.sort((a, b) => {
           if (a.context.documentId !== b.context.documentId) {
             return a.context.documentId < b.context.documentId ? -1 : 1;
-          }
-          if (a.context.scope !== b.context.scope) {
-            return a.context.scope < b.context.scope ? -1 : 1;
           }
           return a.context.ordinal - b.context.ordinal;
         });

--- a/packages/reactor/src/sync/utils.ts
+++ b/packages/reactor/src/sync/utils.ts
@@ -278,6 +278,13 @@ export function toOperationWithContext(
  * a single SyncOperation per group. Within each group, operations are sorted
  * by context.ordinal. The merged SyncOperation keeps the first group member's
  * jobId; all other jobIds are remapped so external dependencies still resolve.
+ *
+ * Only CONTIGUOUS runs merge. A document whose scopes interleave arrives as an
+ * alternating chain (document -> auth -> document -> auth) where each entry
+ * depends on the one before it. Merging every occurrence of a
+ * (documentId, scope, branch) collapses that chain into two nodes that each
+ * depend on the other, which validateBatchStructure rejects as a dependency
+ * cycle. Merging only adjacent entries keeps the chain linear.
  */
 export function consolidateSyncOperations(
   syncOps: SyncOperation[],
@@ -286,33 +293,28 @@ export function consolidateSyncOperations(
     return syncOps;
   }
 
-  type GroupKey = string;
-  const groups = new Map<
-    GroupKey,
-    { ops: SyncOperation[]; canonicalJobId: string }
-  >();
+  const groups: Array<{ ops: SyncOperation[]; canonicalJobId: string }> = [];
   const jobIdRemap = new Map<string, string>();
-  const insertionOrder: GroupKey[] = [];
+  let prevKey: string | null = null;
 
   for (const syncOp of syncOps) {
-    const key: GroupKey = `${syncOp.documentId}|${syncOp.scopes.slice().sort().join(",")}|${syncOp.branch}`;
+    const key = `${syncOp.documentId}|${syncOp.scopes.slice().sort().join(",")}|${syncOp.branch}`;
 
-    const existing = groups.get(key);
-    if (existing) {
-      existing.ops.push(syncOp);
-      if (syncOp.jobId && syncOp.jobId !== existing.canonicalJobId) {
-        jobIdRemap.set(syncOp.jobId, existing.canonicalJobId);
+    const current = key === prevKey ? groups[groups.length - 1] : undefined;
+    if (current) {
+      current.ops.push(syncOp);
+      if (syncOp.jobId && syncOp.jobId !== current.canonicalJobId) {
+        jobIdRemap.set(syncOp.jobId, current.canonicalJobId);
       }
     } else {
-      groups.set(key, { ops: [syncOp], canonicalJobId: syncOp.jobId });
-      insertionOrder.push(key);
+      groups.push({ ops: [syncOp], canonicalJobId: syncOp.jobId });
+      prevKey = key;
     }
   }
 
   const result: SyncOperation[] = [];
 
-  for (const key of insertionOrder) {
-    const group = groups.get(key)!;
+  for (const group of groups) {
     const allOperations = group.ops
       .flatMap((op) => op.operations)
       .sort((a, b) => a.context.ordinal - b.context.ordinal);

--- a/packages/reactor/src/sync/utils.ts
+++ b/packages/reactor/src/sync/utils.ts
@@ -185,11 +185,13 @@ export function batchOperationsByDocument(
  * deferred tail containing the trailing run that shares the same
  * (documentId, branch, scope, timestampUtcMs) as the last operation.
  *
- * The page is assumed to be sorted by (documentId, scope, ordinal), so a
- * same-(docId, scope, ts) run is contiguous and lives at the end of any
- * page that contains its last member. Holding that tail back lets callers
- * prepend it to the next page so a single producer-side execute() call
- * never gets split across two outbound envelopes.
+ * The page is assumed to be grouped by documentId and ordered by ordinal
+ * within a document. One execute() call writes one document, scope and branch,
+ * so its operations take consecutive ordinals: a same-(docId, scope, ts) run is
+ * therefore contiguous and lives at the end of any page that contains its last
+ * member. Holding that tail back lets callers prepend it to the next page so a
+ * single producer-side execute() call never gets split across two outbound
+ * envelopes.
  */
 export function splitTrailingSameTimestampRun(
   operations: OperationWithContext[],

--- a/packages/reactor/test/executor/executor-manager/deferred-dependent-deadlock.test.ts
+++ b/packages/reactor/test/executor/executor-manager/deferred-dependent-deadlock.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../../src/events/event-bus.js";
+import type { IEventBus } from "../../../src/events/interfaces.js";
+import type { IJobExecutor } from "../../../src/executor/interfaces.js";
+import { SimpleJobExecutorManager } from "../../../src/executor/simple-job-executor-manager.js";
+import { InMemoryJobTracker } from "../../../src/job-tracker/in-memory-job-tracker.js";
+import { InMemoryQueue } from "../../../src/queue/queue.js";
+import { NullDocumentModelResolver } from "../../../src/registry/document-model-resolver.js";
+import { DocumentNotFoundError } from "../../../src/shared/errors.js";
+import { JobStatus } from "../../../src/shared/types.js";
+import { createMockLogger, createTestJob } from "../../factories.js";
+
+const DOC = "policied-doc";
+
+/** Long enough that the timeout cannot rescue the hold under test. */
+const NO_RESCUE_MS = 10_000;
+/** Short enough to assert against, long enough to survive a slow runner. */
+const TTL_MS = 60;
+
+const settled = (ms = 250) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * `updateOutbox` sorts a backfill page by scope as a raw string, so a document's
+ * `auth` run is served before the `document` run that creates it, and the
+ * creation is emitted depending on the auth run
+ * (docs/updateoutbox-scope-ordering.md). This is what the receiver then does
+ * with that pair.
+ *
+ * The auth run is deferred because its document is missing, and a hold is
+ * released by a completed CREATE_DOCUMENT for that id -- which is the job
+ * waiting on it. Deferral moves no status and emits no event, so before #2918
+ * bounded the hold neither side could move and nothing was reported.
+ */
+describe("a document's creation queued behind its own deferred auth run", () => {
+  let eventBus: IEventBus;
+  let queue: InMemoryQueue;
+  let jobTracker: InMemoryJobTracker;
+  let manager: SimpleJobExecutorManager;
+  let executed: string[];
+
+  /** Defers anything in the auth scope; every other scope succeeds. */
+  const authDefersExecutor = (): IJobExecutor => ({
+    executeJob: vi
+      .fn()
+      .mockImplementation((job: { id: string; scope: string }) => {
+        executed.push(job.id);
+        if (job.scope === "auth") {
+          return Promise.resolve({
+            success: false,
+            error: new DocumentNotFoundError(DOC),
+          });
+        }
+        return Promise.resolve({ success: true, operations: [] });
+      }),
+  });
+
+  const startManager = (ttlMs: number) => {
+    manager = new SimpleJobExecutorManager(
+      () => authDefersExecutor(),
+      eventBus,
+      queue,
+      jobTracker,
+      createMockLogger(),
+      new NullDocumentModelResolver(),
+      30_000,
+      ttlMs,
+    );
+    return manager.start(1);
+  };
+
+  const authJob = () =>
+    createTestJob({
+      id: "auth-job",
+      kind: "load",
+      documentId: DOC,
+      scope: "auth",
+      maxRetries: 0,
+    });
+
+  const createJob = (queueHint: string[]) =>
+    createTestJob({
+      id: "create-job",
+      kind: "load",
+      documentId: DOC,
+      scope: "document",
+      maxRetries: 0,
+      queueHint,
+    });
+
+  beforeEach(() => {
+    eventBus = new EventBus();
+    queue = new InMemoryQueue(eventBus, new NullDocumentModelResolver());
+    jobTracker = new InMemoryJobTracker(eventBus);
+    executed = [];
+  });
+
+  afterEach(async () => {
+    await manager.stop(false);
+  });
+
+  it("never dispatches the creation while the hold lasts", async () => {
+    await startManager(NO_RESCUE_MS);
+    await queue.enqueue(authJob());
+    await queue.enqueue(createJob(["auth-job"]));
+
+    await settled();
+
+    // The held job's status does not move, which is why nothing surfaced this:
+    // RUNNING is not terminal, so no dead letter and no failed caller.
+    expect(jobTracker.getJobStatus("auth-job")?.status).toBe(JobStatus.RUNNING);
+    // The creation is never even registered, let alone executed.
+    expect(executed).toEqual(["auth-job"]);
+    expect(jobTracker.getJobStatus("create-job")).toBeNull();
+  });
+
+  it("needs the inverted dependency -- a held job alone does not block its document", async () => {
+    await startManager(NO_RESCUE_MS);
+    await queue.enqueue(authJob());
+    await queue.enqueue(createJob([]));
+
+    await settled();
+
+    // Worth pinning: per-document serialization does NOT hold the creation, so
+    // the emitted dependency is what turns a deferral into a deadlock.
+    expect(executed).toContain("create-job");
+  });
+
+  it("dispatches the creation once the hold times out", async () => {
+    await startManager(TTL_MS);
+    await queue.enqueue(authJob());
+    await queue.enqueue(createJob(["auth-job"]));
+
+    await settled();
+
+    expect(jobTracker.getJobStatus("auth-job")?.status).toBe(JobStatus.FAILED);
+    expect(executed).toContain("create-job");
+  });
+});

--- a/packages/reactor/test/sync/sync-manager/scope-ordering.test.ts
+++ b/packages/reactor/test/sync/sync-manager/scope-ordering.test.ts
@@ -158,6 +158,49 @@ describe("updateOutbox scope ordering", () => {
     ]);
   });
 
+  it("keeps a document's scopes interleaved as the index ordered them", async () => {
+    const collectionId = DriveCollectionId.forDrive(DRIVE_ID);
+    const common = {
+      documentId: DOC_ID,
+      documentType: "powerhouse/document-drive",
+      branch: "main",
+      sourceRemote: "",
+    };
+    const history: Array<[string, string]> = [
+      ["document", "CREATE_DOCUMENT"],
+      ["auth", "INITIALIZE_AUTH"],
+      ["global", "SET_NAME"],
+      ["document", "UPGRADE_DOCUMENT"],
+      ["auth", "SET_GRANT"],
+      ["global", "SET_NAME"],
+    ];
+
+    const txn = operationIndex.start();
+    txn.write(
+      history.map(([scope, type], i) => ({
+        ...op(`op-${i}`, 0, scope, type, String((i + 1) * 1000)),
+        ...common,
+        scope,
+      })),
+    );
+    txn.createCollection(collectionId.key);
+    txn.addToCollection(collectionId.key, DOC_ID);
+    await operationIndex.commit(txn);
+
+    const channelConfig: ChannelConfig = { type: "internal", parameters: {} };
+    await syncManager.add("remote1", collectionId, channelConfig);
+
+    await vi.waitFor(() => {
+      expect(emitted).toHaveLength(history.length);
+    });
+
+    // A scope rank would group the two document-scope runs together and deliver
+    // UPGRADE_DOCUMENT ahead of the auth and domain operations it followed.
+    expect(emitted.map((syncOp) => syncOp.scopes[0])).toEqual(
+      history.map(([scope]) => scope),
+    );
+  });
+
   it("does not make a document's creation wait on its auth operation", async () => {
     const collectionId = await seedPoliciedDocument();
 

--- a/packages/reactor/test/sync/sync-manager/scope-ordering.test.ts
+++ b/packages/reactor/test/sync/sync-manager/scope-ordering.test.ts
@@ -142,11 +142,7 @@ describe("updateOutbox scope ordering", () => {
     expect(page.results.map((r) => r.scope)).toEqual(["document", "auth"]);
   });
 
-  // Skipped, not deleted: these two assert the causally correct behaviour rather
-  // than the current one, so they fail until updateOutbox stops reordering a
-  // page's scopes. The fix un-skips them (#2921). The case above stays live,
-  // pinning the index order the sort discards.
-  it.skip("backfills a policied document creation-first", async () => {
+  it("backfills a policied document creation-first", async () => {
     const collectionId = await seedPoliciedDocument();
 
     const channelConfig: ChannelConfig = { type: "internal", parameters: {} };
@@ -162,8 +158,7 @@ describe("updateOutbox scope ordering", () => {
     ]);
   });
 
-  // Skipped for the same reason as above; un-skipped by #2921.
-  it.skip("does not make a document's creation wait on its auth operation", async () => {
+  it("does not make a document's creation wait on its auth operation", async () => {
     const collectionId = await seedPoliciedDocument();
 
     const channelConfig: ChannelConfig = { type: "internal", parameters: {} };

--- a/packages/reactor/test/sync/utils.test.ts
+++ b/packages/reactor/test/sync/utils.test.ts
@@ -1,5 +1,6 @@
 import type { OperationWithContext } from "@powerhousedao/shared/document-model";
 import { describe, expect, it } from "vitest";
+import { validateBatchStructure } from "../../src/core/utils.js";
 import { SyncOperation } from "../../src/sync/sync-operation.js";
 import type { RemoteFilter } from "../../src/sync/types.js";
 import {
@@ -593,5 +594,60 @@ describe("consolidateSyncOperations", () => {
     expect(result).toHaveLength(2);
     expect(result[0].branch).toBe("main");
     expect(result[1].branch).toBe("draft");
+  });
+
+  it("does not merge a scope's runs across an intervening run of another scope", () => {
+    // One document whose scopes interleave, as the operation index orders them.
+    // Merging both `document` runs into one node and both `auth` runs into
+    // another makes each depend on the other.
+    const polled = [
+      makeSyncOp("j1", "doc-a", "document", "main", [1]),
+      makeSyncOp("j2", "doc-a", "auth", "main", [2], ["j1"]),
+      makeSyncOp("j3", "doc-a", "document", "main", [3], ["j2"]),
+      makeSyncOp("j4", "doc-a", "auth", "main", [4], ["j3"]),
+    ];
+
+    const result = consolidateSyncOperations(polled);
+
+    expect(result.map((syncOp) => syncOp.jobId)).toEqual([
+      "j1",
+      "j2",
+      "j3",
+      "j4",
+    ]);
+    expect(result.map((syncOp) => syncOp.jobDependencies)).toEqual([
+      [],
+      ["j1"],
+      ["j2"],
+      ["j3"],
+    ]);
+
+    // The receiver rejects a batch whose dependencies form a cycle, which is
+    // what the merged shape produced.
+    expect(() =>
+      validateBatchStructure(
+        result.map((syncOp) => ({
+          key: syncOp.jobId,
+          dependsOn: syncOp.jobDependencies,
+        })),
+      ),
+    ).not.toThrow();
+  });
+
+  it("still merges a scope's adjacent runs", () => {
+    const polled = [
+      makeSyncOp("j1", "doc-a", "document", "main", [1]),
+      makeSyncOp("j2", "doc-a", "document", "main", [2], ["j1"]),
+      makeSyncOp("j3", "doc-a", "auth", "main", [3], ["j2"]),
+      makeSyncOp("j4", "doc-a", "auth", "main", [4], ["j3"]),
+    ];
+
+    const result = consolidateSyncOperations(polled);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].jobId).toBe("j1");
+    expect(result[0].operations.map((o) => o.context.ordinal)).toEqual([1, 2]);
+    expect(result[1].jobId).toBe("j3");
+    expect(result[1].jobDependencies).toEqual(["j1"]);
   });
 });


### PR DESCRIPTION
`updateOutbox` sorts each backfill page by `(documentId, scope, ordinal)` and
compares scope as a raw string, so for one document the `auth` run sorted ahead
of the `document` run that creates it. `emitBatches` turns emission order into a
dependency through `lastJobByDoc`, so the creation was emitted depending on an
operation for a document that did not exist yet.

A page that carries a document's `CREATE_DOCUMENT` now serves that run first.
Creation is always in the `document` scope
(`document-action-handler.ts:346`), so the run to hoist is unambiguous.

## Why the symptom was silence

The receiver defers the auth run because its document is missing. Deferral moves
no job status and emits no event, and a hold is released by a completed
`CREATE_DOCUMENT` for that id -- which is the job waiting behind it. Neither side
could move and nothing was reported. #2918 bounded that hold, so today it
resolves after 30s with a dead-lettered auth run rather than lasting the process
lifetime.

That dead letter is not recovered in-process. `Mailbox.add` raises
`latestOrdinal` for every operation it takes, whether or not the operation later
fails (`sync/mailbox.ts:99-101`); the poll sends that as `outboxLatest`, and the
server advances `deliveredCount` past it and then skips the entry forever
(`reactor-api/.../resolvers.ts:1419-1428`). Only the durable cursor is
applied-only, so the run comes back on the next process start and not before. A
freshly backfilled policied document therefore keeps its creation and runs
without its auth policy until a restart.

`deferred-dependent-deadlock.test.ts` pins the deadlock, including the case that
isolates the cause: with the dependency removed the creation runs, so
per-document serialization is not what held it.

## Only the creating run moves

An earlier revision of this PR served each page in the operation index's own
order instead, on the grounds that index order is causally safe. That was
reverted. Two measurements, both against the hub-spoke fixture (410 documents,
7,056 operations, 407 of them carrying exactly two scopes):

**It costs a factor of 2.5 in load jobs.**

| batching | load jobs | operations per job |
|---|---|---|
| by (document, scope) | 817 | 8.6 |
| by (document, ordinal) | 2,016 | 3.5 |

Convergence time tracked that ratio -- 2.47x the jobs for 2.64x the wall clock --
so the cost is per-job overhead. On CI it took the 3-spoke leg past its 300s cap
and then took Postgres down with it.

**It does not buy the ordering it appears to buy.** Delivery order is not what
decides the order a document's scopes are applied in. `replayDocument` replays
`Object.values(operations).flatMap(...)`
(`shared/document-model/documents.ts:536`) -- scope by scope, no cross-scope sort
-- and reduces in that order. Given `global@1000`, `local@2000`, `global@3000`,
`local@4000` it applies `global@1000, global@3000, local@2000, local@4000`. The
one place operations from different streams are ordered by timestamp,
`mergeByPosition`/`comparePositions`, is reached only from the auth walk and does
not feed state derivation. So an `UPGRADE_DOCUMENT` is not applied at the
position its timestamp implies whatever order it is delivered in; that belongs in
replay, and is recorded as adjacent defect 5.

A general `document`-before-`auth` rank was also rejected: `comparePositions`
gives `auth` the cross-stream timestamp tie deliberately, and serving document
operations ahead of auth could serve an operation before the grant that
authorizes it.

## The cycle that surfaced on the way

Kept because the defect is real and reachable on `main`.
`consolidateSyncOperations` merged **every** SyncOperation sharing a
`(documentId, scope, branch)`, wherever it sat in the chain. A document whose
scopes interleave arrives as an alternating chain, each entry depending on the
one before it:

```
j1 document  deps []
j2 auth      deps [j1]
j3 document  deps [j2]
j4 auth      deps [j3]
```

Merging both `document` entries into `j1` and both `auth` entries into `j2`
leaves `j1 -> [j2]` and `j2 -> [j1]`, which `validateBatchStructure` rejects for
the whole batch. Merging only contiguous runs keeps it linear. Adjacent runs of
one scope still merge, so the `jobId__p0`/`__p1` page-cap parts and repeated
polls for one document are unaffected.

The sort is per page, so a document with operations in two scopes spanning two
backfill pages reaches the outbox interleaved on `main` too. It needs a
multi-page backfill, which is why the fixture never hit it.

## Not fixed here

`docs/updateoutbox-scope-ordering.md` records five adjacent defects found while
investigating, none of which this touches. The most consequential is that the
cross-scope dependency chain only holds *within* a page, because the push encoder
resolves `dependsOn` against jobs in the same push array and drops the rest.

## Verification

- `pnpm typecheck` (root `tsc --build`) exit 0
- `packages/reactor` 2674/2674 across 155 files; lint 0 errors
- The two cases 78e18948d skipped are un-skipped and pass 3/3; removing just the
  hoist fails 2 of them
- `hub-spoke-catchup.integration.test.ts` 4/4 in 247.53s, against `main` at
  209.42s and 298.93s on the same machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)
