### PR TITLE
fix(shared): move generateMock to a dedicated subpath so runtime bundles drop zocker/faker

### DIFF
--- a/apps/academy/docs/academy/03-Build/01-ManualTodoTutorial/04-WriteDocumentModelTests.md
+++ b/apps/academy/docs/academy/03-Build/01-ManualTodoTutorial/04-WriteDocumentModelTests.md
@@ -39,7 +39,7 @@ Navigate to `/document-models/todo-list/src/tests/todos.test.ts`. You will see t
 
 ```typescript
 import { describe, it, expect } from "vitest";
-import { generateMock } from "@powerhousedao/codegen";
+import { generateMock } from "document-model/mock";
 import {
   reducer,
   utils,
@@ -293,7 +293,7 @@ Here's the complete test file with all updates. Don't forget to add the missing 
 
 ```typescript
 import { describe, it, expect } from "vitest";
-import { generateMock } from "@powerhousedao/codegen";
+import { generateMock } from "document-model/mock";
 import type {
   AddTodoItemInput,
   DeleteTodoItemInput,

--- a/apps/academy/docs/academy/03-Build/02-DocumentModelCreation/06-ImplementDocumentModelTests.md
+++ b/apps/academy/docs/academy/03-Build/02-DocumentModelCreation/06-ImplementDocumentModelTests.md
@@ -29,7 +29,7 @@ This suite tests each operation, verifying not only that the `items` array is co
 
 ```typescript
 import { describe, it, expect } from "vitest";
-import { generateMock } from "document-model";
+import { generateMock } from "document-model/mock";
 import type {
   AddTodoItemInput,
   DeleteTodoItemInput,

--- a/apps/academy/docs/academy/03-Build/06-ExampleUsecases/Chatroom/04-ImplementOperationReducers.md
+++ b/apps/academy/docs/academy/03-Build/06-ExampleUsecases/Chatroom/04-ImplementOperationReducers.md
@@ -249,7 +249,7 @@ Replace the content of `messages.test.ts` with:
  */
 
 import { describe, it, expect } from "vitest";
-import { generateMock } from "@powerhousedao/codegen";
+import { generateMock } from "document-model/mock";
 import {
   reducer,
   utils,

--- a/apps/academy/llms-full.txt
+++ b/apps/academy/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-08-19T15:22:42.159Z
+> Generated: 2026-08-26T14:56:31.426Z
 > Total Documents: 110
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -29706,44 +29706,46 @@ This guide covers **Docker-based deployment**. If you prefer **traditional VM/se
 
 ## Available Docker Images
 
-Powerhouse publishes three official Docker images to the GitHub Container Registry (ghcr.io):
+Powerhouse publishes three official Docker images to the Vetra Harbor registry (`cr.vetra.io`):
 
 ### 1. Connect
 
 The Connect image provides the Powerhouse web application frontend with an embedded Nginx server.
 
 ```
-ghcr.io/powerhouse-inc/powerhouse/connect
+cr.vetra.io/powerhouse-inc-powerhouse/connect
 ```
 
 **Available tags:**
 
 - `latest` - Latest stable release
-- `dev` - Development builds
+- `dev` - Development builds (from `main`)
 - `staging` - Staging builds
-- `vX.Y.Z` - Specific version tags (e.g., `v1.0.0`)
+- `rc` - Release candidates
+- `vX.Y.Z` - Specific version tags (e.g., `v6.2.1`)
 
 ### 2. Switchboard
 
 The Switchboard image provides the backend API server that handles document synchronization and GraphQL endpoints.
 
 ```
-ghcr.io/powerhouse-inc/powerhouse/switchboard
+cr.vetra.io/powerhouse-inc-powerhouse/switchboard
 ```
 
 **Available tags:**
 
 - `latest` - Latest stable release
-- `dev` - Development builds
+- `dev` - Development builds (from `main`)
 - `staging` - Staging builds
-- `vX.Y.Z` - Specific version tags (e.g., `v1.0.0`)
+- `rc` - Release candidates
+- `vX.Y.Z` - Specific version tags (e.g., `v6.2.1`)
 
 ### 3. Academy
 
 The Academy image provides the documentation website.
 
 ```
-ghcr.io/powerhouse-inc/powerhouse/academy
+cr.vetra.io/powerhouse-inc-powerhouse/academy
 ```
 
 **Available tags:**
@@ -29755,36 +29757,50 @@ ghcr.io/powerhouse-inc/powerhouse/academy
 
 ## Quick Start with Docker Compose
 
-The easiest way to run Powerhouse locally is using Docker Compose. Create a `docker-compose.yml` file or use the one provided in the repository:
+The easiest way to run Powerhouse locally is using Docker Compose. The repository ships ready-made compose files — `docker-compose.yml` (production, `latest`), plus per-channel variants `docker-compose.dev.yml` / `docker-compose.test.yml` (`rc`) / `docker-compose.staging.yml`, and a postgres-free `docker-compose.pglite.yml`. The default file:
 
 ```yaml
 name: powerhouse
 
 services:
   connect:
-    image: ghcr.io/powerhouse-inc/powerhouse/connect:dev
+    image: cr.vetra.io/powerhouse-inc-powerhouse/connect:latest
+    # Auto-connect the SPA to the local switchboard.
     environment:
-      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
-      - BASE_PATH=/
+      - 'PH_CONNECT_CONFIG_JSON={"connect":{"drives":{"defaultDrives":[{"url":"http://localhost:4000","name":null,"icon":null}]}}}'
     ports:
-      - "127.0.0.1:3000:4000"
+      - "127.0.0.1:3000:3001"
     networks:
       - powerhouse_network
-    depends_on:
-      postgres:
-        condition: service_healthy
+    hostname: connect.powerhouse
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3001/health"]
+      interval: 30s
+      timeout: 3s
+      start_period: 10s
+      retries: 3
 
   switchboard:
-    image: ghcr.io/powerhouse-inc/powerhouse/switchboard:dev
+    image: cr.vetra.io/powerhouse-inc-powerhouse/switchboard:latest
     environment:
-      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
+      # Reactor storage + entrypoint migration gate.
+      - PH_REACTOR_DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
+      # Read-model storage. Both point at the same database.
+      - PH_SWITCHBOARD_DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
     ports:
-      - "127.0.0.1:4000:4001"
+      - "127.0.0.1:4000:3000"
     networks:
       - powerhouse_network
+    hostname: switchboard.powerhouse
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:3000/health"]
+      interval: 30s
+      timeout: 3s
+      start_period: 30s
+      retries: 3
 
   postgres:
     image: postgres:16.1
@@ -29794,6 +29810,8 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
     networks:
       - powerhouse_network
     healthcheck:
@@ -29804,7 +29822,9 @@ services:
 
 networks:
   powerhouse_network:
-    name: powerhouse_network
+
+volumes:
+  postgres_data:
 ```
 
 ### Running the Stack
@@ -29853,7 +29873,8 @@ Connect's SPA reads runtime configuration from `/powerhouse.config.json`, never 
 | `PORT`                   | Port the nginx server listens on                            | `3001`   |
 | `PH_CONNECT_BASE_PATH`   | nginx base URL path                                         | `/`      |
 | `PH_CONNECT_CONFIG_JSON` | Runtime config JSON to merge into the dist file (see below) | _unset_  |
-| `DATABASE_URL`           | PostgreSQL connection string (for Switchboard, not Connect) | Required |
+
+Connect does **not** read any database variables — it is a static frontend. Database connection strings belong on the Switchboard service (see below).
 
 Sentry (DSN, environment label, tracing flag) is no longer set via per-field env vars — those live in `connect.sentry.*` of `powerhouse.config.json` and ride through `PH_CONNECT_CONFIG_JSON` like every other runtime field. See the example below.
 
@@ -29893,92 +29914,107 @@ The schema for the JSON object lives at `packages/builder-tools/connect-utils/ru
 
 ### Switchboard Environment Variables
 
+#### Storage (Postgres or embedded PGlite)
+
+Switchboard stores the reactor and the read models in one of two backends. When a Postgres URL is set it uses Postgres; otherwise it falls back to its embedded **PGlite** storage (local directories `./.ph/reactor-storage` and `.ph/read-storage` relative to the working directory — persist that directory with a volume, as the repo's `docker-compose.pglite.yml` does).
+
+| Variable                      | Description                                                                    | Default           |
+| ----------------------------- | ------------------------------------------------------------------------------ | ----------------- |
+| `PH_REACTOR_DATABASE_URL`     | Postgres URL for reactor storage; also triggers the entrypoint's migrations    | _unset_ (PGlite)  |
+| `PH_SWITCHBOARD_DATABASE_URL` | Postgres URL for the read model and (as fallback) the reactor                  | _unset_ (PGlite)  |
+| `DATABASE_URL`                | Postgres URL for the read model (checked before `PH_SWITCHBOARD_DATABASE_URL`) | _unset_ (PGlite)  |
+
+For a single-database deployment (the normal case, and what the repo's compose files do), set `PH_REACTOR_DATABASE_URL` and `PH_SWITCHBOARD_DATABASE_URL` to the same URL.
+
+| Variable              | Description                                                                    | Default  |
+| --------------------- | ------------------------------------------------------------------------------ | -------- |
+| `PH_PGLITE_IN_MEMORY` | `1` = run PGlite in memory (no persistence)                                    | _unset_  |
+| `PH_MIGRATE_PGLITE`   | `true` = migrate local PGlite data to the PG version this image ships          | _unset_  |
+| `PH_FORCE_PG_VERSION` | `16` or `17` = wipe the local PGlite data dirs and re-initialize at that major | _unset_  |
+| `SKIP_DB_MIGRATIONS`  | `true` = skip the entrypoint's Postgres migration run                          | _unset_  |
+
 #### Core Configuration
 
-| Variable                      | Description                                            | Default    |
-| ----------------------------- | ------------------------------------------------------ | ---------- |
-| `PORT`                        | Port the server listens on                             | `3000`     |
-| `PH_SWITCHBOARD_PORT`         | Alias for PORT                                         | `$PORT`    |
-| `DATABASE_URL`                | PostgreSQL or SQLite connection string                 | `"dev.db"` |
-| `PH_SWITCHBOARD_DATABASE_URL` | Alias for DATABASE_URL                                 | `"dev.db"` |
-| `BASE_PATH`                   | Base URL path for the API                              | `"/"`      |
-| `PH_PACKAGES`                 | Comma-separated list of packages to install at startup | `""`       |
-
-#### Authentication
-
-| Variable                       | Description                                                  | Default   |
-| ------------------------------ | ------------------------------------------------------------ | --------- |
-| `AUTH_ENABLED`                 | Enable authentication                                        | `"false"` |
-| `ADMINS`                       | Comma-separated list of admin wallet addresses (full access) | `""`      |
-| `DEFAULT_PROTECTION`           | Make all new documents protected by default                  | `"false"` |
-| `DOCUMENT_PERMISSIONS_ENABLED` | Enable per-document permission management                    | `"false"` |
+| Variable                    | Description                                                          | Default                     |
+| --------------------------- | ------------------------------------------------------------------   | -------------------------   |
+| `PORT`                      | Port the server listens on (exported as `PH_SWITCHBOARD_PORT`)       | `3000`                      |
+| `PH_SWITCHBOARD_PORT`       | Explicit port override                                               | `$PORT`                     |
+| `PH_DEFAULT_DRIVE_TYPE`     | `powerhouse/document-drive` or `powerhouse/reactor-drive`            | _unset_                     |
+| `PH_PACKAGES`               | Comma-separated packages installed via pnpm at startup               | `""`                        |
+| `PH_REGISTRY_PACKAGES`      | Comma-separated packages loaded over HTTP from the registry at start | `""`                        |
+| `PH_REGISTRY_URL`           | Package registry base URL for HTTP package loading                   | `https://registry.vetra.io` |
+| `PH_SWITCHBOARD_PUBLIC_URL` | Public origin used for the remote attachment service                 | `http://localhost:$PORT`    |
+| `LOG_LEVEL`                 | Log level                                                            | `info`                      |
 
 #### Error Tracking & Monitoring
 
-| Variable                   | Description                                             | Default |
-| -------------------------- | ------------------------------------------------------- | ------- |
-| `SENTRY_DSN`               | Sentry DSN for error tracking                           | `""`    |
-| `SENTRY_ENV`               | Sentry environment name (e.g., "production", "staging") | `""`    |
-| `PYROSCOPE_SERVER_ADDRESS` | Pyroscope server address for performance profiling      | `""`    |
+| Variable                   | Description                                            | Default |
+| -------------------------- | ------------------------------------------------------ | ------- |
+| `SENTRY_DSN`               | Sentry DSN for error tracking                          | `""`    |
+| `SENTRY_ENV`               | Sentry environment name (e.g. "production", "staging") | `""`    |
+| `SENTRY_TRACING_ENABLED`   | `false` = errors-only Sentry mode (no tracing)         | _unset_ |
+| `TEMPO_ENDPOINT`           | OTLP HTTP endpoint for trace export (Grafana Tempo)    | `""`    |
+| `PYROSCOPE_SERVER_ADDRESS` | Pyroscope server address for performance profiling     | `""`    |
 
 ## Installing Custom Packages
 
-Connect loads custom packages via the `PH_REGISTRY_PACKAGES` environment variable (written to a registry config at startup). Switchboard installs packages via `PH_PACKAGES`.
+The two images load custom packages differently, matching where they run:
 
-```yaml
-services:
-  connect:
-    image: ghcr.io/powerhouse-inc/powerhouse/connect:dev
-    environment:
-      - PH_REGISTRY_PACKAGES=@powerhousedao/todo-demo-package,@powerhousedao/another-package
-```
+- **Connect** loads packages **in the browser at runtime** from the package registry. The registry base URL is the top-level `packageRegistryUrl` field of `powerhouse.config.json` (baked in at image build time). To use different packages or a different registry in a deployment, override those top-level fields with `PH_CONNECT_CONFIG_JSON`, e.g.:
 
-Packages are installed using the `ph install` command before the service starts.
+  ```bash
+  PH_CONNECT_CONFIG_JSON='{"packageRegistryUrl":"https://registry.example","packages":[{"name":"@powerhousedao/todo-demo-package","version":"1.0.0"}]}'
+  ```
+
+- **Switchboard** loads packages **server-side at startup**, in one of two ways:
+  - `PH_PACKAGES` — comma-separated packages installed from the npm registry via pnpm before start.
+  - `PH_REGISTRY_PACKAGES` — comma-separated packages loaded over HTTP from `PH_REGISTRY_URL` at start.
+
+  ```yaml
+  services:
+    switchboard:
+      image: cr.vetra.io/powerhouse-inc-powerhouse/switchboard:dev
+      environment:
+        - PH_PACKAGES=@powerhousedao/todo-demo-package,@powerhousedao/another-package
+  ```
 
 ## Image Architecture
 
+The images are built from a single multi-stage `docker/Dockerfile` (build args: `TAG` — the release tag, and `GIT_SHA`). A shared base stage installs `ph-cmd` for the matching release channel and initializes a project; each target then builds what it needs.
+
 ### Connect Image
 
-The Connect image is based on Alpine Linux and includes:
-
-- Node.js and pnpm
-- Nginx with Brotli compression
-- The `ph-cmd` CLI tool
-- A pre-initialized Powerhouse project
+The Connect target is **nginx:alpine** serving the static SPA — the frontend is built at **image build time** (`ph connect build`), not at container start. It runs as the non-root `nginx` user (UID 101), so pods can set `runAsNonRoot: true`.
 
 At startup, the entrypoint script:
 
-1. Loads any packages specified in `PH_REGISTRY_PACKAGES`
-2. Builds the Connect frontend with `ph connect build`
-3. Configures and starts Nginx to serve the built files
+1. Renders the nginx config from `nginx.conf.template` via envsubst (`PORT`, `PH_CONNECT_BASE_PATH`)
+2. Deep-merges `PH_CONNECT_CONFIG_JSON` into the dist `powerhouse.config.json` (operator-wins)
+3. Re-syncs the Content-Security-Policy registry origin in `index.html` to the effective `packageRegistryUrl`
+4. Validates the config (`nginx -t`) and starts nginx
 
 ### Switchboard Image
 
-The Switchboard image is based on Node.js 24 and includes:
-
-- pnpm package manager
-- The `ph-cmd` CLI tool
-- Prisma CLI for database migrations
-- A pre-initialized Powerhouse project
+The Switchboard target is **Node.js 24 (Alpine)** with pnpm and the `@powerhousedao/switchboard` package installed at image build time from the npm registry at the requested release tag.
 
 At startup, the entrypoint script:
 
-1. Installs any packages specified in `PH_PACKAGES`
-2. Runs Prisma database migrations (if `PH_REACTOR_DATABASE_URL` is set)
+1. Installs any packages listed in `PH_PACKAGES` (pnpm)
+2. Runs the reactor Postgres migrations (Kysely) if `PH_REACTOR_DATABASE_URL` points at a Postgres URL — PGlite migrations run automatically inside the server
 3. Starts the Switchboard server via Node.js
 
 ## Production Considerations
 
 ### Using Specific Version Tags
 
-For production deployments, always use specific version tags instead of `latest` or `dev`:
+For production deployments, always use specific version tags instead of the floating `latest` / `dev` / `rc` / `staging` tags:
 
 ```yaml
 services:
   connect:
-    image: ghcr.io/powerhouse-inc/powerhouse/connect:v1.0.0
+    image: cr.vetra.io/powerhouse-inc-powerhouse/connect:v6.2.1
   switchboard:
-    image: ghcr.io/powerhouse-inc/powerhouse/switchboard:v1.0.0
+    image: cr.vetra.io/powerhouse-inc-powerhouse/switchboard:v6.2.1
 ```
 
 ### Database Persistence
@@ -30002,7 +30038,7 @@ volumes:
 
 ### Health Checks
 
-The provided docker-compose.yml includes health checks for PostgreSQL. Services wait for the database to be healthy before starting, preventing connection errors during startup.
+The provided compose files include health checks for all services: PostgreSQL (`pg_isready`), Connect (`/health` on nginx), and Switchboard (`/health` on the API). Switchboard only starts after the database is healthy, preventing connection errors during startup.
 
 ### Network Security
 
@@ -30010,7 +30046,7 @@ The example configuration binds ports to `127.0.0.1` only:
 
 ```yaml
 ports:
-  - "127.0.0.1:3000:4000"
+  - "127.0.0.1:3000:3001"
 ```
 
 This prevents direct external access. In production, use a reverse proxy (like Nginx or Traefik) to:
@@ -30026,13 +30062,14 @@ For better security, use a `.env` file instead of hardcoding credentials:
 ```bash
 # .env
 POSTGRES_PASSWORD=your-secure-password
-DATABASE_URL=postgres://powerhouse:your-secure-password@postgres:5432/powerhouse
+PH_REACTOR_DATABASE_URL=postgres://powerhouse:your-secure-password@postgres:5432/powerhouse
+PH_SWITCHBOARD_DATABASE_URL=postgres://powerhouse:your-secure-password@postgres:5432/powerhouse
 ```
 
 ```yaml
 services:
   switchboard:
-    image: ghcr.io/powerhouse-inc/powerhouse/switchboard:latest
+    image: cr.vetra.io/powerhouse-inc-powerhouse/switchboard:latest
     env_file:
       - .env
 ```
@@ -30056,7 +30093,7 @@ Ensure the database is ready before services start:
 docker compose logs postgres
 ```
 
-Verify the `DATABASE_URL` format:
+Verify the `PH_REACTOR_DATABASE_URL` / `PH_SWITCHBOARD_DATABASE_URL` format:
 
 ```
 postgres://user:password@host:port/database
@@ -30072,32 +30109,38 @@ If custom packages fail to install, check:
 
 ### Permission Issues
 
-If you encounter permission issues with volumes:
+The Connect container runs as the non-root `nginx` user (UID 101). If you bind-mount files or volumes into it, make sure they are readable by UID 101:
 
 ```bash
-# Fix ownership
-sudo chown -R 1000:1000 ./data
+# Fix ownership for a bind-mounted Connect config
+sudo chown -R 101:101 ./my-config
 ```
+
+Switchboard runs as root, so host-side volume permissions are less restrictive there.
 
 ## Building Custom Images
 
 You can extend the official images for custom deployments:
 
 ```dockerfile
-FROM ghcr.io/powerhouse-inc/powerhouse/connect:latest
+# Switchboard: add server-side packages at build time
+FROM cr.vetra.io/powerhouse-inc-powerhouse/switchboard:latest
+RUN pnpm add --shamefully-hoist @powerhousedao/my-custom-package
+```
 
-# Install additional packages at build time
-RUN ph install @powerhousedao/my-custom-package
-
-# Add custom configuration
-COPY my-nginx.conf /etc/nginx/nginx.conf.template
+```dockerfile
+# Connect: the image is plain nginx serving the pre-built SPA (no Node.js,
+# no ph CLI). Customization means overriding the runtime config via
+# PH_CONNECT_CONFIG_JSON at deploy time, or swapping the served files/config:
+FROM cr.vetra.io/powerhouse-inc-powerhouse/connect:latest
+COPY my-nginx.conf.template /etc/nginx/nginx.conf.template
 ```
 
 Build and push your custom image:
 
 ```bash
-docker build -t my-registry/my-connect:latest .
-docker push my-registry/my-connect:latest
+docker build -t my-registry/my-switchboard:latest .
+docker push my-registry/my-switchboard:latest
 ```
 
 ## Next Steps

--- a/apps/academy/static/llms-full.txt
+++ b/apps/academy/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-08-19T15:22:42.159Z
+> Generated: 2026-08-26T14:56:31.426Z
 > Total Documents: 110
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -29706,44 +29706,46 @@ This guide covers **Docker-based deployment**. If you prefer **traditional VM/se
 
 ## Available Docker Images
 
-Powerhouse publishes three official Docker images to the GitHub Container Registry (ghcr.io):
+Powerhouse publishes three official Docker images to the Vetra Harbor registry (`cr.vetra.io`):
 
 ### 1. Connect
 
 The Connect image provides the Powerhouse web application frontend with an embedded Nginx server.
 
 ```
-ghcr.io/powerhouse-inc/powerhouse/connect
+cr.vetra.io/powerhouse-inc-powerhouse/connect
 ```
 
 **Available tags:**
 
 - `latest` - Latest stable release
-- `dev` - Development builds
+- `dev` - Development builds (from `main`)
 - `staging` - Staging builds
-- `vX.Y.Z` - Specific version tags (e.g., `v1.0.0`)
+- `rc` - Release candidates
+- `vX.Y.Z` - Specific version tags (e.g., `v6.2.1`)
 
 ### 2. Switchboard
 
 The Switchboard image provides the backend API server that handles document synchronization and GraphQL endpoints.
 
 ```
-ghcr.io/powerhouse-inc/powerhouse/switchboard
+cr.vetra.io/powerhouse-inc-powerhouse/switchboard
 ```
 
 **Available tags:**
 
 - `latest` - Latest stable release
-- `dev` - Development builds
+- `dev` - Development builds (from `main`)
 - `staging` - Staging builds
-- `vX.Y.Z` - Specific version tags (e.g., `v1.0.0`)
+- `rc` - Release candidates
+- `vX.Y.Z` - Specific version tags (e.g., `v6.2.1`)
 
 ### 3. Academy
 
 The Academy image provides the documentation website.
 
 ```
-ghcr.io/powerhouse-inc/powerhouse/academy
+cr.vetra.io/powerhouse-inc-powerhouse/academy
 ```
 
 **Available tags:**
@@ -29755,36 +29757,50 @@ ghcr.io/powerhouse-inc/powerhouse/academy
 
 ## Quick Start with Docker Compose
 
-The easiest way to run Powerhouse locally is using Docker Compose. Create a `docker-compose.yml` file or use the one provided in the repository:
+The easiest way to run Powerhouse locally is using Docker Compose. The repository ships ready-made compose files — `docker-compose.yml` (production, `latest`), plus per-channel variants `docker-compose.dev.yml` / `docker-compose.test.yml` (`rc`) / `docker-compose.staging.yml`, and a postgres-free `docker-compose.pglite.yml`. The default file:
 
 ```yaml
 name: powerhouse
 
 services:
   connect:
-    image: ghcr.io/powerhouse-inc/powerhouse/connect:dev
+    image: cr.vetra.io/powerhouse-inc-powerhouse/connect:latest
+    # Auto-connect the SPA to the local switchboard.
     environment:
-      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
-      - BASE_PATH=/
+      - 'PH_CONNECT_CONFIG_JSON={"connect":{"drives":{"defaultDrives":[{"url":"http://localhost:4000","name":null,"icon":null}]}}}'
     ports:
-      - "127.0.0.1:3000:4000"
+      - "127.0.0.1:3000:3001"
     networks:
       - powerhouse_network
-    depends_on:
-      postgres:
-        condition: service_healthy
+    hostname: connect.powerhouse
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3001/health"]
+      interval: 30s
+      timeout: 3s
+      start_period: 10s
+      retries: 3
 
   switchboard:
-    image: ghcr.io/powerhouse-inc/powerhouse/switchboard:dev
+    image: cr.vetra.io/powerhouse-inc-powerhouse/switchboard:latest
     environment:
-      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
+      # Reactor storage + entrypoint migration gate.
+      - PH_REACTOR_DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
+      # Read-model storage. Both point at the same database.
+      - PH_SWITCHBOARD_DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
     ports:
-      - "127.0.0.1:4000:4001"
+      - "127.0.0.1:4000:3000"
     networks:
       - powerhouse_network
+    hostname: switchboard.powerhouse
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:3000/health"]
+      interval: 30s
+      timeout: 3s
+      start_period: 30s
+      retries: 3
 
   postgres:
     image: postgres:16.1
@@ -29794,6 +29810,8 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
     networks:
       - powerhouse_network
     healthcheck:
@@ -29804,7 +29822,9 @@ services:
 
 networks:
   powerhouse_network:
-    name: powerhouse_network
+
+volumes:
+  postgres_data:
 ```
 
 ### Running the Stack
@@ -29853,7 +29873,8 @@ Connect's SPA reads runtime configuration from `/powerhouse.config.json`, never 
 | `PORT`                   | Port the nginx server listens on                            | `3001`   |
 | `PH_CONNECT_BASE_PATH`   | nginx base URL path                                         | `/`      |
 | `PH_CONNECT_CONFIG_JSON` | Runtime config JSON to merge into the dist file (see below) | _unset_  |
-| `DATABASE_URL`           | PostgreSQL connection string (for Switchboard, not Connect) | Required |
+
+Connect does **not** read any database variables — it is a static frontend. Database connection strings belong on the Switchboard service (see below).
 
 Sentry (DSN, environment label, tracing flag) is no longer set via per-field env vars — those live in `connect.sentry.*` of `powerhouse.config.json` and ride through `PH_CONNECT_CONFIG_JSON` like every other runtime field. See the example below.
 
@@ -29893,92 +29914,107 @@ The schema for the JSON object lives at `packages/builder-tools/connect-utils/ru
 
 ### Switchboard Environment Variables
 
+#### Storage (Postgres or embedded PGlite)
+
+Switchboard stores the reactor and the read models in one of two backends. When a Postgres URL is set it uses Postgres; otherwise it falls back to its embedded **PGlite** storage (local directories `./.ph/reactor-storage` and `.ph/read-storage` relative to the working directory — persist that directory with a volume, as the repo's `docker-compose.pglite.yml` does).
+
+| Variable                      | Description                                                                    | Default           |
+| ----------------------------- | ------------------------------------------------------------------------------ | ----------------- |
+| `PH_REACTOR_DATABASE_URL`     | Postgres URL for reactor storage; also triggers the entrypoint's migrations    | _unset_ (PGlite)  |
+| `PH_SWITCHBOARD_DATABASE_URL` | Postgres URL for the read model and (as fallback) the reactor                  | _unset_ (PGlite)  |
+| `DATABASE_URL`                | Postgres URL for the read model (checked before `PH_SWITCHBOARD_DATABASE_URL`) | _unset_ (PGlite)  |
+
+For a single-database deployment (the normal case, and what the repo's compose files do), set `PH_REACTOR_DATABASE_URL` and `PH_SWITCHBOARD_DATABASE_URL` to the same URL.
+
+| Variable              | Description                                                                    | Default  |
+| --------------------- | ------------------------------------------------------------------------------ | -------- |
+| `PH_PGLITE_IN_MEMORY` | `1` = run PGlite in memory (no persistence)                                    | _unset_  |
+| `PH_MIGRATE_PGLITE`   | `true` = migrate local PGlite data to the PG version this image ships          | _unset_  |
+| `PH_FORCE_PG_VERSION` | `16` or `17` = wipe the local PGlite data dirs and re-initialize at that major | _unset_  |
+| `SKIP_DB_MIGRATIONS`  | `true` = skip the entrypoint's Postgres migration run                          | _unset_  |
+
 #### Core Configuration
 
-| Variable                      | Description                                            | Default    |
-| ----------------------------- | ------------------------------------------------------ | ---------- |
-| `PORT`                        | Port the server listens on                             | `3000`     |
-| `PH_SWITCHBOARD_PORT`         | Alias for PORT                                         | `$PORT`    |
-| `DATABASE_URL`                | PostgreSQL or SQLite connection string                 | `"dev.db"` |
-| `PH_SWITCHBOARD_DATABASE_URL` | Alias for DATABASE_URL                                 | `"dev.db"` |
-| `BASE_PATH`                   | Base URL path for the API                              | `"/"`      |
-| `PH_PACKAGES`                 | Comma-separated list of packages to install at startup | `""`       |
-
-#### Authentication
-
-| Variable                       | Description                                                  | Default   |
-| ------------------------------ | ------------------------------------------------------------ | --------- |
-| `AUTH_ENABLED`                 | Enable authentication                                        | `"false"` |
-| `ADMINS`                       | Comma-separated list of admin wallet addresses (full access) | `""`      |
-| `DEFAULT_PROTECTION`           | Make all new documents protected by default                  | `"false"` |
-| `DOCUMENT_PERMISSIONS_ENABLED` | Enable per-document permission management                    | `"false"` |
+| Variable                    | Description                                                          | Default                     |
+| --------------------------- | ------------------------------------------------------------------   | -------------------------   |
+| `PORT`                      | Port the server listens on (exported as `PH_SWITCHBOARD_PORT`)       | `3000`                      |
+| `PH_SWITCHBOARD_PORT`       | Explicit port override                                               | `$PORT`                     |
+| `PH_DEFAULT_DRIVE_TYPE`     | `powerhouse/document-drive` or `powerhouse/reactor-drive`            | _unset_                     |
+| `PH_PACKAGES`               | Comma-separated packages installed via pnpm at startup               | `""`                        |
+| `PH_REGISTRY_PACKAGES`      | Comma-separated packages loaded over HTTP from the registry at start | `""`                        |
+| `PH_REGISTRY_URL`           | Package registry base URL for HTTP package loading                   | `https://registry.vetra.io` |
+| `PH_SWITCHBOARD_PUBLIC_URL` | Public origin used for the remote attachment service                 | `http://localhost:$PORT`    |
+| `LOG_LEVEL`                 | Log level                                                            | `info`                      |
 
 #### Error Tracking & Monitoring
 
-| Variable                   | Description                                             | Default |
-| -------------------------- | ------------------------------------------------------- | ------- |
-| `SENTRY_DSN`               | Sentry DSN for error tracking                           | `""`    |
-| `SENTRY_ENV`               | Sentry environment name (e.g., "production", "staging") | `""`    |
-| `PYROSCOPE_SERVER_ADDRESS` | Pyroscope server address for performance profiling      | `""`    |
+| Variable                   | Description                                            | Default |
+| -------------------------- | ------------------------------------------------------ | ------- |
+| `SENTRY_DSN`               | Sentry DSN for error tracking                          | `""`    |
+| `SENTRY_ENV`               | Sentry environment name (e.g. "production", "staging") | `""`    |
+| `SENTRY_TRACING_ENABLED`   | `false` = errors-only Sentry mode (no tracing)         | _unset_ |
+| `TEMPO_ENDPOINT`           | OTLP HTTP endpoint for trace export (Grafana Tempo)    | `""`    |
+| `PYROSCOPE_SERVER_ADDRESS` | Pyroscope server address for performance profiling     | `""`    |
 
 ## Installing Custom Packages
 
-Connect loads custom packages via the `PH_REGISTRY_PACKAGES` environment variable (written to a registry config at startup). Switchboard installs packages via `PH_PACKAGES`.
+The two images load custom packages differently, matching where they run:
 
-```yaml
-services:
-  connect:
-    image: ghcr.io/powerhouse-inc/powerhouse/connect:dev
-    environment:
-      - PH_REGISTRY_PACKAGES=@powerhousedao/todo-demo-package,@powerhousedao/another-package
-```
+- **Connect** loads packages **in the browser at runtime** from the package registry. The registry base URL is the top-level `packageRegistryUrl` field of `powerhouse.config.json` (baked in at image build time). To use different packages or a different registry in a deployment, override those top-level fields with `PH_CONNECT_CONFIG_JSON`, e.g.:
 
-Packages are installed using the `ph install` command before the service starts.
+  ```bash
+  PH_CONNECT_CONFIG_JSON='{"packageRegistryUrl":"https://registry.example","packages":[{"name":"@powerhousedao/todo-demo-package","version":"1.0.0"}]}'
+  ```
+
+- **Switchboard** loads packages **server-side at startup**, in one of two ways:
+  - `PH_PACKAGES` — comma-separated packages installed from the npm registry via pnpm before start.
+  - `PH_REGISTRY_PACKAGES` — comma-separated packages loaded over HTTP from `PH_REGISTRY_URL` at start.
+
+  ```yaml
+  services:
+    switchboard:
+      image: cr.vetra.io/powerhouse-inc-powerhouse/switchboard:dev
+      environment:
+        - PH_PACKAGES=@powerhousedao/todo-demo-package,@powerhousedao/another-package
+  ```
 
 ## Image Architecture
 
+The images are built from a single multi-stage `docker/Dockerfile` (build args: `TAG` — the release tag, and `GIT_SHA`). A shared base stage installs `ph-cmd` for the matching release channel and initializes a project; each target then builds what it needs.
+
 ### Connect Image
 
-The Connect image is based on Alpine Linux and includes:
-
-- Node.js and pnpm
-- Nginx with Brotli compression
-- The `ph-cmd` CLI tool
-- A pre-initialized Powerhouse project
+The Connect target is **nginx:alpine** serving the static SPA — the frontend is built at **image build time** (`ph connect build`), not at container start. It runs as the non-root `nginx` user (UID 101), so pods can set `runAsNonRoot: true`.
 
 At startup, the entrypoint script:
 
-1. Loads any packages specified in `PH_REGISTRY_PACKAGES`
-2. Builds the Connect frontend with `ph connect build`
-3. Configures and starts Nginx to serve the built files
+1. Renders the nginx config from `nginx.conf.template` via envsubst (`PORT`, `PH_CONNECT_BASE_PATH`)
+2. Deep-merges `PH_CONNECT_CONFIG_JSON` into the dist `powerhouse.config.json` (operator-wins)
+3. Re-syncs the Content-Security-Policy registry origin in `index.html` to the effective `packageRegistryUrl`
+4. Validates the config (`nginx -t`) and starts nginx
 
 ### Switchboard Image
 
-The Switchboard image is based on Node.js 24 and includes:
-
-- pnpm package manager
-- The `ph-cmd` CLI tool
-- Prisma CLI for database migrations
-- A pre-initialized Powerhouse project
+The Switchboard target is **Node.js 24 (Alpine)** with pnpm and the `@powerhousedao/switchboard` package installed at image build time from the npm registry at the requested release tag.
 
 At startup, the entrypoint script:
 
-1. Installs any packages specified in `PH_PACKAGES`
-2. Runs Prisma database migrations (if `PH_REACTOR_DATABASE_URL` is set)
+1. Installs any packages listed in `PH_PACKAGES` (pnpm)
+2. Runs the reactor Postgres migrations (Kysely) if `PH_REACTOR_DATABASE_URL` points at a Postgres URL — PGlite migrations run automatically inside the server
 3. Starts the Switchboard server via Node.js
 
 ## Production Considerations
 
 ### Using Specific Version Tags
 
-For production deployments, always use specific version tags instead of `latest` or `dev`:
+For production deployments, always use specific version tags instead of the floating `latest` / `dev` / `rc` / `staging` tags:
 
 ```yaml
 services:
   connect:
-    image: ghcr.io/powerhouse-inc/powerhouse/connect:v1.0.0
+    image: cr.vetra.io/powerhouse-inc-powerhouse/connect:v6.2.1
   switchboard:
-    image: ghcr.io/powerhouse-inc/powerhouse/switchboard:v1.0.0
+    image: cr.vetra.io/powerhouse-inc-powerhouse/switchboard:v6.2.1
 ```
 
 ### Database Persistence
@@ -30002,7 +30038,7 @@ volumes:
 
 ### Health Checks
 
-The provided docker-compose.yml includes health checks for PostgreSQL. Services wait for the database to be healthy before starting, preventing connection errors during startup.
+The provided compose files include health checks for all services: PostgreSQL (`pg_isready`), Connect (`/health` on nginx), and Switchboard (`/health` on the API). Switchboard only starts after the database is healthy, preventing connection errors during startup.
 
 ### Network Security
 
@@ -30010,7 +30046,7 @@ The example configuration binds ports to `127.0.0.1` only:
 
 ```yaml
 ports:
-  - "127.0.0.1:3000:4000"
+  - "127.0.0.1:3000:3001"
 ```
 
 This prevents direct external access. In production, use a reverse proxy (like Nginx or Traefik) to:
@@ -30026,13 +30062,14 @@ For better security, use a `.env` file instead of hardcoding credentials:
 ```bash
 # .env
 POSTGRES_PASSWORD=your-secure-password
-DATABASE_URL=postgres://powerhouse:your-secure-password@postgres:5432/powerhouse
+PH_REACTOR_DATABASE_URL=postgres://powerhouse:your-secure-password@postgres:5432/powerhouse
+PH_SWITCHBOARD_DATABASE_URL=postgres://powerhouse:your-secure-password@postgres:5432/powerhouse
 ```
 
 ```yaml
 services:
   switchboard:
-    image: ghcr.io/powerhouse-inc/powerhouse/switchboard:latest
+    image: cr.vetra.io/powerhouse-inc-powerhouse/switchboard:latest
     env_file:
       - .env
 ```
@@ -30056,7 +30093,7 @@ Ensure the database is ready before services start:
 docker compose logs postgres
 ```
 
-Verify the `DATABASE_URL` format:
+Verify the `PH_REACTOR_DATABASE_URL` / `PH_SWITCHBOARD_DATABASE_URL` format:
 
 ```
 postgres://user:password@host:port/database
@@ -30072,32 +30109,38 @@ If custom packages fail to install, check:
 
 ### Permission Issues
 
-If you encounter permission issues with volumes:
+The Connect container runs as the non-root `nginx` user (UID 101). If you bind-mount files or volumes into it, make sure they are readable by UID 101:
 
 ```bash
-# Fix ownership
-sudo chown -R 1000:1000 ./data
+# Fix ownership for a bind-mounted Connect config
+sudo chown -R 101:101 ./my-config
 ```
+
+Switchboard runs as root, so host-side volume permissions are less restrictive there.
 
 ## Building Custom Images
 
 You can extend the official images for custom deployments:
 
 ```dockerfile
-FROM ghcr.io/powerhouse-inc/powerhouse/connect:latest
+# Switchboard: add server-side packages at build time
+FROM cr.vetra.io/powerhouse-inc-powerhouse/switchboard:latest
+RUN pnpm add --shamefully-hoist @powerhousedao/my-custom-package
+```
 
-# Install additional packages at build time
-RUN ph install @powerhousedao/my-custom-package
-
-# Add custom configuration
-COPY my-nginx.conf /etc/nginx/nginx.conf.template
+```dockerfile
+# Connect: the image is plain nginx serving the pre-built SPA (no Node.js,
+# no ph CLI). Customization means overriding the runtime config via
+# PH_CONNECT_CONFIG_JSON at deploy time, or swapping the served files/config:
+FROM cr.vetra.io/powerhouse-inc-powerhouse/connect:latest
+COPY my-nginx.conf.template /etc/nginx/nginx.conf.template
 ```
 
 Build and push your custom image:
 
 ```bash
-docker build -t my-registry/my-connect:latest .
-docker push my-registry/my-connect:latest
+docker build -t my-registry/my-switchboard:latest .
+docker push my-registry/my-switchboard:latest
 ```
 
 ## Next Steps

--- a/packages/codegen/src/codegen/migrate.ts
+++ b/packages/codegen/src/codegen/migrate.ts
@@ -31,7 +31,7 @@ import {
   prop,
 } from "remeda";
 import type { Project } from "ts-morph";
-import { buildTsMorphProject } from "utils";
+import { buildTsMorphProject, fixGenerateMockImports } from "utils";
 import { writePackage } from "write-package";
 import { detectFeatures } from "./features.js";
 import { generateAll } from "./generate.js";
@@ -81,10 +81,6 @@ export function fixLegacyImportPaths(
   for (const sourceFile of sourceFiles) {
     const importStatements = sourceFile.getImportDeclarations();
     for (const importStatement of importStatements) {
-      const namedImports = map(
-        importStatement.getNamedImports(),
-        (importSpecifier) => importSpecifier.getText(),
-      );
       const moduleSpecifier = importStatement.getModuleSpecifier();
       const moduleSpecifierText = moduleSpecifier.getLiteralText();
       // remove usage of the old `package-name/` style paths
@@ -92,10 +88,6 @@ export function fixLegacyImportPaths(
         moduleSpecifier.setLiteralValue(
           moduleSpecifierText.replace(`${packageName}/`, ""),
         );
-      }
-      // I saw this invalid import enough that it seemed worthwhile to fix it here
-      if (namedImports.includes("generateMock")) {
-        moduleSpecifier.setLiteralValue("document-model");
       }
       // attempt to fix absolute import paths for document models like `../../../document-models/model/something/something.js`
       // these don't work anymore with the versioned document models, since the absolute file paths are different
@@ -107,6 +99,7 @@ export function fixLegacyImportPaths(
         moduleSpecifier.setLiteralValue(`document-models/${match[2]}`);
       }
     }
+    fixGenerateMockImports(sourceFile);
   }
 }
 

--- a/packages/codegen/src/file-builders/document-model/tests-dir.ts
+++ b/packages/codegen/src/file-builders/document-model/tests-dir.ts
@@ -17,9 +17,13 @@ import {
   getMockOverrideFieldNames,
 } from "../../codegen/graphql.js";
 import {
+  fixGenerateMockImports,
   formatSourceFileWithPrettier,
+  GENERATE_MOCK_MODULE_SPECIFIER,
+  GENERATE_MOCK_NAME,
   getOrCreateSourceFile,
   getPreviousVersionSourceFile,
+  hasGenerateMockImport,
   updateVersionedImports,
 } from "utils";
 
@@ -70,7 +74,7 @@ export async function makeOperationModuleTestFile(
     } else {
       sourceFile.replaceWithText(
         ts`
-        import { generateMock } from "document-model";
+        import { generateMock } from "document-model/mock";
         import { describe, expect, it } from "vitest";
 
         describe("${moduleOperationsTypeName}", () => {
@@ -184,22 +188,14 @@ export async function makeOperationModuleTestFile(
 
   describeCallBody.addStatements(testCasesToAdd);
 
-  const GENERATE_MOCK_NAME = "generateMock";
-  const GENERATE_MOCK_MODULE_SPECIFIER = "document-model";
-
-  const generateMockImport = sourceFile.getImportDeclaration((i) =>
-    i.getNamedImports().some((v) => v.getText().includes(GENERATE_MOCK_NAME)),
-  );
-
-  const hasGenerateMockInSourceFile = sourceFile
-    .getText()
-    .includes(GENERATE_MOCK_NAME);
-
-  if (hasGenerateMockInSourceFile && !generateMockImport) {
-    sourceFile.addImportDeclaration({
-      namedImports: [GENERATE_MOCK_NAME],
-      moduleSpecifier: GENERATE_MOCK_MODULE_SPECIFIER,
-    });
+  if (sourceFile.getText().includes(GENERATE_MOCK_NAME)) {
+    fixGenerateMockImports(sourceFile);
+    if (!hasGenerateMockImport(sourceFile)) {
+      sourceFile.addImportDeclaration({
+        namedImports: [GENERATE_MOCK_NAME],
+        moduleSpecifier: GENERATE_MOCK_MODULE_SPECIFIER,
+      });
+    }
   }
 
   sourceFile.fixUnusedIdentifiers();

--- a/packages/codegen/src/templates/document-model/tests/module.test.ts
+++ b/packages/codegen/src/templates/document-model/tests/module.test.ts
@@ -123,7 +123,7 @@ export const documentModelOperationsModuleTestFileTemplate = (
  */
 
 import { describe, it, expect } from 'vitest';
-import { generateMock } from 'document-model';
+import { generateMock } from 'document-model/mock';
 import {
   reducer,
   utils,

--- a/packages/codegen/src/utils/generate-mock-import.ts
+++ b/packages/codegen/src/utils/generate-mock-import.ts
@@ -1,0 +1,51 @@
+import type { SourceFile } from "ts-morph";
+
+export const GENERATE_MOCK_NAME = "generateMock";
+export const GENERATE_MOCK_MODULE_SPECIFIER = "document-model/mock";
+
+/**
+ * Points every `generateMock` import at its subpath. An import that also
+ * brings in other names keeps them where they are and gets a separate
+ * `generateMock` import added.
+ */
+export function fixGenerateMockImports(sourceFile: SourceFile) {
+  for (const importDeclaration of sourceFile.getImportDeclarations()) {
+    const namedImports = importDeclaration.getNamedImports();
+    const generateMockSpecifier = namedImports.find(
+      (namedImport) => namedImport.getName() === GENERATE_MOCK_NAME,
+    );
+    if (!generateMockSpecifier) continue;
+    if (
+      importDeclaration.getModuleSpecifierValue() ===
+      GENERATE_MOCK_MODULE_SPECIFIER
+    ) {
+      continue;
+    }
+
+    const importsOnlyGenerateMock =
+      namedImports.length === 1 &&
+      !importDeclaration.getDefaultImport() &&
+      !importDeclaration.getNamespaceImport();
+    if (importsOnlyGenerateMock) {
+      importDeclaration.setModuleSpecifier(GENERATE_MOCK_MODULE_SPECIFIER);
+      continue;
+    }
+
+    const alias = generateMockSpecifier.getAliasNode()?.getText();
+    generateMockSpecifier.remove();
+    sourceFile.addImportDeclaration({
+      namedImports: [{ name: GENERATE_MOCK_NAME, alias }],
+      moduleSpecifier: GENERATE_MOCK_MODULE_SPECIFIER,
+    });
+  }
+}
+
+export function hasGenerateMockImport(sourceFile: SourceFile) {
+  return sourceFile
+    .getImportDeclarations()
+    .some((importDeclaration) =>
+      importDeclaration
+        .getNamedImports()
+        .some((namedImport) => namedImport.getName() === GENERATE_MOCK_NAME),
+    );
+}

--- a/packages/codegen/src/utils/index.mts
+++ b/packages/codegen/src/utils/index.mts
@@ -2,6 +2,7 @@ export * from "./cli.js";
 export * from "./constants.js";
 export * from "./document-type-metadata.js";
 export * from "./format-with-prettier.js";
+export * from "./generate-mock-import.js";
 export * from "./get-editor-metadata.js";
 export * from "./get-processor-metadata.js";
 export * from "./get-subgraph-metadata.js";

--- a/packages/document-model/build.ts
+++ b/packages/document-model/build.ts
@@ -1,7 +1,7 @@
 import { build } from "tsdown";
 
 await build({
-  entry: ["index.ts"],
+  entry: ["index.ts", "mock.ts"],
   outDir: "dist",
   platform: "neutral",
   clean: true,

--- a/packages/document-model/mock.ts
+++ b/packages/document-model/mock.ts
@@ -1,0 +1,1 @@
+export { generateMock } from "@powerhousedao/shared/document-model/mock";

--- a/packages/document-model/package.json
+++ b/packages/document-model/package.json
@@ -18,6 +18,11 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./mock": {
+      "source": "./mock.ts",
+      "import": "./dist/mock.js",
+      "types": "./dist/mock.d.ts"
+    },
     "./test": {
       "source": "./test/index.ts",
       "import": "./dist/test/index.js",

--- a/packages/reactor-group/document-models/reactor-group/v1/tests/group.test.ts
+++ b/packages/reactor-group/document-models/reactor-group/v1/tests/group.test.ts
@@ -1,4 +1,4 @@
-import { generateMock } from "document-model";
+import { generateMock } from "document-model/mock";
 import {
   addMember,
   AddMemberInputSchema,

--- a/packages/shared/document-drive/src/tests/drive.test.ts
+++ b/packages/shared/document-drive/src/tests/drive.test.ts
@@ -17,7 +17,7 @@ import {
 } from "../../gen/schema/zod.js";
 import { driveCreateDocument } from "../../gen/utils.js";
 import { beforeEach, describe, expect, it } from "vitest";
-import { generateMock } from "./generate-mock.js";
+import { generateMock } from "../../../document-model/mock.js";
 
 describe("Drive Operations", () => {
   let document: DocumentDriveDocument;

--- a/packages/shared/document-drive/src/tests/generate-mock.ts
+++ b/packages/shared/document-drive/src/tests/generate-mock.ts
@@ -1,8 +1,0 @@
-import type { z } from "zod";
-import { zocker } from "zocker";
-
-export function generateMock<TSchema extends z.ZodType>(
-  schema: TSchema,
-): z.infer<TSchema> {
-  return zocker(schema).generate() as z.infer<TSchema>;
-}

--- a/packages/shared/document-drive/src/tests/node.test.ts
+++ b/packages/shared/document-drive/src/tests/node.test.ts
@@ -27,7 +27,7 @@ import {
 } from "../../gen/schema/zod.js";
 import { driveCreateDocument } from "../../gen/utils.js";
 import { beforeEach, describe, expect, it } from "vitest";
-import { generateMock } from "./generate-mock.js";
+import { generateMock } from "../../../document-model/mock.js";
 import { createDocumentWithNodes } from "./test-factories.js";
 
 describe("Node Operations", () => {

--- a/packages/shared/document-model/utils.test.ts
+++ b/packages/shared/document-model/utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { generateMock as deprecatedGenerateMock } from "./utils.js";
+import { generateMock } from "./mock.js";
+
+describe("generateMock barrel stub", () => {
+  it("throws with the new import path", () => {
+    expect(() => deprecatedGenerateMock(z.object({}))).toThrow(
+      /document-model\/mock/,
+    );
+  });
+
+  it("is not the real implementation", () => {
+    expect(deprecatedGenerateMock).not.toBe(generateMock);
+    expect(() => generateMock(z.object({ a: z.string() }))).not.toThrow();
+  });
+});

--- a/packages/shared/document-model/utils.ts
+++ b/packages/shared/document-model/utils.ts
@@ -1,5 +1,5 @@
-export { generateMock } from "./mock.js";
 import { hashBrowser } from "./crypto.js";
+import type { z } from "zod";
 
 export function generateId(method?: "UUIDv4"): string {
   if (method && method.toString() !== "UUIDv4") {
@@ -22,4 +22,21 @@ export function deriveOperationId(
 ): string {
   const input = `${documentId}:${scope}:${branch}:${actionId}`;
   return hashBrowser(input, "sha1", "hex").slice(0, 32);
+}
+
+/**
+ * @deprecated Moved to `document-model/mock`
+ * (`@powerhousedao/shared/document-model/mock`) so runtime bundles no longer
+ * ship zocker and faker. This stub only throws; update the import or run
+ * `ph migrate`.
+ */
+export function generateMock<TSchema extends z.ZodType>(
+  _schema: TSchema,
+  _overrides?: Partial<z.infer<TSchema>>,
+): z.infer<TSchema> {
+  throw new Error(
+    'generateMock is no longer exported from "document-model" or ' +
+      '"@powerhousedao/shared/document-model". Import it from ' +
+      '"document-model/mock" instead, or run `ph migrate` to rewrite the import.',
+  );
 }

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
       "document-model/action-transport.test.ts",
       "document-model/mock.test.ts",
       "document-model/signature-transport.test.ts",
+      "document-model/utils.test.ts",
       "registry/manifest-slim.test.ts",
     ],
     exclude: ["**/node_modules/**", "**/dist/**"],

--- a/packages/vetra/document-models/app-module/v1/tests/base-operations.test.ts
+++ b/packages/vetra/document-models/app-module/v1/tests/base-operations.test.ts
@@ -3,7 +3,7 @@
  * - change it by adding new tests or modifying the existing ones
  */
 
-import { generateMock } from "@powerhousedao/shared/document-model";
+import { generateMock } from "@powerhousedao/shared/document-model/mock";
 import type {
   AddDocumentTypeInput,
   AppModuleDocument,

--- a/packages/vetra/document-models/app-module/v1/tests/dnd-operations.test.ts
+++ b/packages/vetra/document-models/app-module/v1/tests/dnd-operations.test.ts
@@ -3,7 +3,7 @@
  * - change it by adding new tests or modifying the existing ones
  */
 
-import { generateMock } from "@powerhousedao/shared/document-model";
+import { generateMock } from "@powerhousedao/shared/document-model/mock";
 import type {
   AppModuleDocument,
   SetDragAndDropEnabledInput,

--- a/packages/vetra/document-models/document-editor/v1/tests/base-operations.test.ts
+++ b/packages/vetra/document-models/document-editor/v1/tests/base-operations.test.ts
@@ -3,7 +3,7 @@
  * - change it by adding new tests or modifying the existing ones
  */
 
-import { generateMock } from "@powerhousedao/shared/document-model";
+import { generateMock } from "@powerhousedao/shared/document-model/mock";
 import type {
   AddDocumentTypeInput,
   DocumentEditorDocument,

--- a/packages/vetra/document-models/processor-module/v1/tests/base-operations.test.ts
+++ b/packages/vetra/document-models/processor-module/v1/tests/base-operations.test.ts
@@ -3,7 +3,7 @@
  * - change it by adding new tests or modifying the existing ones
  */
 
-import { generateMock } from "@powerhousedao/shared/document-model";
+import { generateMock } from "@powerhousedao/shared/document-model/mock";
 import type {
   AddDocumentTypeInput,
   ProcessorModuleDocument,

--- a/packages/vetra/document-models/subgraph-module/v1/tests/base-operations.test.ts
+++ b/packages/vetra/document-models/subgraph-module/v1/tests/base-operations.test.ts
@@ -3,7 +3,7 @@
  * - change it by adding new tests or modifying the existing ones
  */
 
-import { generateMock } from "@powerhousedao/shared/document-model";
+import { generateMock } from "@powerhousedao/shared/document-model/mock";
 import type {
   SetSubgraphNameInput,
   SubgraphModuleDocument,

--- a/packages/vetra/document-models/vetra-package/v1/tests/base-operations.test.ts
+++ b/packages/vetra/document-models/vetra-package/v1/tests/base-operations.test.ts
@@ -3,7 +3,7 @@
  * - change it by adding new tests or modifying the existing ones
  */
 
-import { generateMock } from "@powerhousedao/shared/document-model";
+import { generateMock } from "@powerhousedao/shared/document-model/mock";
 import type {
   AddPackageKeywordInput,
   SetPackageAuthorInput,

--- a/test/codegen/tests/datetime-mock-override.test.ts
+++ b/test/codegen/tests/datetime-mock-override.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@powerhousedao/codegen";
 import type { OperationSpecification } from "@powerhousedao/shared/document-model";
 import { makeTestCaseForOperation } from "@powerhousedao/codegen/templates";
-import { generateMock } from "document-model";
+import { generateMock } from "document-model/mock";
 import { describe, expect, test } from "bun:test";
 import { z } from "zod";
 

--- a/test/versioned-documents/document-models/todo/v1/src/tests/todo-operations.test.ts
+++ b/test/versioned-documents/document-models/todo/v1/src/tests/todo-operations.test.ts
@@ -1,4 +1,4 @@
-import { generateMock } from "document-model";
+import { generateMock } from "document-model/mock";
 import {
   addTodo,
   AddTodoInputSchema,

--- a/test/versioned-documents/document-models/todo/v1/tests/todo-operations.test.ts
+++ b/test/versioned-documents/document-models/todo/v1/tests/todo-operations.test.ts
@@ -1,4 +1,4 @@
-import { generateMock } from "document-model";
+import { generateMock } from "document-model/mock";
 import {
   addTodo,
   AddTodoInputSchema,

--- a/test/versioned-documents/document-models/todo/v2/src/tests/todo-operations.test.ts
+++ b/test/versioned-documents/document-models/todo/v2/src/tests/todo-operations.test.ts
@@ -1,4 +1,4 @@
-import { generateMock } from "document-model";
+import { generateMock } from "document-model/mock";
 import {
   addTodo,
   AddTodoInputSchema,

--- a/test/versioned-documents/document-models/todo/v2/tests/todo-operations.test.ts
+++ b/test/versioned-documents/document-models/todo/v2/tests/todo-operations.test.ts
@@ -1,4 +1,4 @@
-import { generateMock } from "document-model";
+import { generateMock } from "document-model/mock";
 import {
   addTodo,
   AddTodoInputSchema,


### PR DESCRIPTION
## Problem

`generateMock` is a test-only helper that wraps `zocker` (which pulls in `@faker-js/faker`). It was re-exported from the runtime barrel of `@powerhousedao/shared`:

- `packages/shared/document-model/utils.ts` → `export { generateMock } from "./mock.js"`
- `packages/shared/document-model/index.ts` → `export * from "./utils.js"`
- `document-model` re-exports `@powerhousedao/shared/document-model` from its main entry

So every app importing `document-model` (every generated document-model package, every Connect/Next app) shipped zocker + faker — roughly 420 KiB uncompressed in a Next.js consumer. `zocker` is a runtime dependency of `@powerhousedao/shared`, and neither zocker nor faker declare `sideEffects: false`, so bundlers could not drop it. There are no runtime consumers of `generateMock`; every user is a test, story, or codegen template.

## Change

- **`@powerhousedao/shared`**: `generateMock` is no longer re-exported from `document-model/utils.ts` (and therefore not from the `@powerhousedao/shared/document-model` barrel). The implementation stays in `document-model/mock.ts`, already emitted as its own entry and reachable at `@powerhousedao/shared/document-model/mock`. `dist/document-model/index.js` no longer references zocker. The barrel keeps a `@deprecated` `generateMock` stub with the same signature that throws at runtime with the new import path, so a stale import still type-checks (with a deprecation strike-through) and fails with a clear message instead of a missing export.
- **`document-model`**: new `./mock` subpath export (`mock.ts` → `dist/mock.js` + `dist/mock.d.ts`) that re-exports `generateMock` from `@powerhousedao/shared/document-model/mock`. `sideEffects: false` is preserved.
- **`@powerhousedao/codegen`**: generated test files import from `document-model/mock`. A shared `fixGenerateMockImports` helper (used by both the test-file builder and `ph migrate`) rewrites any existing `generateMock` import — from `document-model`, `@powerhousedao/codegen`, or elsewhere — to `document-model/mock`, splitting it off when the declaration also imports other names and preserving aliases.
- Every in-repo import updated (reactor-group, vetra, versioned-documents, test/codegen, academy docs). The duplicate zocker wrapper in `packages/shared/document-drive/src/tests/generate-mock.ts` is removed in favour of the real implementation.

## Migration

```diff
- import { generateMock } from "document-model";
+ import { generateMock } from "document-model/mock";
```

Running `ph migrate` (or regenerating document models with `ph generate`) rewrites the import automatically.

The old export still exists but throws:

```
generateMock is no longer exported from "document-model" or "@powerhousedao/shared/document-model". Import it from "document-model/mock" instead, or run `ph migrate` to rewrite the import.
```

## Verification

- `pnpm --filter=@powerhousedao/shared build`, `pnpm --filter=document-model build`, `pnpm --filter=@powerhousedao/codegen build`
- `tsc --build` over shared, document-model, codegen, vetra, reactor-group, versioned-documents
- `eslint` for codegen, document-model, vetra, reactor-group (0 errors)
- `vitest` for shared (182, incl. new `document-model/utils.test.ts` covering the throwing stub), document-model (392), vetra document-models (132), reactor-group (21), versioned-documents document-models (44)
- `pnpm test:codegen` (generated-project suite)
- `grep -rn "zocker\|generateMock\|mock.js" packages/shared/dist/document-model/index.js packages/document-model/dist/index.js` → no matches

