### PR TITLE
fix(reactor): stable processor cursor ids behind legacyProcessorIds flag

### DIFF
--- a/apps/switchboard/src/server.mts
+++ b/apps/switchboard/src/server.mts
@@ -459,7 +459,11 @@ async function initServer(
 
     const reactorBuilder = new ReactorBuilder()
       .withEventBus(new EventBus())
-      .withKysely(baseKysely);
+      .withKysely(baseKysely)
+      .withFeatures({
+        legacyProcessorIds:
+          process.env.REACTOR_LEGACY_PROCESSOR_IDS !== "false",
+      });
 
     const clientBuilder = new ReactorClientBuilder().withReactorBuilder(
       reactorBuilder,

--- a/packages/reactor/src/core/reactor-builder.ts
+++ b/packages/reactor/src/core/reactor-builder.ts
@@ -181,7 +181,10 @@ export class ReactorBuilder {
   private logger?: ILogger;
   private documentModelSources: DocumentModelSource[] = [];
   private upgradeManifests: UpgradeManifest<readonly number[]>[] = [];
-  private features: ReactorFeatures = { legacyStorageEnabled: false };
+  private features: ReactorFeatures = {
+    legacyStorageEnabled: false,
+    legacyProcessorIds: true,
+  };
   private readModels: IReadModel[] = [];
   private readModelFactories: ReadModelFactory[] = [];
   private executorManager: IJobExecutorManager | undefined;
@@ -662,6 +665,7 @@ export class ReactorBuilder {
       processorManagerConsistencyTracker,
       this.logger!,
       this.driveContainerTypes,
+      { legacyProcessorIds: this.features.legacyProcessorIds !== false },
     );
 
     try {

--- a/packages/reactor/src/processors/processor-manager.ts
+++ b/packages/reactor/src/processors/processor-manager.ts
@@ -25,7 +25,14 @@ import {
   extractDriveHeader,
   isDriveDeletion,
   matchesFilter,
+  resolveProcessorSlots,
 } from "./utils.js";
+
+export type ProcessorManagerOptions = {
+  // Key cursors by array position (default). Off derives stable keys from
+  // record id, namespace or class name, so reordering factories is safe.
+  legacyProcessorIds?: boolean;
+};
 
 /**
  * Manages processor lifecycle based on operations.
@@ -50,6 +57,7 @@ export class ProcessorManager
   private cursorCache: Map<string, ProcessorCursorRow> = new Map();
   private logger: ILogger;
   private driveContainerTypes: ReadonlySet<string>;
+  private legacyProcessorIds: boolean;
 
   constructor(
     db: Kysely<DocumentViewDatabase>,
@@ -58,6 +66,7 @@ export class ProcessorManager
     consistencyTracker: IConsistencyTracker,
     logger: ILogger,
     driveContainerTypes: ReadonlySet<string>,
+    options: ProcessorManagerOptions = {},
   ) {
     super(db, operationIndex, writeCache, consistencyTracker, {
       readModelId: "processor-manager",
@@ -65,6 +74,7 @@ export class ProcessorManager
     });
     this.logger = logger;
     this.driveContainerTypes = driveContainerTypes;
+    this.legacyProcessorIds = options.legacyProcessorIds ?? true;
   }
 
   override async init(): Promise<void> {
@@ -233,10 +243,11 @@ export class ProcessorManager
     if (records.length === 0) return;
 
     const trackedList: TrackedProcessor[] = [];
+    const slots = resolveProcessorSlots(records, this.legacyProcessorIds);
 
     for (let i = 0; i < records.length; i++) {
       const record = records[i]!;
-      const processorId = `${identifier}:${driveId}:${i}`;
+      const processorId = `${identifier}:${driveId}:${slots[i]}`;
 
       const cached = this.cursorCache.get(processorId);
       let lastOrdinal: number;
@@ -275,19 +286,20 @@ export class ProcessorManager
       await this.saveProcessorCursor(tracked);
     }
 
-    // Clean up orphaned cursor rows from previous runs with more processors
+    // Cursors this factory no longer produces for the drive are orphans.
+    const liveIds = new Set(trackedList.map((t) => t.processorId));
     await this.db
       .deleteFrom("ProcessorCursor")
       .where("factoryId", "=", identifier)
       .where("driveId", "=", driveId)
-      .where("processorIndex", ">=", records.length)
+      .where("processorId", "not in", [...liveIds])
       .execute();
 
     for (const [id, row] of this.cursorCache) {
       if (
         row.factoryId === identifier &&
         row.driveId === driveId &&
-        row.processorIndex >= records.length
+        !liveIds.has(id)
       ) {
         this.cursorCache.delete(id);
       }

--- a/packages/reactor/src/processors/utils.ts
+++ b/packages/reactor/src/processors/utils.ts
@@ -1,5 +1,8 @@
 import type { OperationWithContext } from "@powerhousedao/shared/document-model";
-import type { ProcessorFilter } from "@powerhousedao/shared/processors";
+import type {
+  ProcessorFilter,
+  ProcessorRecord,
+} from "@powerhousedao/shared/processors";
 import type { PHDocumentHeader } from "@powerhousedao/shared/document-model";
 
 export function isDriveDeletion(op: OperationWithContext): boolean {
@@ -75,4 +78,38 @@ export function matchesFilter(
   }
 
   return true;
+}
+
+function nonEmpty(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function namespaceOf(processor: object): string | undefined {
+  return nonEmpty((processor as { namespace?: unknown }).namespace);
+}
+
+function classNameOf(processor: object): string | undefined {
+  const name = processor.constructor.name;
+  return name && name !== "Object" ? name : undefined;
+}
+
+// Cursor key of each record within its factory and drive. Legacy mode keeps
+// the array index; otherwise id, then namespace, then class name, then index.
+export function resolveProcessorSlots(
+  records: ProcessorRecord[],
+  legacy: boolean,
+): string[] {
+  if (legacy) return records.map((_, i) => String(i));
+
+  const seen = new Map<string, number>();
+  return records.map((record, i) => {
+    const base =
+      nonEmpty(record.id) ??
+      namespaceOf(record.processor) ??
+      classNameOf(record.processor) ??
+      String(i);
+    const count = seen.get(base) ?? 0;
+    seen.set(base, count + 1);
+    return count === 0 ? base : `${base}#${count}`;
+  });
 }

--- a/packages/reactor/test/processors/processor-manager.test.ts
+++ b/packages/reactor/test/processors/processor-manager.test.ts
@@ -1,5 +1,8 @@
 import { PGlite } from "@electric-sql/pglite";
-import { driveDocumentModelModule } from "@powerhousedao/shared/document-drive";
+import {
+  driveDocumentModelModule,
+  setDriveName,
+} from "@powerhousedao/shared/document-drive";
 import {
   generateId,
   type DocumentModelModule,
@@ -39,11 +42,13 @@ const DRIVE_DOCUMENT_TYPE = "powerhouse/document-drive";
 
 type CombinedDatabase = StorageDatabase & DocumentViewDatabase;
 
-function createMockProcessor(): IProcessor & {
+function createMockProcessor(namespace?: string): IProcessor & {
   receivedOperations: OperationWithContext[];
   disconnected: boolean;
 } {
   const processor = {
+    // Mirrors RelationalDbProcessor, whose namespace keys derived cursor ids.
+    ...(namespace ? { namespace } : {}),
     receivedOperations: [] as OperationWithContext[],
     disconnected: false,
     onOperations: vi.fn().mockImplementation((ops: OperationWithContext[]) => {
@@ -890,6 +895,52 @@ describe("ProcessorManager Standalone Tests", () => {
     });
   });
 
+  describe("Cursor ids", () => {
+    it("should key cursors by array position by default", async () => {
+      const driveId = generateId();
+      const factory: ProcessorFactory = () => [
+        { processor: createMockProcessor("company_list_v1"), filter: {} },
+      ];
+      await processorManager.registerFactory("pkg", factory);
+      await processorManager.indexOperations([makeDriveCreateOp(driveId, 1)]);
+
+      expect(processorManager.get(`pkg:${driveId}:0`)).toBeDefined();
+    });
+
+    it("should key cursors by derived slot when legacy ids are off", async () => {
+      const manager = new ProcessorManager(
+        db as unknown as Kysely<DocumentViewDatabase>,
+        operationIndex,
+        mockWriteCache,
+        new ConsistencyTracker(),
+        new ConsoleLogger(["test"]),
+        DEFAULT_DRIVE_CONTAINER_TYPES,
+        { legacyProcessorIds: false },
+      );
+      await manager.init();
+
+      const driveId = generateId();
+      const factory: ProcessorFactory = () => [
+        { processor: createMockProcessor("company_list_v1"), filter: {} },
+        { processor: createMockProcessor(), filter: {}, id: "explicit" },
+        { processor: createMockProcessor(), filter: {} },
+      ];
+      await manager.registerFactory("pkg", factory);
+      await manager.indexOperations([makeDriveCreateOp(driveId, 1)]);
+
+      expect(
+        manager
+          .getAll()
+          .map((t) => t.processorId)
+          .sort(),
+      ).toEqual([
+        `pkg:${driveId}:2`,
+        `pkg:${driveId}:company_list_v1`,
+        `pkg:${driveId}:explicit`,
+      ]);
+    });
+  });
+
   describe("Per-Processor Consistency", () => {
     it("should persist cursor per processor", async () => {
       const driveId = generateId();
@@ -1482,5 +1533,174 @@ describe("ProcessorManager Backfill Paging Regression", () => {
     expect(lastReceivedOrdinal).toBe(HUGE_PAGE_SIZE);
 
     await db.destroy();
+  });
+});
+
+describe("ProcessorManager Cursor Identity Across Restarts", () => {
+  let database: Kysely<Database>;
+  let started: InProcessReactorModule[] = [];
+
+  beforeEach(() => {
+    database = new Kysely<Database>({
+      dialect: new PGliteDialect(new PGlite()),
+    });
+  });
+
+  afterEach(async () => {
+    for (const module of started) {
+      await module.reactor.kill().completed;
+    }
+    started = [];
+    await database.destroy();
+  });
+
+  // Each call is one deployment; they share the database like a redeploy does.
+  async function deploy(): Promise<InProcessReactorModule> {
+    const module = await new ReactorBuilder()
+      .withKysely(database)
+      .withFeatures({ legacyProcessorIds: false })
+      .withDocumentModelSources([
+        documentModelDocumentModelModule as unknown as DocumentModelModule,
+        driveDocumentModelModule as unknown as DocumentModelModule,
+      ])
+      .buildModule();
+    started.push(module);
+    return module;
+  }
+
+  async function waitForJob(
+    module: InProcessReactorModule,
+    jobId: string,
+  ): Promise<void> {
+    await vi.waitUntil(
+      async () => {
+        const status = await module.reactor.getJobStatus(jobId);
+        if (status.status === JobStatus.FAILED) {
+          throw new Error(`Job failed: ${status.error?.message}`);
+        }
+        return status.status === JobStatus.READ_READY;
+      },
+      { timeout: 5000 },
+    );
+  }
+
+  // Creation and edit are serialized: concurrent batches can starve delivery.
+  async function createDriveWithOps(
+    module: InProcessReactorModule,
+  ): Promise<string> {
+    const driveDoc = driveDocumentModelModule.utils.createDocument();
+    const created = await module.reactor.create(driveDoc);
+    await waitForJob(module, created.id);
+    const renamed = await module.reactor.execute(driveDoc.header.id, "main", [
+      setDriveName({ name: "renamed" }),
+    ]);
+    await waitForJob(module, renamed.id);
+    return driveDoc.header.id;
+  }
+
+  function ordinalsOf(processor: ReturnType<typeof createMockProcessor>) {
+    return processor.receivedOperations
+      .map((op) => op.context.ordinal)
+      .sort((a, b) => a - b);
+  }
+
+  // Ids are what is under test, so processors are located by identity instead.
+  function trackedFor(module: InProcessReactorModule, processor: IProcessor) {
+    return module.processorManager
+      .getAll()
+      .find((t) => t.record.processor === processor);
+  }
+
+  async function waitForCursor(
+    module: InProcessReactorModule,
+    processor: IProcessor,
+    ordinal: number,
+  ): Promise<void> {
+    await vi.waitFor(
+      () => expect(trackedFor(module, processor)?.lastOrdinal).toBe(ordinal),
+      { timeout: 5000 },
+    );
+  }
+
+  it("should backfill a processor inserted before existing ones in the factory array", async () => {
+    const first = await deploy();
+    const existing = createMockProcessor("existing_v1");
+    await first.processorManager.registerFactory("pkg", () => [
+      { processor: existing, filter: {} },
+    ]);
+
+    await createDriveWithOps(first);
+    const seen = ordinalsOf(existing);
+    expect(seen.length).toBeGreaterThanOrEqual(3);
+    await waitForCursor(first, existing, seen[seen.length - 1]!);
+    await first.reactor.kill().completed;
+
+    // Redeploy with a new processor inserted at index 0.
+    const second = await deploy();
+    const added = createMockProcessor("added_v1");
+    const existing2 = createMockProcessor("existing_v1");
+    await second.processorManager.registerFactory("pkg", () => [
+      { processor: added, filter: {} },
+      { processor: existing2, filter: {} },
+    ]);
+
+    // Never seen anything: full history expected.
+    expect(ordinalsOf(added)).toEqual(seen);
+    // Already caught up: nothing expected.
+    expect(existing2.receivedOperations).toHaveLength(0);
+  });
+
+  it("should keep a processor's cursor and status when one before it is removed", async () => {
+    const first = await deploy();
+    const a = createMockProcessor("a_v1");
+    const b = createMockProcessor("b_v1");
+    const c = createMockProcessor("c_v1");
+    // `c` fails on every delivery, so it stays errored with its cursor frozen.
+    c.onOperations = vi.fn().mockRejectedValue(new Error("boom"));
+    await first.processorManager.registerFactory("pkg", () => [
+      { processor: a, filter: {} },
+      { processor: b, filter: {} },
+      { processor: c, filter: {} },
+    ]);
+
+    const driveId = await createDriveWithOps(first);
+    const seen = ordinalsOf(b);
+    expect(seen.length).toBeGreaterThanOrEqual(3);
+    await waitForCursor(first, b, seen[seen.length - 1]!);
+    await vi.waitFor(
+      () => expect(trackedFor(first, c)?.status).toBe("errored"),
+      { timeout: 5000 },
+    );
+    await first.reactor.kill().completed;
+
+    // Redeploy without `b`: `c` moves from index 2 to index 1.
+    const second = await deploy();
+    const a2 = createMockProcessor("a_v1");
+    const c2 = createMockProcessor("c_v1");
+    await second.processorManager.registerFactory("pkg", () => [
+      { processor: a2, filter: {} },
+      { processor: c2, filter: {} },
+    ]);
+
+    expect(a2.receivedOperations).toHaveLength(0);
+
+    // `c` must come back as itself: still errored, and a retry delivers
+    // everything it missed rather than resuming from `b`'s cursor.
+    const restored = trackedFor(second, c2)!;
+    expect(restored.status).toBe("errored");
+    await restored.retry();
+    expect(ordinalsOf(c2)).toEqual(seen);
+
+    // `b`'s cursor is an orphan now.
+    const cursors = await database
+      .withSchema(REACTOR_SCHEMA)
+      .selectFrom("ProcessorCursor")
+      .select("processorId")
+      .where("factoryId", "=", "pkg")
+      .execute();
+    expect(cursors.map((row) => row.processorId).sort()).toEqual([
+      `pkg:${driveId}:a_v1`,
+      `pkg:${driveId}:c_v1`,
+    ]);
   });
 });

--- a/packages/reactor/test/processors/utils.test.ts
+++ b/packages/reactor/test/processors/utils.test.ts
@@ -1,7 +1,14 @@
 import type { OperationWithContext } from "@powerhousedao/shared/document-model";
-import type { ProcessorFilter } from "@powerhousedao/shared/processors";
+import type {
+  IProcessor,
+  ProcessorFilter,
+  ProcessorRecord,
+} from "@powerhousedao/shared/processors";
 import { describe, expect, it } from "vitest";
-import { matchesFilter } from "../../src/processors/utils.js";
+import {
+  matchesFilter,
+  resolveProcessorSlots,
+} from "../../src/processors/utils.js";
 
 function createOperation(context: {
   documentId: string;
@@ -297,5 +304,66 @@ describe("matchesFilter", () => {
 
       expect(matchesFilter(op, filter)).toBe(true);
     });
+  });
+});
+
+describe("resolveProcessorSlots", () => {
+  const stub: IProcessor = {
+    onOperations: () => Promise.resolve(),
+    onDisconnect: () => Promise.resolve(),
+  };
+  class Named implements IProcessor {
+    onOperations = () => Promise.resolve();
+    onDisconnect = () => Promise.resolve();
+  }
+  const record = (
+    processor: IProcessor & { namespace?: string },
+    id?: string,
+  ): ProcessorRecord => ({
+    processor,
+    filter: {},
+    ...(id ? { id } : {}),
+  });
+
+  it("should use array positions in legacy mode", () => {
+    const records = [record(new Named()), record({ ...stub, namespace: "ns" })];
+    expect(resolveProcessorSlots(records, true)).toEqual(["0", "1"]);
+  });
+
+  it("should prefer id, then namespace, then class name, then position", () => {
+    const records = [
+      record(new Named(), "explicit"),
+      record({ ...stub, namespace: "company_list_v1" }),
+      record(new Named()),
+      record(stub),
+    ];
+    expect(resolveProcessorSlots(records, false)).toEqual([
+      "explicit",
+      "company_list_v1",
+      "Named",
+      "3",
+    ]);
+  });
+
+  it("should suffix repeated keys by occurrence", () => {
+    const records = [
+      record(new Named()),
+      record(new Named()),
+      record(new Named()),
+    ];
+    expect(resolveProcessorSlots(records, false)).toEqual([
+      "Named",
+      "Named#1",
+      "Named#2",
+    ]);
+  });
+
+  it("should ignore empty ids and namespaces", () => {
+    expect(
+      resolveProcessorSlots(
+        [record({ ...stub, namespace: "" }, ""), record(stub, "")],
+        false,
+      ),
+    ).toEqual(["0", "1"]);
   });
 });

--- a/packages/shared/processors/types.ts
+++ b/packages/shared/processors/types.ts
@@ -65,6 +65,9 @@ export type ProcessorRecord = {
   processor: IProcessor;
   filter: ProcessorFilter;
   startFrom?: "beginning" | "current";
+  // Stable cursor key within its factory and drive. Derived from the
+  // processor's namespace or class name when omitted.
+  id?: string;
 };
 
 /**


### PR DESCRIPTION
## Problem

`ProcessorManager` persists each processor's cursor under `${package}:${drive}:${arrayIndex}`. When a factory's record array changes shape between deploys (a new processor inserted before existing ones, or one removed from the middle), every later processor silently takes over another processor's cursor:

- the inserted processor inherits a caught-up cursor and **never backfills** existing documents;
- a shifted processor inherits its neighbour's cursor and status, losing its own.

Codegen appends on `ph generate processor`, but rebuilds the list **alphabetically** from the `processors/` directory when `connect.ts`/`switchboard.ts` is regenerated, so this is easy to hit in practice.

## Fix

- `ProcessorRecord.id?: string` — optional explicit cursor key.
- `resolveProcessorSlots(records, legacy)`: legacy → array index (unchanged ids); otherwise `id` → `processor.namespace` (every `RelationalDbProcessor`) → class name → index, with `#n` suffixes for repeats.
- Orphan cursor cleanup now deletes rows for the factory+drive whose id was not produced this run (equivalent to the old `processorIndex >= length` rule in legacy mode).
- New `ReactorFeatures.legacyProcessorIds`, **default `true`**, threaded through `ReactorBuilder` → `ProcessorManager` (optional constructor arg). Switchboard: `REACTOR_LEGACY_PROCESSOR_IDS=false` opts in.

Legacy stays the default because switching derives new ids for every processor, which triggers a full backfill from ordinal 0 on the next boot. That is safe for idempotent processors but would double the append-only `drive-analytics` metrics and is unknowable for third-party processors.

## Tests

- `ProcessorManager Cursor Identity Across Restarts`: two real reactors over one PGlite database (redeploy simulation), drive created/edited through the reactor; insertion-before and removal-from-middle cases, plus orphan cleanup.
- `Cursor ids`: default keeps positional ids; derived mode yields namespace/explicit/index ids.
- `resolveProcessorSlots` unit tests.