### PR TITLE
Roll a failed job back instead of committing its prefix

### DIFF
--- a/packages/reactor/src/executor/document-action-handler.ts
+++ b/packages/reactor/src/executor/document-action-handler.ts
@@ -280,6 +280,12 @@ export class DocumentActionHandler {
       [job.scope]: [...(standing.operations[job.scope] ?? []), operation],
     };
 
+    executing.touchedStreams.push({
+      documentId: job.documentId,
+      scope: job.scope,
+      branch: job.branch,
+    });
+
     stores.writeCache.putState(
       job.documentId,
       job.scope,
@@ -384,6 +390,12 @@ export class DocumentActionHandler {
       ...document.operations,
       [job.scope]: [...(document.operations[job.scope] ?? []), operation],
     };
+
+    executing.touchedStreams.push({
+      documentId: document.header.id,
+      scope: job.scope,
+      branch: job.branch,
+    });
 
     stores.writeCache.putState(
       document.header.id,
@@ -528,6 +540,12 @@ export class DocumentActionHandler {
       ...document.operations,
       [job.scope]: [...(document.operations[job.scope] ?? []), operation],
     };
+
+    executing.touchedStreams.push({
+      documentId,
+      scope: job.scope,
+      branch: job.branch,
+    });
 
     stores.writeCache.putState(
       documentId,
@@ -816,6 +834,12 @@ export class DocumentActionHandler {
       [job.scope]: [...(document.operations[job.scope] ?? []), operation],
     };
 
+    executing.touchedStreams.push({
+      documentId,
+      scope: job.scope,
+      branch: job.branch,
+    });
+
     stores.writeCache.putState(
       documentId,
       job.scope,
@@ -1035,6 +1059,20 @@ export class DocumentActionHandler {
     };
     const resultingState = JSON.stringify(resultingStateObj);
 
+    executing.touchedStreams.push({
+      documentId: input.sourceId,
+      scope: job.scope,
+      branch: job.branch,
+    });
+
+    // The target's collection membership is derived from the rows just
+    // written, and a read can refill it before the transaction commits.
+    executing.touchedStreams.push({
+      documentId: input.targetId,
+      scope: job.scope,
+      branch: job.branch,
+    });
+
     stores.writeCache.putState(
       input.sourceId,
       job.scope,
@@ -1082,6 +1120,10 @@ export class DocumentActionHandler {
   ): Promise<Operation[] | JobResult> {
     const { documentId, documentType, scope, branch } = target;
     const { job, startTime, stores, signal } = executing;
+
+    // Recorded before the apply, not after: the rows an apply that throws left
+    // behind are the ones a rollback has to take the cached state of with it.
+    executing.touchedStreams.push({ documentId, scope, branch });
 
     let storedOperations: Operation[];
 

--- a/packages/reactor/src/executor/document-action-handler.ts
+++ b/packages/reactor/src/executor/document-action-handler.ts
@@ -280,11 +280,7 @@ export class DocumentActionHandler {
       [job.scope]: [...(standing.operations[job.scope] ?? []), operation],
     };
 
-    executing.touchedStreams.push({
-      documentId: job.documentId,
-      scope: job.scope,
-      branch: job.branch,
-    });
+    executing.touchedStreams.add(job.documentId, job.scope, job.branch);
 
     stores.writeCache.putState(
       job.documentId,
@@ -391,11 +387,7 @@ export class DocumentActionHandler {
       [job.scope]: [...(document.operations[job.scope] ?? []), operation],
     };
 
-    executing.touchedStreams.push({
-      documentId: document.header.id,
-      scope: job.scope,
-      branch: job.branch,
-    });
+    executing.touchedStreams.add(document.header.id, job.scope, job.branch);
 
     stores.writeCache.putState(
       document.header.id,
@@ -541,11 +533,7 @@ export class DocumentActionHandler {
       [job.scope]: [...(document.operations[job.scope] ?? []), operation],
     };
 
-    executing.touchedStreams.push({
-      documentId,
-      scope: job.scope,
-      branch: job.branch,
-    });
+    executing.touchedStreams.add(documentId, job.scope, job.branch);
 
     stores.writeCache.putState(
       documentId,
@@ -834,11 +822,7 @@ export class DocumentActionHandler {
       [job.scope]: [...(document.operations[job.scope] ?? []), operation],
     };
 
-    executing.touchedStreams.push({
-      documentId,
-      scope: job.scope,
-      branch: job.branch,
-    });
+    executing.touchedStreams.add(documentId, job.scope, job.branch);
 
     stores.writeCache.putState(
       documentId,
@@ -1059,19 +1043,11 @@ export class DocumentActionHandler {
     };
     const resultingState = JSON.stringify(resultingStateObj);
 
-    executing.touchedStreams.push({
-      documentId: input.sourceId,
-      scope: job.scope,
-      branch: job.branch,
-    });
+    executing.touchedStreams.add(input.sourceId, job.scope, job.branch);
 
     // The target's collection membership is derived from the rows just
     // written, and a read can refill it before the transaction commits.
-    executing.touchedStreams.push({
-      documentId: input.targetId,
-      scope: job.scope,
-      branch: job.branch,
-    });
+    executing.touchedStreams.add(input.targetId, job.scope, job.branch);
 
     stores.writeCache.putState(
       input.sourceId,
@@ -1123,7 +1099,7 @@ export class DocumentActionHandler {
 
     // Recorded before the apply, not after: the rows an apply that throws left
     // behind are the ones a rollback has to take the cached state of with it.
-    executing.touchedStreams.push({ documentId, scope, branch });
+    executing.touchedStreams.add(documentId, scope, branch);
 
     let storedOperations: Operation[];
 

--- a/packages/reactor/src/executor/document-action-handler.ts
+++ b/packages/reactor/src/executor/document-action-handler.ts
@@ -1046,7 +1046,10 @@ export class DocumentActionHandler {
     executing.touchedStreams.add(input.sourceId, job.scope, job.branch);
 
     // The target's collection membership is derived from the rows just
-    // written, and a read can refill it before the transaction commits.
+    // written. No read inside a job refills it today -- the only one asks for
+    // the operation's own document -- so evicting it on rollback is insurance,
+    // kept because the eviction is keyed to what the job touched rather than
+    // to what one read path currently happens to ask for.
     executing.touchedStreams.add(input.targetId, job.scope, job.branch);
 
     stores.writeCache.putState(

--- a/packages/reactor/src/executor/simple-job-executor.ts
+++ b/packages/reactor/src/executor/simple-job-executor.ts
@@ -64,6 +64,7 @@ import type {
   PendingWrite,
   PositionedWrites,
   ReactorFeatureFlags,
+  TouchedStream,
 } from "./types.js";
 import {
   buildErrorResult,
@@ -123,6 +124,27 @@ type PreparedWrite = {
   appendCondition?: AppendCondition;
   denied: boolean;
 };
+
+/** What a job produced inside the execution scope, before anything is durable. */
+type ScopeOutcome = {
+  result: JobResult;
+  pendingEvent?: JobWriteReadyEvent;
+};
+
+/**
+ * Carries a failed job out of the execution scope so its transaction rolls
+ * back. A scope callback that returns commits, whatever result it returns, so
+ * a returned failure would leave the writes the job made before it failed
+ * standing. Never escapes executeJob: the failure goes back to being a
+ * returned JobResult there, which is what the queue, the worker protocol and
+ * every test expect a failed job to look like.
+ */
+class JobRollbackSignal extends Error {
+  constructor(readonly result: JobResult) {
+    super("job rolled back");
+    this.name = "JobRollbackSignal";
+  }
+}
 
 export class SimpleJobExecutor implements IJobExecutor {
   private config: Required<JobExecutorConfig>;
@@ -188,221 +210,62 @@ export class SimpleJobExecutor implements IJobExecutor {
   /**
    * Execute a single job by applying all its actions through the appropriate reducers.
    * Actions are processed sequentially in order.
+   *
+   * The whole job runs inside one execution scope, and a scope callback that
+   * returns commits. A failed job must therefore leave the scope by throwing,
+   * or the writes it made before it failed would be durable: JobRollbackSignal
+   * carries the failure out through the transaction and this method turns it
+   * back into the returned JobResult every caller expects. A job either fully
+   * applies or leaves nothing behind.
    */
   async executeJob(job: Job, signal?: AbortSignal): Promise<JobResult> {
     const startTime = Date.now();
 
-    // Track document IDs touched during execution for cache invalidation on rollback
-    const touchedCacheEntries: Array<{
-      documentId: string;
-      scope: string;
-      branch: string;
-    }> = [];
+    // Streams the job wrote, to evict when its transaction does not commit
+    const touchedStreams: TouchedStream[] = [];
 
     // Entries handlers request invalidated only after the transaction commits
-    const postCommitInvalidations: Array<{
-      documentId: string;
-      scope: string;
-      branch: string;
-    }> = [];
+    const postCommitInvalidations: TouchedStream[] = [];
 
-    let pendingEvent: JobWriteReadyEvent | undefined;
-    let result: JobResult;
+    let outcome: ScopeOutcome;
     try {
-      result = await this.executionScope.run(async (stores) => {
-        const indexTxn = stores.operationIndex.start();
-
-        if (job.kind === "load") {
-          const loadResult = await this.executeLoadJob({
-            job,
-            startTime,
-            indexTxn,
-            stores,
-            signal,
-            replayingAcceptedHistory: true,
-            evaluatedByPosition: false,
-            postCommitInvalidations,
-          });
-          if (loadResult.success && loadResult.operationsWithContext) {
-            for (const owc of loadResult.operationsWithContext) {
-              touchedCacheEntries.push({
-                documentId: owc.context.documentId,
-                scope: owc.context.scope,
-                branch: owc.context.branch,
-              });
-            }
-
-            const ordinals = await stores.operationIndex.commit(
-              indexTxn,
-              signal,
-            );
-
-            for (let i = 0; i < loadResult.operationsWithContext.length; i++) {
-              loadResult.operationsWithContext[i].context.ordinal = ordinals[i];
-            }
-            const collectionMemberships =
-              loadResult.operationsWithContext.length > 0
-                ? await this.getCollectionMembershipsForOperations(
-                    loadResult.operationsWithContext,
-                    stores,
-                  )
-                : {};
-            pendingEvent = {
-              jobId: job.id,
-              operations: loadResult.operationsWithContext,
-              jobMeta: job.meta,
-              collectionMemberships,
-            };
-          }
-          return loadResult;
-        }
-
-        if (job.kind === "reevaluation") {
-          const reevalResult = await this.executeReevaluationJob({
-            job,
-            startTime,
-            indexTxn,
-            stores,
-            signal,
-            replayingAcceptedHistory: false,
-            evaluatedByPosition: false,
-            postCommitInvalidations,
-          });
-          if (reevalResult.success && reevalResult.operationsWithContext) {
-            for (const owc of reevalResult.operationsWithContext) {
-              touchedCacheEntries.push({
-                documentId: owc.context.documentId,
-                scope: owc.context.scope,
-                branch: owc.context.branch,
-              });
-            }
-
-            const ordinals = await stores.operationIndex.commit(
-              indexTxn,
-              signal,
-            );
-
-            for (
-              let i = 0;
-              i < reevalResult.operationsWithContext.length;
-              i++
-            ) {
-              reevalResult.operationsWithContext[i].context.ordinal =
-                ordinals[i];
-            }
-            if (reevalResult.operationsWithContext.length > 0) {
-              const collectionMemberships =
-                await this.getCollectionMembershipsForOperations(
-                  reevalResult.operationsWithContext,
-                  stores,
-                );
-              pendingEvent = {
-                jobId: job.id,
-                operations: reevalResult.operationsWithContext,
-                jobMeta: job.meta,
-                collectionMemberships,
-              };
-            }
-          }
-          return reevalResult;
-        }
-
-        const positioned = await this.positionByTimestamp(job, stores, signal);
-        if (positioned.error) {
-          return buildErrorResult(job, positioned.error, startTime);
-        }
-
-        const executing: ExecutingJob = {
+      outcome = await this.executionScope.run(async (stores) => {
+        const scoped = await this.executeInScope({
           job,
           startTime,
-          indexTxn,
           stores,
           signal,
-          replayingAcceptedHistory: false,
-          evaluatedByPosition: positioned.evaluatedByPosition,
+          touchedStreams,
           postCommitInvalidations,
-        };
+        });
 
-        const actionResult = await this.processActions(
-          positioned.writes,
-          executing,
-        );
-
-        if (!actionResult.success) {
-          return {
-            job,
-            success: false as const,
-            error: actionResult.error,
-            duration: Date.now() - startTime,
-          };
+        if (!scoped.result.success) {
+          throw new JobRollbackSignal(scoped.result);
         }
 
-        if (actionResult.operationsWithContext.length > 0) {
-          for (const owc of actionResult.operationsWithContext) {
-            touchedCacheEntries.push({
-              documentId: owc.context.documentId,
-              scope: owc.context.scope,
-              branch: owc.context.branch,
-            });
-          }
-        }
-
-        // Put here because a re-eval pass writes through the same db db
-        // transaction.
-        const reevaluationError = await this.reevaluateIfCriteriaMet(
-          { scope: job.scope, operations: actionResult.generatedOperations },
-          executing,
-        );
-        if (reevaluationError) {
-          return {
-            job,
-            success: false as const,
-            error: reevaluationError,
-            duration: Date.now() - startTime,
-          };
-        }
-
-        const ordinals = await stores.operationIndex.commit(indexTxn, signal);
-
-        if (actionResult.operationsWithContext.length > 0) {
-          for (let i = 0; i < actionResult.operationsWithContext.length; i++) {
-            actionResult.operationsWithContext[i].context.ordinal = ordinals[i];
-          }
-          const collectionMemberships =
-            await this.getCollectionMembershipsForOperations(
-              actionResult.operationsWithContext,
-              stores,
-            );
-          pendingEvent = {
-            jobId: job.id,
-            operations: actionResult.operationsWithContext,
-            jobMeta: job.meta,
-            collectionMemberships,
-          };
-        }
-
-        return {
-          job,
-          success: true as const,
-          operations: actionResult.generatedOperations,
-          operationsWithContext: actionResult.operationsWithContext,
-          duration: Date.now() - startTime,
-        };
+        return scoped;
       }, signal);
     } catch (error) {
-      for (const entry of touchedCacheEntries) {
+      // The caches are shared with the copies the scope hands the job, so the
+      // rollback that just happened undid none of what the job put in them.
+      for (const entry of touchedStreams) {
         this.writeCache.invalidate(entry.documentId, entry.scope, entry.branch);
         this.documentMetaCache.invalidate(entry.documentId, entry.branch);
+        this.collectionMembershipCache.invalidate(entry.documentId);
       }
+
+      if (error instanceof JobRollbackSignal) {
+        return error.result;
+      }
+
       throw error;
     }
 
-    if (result.success) {
-      for (const entry of postCommitInvalidations) {
-        this.writeCache.invalidate(entry.documentId, entry.scope, entry.branch);
-      }
+    for (const entry of postCommitInvalidations) {
+      this.writeCache.invalidate(entry.documentId, entry.scope, entry.branch);
     }
 
+    const { pendingEvent } = outcome;
     if (pendingEvent) {
       this.eventBus
         .emit(ReactorEventTypes.JOB_WRITE_READY, pendingEvent)
@@ -415,7 +278,191 @@ export class SimpleJobExecutor implements IJobExecutor {
         });
     }
 
-    return result;
+    return outcome.result;
+  }
+
+  /**
+   * The body of a job, run inside the execution scope's transaction.
+   *
+   * The stores and caches it works through are the copies scoped to that
+   * transaction, so nothing it does is durable until the scope commits. The
+   * write-ready event is handed back rather than emitted, because a job that
+   * has not committed yet has nothing to announce.
+   */
+  private async executeInScope(params: {
+    job: Job;
+    startTime: number;
+    stores: ExecutionStores;
+    signal?: AbortSignal;
+    touchedStreams: TouchedStream[];
+    postCommitInvalidations: TouchedStream[];
+  }): Promise<ScopeOutcome> {
+    const {
+      job,
+      startTime,
+      stores,
+      signal,
+      touchedStreams,
+      postCommitInvalidations,
+    } = params;
+
+    let pendingEvent: JobWriteReadyEvent | undefined;
+    const indexTxn = stores.operationIndex.start();
+
+    if (job.kind === "load") {
+      const loadResult = await this.executeLoadJob({
+        job,
+        startTime,
+        indexTxn,
+        stores,
+        signal,
+        replayingAcceptedHistory: true,
+        evaluatedByPosition: false,
+        postCommitInvalidations,
+        touchedStreams,
+      });
+      if (loadResult.success && loadResult.operationsWithContext) {
+        const ordinals = await stores.operationIndex.commit(indexTxn, signal);
+
+        for (let i = 0; i < loadResult.operationsWithContext.length; i++) {
+          loadResult.operationsWithContext[i].context.ordinal = ordinals[i];
+        }
+        const collectionMemberships =
+          loadResult.operationsWithContext.length > 0
+            ? await this.getCollectionMembershipsForOperations(
+                loadResult.operationsWithContext,
+                stores,
+              )
+            : {};
+        pendingEvent = {
+          jobId: job.id,
+          operations: loadResult.operationsWithContext,
+          jobMeta: job.meta,
+          collectionMemberships,
+        };
+      }
+      return { result: loadResult, pendingEvent };
+    }
+
+    if (job.kind === "reevaluation") {
+      const reevalResult = await this.executeReevaluationJob({
+        job,
+        startTime,
+        indexTxn,
+        stores,
+        signal,
+        replayingAcceptedHistory: false,
+        evaluatedByPosition: false,
+        postCommitInvalidations,
+        touchedStreams,
+      });
+      if (reevalResult.success && reevalResult.operationsWithContext) {
+        const ordinals = await stores.operationIndex.commit(indexTxn, signal);
+
+        for (let i = 0; i < reevalResult.operationsWithContext.length; i++) {
+          reevalResult.operationsWithContext[i].context.ordinal = ordinals[i];
+        }
+        if (reevalResult.operationsWithContext.length > 0) {
+          const collectionMemberships =
+            await this.getCollectionMembershipsForOperations(
+              reevalResult.operationsWithContext,
+              stores,
+            );
+          pendingEvent = {
+            jobId: job.id,
+            operations: reevalResult.operationsWithContext,
+            jobMeta: job.meta,
+            collectionMemberships,
+          };
+        }
+      }
+      return { result: reevalResult, pendingEvent };
+    }
+
+    const positioned = await this.positionByTimestamp(job, stores, signal);
+    if (positioned.error) {
+      return {
+        result: buildErrorResult(job, positioned.error, startTime),
+        pendingEvent,
+      };
+    }
+
+    const executing: ExecutingJob = {
+      job,
+      startTime,
+      indexTxn,
+      stores,
+      signal,
+      replayingAcceptedHistory: false,
+      evaluatedByPosition: positioned.evaluatedByPosition,
+      postCommitInvalidations,
+      touchedStreams,
+    };
+
+    const actionResult = await this.processActions(
+      positioned.writes,
+      executing,
+    );
+
+    if (!actionResult.success) {
+      return {
+        result: {
+          job,
+          success: false as const,
+          error: actionResult.error,
+          duration: Date.now() - startTime,
+        },
+        pendingEvent,
+      };
+    }
+
+    // Put here because a re-eval pass writes through the same db db
+    // transaction.
+    const reevaluationError = await this.reevaluateIfCriteriaMet(
+      { scope: job.scope, operations: actionResult.generatedOperations },
+      executing,
+    );
+    if (reevaluationError) {
+      return {
+        result: {
+          job,
+          success: false as const,
+          error: reevaluationError,
+          duration: Date.now() - startTime,
+        },
+        pendingEvent,
+      };
+    }
+
+    const ordinals = await stores.operationIndex.commit(indexTxn, signal);
+
+    if (actionResult.operationsWithContext.length > 0) {
+      for (let i = 0; i < actionResult.operationsWithContext.length; i++) {
+        actionResult.operationsWithContext[i].context.ordinal = ordinals[i];
+      }
+      const collectionMemberships =
+        await this.getCollectionMembershipsForOperations(
+          actionResult.operationsWithContext,
+          stores,
+        );
+      pendingEvent = {
+        jobId: job.id,
+        operations: actionResult.operationsWithContext,
+        jobMeta: job.meta,
+        collectionMemberships,
+      };
+    }
+
+    return {
+      result: {
+        job,
+        success: true as const,
+        operations: actionResult.generatedOperations,
+        operationsWithContext: actionResult.operationsWithContext,
+        duration: Date.now() - startTime,
+      },
+      pendingEvent,
+    };
   }
 
   private async getCollectionMembershipsForOperations(
@@ -852,6 +899,14 @@ export class SimpleJobExecutor implements IJobExecutor {
     const scope = first.scope;
     const documentType = first.document.header.documentType;
     const operations = prepared.map((write) => write.operation);
+
+    // Recorded before the apply, not after: the rows an apply that throws left
+    // behind are the ones a rollback has to take the cached state of with it.
+    executing.touchedStreams.push({
+      documentId: job.documentId,
+      scope,
+      branch: job.branch,
+    });
 
     let storedOperations: Operation[];
     try {

--- a/packages/reactor/src/executor/simple-job-executor.ts
+++ b/packages/reactor/src/executor/simple-job-executor.ts
@@ -384,10 +384,7 @@ export class SimpleJobExecutor implements IJobExecutor {
 
     const positioned = await this.positionByTimestamp(job, stores, signal);
     if (positioned.error) {
-      return {
-        result: buildErrorResult(job, positioned.error, startTime),
-        pendingEvent,
-      };
+      return { result: buildErrorResult(job, positioned.error, startTime) };
     }
 
     const executing: ExecutingJob = {
@@ -415,12 +412,10 @@ export class SimpleJobExecutor implements IJobExecutor {
           error: actionResult.error,
           duration: Date.now() - startTime,
         },
-        pendingEvent,
       };
     }
 
-    // Put here because a re-eval pass writes through the same db db
-    // transaction.
+    // Put here because a re-eval pass writes through the same db transaction.
     const reevaluationError = await this.reevaluateIfCriteriaMet(
       { scope: job.scope, operations: actionResult.generatedOperations },
       executing,
@@ -433,7 +428,6 @@ export class SimpleJobExecutor implements IJobExecutor {
           error: reevaluationError,
           duration: Date.now() - startTime,
         },
-        pendingEvent,
       };
     }
 

--- a/packages/reactor/src/executor/simple-job-executor.ts
+++ b/packages/reactor/src/executor/simple-job-executor.ts
@@ -217,7 +217,15 @@ export class SimpleJobExecutor implements IJobExecutor {
    * or the writes it made before it failed would be durable: JobRollbackSignal
    * carries the failure out through the transaction and this method turns it
    * back into the returned JobResult every caller expects. A job either fully
-   * applies or leaves nothing behind.
+   * applies or leaves nothing durable behind.
+   *
+   * Durable is the whole of the guarantee. The caches are shared with the
+   * copies the scope hands the job, so a failed job's writes sit in them from
+   * the moment it makes them until the eviction below, and a concurrent read
+   * in that window sees a write that is never going to commit. The window is
+   * not new -- it has always been there for a job that failed by throwing --
+   * but nothing here closes it, and a caller that needs to know a write is
+   * real has the job status to ask.
    */
   async executeJob(job: Job, signal?: AbortSignal): Promise<JobResult> {
     const startTime = Date.now();
@@ -247,13 +255,7 @@ export class SimpleJobExecutor implements IJobExecutor {
         return scoped;
       }, signal);
     } catch (error) {
-      // The caches are shared with the copies the scope hands the job, so the
-      // rollback that just happened undid none of what the job put in them.
-      for (const entry of touchedStreams) {
-        this.writeCache.invalidate(entry.documentId, entry.scope, entry.branch);
-        this.documentMetaCache.invalidate(entry.documentId, entry.branch);
-        this.collectionMembershipCache.invalidate(entry.documentId);
-      }
+      this.evictTouchedStreams(touchedStreams);
 
       if (error instanceof JobRollbackSignal) {
         return error.result;
@@ -464,6 +466,33 @@ export class SimpleJobExecutor implements IJobExecutor {
       },
       pendingEvent,
     };
+  }
+
+  /**
+   * Drops the cached state of every stream a job wrote, after its transaction
+   * did not commit.
+   *
+   * The caches are shared by reference with the copies the scope hands the job,
+   * so a rollback undoes nothing in them: what the job put there survives, as
+   * does anything a read filled from the store while the job's own writes were
+   * still uncommitted. An eviction that throws is swallowed rather than allowed
+   * to replace the failure the caller is owed, and the remaining streams are
+   * still evicted.
+   */
+  private evictTouchedStreams(touchedStreams: TouchedStreams): void {
+    for (const entry of touchedStreams) {
+      try {
+        this.writeCache.invalidate(entry.documentId, entry.scope, entry.branch);
+        this.documentMetaCache.invalidate(entry.documentId, entry.branch);
+        this.collectionMembershipCache.invalidate(entry.documentId);
+      } catch (error) {
+        this.logger.error(
+          "Failed to evict cached state for rolled back @Stream : @Error",
+          entry,
+          error,
+        );
+      }
+    }
   }
 
   private async getCollectionMembershipsForOperations(

--- a/packages/reactor/src/executor/simple-job-executor.ts
+++ b/packages/reactor/src/executor/simple-job-executor.ts
@@ -73,6 +73,7 @@ import {
   getNextIndexForScope,
   isGenesisOperation,
   refusalError,
+  TouchedStreams,
 } from "./util.js";
 
 const MAX_SKIP_THRESHOLD = 1000;
@@ -222,7 +223,7 @@ export class SimpleJobExecutor implements IJobExecutor {
     const startTime = Date.now();
 
     // Streams the job wrote, to evict when its transaction does not commit
-    const touchedStreams: TouchedStream[] = [];
+    const touchedStreams = new TouchedStreams();
 
     // Entries handlers request invalidated only after the transaction commits
     const postCommitInvalidations: TouchedStream[] = [];
@@ -294,7 +295,7 @@ export class SimpleJobExecutor implements IJobExecutor {
     startTime: number;
     stores: ExecutionStores;
     signal?: AbortSignal;
-    touchedStreams: TouchedStream[];
+    touchedStreams: TouchedStreams;
     postCommitInvalidations: TouchedStream[];
   }): Promise<ScopeOutcome> {
     const {
@@ -902,11 +903,7 @@ export class SimpleJobExecutor implements IJobExecutor {
 
     // Recorded before the apply, not after: the rows an apply that throws left
     // behind are the ones a rollback has to take the cached state of with it.
-    executing.touchedStreams.push({
-      documentId: job.documentId,
-      scope,
-      branch: job.branch,
-    });
+    executing.touchedStreams.add(job.documentId, scope, job.branch);
 
     let storedOperations: Operation[];
     try {

--- a/packages/reactor/src/executor/simple-job-executor.ts
+++ b/packages/reactor/src/executor/simple-job-executor.ts
@@ -1072,10 +1072,12 @@ export class SimpleJobExecutor implements IJobExecutor {
    * produced - but the result is threaded in memory rather than read back from
    * the cache, and the whole run reaches the store in a single apply.
    *
-   * A write that cannot be prepared, or that turns out to be denied, abandons
-   * the batch and the caller replays the whole job one write at a time. That is
-   * simpler than committing a partial run, and these are the paths where the
-   * per-write behaviour is load-bearing.
+   * A write that turns out to be denied abandons the batch and replays the run
+   * one write at a time, because a denied write holds a position of its own and
+   * that is the path where the per-write behaviour is load-bearing. A write
+   * that cannot be prepared fails the job outright: preparing is a read, so the
+   * replay would only reach the same failure, and the job leaves nothing behind
+   * either way.
    */
   private async executeRegularActionsBatched(
     writes: PendingWrite[],
@@ -1088,14 +1090,7 @@ export class SimpleJobExecutor implements IJobExecutor {
     for (const write of writes) {
       const outcome = await this.prepareRegularWrite(write, executing, carried);
       if ("success" in outcome) {
-        // A write that refuses or fails part-way through leaves the writes
-        // before it standing when they go one at a time, and preparing is a
-        // read, so replaying the run per write reaches the same failure with
-        // the same operations behind it. Only the first write has nothing to
-        // replay.
-        return prepared.length === 0
-          ? outcome
-          : this.executeRegularActionsSequentially(writes, executing);
+        return outcome;
       }
       if (outcome.denied) {
         return this.executeRegularActionsSequentially(writes, executing);

--- a/packages/reactor/src/executor/types.ts
+++ b/packages/reactor/src/executor/types.ts
@@ -6,6 +6,7 @@ import type { Operation } from "@powerhousedao/shared/document-model";
 import type { Job } from "../queue/types.js";
 import type { IOperationIndexTxn } from "../cache/operation-index-types.js";
 import type { ExecutionStores } from "./execution-scope.js";
+import type { TouchedStreams } from "./util.js";
 
 /**
  * One action to write, and everything known about it before it is written.
@@ -75,7 +76,7 @@ export type ExecutingJob = {
    * survive the rollback, and so does anything a read filled from the store
    * while the job's own writes were still uncommitted.
    */
-  touchedStreams: TouchedStream[];
+  touchedStreams: TouchedStreams;
 };
 
 export type PositionedWrites = {

--- a/packages/reactor/src/executor/types.ts
+++ b/packages/reactor/src/executor/types.ts
@@ -195,10 +195,12 @@ export type JobExecutorConfig = {
    * this never changes which operations are produced -- only how many
    * transactions they arrive in.
    *
-   * It does change one thing beyond performance: a batched job's writes are
-   * atomic, so a job that fails partway through leaves nothing behind where it
-   * used to leave the operations it had already applied. Set it false to get
-   * the per-operation behaviour back.
+   * Atomicity is not one of the things it changes. A job either fully applies
+   * or leaves nothing behind regardless of this setting, because the whole job
+   * runs inside the execution scope's transaction and a failure rolls it back.
+   * That guarantee belongs to KyselyExecutionScope, which backs both Postgres
+   * and PGlite; DefaultExecutionScope opens no transaction and is used only by
+   * unit-test harnesses, which therefore see writes survive a failed job.
    */
   batchApplies?: boolean;
 };

--- a/packages/reactor/src/executor/types.ts
+++ b/packages/reactor/src/executor/types.ts
@@ -197,8 +197,9 @@ export type JobExecutorConfig = {
    * transactions they arrive in.
    *
    * Atomicity is not one of the things it changes. A job either fully applies
-   * or leaves nothing behind regardless of this setting, because the whole job
-   * runs inside the execution scope's transaction and a failure rolls it back.
+   * or leaves nothing durable behind regardless of this setting, because the
+   * whole job runs inside the execution scope's transaction and a failure
+   * rolls it back.
    * That guarantee belongs to KyselyExecutionScope, which backs both Postgres
    * and PGlite; DefaultExecutionScope opens no transaction and is used only by
    * unit-test harnesses, which therefore see writes survive a failed job.

--- a/packages/reactor/src/executor/types.ts
+++ b/packages/reactor/src/executor/types.ts
@@ -27,6 +27,16 @@ export type PendingWrite = {
 };
 
 /**
+ * A stream a job wrote to, or whose cached state a job's uncommitted writes
+ * could have filled.
+ */
+export type TouchedStream = {
+  documentId: string;
+  scope: string;
+  branch: string;
+};
+
+/**
  * The job in flight, and what a write is committed through.
  */
 export type ExecutingJob = {
@@ -56,11 +66,16 @@ export type ExecutingJob = {
    * invalidating them mid-transaction lets a concurrent read repopulate the
    * cache with pre-upgrade state that then survives the commit.
    */
-  postCommitInvalidations: Array<{
-    documentId: string;
-    scope: string;
-    branch: string;
-  }>;
+  postCommitInvalidations: TouchedStream[];
+
+  /**
+   * Streams this job wrote, to the store or to a cache. The caches are shared
+   * by reference with the copies scoped to the execution transaction, so a job
+   * whose transaction rolls back has to evict them itself: the writes it made
+   * survive the rollback, and so does anything a read filled from the store
+   * while the job's own writes were still uncommitted.
+   */
+  touchedStreams: TouchedStream[];
 };
 
 export type PositionedWrites = {

--- a/packages/reactor/src/executor/util.ts
+++ b/packages/reactor/src/executor/util.ts
@@ -23,7 +23,7 @@ import type {
   ConsistencyCoordinate,
   ConsistencyToken,
 } from "../shared/types.js";
-import type { JobResult } from "./types.js";
+import type { JobResult, TouchedStream } from "./types.js";
 
 export { applyDeleteDocumentAction, applyUpgradeDocumentAction };
 
@@ -329,4 +329,29 @@ export function isGenesisOperation(operation: Operation): boolean {
     return false;
   }
   return (operation.action.input as { fromVersion?: number }).fromVersion === 0;
+}
+
+/**
+ * The distinct streams a job wrote, collected so a rollback knows what to evict.
+ *
+ * A write records its stream on every apply, and a long run applies the same
+ * stream hundreds of times, so this keeps one entry per stream rather than one
+ * per write: the eviction only cares which streams were touched, and the
+ * successful jobs that never read this back pay for a lookup instead of an
+ * allocation.
+ */
+export class TouchedStreams {
+  private readonly streams = new Map<string, TouchedStream>();
+
+  add(documentId: string, scope: string, branch: string): void {
+    const key = `${documentId}\u0000${scope}\u0000${branch}`;
+    if (this.streams.has(key)) {
+      return;
+    }
+    this.streams.set(key, { documentId, scope, branch });
+  }
+
+  [Symbol.iterator](): IterableIterator<TouchedStream> {
+    return this.streams.values();
+  }
 }

--- a/packages/reactor/test/decision/conditions.integration.test.ts
+++ b/packages/reactor/test/decision/conditions.integration.test.ts
@@ -107,8 +107,10 @@ describe("conditions end to end", () => {
       branch: "main",
       scopes: ["global"],
     });
-    const stored = (result as Record<string, { results: Operation[] }>).global
-      .results;
+    // A scope no operation ever reached is absent from the result, not empty.
+    const stored =
+      (result as Record<string, { results: Operation[] } | undefined>).global
+        ?.results ?? [];
     return garbageCollect(sortOperations([...stored])).map((operation) => ({
       type: operation.action.type,
       denied: operation.deniedReason !== undefined,
@@ -232,6 +234,11 @@ describe("conditions end to end", () => {
    * write after it needs. Persisting a job's operations together must not
    * decide the later ones against the state as it stood before the job: the
    * run is judged the same whether or not it shares a transaction.
+   *
+   * The refusal takes the whole job with it either way. The job runs inside one
+   * transaction and a failure rolls it back, so the write that closed the grant
+   * is not left standing on its own - which is also what keeps the refusal from
+   * being permanent, since the grant it closed is still open on a retry.
    */
   for (const batchApplies of [true, false]) {
     it(`a run's own write closes the grant for the ones after it (batchApplies: ${batchApplies})`, async () => {
@@ -251,9 +258,7 @@ describe("conditions end to end", () => {
       );
 
       expect(refusal).toMatch(/denied|Authorization/i);
-      expect(await appliedGlobal(docId)).toEqual([
-        { type: "SET_MODEL_NAME", denied: false },
-      ]);
+      expect(await appliedGlobal(docId)).toEqual([]);
     });
   }
 

--- a/packages/reactor/test/executor/batch-applies-atomicity.test.ts
+++ b/packages/reactor/test/executor/batch-applies-atomicity.test.ts
@@ -20,7 +20,13 @@ import {
 const DOC_ID = "doc-1";
 const DOC_TYPE = "powerhouse/document-model";
 
-/** A batched run shares one transaction, so a store failure must lose all of it. */
+/**
+ * A batched run shares one store transaction, so a store failure must lose all
+ * of it. This harness builds the executor without an execution scope, so what
+ * it sees is what the batching alone gives; the job-level guarantee that a
+ * failed job leaves nothing behind belongs to the execution scope and is pinned
+ * in test/executor/integration.test.ts.
+ */
 describe("batched applies: a store failure loses the whole run", () => {
   let store: ReturnType<typeof createMockOperationStore>;
   let applied: unknown[][];
@@ -173,8 +179,12 @@ describe("batched applies: a store failure loses the whole run", () => {
     );
   });
 
-  it("keeps the writes before the failure when batching is off", async () => {
-    // the pre-batching behaviour the `!` commit replaced
+  it("keeps the writes before the failure, having no transaction to roll back", async () => {
+    // Not the reactor's behaviour: this harness builds the executor without an
+    // execution scope, so it runs DefaultExecutionScope, which opens no
+    // transaction and applies each write as it is made. Atomicity is the
+    // scope's guarantee, and every reactor is built with the Kysely one - see
+    // test/executor/integration.test.ts, which pins both scopes side by side.
     failStoreAt(4);
     const result = await run(false, 10);
 

--- a/packages/reactor/test/executor/batch-applies-partial-failure.test.ts
+++ b/packages/reactor/test/executor/batch-applies-partial-failure.test.ts
@@ -1,0 +1,144 @@
+import type {
+  Action,
+  Grant,
+  Operation,
+} from "@powerhousedao/shared/document-model";
+import {
+  addModule,
+  garbageCollect,
+  initializeAuth,
+  setModelName,
+  sortOperations,
+} from "@powerhousedao/shared/document-model";
+import { documentModelDocumentModelModule } from "document-model";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ReactorBuilder } from "../../src/core/reactor-builder.js";
+import type { IReactor } from "../../src/core/types.js";
+import { JobStatus } from "../../src/shared/types.js";
+import { createDocModelDocument } from "../factories.js";
+
+const ADMIN = "0xAdmin";
+const WRITER = "0xWriter";
+
+function signedBy<T extends Action>(action: T, address: string): T {
+  return {
+    ...action,
+    context: {
+      signer: {
+        user: { address, networkId: "", chainId: 0 },
+        app: { name: "test", key: "" },
+        signatures: [],
+      },
+    },
+  };
+}
+
+const adminGrant: Grant = {
+  id: "g-admin",
+  description: "admin executes everything",
+  effect: "allow",
+  principal: { address: ADMIN },
+  capability: { can: "execute", scope: "*" },
+};
+
+const whileUnnamed: Grant = {
+  id: "g-while-unnamed",
+  description: "open until named",
+  effect: "allow",
+  principal: { anyone: true },
+  capability: { can: "execute", scope: "global" },
+  where: { eq: [{ attr: "doc.global.name" }, { lit: "" }] },
+};
+
+/** batchApplies documents that a failed job leaves nothing behind. */
+describe("batched applies: what a partial failure leaves behind", () => {
+  let reactor: IReactor;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    reactor?.kill();
+    vi.useRealTimers();
+  });
+
+  async function build(): Promise<IReactor> {
+    return new ReactorBuilder()
+      .withDocumentModelSources([documentModelDocumentModelModule as never])
+      .withExecutorConfig({
+        featureFlags: {
+          documentDecisions: true,
+          authEnforcement: true,
+          authGroups: true,
+          authConditions: true,
+        },
+      })
+      .build();
+  }
+
+  async function settle(jobId: string): Promise<string | undefined> {
+    await vi.waitUntil(async () => {
+      const status = await reactor.getJobStatus(jobId);
+      return (
+        status.status === JobStatus.FAILED ||
+        status.status === JobStatus.READ_READY
+      );
+    });
+    const status = await reactor.getJobStatus(jobId);
+    return status.status === JobStatus.FAILED
+      ? (status.error?.message ?? "job failed")
+      : undefined;
+  }
+
+  async function appliedGlobal(documentId: string): Promise<string[]> {
+    const result = await reactor.getOperations(documentId, {
+      branch: "main",
+      scopes: ["global"],
+    });
+    // A scope no operation ever reached is absent from the result, not empty.
+    const stored =
+      (result as Record<string, { results: Operation[] } | undefined>).global
+        ?.results ?? [];
+    return garbageCollect(sortOperations([...stored])).map(
+      (operation) => operation.action.type,
+    );
+  }
+
+  async function createGatedDocument(id: string): Promise<string> {
+    const document = createDocModelDocument({ id });
+    expect(await settle((await reactor.create(document)).id)).toBeUndefined();
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:01.000Z"));
+    expect(
+      await settle(
+        (
+          await reactor.execute(document.header.id, "main", [
+            initializeAuth({ version: 1, grants: [adminGrant, whileUnnamed] }),
+          ])
+        ).id,
+      ),
+    ).toBeUndefined();
+    return document.header.id;
+  }
+
+  it("a job that fails partway through leaves nothing behind", async () => {
+    reactor = await build();
+    const docId = await createGatedDocument("partial-failure");
+
+    // naming the model closes the grant the module after it needs
+    vi.setSystemTime(new Date("2026-01-01T00:00:02.000Z"));
+    const refusal = await settle(
+      (
+        await reactor.execute(docId, "main", [
+          signedBy(setModelName({ name: "locked" }), WRITER),
+          signedBy(addModule({ id: "m1", name: "m1" }), WRITER),
+        ])
+      ).id,
+    );
+
+    expect(refusal).toMatch(/denied|Authorization/i);
+    expect(await appliedGlobal(docId)).toEqual([]);
+  });
+});

--- a/packages/reactor/test/executor/document-action-handler/unit.test.ts
+++ b/packages/reactor/test/executor/document-action-handler/unit.test.ts
@@ -162,6 +162,7 @@ function execute(
       replayingAcceptedHistory: false,
       evaluatedByPosition: false,
       postCommitInvalidations: [],
+      touchedStreams: [],
     },
   );
 }

--- a/packages/reactor/test/executor/document-action-handler/unit.test.ts
+++ b/packages/reactor/test/executor/document-action-handler/unit.test.ts
@@ -7,7 +7,10 @@ import { DEFAULT_DRIVE_CONTAINER_TYPES } from "../../../src/core/drive-container
 import { DocumentActionHandler } from "../../../src/executor/document-action-handler.js";
 import { selectDecisionModel } from "../../../src/decision/registered-model.js";
 import type { ExecutionStores } from "../../../src/executor/execution-scope.js";
-import { targetDocumentId } from "../../../src/executor/util.js";
+import {
+  targetDocumentId,
+  TouchedStreams,
+} from "../../../src/executor/util.js";
 import type { Job } from "../../../src/queue/types.js";
 import {
   createMockCollectionMembershipCache,
@@ -162,7 +165,7 @@ function execute(
       replayingAcceptedHistory: false,
       evaluatedByPosition: false,
       postCommitInvalidations: [],
-      touchedStreams: [],
+      touchedStreams: new TouchedStreams(),
     },
   );
 }

--- a/packages/reactor/test/executor/integration.test.ts
+++ b/packages/reactor/test/executor/integration.test.ts
@@ -66,6 +66,7 @@ describe.each(scopeVariants)(
     let writeCache: KyselyWriteCache;
     let operationIndex: KyselyOperationIndex;
     let documentMetaCache: DocumentMetaCache;
+    let collectionMembershipCache: CollectionMembershipCache;
     let eventBus: IEventBus;
 
     async function createDocumentWithCreateOperation(
@@ -193,9 +194,7 @@ describe.each(scopeVariants)(
       });
       await documentMetaCache.startup();
 
-      const collectionMembershipCache = new CollectionMembershipCache(
-        operationIndex,
-      );
+      collectionMembershipCache = new CollectionMembershipCache(operationIndex);
 
       const executionScope = createScope(
         db,
@@ -1637,6 +1636,77 @@ describe.each(scopeVariants)(
           );
           expect(stored.results).toHaveLength(2);
           expect(cached.header.revision.document).toBe(2);
+        });
+
+        it("evicts what it cached when the transaction itself fails to commit", async () => {
+          // The failure classes above all abandon the job mid-body. This one
+          // lets the body run to completion -- so every cache holds the job's
+          // writes and the write cache holds the new revision -- and then fails
+          // the commit, which is the only point at which a job that did
+          // everything right still leaves nothing behind.
+          const driveDoc = driveDocumentModelModule.utils.createDocument();
+          const driveId = driveDoc.header.id;
+          await createDocumentWithCreateOperation(
+            driveId,
+            driveDoc.header.documentType,
+            driveDoc.state,
+          );
+
+          const realTransaction = db.transaction.bind(db);
+          const transactionSpy = vi
+            .spyOn(db, "transaction")
+            .mockImplementation(() => {
+              const builder = realTransaction();
+              const execute = builder.execute.bind(builder);
+              return {
+                execute: (fn: (trx: unknown) => Promise<unknown>) =>
+                  execute(async (trx) => {
+                    await fn(trx);
+                    throw new Error("commit-fail");
+                  }),
+              } as unknown as ReturnType<typeof db.transaction>;
+            });
+
+          const job: Job = {
+            id: "job-commit-failure",
+            kind: "mutation",
+            documentId: driveId,
+            scope: "global",
+            branch: "main",
+            actions: [
+              {
+                id: "commit-failure-action",
+                type: "ADD_FOLDER",
+                scope: "global",
+                timestampUtcMs: new Date().toISOString(),
+                input: {
+                  id: "folder-commit-failure",
+                  name: "Commit Failure Folder",
+                  parentFolder: null,
+                },
+              },
+            ],
+            operations: [],
+            createdAt: new Date().toISOString(),
+            queueHint: [],
+            errorHistory: [],
+            meta: { batchId: "test", batchJobIds: ["job-commit-failure"] },
+          };
+
+          await expect(executor.executeJob(job)).rejects.toThrow("commit-fail");
+
+          transactionSpy.mockRestore();
+
+          expect(
+            writeCache.getStream(driveId, "global", "main"),
+          ).toBeUndefined();
+          const stored = await operationStore.getSince(
+            driveId,
+            "global",
+            "main",
+            -1,
+          );
+          expect(stored.results).toHaveLength(0);
         });
 
         it("persists nothing when a load job fails part-way through", async () => {

--- a/packages/reactor/test/executor/integration.test.ts
+++ b/packages/reactor/test/executor/integration.test.ts
@@ -25,7 +25,7 @@ import { DocumentModelRegistry } from "../../src/registry/implementation.js";
 import type { IDocumentModelRegistry } from "../../src/registry/interfaces.js";
 import { DocumentDeletedError } from "../../src/shared/errors.js";
 import type { KyselyKeyframeStore } from "../../src/storage/kysely/keyframe-store.js";
-import type { KyselyOperationStore } from "../../src/storage/kysely/store.js";
+import { KyselyOperationStore } from "../../src/storage/kysely/store.js";
 import type { Database as DatabaseSchema } from "../../src/storage/kysely/types.js";
 import {
   createMockLogger,
@@ -1518,6 +1518,94 @@ describe.each(scopeVariants)(
         ).length;
       }
 
+      /**
+       * A load job of three operations, the store rejecting the second. Load
+       * replays accepted history, which never batches, so every operation
+       * reaches the store through an apply of its own and the failure lands
+       * with the one before it already written.
+       */
+      async function runPartiallyFailingLoadJob(): Promise<{
+        driveId: string;
+        success: boolean;
+      }> {
+        const driveDoc = driveDocumentModelModule.utils.createDocument();
+        const driveId = driveDoc.header.id;
+        await createDocumentWithCreateOperation(
+          driveId,
+          driveDoc.header.documentType,
+          driveDoc.state,
+        );
+
+        const operations = [0, 1, 2].map((index) => {
+          const actionId = `load-atomicity-action-${index}`;
+          const timestampUtcMs = new Date(
+            Date.UTC(2026, 0, 1, 0, 0, index),
+          ).toISOString();
+          return {
+            id: deriveOperationId(driveId, "global", "main", actionId),
+            index,
+            timestampUtcMs,
+            hash: "",
+            skip: 0,
+            action: {
+              id: actionId,
+              type: "ADD_FOLDER",
+              scope: "global",
+              timestampUtcMs,
+              input: {
+                id: `load-folder-${index}`,
+                name: `Load Folder ${index}`,
+                parentFolder: null,
+              },
+            },
+          };
+        });
+
+        const job: Job = {
+          id: "job-load-partial-failure",
+          kind: "load",
+          documentId: driveId,
+          scope: "global",
+          branch: "main",
+          actions: [],
+          operations,
+          createdAt: new Date().toISOString(),
+          queueHint: [],
+          errorHistory: [],
+          meta: { batchId: "test", batchJobIds: ["job-load-partial-failure"] },
+        };
+
+        const realApply = KyselyOperationStore.prototype.apply;
+        const applySpy = vi
+          .spyOn(KyselyOperationStore.prototype, "apply")
+          .mockImplementation(function (
+            this: KyselyOperationStore,
+            ...args: Parameters<KyselyOperationStore["apply"]>
+          ) {
+            const scope = args[2];
+            const revision = args[4];
+            if (scope === "global" && revision === 1) {
+              return Promise.reject(new Error("load store failure"));
+            }
+            return realApply.apply(this, args);
+          });
+
+        const result = await executor.executeJob(job);
+        applySpy.mockRestore();
+
+        return { driveId, success: result.success };
+      }
+
+      async function foldersOn(driveId: string): Promise<number> {
+        const operations = await operationStore.getSince(
+          driveId,
+          "global",
+          "main",
+          -1,
+        );
+        return operations.results.length;
+      }
+
       it("returns the failure rather than throwing it", async () => {
         // The rollback leaves through a throw, but no caller ever sees one: a
         // failed job is a returned result, the same as it has always been.
@@ -1550,6 +1638,15 @@ describe.each(scopeVariants)(
           expect(stored.results).toHaveLength(2);
           expect(cached.header.revision.document).toBe(2);
         });
+
+        it("persists nothing when a load job fails part-way through", async () => {
+          // The load path never batches, so the store held the first operation
+          // when the second was refused. Only the rollback takes it back.
+          const { driveId, success } = await runPartiallyFailingLoadJob();
+
+          expect(success).toBe(false);
+          expect(await foldersOn(driveId)).toBe(0);
+        });
       } else {
         it("keeps the writes before the failure, having no transaction to roll back", async () => {
           // DefaultExecutionScope runs the job against the stores directly, so
@@ -1558,6 +1655,13 @@ describe.each(scopeVariants)(
           const { driveId } = await runPartiallyFailingJob();
 
           expect(await relationshipsOn(driveId)).toBe(1);
+        });
+
+        it("keeps a load job's earlier operations for the same reason", async () => {
+          const { driveId, success } = await runPartiallyFailingLoadJob();
+
+          expect(success).toBe(false);
+          expect(await foldersOn(driveId)).toBe(1);
         });
       }
     });

--- a/packages/reactor/test/executor/integration.test.ts
+++ b/packages/reactor/test/executor/integration.test.ts
@@ -57,7 +57,7 @@ const scopeVariants: ScopeVariant[] = [
 
 describe.each(scopeVariants)(
   "SimpleJobExecutor Integration ($name)",
-  ({ createScope }) => {
+  ({ name, createScope }) => {
     let executor: SimpleJobExecutor;
     let registry: IDocumentModelRegistry;
     let db: Kysely<DatabaseSchema>;
@@ -1432,6 +1432,134 @@ describe.each(scopeVariants)(
 
         invalidateSpy.mockRestore();
       });
+    });
+
+    /**
+     * A job either fully applies or leaves nothing behind. The guarantee comes
+     * from the execution scope's transaction, so it is a property of which
+     * scope the executor was built with, not of anything the job does.
+     */
+    describe("Job Atomicity on Failure", () => {
+      /**
+       * Two writes, the second refused: a relationship whose source and target
+       * are the same document is rejected before it reaches the store, after
+       * the one before it has already been applied.
+       */
+      async function runPartiallyFailingJob(): Promise<{
+        driveId: string;
+        success: boolean;
+      }> {
+        const driveDoc = driveDocumentModelModule.utils.createDocument();
+        const driveId = driveDoc.header.id;
+        await createDocumentWithCreateOperation(
+          driveId,
+          driveDoc.header.documentType,
+          driveDoc.state,
+        );
+
+        const childDoc = driveDocumentModelModule.utils.createDocument();
+        childDoc.header.id = "atomicity-child";
+        await createDocumentWithCreateOperation(
+          childDoc.header.id,
+          childDoc.header.documentType,
+          childDoc.state,
+        );
+
+        const job: Job = {
+          id: "job-partial-failure",
+          kind: "mutation",
+          documentId: driveId,
+          scope: "document",
+          branch: "main",
+          actions: [
+            {
+              id: "atomicity-action-1",
+              type: "ADD_RELATIONSHIP",
+              scope: "document",
+              timestampUtcMs: new Date().toISOString(),
+              input: {
+                sourceId: driveId,
+                targetId: childDoc.header.id,
+                relationshipType: "child",
+              },
+            },
+            {
+              id: "atomicity-action-2",
+              type: "ADD_RELATIONSHIP",
+              scope: "document",
+              timestampUtcMs: new Date().toISOString(),
+              input: {
+                sourceId: driveId,
+                targetId: driveId,
+                relationshipType: "child",
+              },
+            },
+          ],
+          operations: [],
+          createdAt: new Date().toISOString(),
+          queueHint: [],
+          errorHistory: [],
+          meta: { batchId: "test", batchJobIds: ["job-partial-failure"] },
+        };
+
+        const result = await executor.executeJob(job);
+        return { driveId, success: result.success };
+      }
+
+      async function relationshipsOn(driveId: string): Promise<number> {
+        const operations = await operationStore.getSince(
+          driveId,
+          "document",
+          "main",
+          -1,
+        );
+        return operations.results.filter(
+          (operation) => operation.action.type === "ADD_RELATIONSHIP",
+        ).length;
+      }
+
+      it("returns the failure rather than throwing it", async () => {
+        // The rollback leaves through a throw, but no caller ever sees one: a
+        // failed job is a returned result, the same as it has always been.
+        const { success } = await runPartiallyFailingJob();
+        expect(success).toBe(false);
+      });
+
+      if (name === "KyselyExecutionScope") {
+        it("persists nothing when a job fails part-way through", async () => {
+          const { driveId } = await runPartiallyFailingJob();
+
+          expect(await relationshipsOn(driveId)).toBe(0);
+        });
+
+        it("leaves no cached state behind for the writes it rolled back", async () => {
+          const { driveId } = await runPartiallyFailingJob();
+
+          // A rollback undoes nothing in the caches, which are shared with the
+          // copies the scope hands the job, so the executor evicts them itself.
+          // The document was set up with two operations and the job's own write
+          // is gone, so a cache still holding it would read one revision ahead
+          // of the store.
+          const cached = await writeCache.getState(driveId, "document", "main");
+          const stored = await operationStore.getSince(
+            driveId,
+            "document",
+            "main",
+            -1,
+          );
+          expect(stored.results).toHaveLength(2);
+          expect(cached.header.revision.document).toBe(2);
+        });
+      } else {
+        it("keeps the writes before the failure, having no transaction to roll back", async () => {
+          // DefaultExecutionScope runs the job against the stores directly, so
+          // each write is durable as it is made. It backs unit-test harnesses
+          // only; nothing the reactor builds runs this way.
+          const { driveId } = await runPartiallyFailingJob();
+
+          expect(await relationshipsOn(driveId)).toBe(1);
+        });
+      }
     });
   },
 );

--- a/packages/reactor/test/executor/job-atomicity.test.ts
+++ b/packages/reactor/test/executor/job-atomicity.test.ts
@@ -50,8 +50,14 @@ const whileUnnamed: Grant = {
   where: { eq: [{ attr: "doc.global.name" }, { lit: "" }] },
 };
 
-/** batchApplies documents that a failed job leaves nothing behind. */
-describe("batched applies: what a partial failure leaves behind", () => {
+/**
+ * A failed job leaves nothing behind, end to end through a built reactor.
+ *
+ * Nothing here varies batchApplies, because atomicity does not depend on it:
+ * the whole job runs inside the execution scope's transaction and a failure
+ * rolls it back whether its writes reached the store in one apply or many.
+ */
+describe("a job that fails part-way through", () => {
   let reactor: IReactor;
 
   beforeEach(() => {

--- a/packages/reactor/test/executor/job-retry-atomicity.test.ts
+++ b/packages/reactor/test/executor/job-retry-atomicity.test.ts
@@ -1,0 +1,109 @@
+import type { Operation } from "@powerhousedao/shared/document-model";
+import {
+  setModelDescription,
+  setModelName,
+  sortOperations,
+} from "@powerhousedao/shared/document-model";
+import { documentModelDocumentModelModule } from "document-model";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ReactorBuilder } from "../../src/core/reactor-builder.js";
+import type { IReactor } from "../../src/core/types.js";
+import { JobStatus } from "../../src/shared/types.js";
+import { KyselyOperationStore } from "../../src/storage/kysely/store.js";
+import { createDocModelDocument } from "../factories.js";
+
+/**
+ * A retry re-runs a job's whole action list, so what the attempt before it left
+ * behind is applied a second time. Nothing dedupes it: the store's uniqueness
+ * is on (opId, index, skip), and the retry writes the same actions at new
+ * indices. Rolling a failed job back is what keeps a retry from duplicating.
+ */
+describe("a retry after a mid-run failure", () => {
+  let reactor: IReactor;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    reactor?.kill();
+    vi.useRealTimers();
+  });
+
+  async function settle(jobId: string): Promise<string | undefined> {
+    await vi.waitUntil(async () => {
+      const status = await reactor.getJobStatus(jobId);
+      return (
+        status.status === JobStatus.FAILED ||
+        status.status === JobStatus.READ_READY
+      );
+    });
+    const status = await reactor.getJobStatus(jobId);
+    return status.status === JobStatus.FAILED
+      ? (status.error?.message ?? "job failed")
+      : undefined;
+  }
+
+  it("does not apply the writes before the failure a second time", async () => {
+    // One apply per action, so the failure can land between two writes rather
+    // than taking the whole batch with it.
+    reactor = await new ReactorBuilder()
+      .withDocumentModelSources([documentModelDocumentModelModule as never])
+      .withExecutorConfig({ batchApplies: false })
+      .build();
+
+    const document = createDocModelDocument({ id: "retry-duplication" });
+    expect(await settle((await reactor.create(document)).id)).toBeUndefined();
+
+    // The second of the run's writes fails once, transiently: a fault the job
+    // is retried for, not a refusal it is failed for.
+    const apply = KyselyOperationStore.prototype.apply;
+    let failed = false;
+    vi.spyOn(KyselyOperationStore.prototype, "apply").mockImplementation(
+      function (
+        this: KyselyOperationStore,
+        ...args: Parameters<KyselyOperationStore["apply"]>
+      ) {
+        const [, , scope, , index] = args;
+        if (!failed && scope === "global" && index === 1) {
+          failed = true;
+          return Promise.reject(new Error("transient store failure"));
+        }
+        return apply.apply(this, args);
+      },
+    );
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:01.000Z"));
+    const failure = await settle(
+      (
+        await reactor.execute(document.header.id, "main", [
+          setModelName({ name: "named" }),
+          setModelDescription({ description: "described" }),
+        ])
+      ).id,
+    );
+
+    expect(failed).toBe(true);
+    expect(failure).toBeUndefined();
+
+    const result = await reactor.getOperations(document.header.id, {
+      branch: "main",
+      scopes: ["global"],
+    });
+    const stored = sortOperations([
+      ...((result as Record<string, { results: Operation[] } | undefined>)
+        .global?.results ?? []),
+    ]);
+
+    // The failed attempt left nothing, so the retry's writes are the only ones.
+    expect(stored.map((operation) => operation.action.type)).toEqual([
+      "SET_MODEL_NAME",
+      "SET_MODEL_DESCRIPTION",
+    ]);
+    expect(new Set(stored.map((operation) => operation.action.id)).size).toBe(
+      2,
+    );
+  });
+});

--- a/packages/reactor/test/executor/job-retry-atomicity.test.ts
+++ b/packages/reactor/test/executor/job-retry-atomicity.test.ts
@@ -66,8 +66,9 @@ describe("a retry after a mid-run failure", () => {
         this: KyselyOperationStore,
         ...args: Parameters<KyselyOperationStore["apply"]>
       ) {
-        const [, , scope, , index] = args;
-        if (!failed && scope === "global" && index === 1) {
+        const scope = args[2];
+        const revision = args[4];
+        if (!failed && scope === "global" && revision === 1) {
           failed = true;
           return Promise.reject(new Error("transient store failure"));
         }


### PR DESCRIPTION
#2929 batches a job's operations into one store transaction, and its
docstring claims "a job that fails partway through leaves nothing
behind". That only held for store-commit failures. The red test proving
the gap was shelved out of the PR before merge (f682b512f); it is
un-shelved here, and the gap is closed.

## The bug

The whole job already runs inside one `db.transaction()`
(`execution-scope.ts`). But a scope callback that **returns** commits —
only a **throw** rolls back. Every failure in the executor is a returned
`JobResult`, so a failed job's already-applied writes landed in the
operation store and the write cache.

That prefix is not a benign semantic:

- The operation-index txn commits only on success, and `JOB_WRITE_READY`
  fires only on success. Sync's only outbox sources are blind to the
  prefix, so it **never syncs** — but the write cache keeps it, the next
  successful job reduces on top of it, and peers receive history built on
  an operation they were never given.
- Locally it is a **duplication bug**. `queue.retryJob` re-enqueues the
  same job with its full action list and the mutation path has no
  action-id dedup, so a failure at action *k* commits `0..k-1` and the
  retry re-applies all *n* from the new head. The `(opId, index, skip)`
  unique constraint does not block it. There is a regression test for
  this: without the fix `SET_MODEL_NAME` appears **twice** in the log of
  a job that ultimately succeeded.
- For load jobs it was worse — nine failure classes left a committed
  prefix, including one where reshuffle gives the whole skipCount to
  write 0, so a failure at *k>0* commits a skip that supersedes local
  accepted history whose re-appends sat in the uncommitted tail.

## The fix

One funnel point. The `executionScope.run` callback body is extracted
into `executeInScope`, and a failed result is thrown as a module-private
`JobRollbackSignal` at that single boundary so the transaction rolls
back. `executeJob` catches it and returns the carried `JobResult` — no
caller sees a throw, and the signal never escapes into a pooled worker
(which flattens throws to a name and classifies by it). A genuine throw
is rethrown unchanged.

The caches are shared by reference with the copies the scope hands the
job, so the rollback undoes nothing in them, and a read that missed while
the job held uncommitted writes filled from them too. The streams a job
writes are recorded on `ExecutingJob` — at both `operationStore.apply`
funnels and at every `putState`/`putDocumentMeta` site, several of which
target a different document than the job's own — and evicted when the
transaction does not commit.

This fixes mutation **and** load jobs at once, including all nine load
classes, because the whole job becomes the atom.

## The invariant this delivers

> A job either fully applies or leaves nothing behind. When it applies,
> the input's action ids are a subset of the applied log's action ids
> (reshuffle may add re-appends and position holders).

Atomicity is a property of the **execution scope**, not of
`batchApplies`: it holds under `KyselyExecutionScope` (Postgres and
PGlite alike) regardless of that flag. `DefaultExecutionScope` opens no
transaction and backs unit-test harnesses only, which is why those still
observe a failed job's writes — the tests now say so explicitly.

## Semantics change to sign off

`conditions.integration.test.ts`, grant-closing case, both `batchApplies`
legs: a run whose own write closes the grant the next write needs now
persists **nothing** instead of leaving `SET_MODEL_NAME` behind. The
refusal itself is unchanged. As a side effect the refusal is no longer
self-perpetuating — the grant it closed is open again on a retry.

## Also here

A prepare failure in the batched path now returns the failure instead of
replaying the run one write at a time. That replay existed to reproduce
the prefix; with nothing left behind it only reaches the same failure at
twice the cost, touching every cache on the way. Denials still fall back
per write — a denied write holds a position of its own.

## Verification

Full package green (166 files / 2750 tests), `tsc --build` clean, lint
clean. The new coverage was mutation-tested: with the signal disabled,
the two Kysely-leg integration tests and the retry-duplication test all
go red. Note the un-shelved test passes on the batched-fallback change
alone, so it is *not* the rollback pin — the commit message says which
tests are.

## Deliberately not in scope

- `executeBatch` atomicity. Refuted by evidence: worker-pool jobs run on
  separate OS threads with their own connections, so a shared
  transaction needs 2PC. What is deliverable there is containment
  (ordered, stops at first failure) plus a same-stream merge — filed
  separately, they touch the queue and the public return shape.
- The NOOP skip-clobber in `executeLoadJob`, and sync-layer loss classes
  that exist independent of atomicity (no dead-letter redrive;
  `AUTH_TIMESTAMP_NOT_MONOTONIC` dead-letters without quarantining).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
