### PR TITLE
fix(renown): keep sign-in failures on the page, and support pre-dev.54 switchboards

### DIFF
--- a/packages/reactor-browser/src/renown/use-renown-auth.ts
+++ b/packages/reactor-browser/src/renown/use-renown-auth.ts
@@ -1,4 +1,8 @@
-import type { LoginStatus, User } from "@renown/sdk";
+import {
+  MissingSwitchboardError,
+  type LoginStatus,
+  type User,
+} from "@renown/sdk";
 import type { LoginMethod, WalletSession } from "@renown/sdk/wallet";
 import { useCallback, useState, useSyncExternalStore } from "react";
 import { useLoginStatus, useUser } from "../hooks/renown.js";
@@ -103,15 +107,17 @@ export function useRenownAuth(): RenownAuth {
           openRenown();
           return;
         }
-        // completeSignIn throws when no switchboard is configured; fall back to
-        // the redirect flow only in that case so login still succeeds.
+        // completeSignIn throws MissingSwitchboardError when none is configured;
+        // fall back to the redirect flow only in that case so login still succeeds.
         await completeSignIn(resolved);
       } catch (e) {
         const err = e instanceof Error ? e : new Error(String(e));
         // A cancel clears pending (finally) without showing a red error.
         if (isUserCancellation(err)) return;
         setError(err);
-        if (/switchboard/i.test(err.message)) openRenown();
+        // Only when there is nowhere to post the credential. A switchboard that
+        // REJECTED it is a failure to show, not a reason to leave the page.
+        if (MissingSwitchboardError.is(err)) openRenown();
       } finally {
         setPending(false);
       }

--- a/packages/reactor-browser/test/renown/login-fallback.test.tsx
+++ b/packages/reactor-browser/test/renown/login-fallback.test.tsx
@@ -1,0 +1,98 @@
+import { MissingSwitchboardError, type IRenown } from "@renown/sdk";
+import type { WalletSession } from "@renown/sdk/wallet";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+import { render } from "vitest-browser-react";
+import { addRenownEventHandler, setRenown } from "../../src/hooks/renown.js";
+import { useRenownAuth } from "../../src/renown/use-renown-auth.js";
+
+/* `login()` posts the credential to the app's switchboard. A missing switchboard
+   is the one case where handing off to renown.id is right; any other failure has
+   to stay on the page as `error`, or the user never sees it. */
+
+function session(address: `0x${string}`): WalletSession {
+  return {
+    address,
+    chainId: 1,
+    signTypedData: () => Promise.resolve("0x" as `0x${string}`),
+  };
+}
+
+function renownRejectingWith(error: Error): IRenown {
+  return {
+    status: "not-authorized",
+    user: undefined,
+    on: () => () => undefined,
+    signIn: () => Promise.reject(error),
+  } as unknown as IRenown;
+}
+
+function Probe({ session }: { session: WalletSession }) {
+  const { login, error, pending } = useRenownAuth();
+  return (
+    <>
+      <button onClick={() => login(session)}>login</button>
+      <span data-testid="pending">{String(pending)}</span>
+      <span data-testid="error">{error?.message ?? ""}</span>
+    </>
+  );
+}
+
+let open: MockInstance<typeof window.open>;
+
+beforeEach(() => {
+  addRenownEventHandler();
+  // `openRenown` navigates with `window.open(url, "_self")`; never in a test.
+  open = vi.spyOn(window, "open").mockImplementation(() => null);
+});
+
+afterEach(() => {
+  open.mockRestore();
+  install(undefined);
+});
+
+/* Both readers: the hook store feeds `useUser`/`useLoginStatus`; `window.ph`
+   is what `completeSignIn` posts through. */
+function install(renown: IRenown | undefined) {
+  setRenown(renown);
+  const ph = (window.ph ??= {});
+  ph.renown = renown;
+}
+
+describe("useRenownAuth login fallback", () => {
+  it("surfaces a switchboard rejection instead of redirecting", async () => {
+    install(renownRejectingWith(new Error("Switchboard request failed: 400")));
+    const screen = render(
+      <Probe session={session("0x1000000000000000000000000000000000000001")} />,
+    );
+
+    await screen.getByRole("button").click();
+
+    await expect
+      .element(screen.getByTestId("error"))
+      .toHaveTextContent("Switchboard request failed: 400");
+    await expect
+      .element(screen.getByTestId("pending"))
+      .toHaveTextContent("false");
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("redirects to Renown only when no switchboard is configured", async () => {
+    install(renownRejectingWith(new MissingSwitchboardError()));
+    const screen = render(
+      <Probe session={session("0x1000000000000000000000000000000000000002")} />,
+    );
+
+    await screen.getByRole("button").click();
+
+    await vi.waitFor(() => expect(open).toHaveBeenCalledTimes(1));
+    expect(open.mock.calls[0]?.[1]).toBe("_self");
+  });
+});

--- a/packages/renown/src/common.ts
+++ b/packages/renown/src/common.ts
@@ -10,7 +10,10 @@ import {
 } from "./credential.js";
 import { RenownCryptoSigner, type IRenownCrypto } from "./crypto/index.js";
 import { MemoryStorage } from "./storage/common.js";
-import type { SwitchboardClient } from "./switchboard.js";
+import {
+  MissingSwitchboardError,
+  type SwitchboardClient,
+} from "./switchboard.js";
 import type {
   CreateBearerTokenOptions,
   IProof,
@@ -149,11 +152,7 @@ export class Renown implements IRenown {
   // Sign in without the Renown redirect: build + sign a delegation credential
   // with the caller's wallet signer, write it to the switchboard, then log in.
   async signIn(params: SignInParams): Promise<User> {
-    if (!this.#switchboard) {
-      throw new Error(
-        "signIn requires a switchboard endpoint. Set switchboardUrl or a discoverable baseUrl.",
-      );
-    }
+    if (!this.#switchboard) throw new MissingSwitchboardError();
     const {
       address,
       chainId,

--- a/packages/renown/src/switchboard.ts
+++ b/packages/renown/src/switchboard.ts
@@ -142,6 +142,27 @@ const MUTATE_DOCUMENT_MUTATION = /* GraphQL */ `
   }
 `;
 
+/* Switchboards older than 6.2.2-dev.54 have no `execute`; their `mutateDocument`
+   takes the same envelopes as untyped JSON. Same selection, so one result shape. */
+const LEGACY_MUTATE_DOCUMENT_MUTATION = /* GraphQL */ `
+  mutation MutateDocument(
+    $documentIdentifier: String!
+    $actions: [JSONObject!]!
+  ) {
+    mutateDocument(documentIdentifier: $documentIdentifier, actions: $actions) {
+      id
+    }
+  }
+`;
+
+// graphql-js validation failure for a field the server's schema lacks.
+function isUnknownExecuteField(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    /Cannot query field "execute" on type "Mutation"/.test(error.message)
+  );
+}
+
 const RENOWN_CREDENTIAL_DOC_TYPE = "powerhouse/renown-credential";
 const RENOWN_USER_DOC_TYPE = "powerhouse/renown-user";
 
@@ -240,6 +261,8 @@ export type SwitchboardSource = string | SwitchboardRequestFn;
 export class SwitchboardClient {
   #endpoint: string | undefined;
   #transport: SwitchboardRequestFn;
+  // Set once the switchboard has rejected `execute`, so later writes skip the probe.
+  #legacyMutate = false;
 
   constructor(source: SwitchboardSource) {
     if (typeof source === "string") {
@@ -266,15 +289,17 @@ export class SwitchboardClient {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ query, variables }),
     });
-    if (!response.ok) {
-      throw new Error(`Switchboard request failed: ${response.status}`);
-    }
-    const body = (await response.json()) as {
-      data?: unknown;
-      errors?: { message: string }[];
-    };
-    if (body.errors?.length) {
+    /* A validation failure comes back as 400 WITH a GraphQL error body, so read
+       it before judging the status: the messages say what was wrong, the code
+       only that something was. */
+    const body = (await response.json().catch(() => undefined)) as
+      | { data?: unknown; errors?: { message: string }[] }
+      | undefined;
+    if (body?.errors?.length) {
       throw new Error(body.errors.map((e) => e.message).join("; "));
+    }
+    if (!response.ok || !body) {
+      throw new Error(`Switchboard request failed: ${response.status}`);
     }
     // `#request` rejects an empty `data` for every transport, HTTP or local.
     return body.data;
@@ -365,9 +390,21 @@ export class SwitchboardClient {
     documentIdentifier: string,
     actions: Action[],
   ): Promise<string> {
+    const variables = { documentIdentifier, actions };
+    if (!this.#legacyMutate) {
+      try {
+        const { mutateDocument } = await this.#request<{
+          mutateDocument: { id: string };
+        }>(MUTATE_DOCUMENT_MUTATION, variables);
+        return mutateDocument.id;
+      } catch (error) {
+        if (!isUnknownExecuteField(error)) throw error;
+        this.#legacyMutate = true;
+      }
+    }
     const { mutateDocument } = await this.#request<{
       mutateDocument: { id: string };
-    }>(MUTATE_DOCUMENT_MUTATION, { documentIdentifier, actions });
+    }>(LEGACY_MUTATE_DOCUMENT_MUTATION, variables);
     return mutateDocument.id;
   }
 

--- a/packages/renown/src/switchboard.ts
+++ b/packages/renown/src/switchboard.ts
@@ -9,6 +9,25 @@ import type {
   RenownProfile,
 } from "./types.js";
 
+/** Thrown by `signIn` when the instance has no switchboard to write the
+ * credential to, so a host can fall back to the Renown redirect flow. */
+export class MissingSwitchboardError extends Error {
+  constructor() {
+    super(
+      "signIn requires a switchboard endpoint. Set switchboardUrl or a discoverable baseUrl.",
+    );
+    this.name = "MissingSwitchboardError";
+  }
+
+  /** `instanceof` fails across duplicate SDK copies, so match by name too. */
+  static is(error: unknown): error is MissingSwitchboardError {
+    return (
+      error instanceof MissingSwitchboardError ||
+      (error instanceof Error && error.name === "MissingSwitchboardError")
+    );
+  }
+}
+
 // Per-user drive convention shared with the Renown app: `renown-<address>`.
 // The read-model ignores driveId, but we pass it for parity.
 function userDriveId(address: string): string {

--- a/packages/renown/test/switchboard.test.ts
+++ b/packages/renown/test/switchboard.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAction } from "@powerhousedao/shared/document-model";
 import { CREDENTIAL_TYPES } from "../src/constants.js";
 import { SwitchboardClient } from "../src/switchboard.js";
 import type { PowerhouseVerifiableCredential } from "../src/types.js";
@@ -299,6 +300,95 @@ describe("SwitchboardClient", () => {
       mockGraphql({ renownUsers: [] });
       const profile = await client.getProfileByAddress(ADDRESS);
       expect(profile).toBeUndefined();
+    });
+  });
+
+  describe("mutateDocument", () => {
+    const UNKNOWN_EXECUTE = {
+      errors: [
+        {
+          message: 'Cannot query field "execute" on type "Mutation".',
+          extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+        },
+      ],
+    };
+
+    // Own instance per test: the fallback is remembered on the client.
+    const fresh = () => new SwitchboardClient("http://sb.test/graphql");
+
+    // A pre-dev.54 switchboard: `execute` fails validation, `mutateDocument` works.
+    function mockLegacyReactor() {
+      const calls: ReactorCall[] = [];
+      vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+        const body = JSON.parse(init?.body as string) as ReactorCall;
+        calls.push(body);
+        if (body.query.includes("execute(")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(UNKNOWN_EXECUTE), { status: 400 }),
+          );
+        }
+        const data = {
+          mutateDocument: { id: body.variables.documentIdentifier },
+        };
+        return Promise.resolve(
+          new Response(JSON.stringify({ data }), { status: 200 }),
+        );
+      });
+      return calls;
+    }
+
+    it("falls back to the legacy mutateDocument when the switchboard has no execute", async () => {
+      const calls = mockLegacyReactor();
+      const action = createAction("INIT", { id: "cred" });
+
+      const id = await fresh().mutateDocument("doc-1", [action]);
+
+      expect(id).toBe("doc-1");
+      expect(calls).toHaveLength(2);
+      expect(calls[0].query).toContain("execute(");
+      expect(calls[1].query).toContain("mutateDocument(");
+      expect(calls[1].query).not.toContain("execute");
+      expect(calls[1].variables).toEqual({
+        documentIdentifier: "doc-1",
+        actions: [action],
+      });
+    });
+
+    it("remembers the fallback instead of probing on every write", async () => {
+      const calls = mockLegacyReactor();
+      const action = createAction("INIT", { id: "cred" });
+
+      const sb = fresh();
+      await sb.mutateDocument("doc-1", [action]);
+      await sb.mutateDocument("doc-2", [action]);
+
+      const probes = calls.filter((c) => c.query.includes("execute("));
+      expect(probes).toHaveLength(1);
+      expect(calls).toHaveLength(3);
+    });
+
+    it("surfaces any other rejection instead of retrying", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({ errors: [{ message: "Document not found" }] }),
+          { status: 400 },
+        ),
+      );
+
+      await expect(
+        fresh().mutateDocument("doc-1", [createAction("INIT", {})]),
+      ).rejects.toThrow("Document not found");
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports the status when a failed response carries no GraphQL errors", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("Bad Gateway", { status: 502 }),
+      );
+
+      await expect(
+        fresh().mutateDocument("doc-1", [createAction("INIT", {})]),
+      ).rejects.toThrow("Switchboard request failed: 502");
     });
   });
 


### PR DESCRIPTION
Two fixes for in-page (whitelabel) Renown sign-in, found while debugging a portal whose sign-in bounced to renown.id after bumping to dev.59.

## 1. A rejected credential redirected to renown.id

`useRenownAuth().login` (reactor-browser) fell back to the redirect flow on any error whose message matched `/switchboard/i`:

```ts
setError(err);
if (/switchboard/i.test(err.message)) openRenown();
```

That was meant for the one case where the SDK has no switchboard configured, but the SDK's own client throws `Switchboard request failed: <status>`, so a credential the switchboard **rejected** navigated the page away before the error was ever shown. For a whitelabel (Privy) sign-in, where Privy has already authenticated the visitor and the host owns the screens, that redirect is a dead end.

- `@renown/sdk`: `Renown.signIn` throws a typed, exported `MissingSwitchboardError` when no switchboard is configured (`.is()` matches by name too, since consumers can end up with two SDK copies). Message text unchanged.
- `reactor-browser`: the hook redirects only on that error. Everything else stays on the page as `error`.

## 2. The rejection itself: `execute` does not exist on older switchboards

`SwitchboardClient` writes through `execute`, which reactor-api only gained in **6.2.2-dev.54** (7af2c4477 / 4d4740add). `switchboard.renown.vetra.io` is still on an older build and answers with HTTP 400 + `Cannot query field "execute" on type "Mutation"` — so every SDK ≥ dev.54 failed to issue a credential there.

- On exactly that validation error the client retries through the deprecated `mutateDocument(documentIdentifier, actions: [JSONObject!]!)`, and remembers the choice so later writes skip the probe. Any other error is rethrown untouched.
- `#post` now reads the GraphQL error body before judging the HTTP status, so a 400 reports the server's message instead of only the code.

Upgrading that deployment is still the real fix; this keeps the SDK working against whatever is deployed in the meantime.

## Tests

- `reactor-browser/test/renown/login-fallback.test.tsx`: a switchboard rejection surfaces as `error` with no `window.open`; a `MissingSwitchboardError` still redirects with `_self`. The first case fails against the old regex.
- `renown/test/switchboard.test.ts`: falls back to `mutateDocument` on the unknown-field error with the same variables; probes once per client; rethrows other errors without retrying; reports the status when a failed response has no GraphQL body.

`@renown/sdk`: 159 tests pass. `reactor-browser` renown suite (chromium): 24 pass.