### PR TITLE
feat(renown): headless Privy email login, chain pinning, on-demand wallet mount

### DIFF
--- a/apps/academy/docs/academy/03-Build/03-BuildingUserExperiences/07-Authorization/01-RenownAuthenticationFlow.md
+++ b/apps/academy/docs/academy/03-Build/03-BuildingUserExperiences/07-Authorization/01-RenownAuthenticationFlow.md
@@ -158,7 +158,7 @@ Under SSR the cookie seeds the server render and hydration (it is the only thing
 
 ### Custom sign-in screens (headless Privy)
 
-If you want your own email sign-in screens instead of Privy's modal, keep the same `RenownProvider` setup and drive the Privy adapter directly with `useRenownWalletAdapter`. It returns the mounted adapter's controller — for Privy that adds `sendCode(email)` / `loginWithCode(code)` plus its auth state — and rendering it is what loads Privy, so a visitor on a page that never renders it downloads no `@privy-io` code. The session `loginWithCode` resolves with goes straight to `login(session)`; the embedded wallet signs the credential silently.
+If you want your own email sign-in screens instead of Privy's modal, keep the same `RenownProvider` setup and drive the Privy adapter directly with `useRenownWalletAdapter`. It returns the mounted adapter's controller — for Privy that adds `sendCode(email)` / `loginWithCode(code)` plus its auth state — and rendering it is what loads Privy, so a visitor on a page that never renders it downloads no `@privy-io` code. Pass the session that `loginWithCode` resolves to straight into `login(session)`; the embedded wallet signs the credential silently.
 
 ```tsx
 import { useRenownAuth, useRenownWalletAdapter } from "@powerhousedao/reactor-browser/renown";

--- a/apps/academy/docs/academy/03-Build/03-BuildingUserExperiences/07-Authorization/01-RenownAuthenticationFlow.md
+++ b/apps/academy/docs/academy/03-Build/03-BuildingUserExperiences/07-Authorization/01-RenownAuthenticationFlow.md
@@ -156,6 +156,30 @@ Gate any component on auth with a plain `if (!user)` from `useRenownAuth()`; for
 
 Under SSR the cookie seeds the server render and hydration (it is the only thing readable server-side), then `localStorage` takes over once mounted, since that is the credential the SDK actually restores. Include the `documentId`/`username`/`userImage` fields in the cookie's profile hint so both sources agree on name, avatar and profile links — type the route handler with `RenownSessionCookie` rather than redeclaring the payload shape.
 
+### Custom sign-in screens (headless Privy)
+
+If you want your own email sign-in screens instead of Privy's modal, keep the same `RenownProvider` setup and drive the Privy adapter directly with `useRenownWalletAdapter`. It returns the mounted adapter's controller — for Privy that adds `sendCode(email)` / `loginWithCode(code)` plus its auth state — and rendering it is what loads Privy, so a visitor on a page that never renders it downloads no `@privy-io` code. The session `loginWithCode` resolves with goes straight to `login(session)`; the embedded wallet signs the credential silently.
+
+```tsx
+import { useRenownAuth, useRenownWalletAdapter } from "@powerhousedao/reactor-browser/renown";
+// Type-only import: erased at runtime, so @privy-io stays out of your bundle.
+import type { PrivyWalletController } from "@renown/sdk/wallet/privy";
+
+function EmailLogin() {
+  const privy = useRenownWalletAdapter<PrivyWalletController>("privy");
+  const { login } = useRenownAuth();
+  if (!privy) return <Spinner />;
+  return (
+    <>
+      <EmailForm onSubmit={(email) => privy.sendCode(email)} />
+      <CodeForm onSubmit={async (code) => login(await privy.loginWithCode(code))} />
+    </>
+  );
+}
+```
+
+Configure the adapter with `methods: ["email"]` and the `chain` Renown issues on (`privyAdapter({ appId, methods: ["email"], chain: mainnet })`). The `@powerhousedao/reactor-browser` README has the full example, including the OTP status and error state.
+
 ### Testing sign-in (mock adapter)
 
 Real wallets and Google OAuth can't run in headless CI, so `@renown/sdk` ships a **mock wallet adapter** (`@renown/sdk/wallet/mock`) for e2e/dev. It is a headless signer backed by a local key (real EIP-712 signatures, no wallet extension or OAuth), so sign-in runs deterministically:

--- a/apps/academy/llms-full.txt
+++ b/apps/academy/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-08-27T08:27:52.720Z
+> Generated: 2026-08-27T08:27:53.884Z
 > Total Documents: 110
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -23742,7 +23742,7 @@ Under SSR the cookie seeds the server render and hydration (it is the only thing
 
 ### Custom sign-in screens (headless Privy)
 
-If you want your own email sign-in screens instead of Privy's modal, keep the same `RenownProvider` setup and drive the Privy adapter directly with `useRenownWalletAdapter`. It returns the mounted adapter's controller — for Privy that adds `sendCode(email)` / `loginWithCode(code)` plus its auth state — and rendering it is what loads Privy, so a visitor on a page that never renders it downloads no `@privy-io` code. The session `loginWithCode` resolves with goes straight to `login(session)`; the embedded wallet signs the credential silently.
+If you want your own email sign-in screens instead of Privy's modal, keep the same `RenownProvider` setup and drive the Privy adapter directly with `useRenownWalletAdapter`. It returns the mounted adapter's controller — for Privy that adds `sendCode(email)` / `loginWithCode(code)` plus its auth state — and rendering it is what loads Privy, so a visitor on a page that never renders it downloads no `@privy-io` code. Pass the session that `loginWithCode` resolves to straight into `login(session)`; the embedded wallet signs the credential silently.
 
 ```tsx
 

--- a/apps/academy/llms-full.txt
+++ b/apps/academy/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-08-26T14:56:31.426Z
+> Generated: 2026-08-27T08:27:52.720Z
 > Total Documents: 110
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -23739,6 +23739,30 @@ Gate any component on auth with a plain `if (!user)` from `useRenownAuth()`; for
 - **SSR apps** (Next.js): pass a server-resolved `session` (from a verified session cookie) so authenticated content renders on the server too. Read the cookie in a Data Access Layer with `verifyRenownSession` from `@renown/sdk/node`; passing `session` also keeps the cookie in sync after login/logout. A complete Next.js reference lives in the monorepo at `test/test-fusion`, and the `@powerhousedao/reactor-browser` README ("Renown in-page sign-in") has the full API.
 
 Under SSR the cookie seeds the server render and hydration (it is the only thing readable server-side), then `localStorage` takes over once mounted, since that is the credential the SDK actually restores. Include the `documentId`/`username`/`userImage` fields in the cookie's profile hint so both sources agree on name, avatar and profile links — type the route handler with `RenownSessionCookie` rather than redeclaring the payload shape.
+
+### Custom sign-in screens (headless Privy)
+
+If you want your own email sign-in screens instead of Privy's modal, keep the same `RenownProvider` setup and drive the Privy adapter directly with `useRenownWalletAdapter`. It returns the mounted adapter's controller — for Privy that adds `sendCode(email)` / `loginWithCode(code)` plus its auth state — and rendering it is what loads Privy, so a visitor on a page that never renders it downloads no `@privy-io` code. The session `loginWithCode` resolves with goes straight to `login(session)`; the embedded wallet signs the credential silently.
+
+```tsx
+
+// Type-only import: erased at runtime, so @privy-io stays out of your bundle.
+
+
+function EmailLogin() {
+  const privy = useRenownWalletAdapter<PrivyWalletController>("privy");
+  const { login } = useRenownAuth();
+  if (!privy) return <Spinner />;
+  return (
+    <>
+      <EmailForm onSubmit={(email) => privy.sendCode(email)} />
+      <CodeForm onSubmit={async (code) => login(await privy.loginWithCode(code))} />
+    </>
+  );
+}
+```
+
+Configure the adapter with `methods: ["email"]` and the `chain` Renown issues on (`privyAdapter({ appId, methods: ["email"], chain: mainnet })`). The `@powerhousedao/reactor-browser` README has the full example, including the OTP status and error state.
 
 ### Testing sign-in (mock adapter)
 

--- a/apps/academy/static/llms-full.txt
+++ b/apps/academy/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-08-27T08:27:52.720Z
+> Generated: 2026-08-27T08:27:53.884Z
 > Total Documents: 110
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -23742,7 +23742,7 @@ Under SSR the cookie seeds the server render and hydration (it is the only thing
 
 ### Custom sign-in screens (headless Privy)
 
-If you want your own email sign-in screens instead of Privy's modal, keep the same `RenownProvider` setup and drive the Privy adapter directly with `useRenownWalletAdapter`. It returns the mounted adapter's controller — for Privy that adds `sendCode(email)` / `loginWithCode(code)` plus its auth state — and rendering it is what loads Privy, so a visitor on a page that never renders it downloads no `@privy-io` code. The session `loginWithCode` resolves with goes straight to `login(session)`; the embedded wallet signs the credential silently.
+If you want your own email sign-in screens instead of Privy's modal, keep the same `RenownProvider` setup and drive the Privy adapter directly with `useRenownWalletAdapter`. It returns the mounted adapter's controller — for Privy that adds `sendCode(email)` / `loginWithCode(code)` plus its auth state — and rendering it is what loads Privy, so a visitor on a page that never renders it downloads no `@privy-io` code. Pass the session that `loginWithCode` resolves to straight into `login(session)`; the embedded wallet signs the credential silently.
 
 ```tsx
 

--- a/apps/academy/static/llms-full.txt
+++ b/apps/academy/static/llms-full.txt
@@ -1,6 +1,6 @@
 # Powerhouse Academy - Complete Documentation
 
-> Generated: 2026-08-26T14:56:31.426Z
+> Generated: 2026-08-27T08:27:52.720Z
 > Total Documents: 110
 > Source: https://academy.vetra.io/llms-full.txt
 
@@ -23739,6 +23739,30 @@ Gate any component on auth with a plain `if (!user)` from `useRenownAuth()`; for
 - **SSR apps** (Next.js): pass a server-resolved `session` (from a verified session cookie) so authenticated content renders on the server too. Read the cookie in a Data Access Layer with `verifyRenownSession` from `@renown/sdk/node`; passing `session` also keeps the cookie in sync after login/logout. A complete Next.js reference lives in the monorepo at `test/test-fusion`, and the `@powerhousedao/reactor-browser` README ("Renown in-page sign-in") has the full API.
 
 Under SSR the cookie seeds the server render and hydration (it is the only thing readable server-side), then `localStorage` takes over once mounted, since that is the credential the SDK actually restores. Include the `documentId`/`username`/`userImage` fields in the cookie's profile hint so both sources agree on name, avatar and profile links — type the route handler with `RenownSessionCookie` rather than redeclaring the payload shape.
+
+### Custom sign-in screens (headless Privy)
+
+If you want your own email sign-in screens instead of Privy's modal, keep the same `RenownProvider` setup and drive the Privy adapter directly with `useRenownWalletAdapter`. It returns the mounted adapter's controller — for Privy that adds `sendCode(email)` / `loginWithCode(code)` plus its auth state — and rendering it is what loads Privy, so a visitor on a page that never renders it downloads no `@privy-io` code. The session `loginWithCode` resolves with goes straight to `login(session)`; the embedded wallet signs the credential silently.
+
+```tsx
+
+// Type-only import: erased at runtime, so @privy-io stays out of your bundle.
+
+
+function EmailLogin() {
+  const privy = useRenownWalletAdapter<PrivyWalletController>("privy");
+  const { login } = useRenownAuth();
+  if (!privy) return <Spinner />;
+  return (
+    <>
+      <EmailForm onSubmit={(email) => privy.sendCode(email)} />
+      <CodeForm onSubmit={async (code) => login(await privy.loginWithCode(code))} />
+    </>
+  );
+}
+```
+
+Configure the adapter with `methods: ["email"]` and the `chain` Renown issues on (`privyAdapter({ appId, methods: ["email"], chain: mainnet })`). The `@powerhousedao/reactor-browser` README has the full example, including the OTP status and error state.
 
 ### Testing sign-in (mock adapter)
 

--- a/apps/connect/src/components/renown-adapter-descriptors.ts
+++ b/apps/connect/src/components/renown-adapter-descriptors.ts
@@ -6,10 +6,11 @@ import {
   type PHRenownMockAdapterConfig,
 } from "@renown/sdk/wallet/mock";
 import { privyAdapter, type PrivyLoginMethod } from "@renown/sdk/wallet/privy";
-import { rainbowAdapter, type PHRenownChain } from "@renown/sdk/wallet/rainbow";
+import { rainbowAdapter } from "@renown/sdk/wallet/rainbow";
 import {
   arbitrum,
   base,
+  type Chain,
   mainnet,
   optimism,
   polygon,
@@ -41,7 +42,7 @@ function describe(
 
 // `connect.renown.chainId` is an id, but the adapter needs the chain object, so
 // only a listed chain can be offered.
-const CHAINS_BY_ID = new Map<number, PHRenownChain>(
+const CHAINS_BY_ID = new Map<number, Chain>(
   [mainnet, sepolia, polygon, optimism, arbitrum, base].map((chain) => [
     chain.id,
     chain,
@@ -52,7 +53,7 @@ const CHAINS_BY_ID = new Map<number, PHRenownChain>(
 // UI has to offer that chain and no other.
 function chainsFor(
   chainId: number | undefined,
-): readonly [PHRenownChain, ...PHRenownChain[]] | undefined {
+): readonly [Chain, ...Chain[]] | undefined {
   if (chainId === undefined) return undefined;
   const chain = CHAINS_BY_ID.get(chainId);
   if (!chain) {
@@ -94,6 +95,7 @@ export function configToDescriptors(
             // Methods come from JSON, so unvalidated here; the adapter's
             // resolver rejects anything it can't drive.
             methods: methods as PrivyLoginMethod[] | undefined,
+            chain: chains?.[0],
           })),
       );
     }

--- a/packages/reactor-browser/README.md
+++ b/packages/reactor-browser/README.md
@@ -738,8 +738,8 @@ app shell; a signed-out visitor on a route that never renders it downloads no
 wallet code. `undefined` until the adapter is mounted.
 
 Privy's controller adds email OTP (`sendCode` / `loginWithCode`) plus its auth
-state. Pair it with `login(session)` — the session `loginWithCode` resolves with
-is a Privy embedded wallet, which signs the Renown credential silently:
+state. Pass the session that `loginWithCode` resolves to into `login(session)`;
+it is a Privy embedded wallet, so it signs the Renown credential silently:
 
 ```tsx
 "use client";

--- a/packages/reactor-browser/README.md
+++ b/packages/reactor-browser/README.md
@@ -724,6 +724,57 @@ mounted **outside** the provider's subtree still gets the full list — Connect
 renders its login modal as a sibling of the app. Empty when no provider is
 mounted, which is the redirect-only case.
 
+### `useRenownWalletAdapter<T>(id)` — headless sign-in (custom screens)
+
+Returns the controller of one mounted adapter by its `meta.id`, typed as that
+adapter's own surface, so a host can draw its own sign-in screens without
+importing the wallet library. Rendering the hook activates the wallet tree (that
+is when the adapter's library loads), so call it from the sign-in route, not the
+app shell; a signed-out visitor on a route that never renders it downloads no
+wallet code. `undefined` until the adapter is mounted.
+
+Privy's controller adds email OTP (`sendCode` / `loginWithCode`) plus its auth
+state. Pair it with `login(session)` — the session `loginWithCode` resolves with
+is a Privy embedded wallet, which signs the Renown credential silently:
+
+```tsx
+"use client";
+import { useRenownAuth, useRenownWalletAdapter } from "@powerhousedao/reactor-browser/renown";
+// Type-only import: erased at runtime, so @privy-io stays out of the bundle.
+import type { PrivyWalletController } from "@renown/sdk/wallet/privy";
+import { useSyncExternalStore } from "react";
+
+function EmailLogin() {
+  const privy = useRenownWalletAdapter<PrivyWalletController>("privy");
+  const { login } = useRenownAuth();
+  const state = useSyncExternalStore(
+    privy?.subscribeState ?? (() => () => {}),
+    () => privy?.getState(),
+    () => undefined,
+  );
+
+  if (!privy) return <Spinner />; // Privy is loading
+  return (
+    <>
+      <EmailForm
+        busy={state?.emailStatus === "sending-code"}
+        onSubmit={(email) => privy.sendCode(email, { disableSignup: true })}
+      />
+      <CodeForm
+        busy={state?.emailStatus === "submitting-code"}
+        error={state?.emailError}
+        onSubmit={async (code) => login(await privy.loginWithCode(code))}
+      />
+    </>
+  );
+}
+```
+
+`privyAdapter({ …, methods: ["email"], chain })` keeps Privy's own modal
+restricted to email (so it skips the wallet connectors) and pins the embedded
+wallet to the chain Renown issues on — pass the same chain you set as
+`chainId`.
+
 ### Next.js
 
 The integration is the same, with four things worth knowing:

--- a/packages/reactor-browser/README.md
+++ b/packages/reactor-browser/README.md
@@ -777,7 +777,10 @@ function EmailLogin() {
 `privyAdapter({ …, methods: ["email"], chain })` keeps Privy's own modal
 restricted to email (so it skips the wallet connectors) and pins the embedded
 wallet to the chain Renown issues on — pass the same chain you set as
-`chainId`.
+`chainId`. The adapter also sets Privy's `appearance.walletList` to
+`["detected_ethereum_wallets"]`: any other value makes Privy fetch the
+WalletConnect explorer listings (~163 KB) on mount, even with external wallets
+disabled. Pass `walletList` to override if you do want those listings.
 
 ### Next.js
 

--- a/packages/reactor-browser/README.md
+++ b/packages/reactor-browser/README.md
@@ -706,9 +706,13 @@ every real operation.
 ### `RenownWalletProvider`
 
 Registers the login activator, lazy-mounts the given adapters, and merges them
-into one controller for `useRenownAuth`. The wallet Provider tree wraps only the
-adapter bridges (each library's modal portals to `<body>`), never your
-`children`, so activating login never remounts your app. Props: `adapters`
+into one controller for `useRenownAuth`. Adapters mount on first demand — a
+`login()` click, `logout()`, `useRenownWalletAdapter`, or an OAuth redirect
+return — not because a stored session was restored, so a signed-in visitor on a
+page that never signs in or out downloads no wallet code. Once mounted they stay
+mounted for the page's life. The wallet Provider tree wraps only the adapter
+bridges (each library's modal portals to `<body>`), never your `children`, so
+activating login never remounts your app. Props: `adapters`
 (`WalletAdapterDescriptor[]`), `theme?`, `children`.
 
 ### `useRenownLoginMethods(labels?)`

--- a/packages/reactor-browser/src/renown/index.ts
+++ b/packages/reactor-browser/src/renown/index.ts
@@ -36,6 +36,7 @@ export {
   useRenownLoginMethods,
   type RenownLoginMethod,
 } from "./login-methods.js";
+export { useRenownWalletAdapter } from "./use-renown-wallet-adapter.js";
 // Only the session action is public. Wallet-controller registry (mutators and
 // the ready waiter) stays internal wiring between the provider and useRenownAuth.
 export { openRenown } from "./session.js";

--- a/packages/reactor-browser/src/renown/session.ts
+++ b/packages/reactor-browser/src/renown/session.ts
@@ -2,7 +2,10 @@ import type { IRenown, User } from "@renown/sdk";
 import type { WalletSession } from "@renown/sdk/wallet";
 import { logger } from "document-model";
 import { RENOWN_CHAIN_ID, RENOWN_NETWORK_ID, RENOWN_URL } from "./constants.js";
-import { getActiveWalletController } from "./wallet-registry.js";
+import {
+  getActiveWalletController,
+  getWalletActivator,
+} from "./wallet-registry.js";
 
 export function openRenown(documentId?: string) {
   const renown = window.ph?.renown;
@@ -134,10 +137,13 @@ export async function login(
 }
 
 export async function logout() {
-  // Disconnect the wallet first — while still authenticated the adapters are
-  // mounted, so each adapter's own logout (Privy clears its session) runs first.
+  // Run the adapter's own logout first (Privy clears its session) so the next
+  // login can't silently resume it. Adapters mount on demand, so activate when
+  // none is mounted yet; with no activator (redirect-only) there is nothing to end.
   try {
-    await getActiveWalletController()?.disconnect();
+    const controller =
+      getActiveWalletController() ?? (await getWalletActivator()?.());
+    await controller?.disconnect();
   } catch (error) {
     logger.error(error instanceof Error ? error.message : String(error));
   }

--- a/packages/reactor-browser/src/renown/use-renown-wallet-adapter.ts
+++ b/packages/reactor-browser/src/renown/use-renown-wallet-adapter.ts
@@ -1,0 +1,43 @@
+import type { WalletController } from "@renown/sdk/wallet";
+import { logger } from "document-model";
+import { useEffect, useSyncExternalStore } from "react";
+import {
+  getServerWalletAdapterControllers,
+  getWalletActivator,
+  getWalletAdapterControllers,
+  subscribeWalletActivator,
+  subscribeWalletAdapterControllers,
+} from "./wallet-registry.js";
+
+/** The controller of one adapter mounted by {@link RenownWalletProvider}, by its `meta.id`, typed as that adapter's own surface — e.g. `useRenownWalletAdapter<PrivyWalletController>("privy")` for headless email OTP. Rendering it activates the wallet tree (the adapter's library loads then), so call it from the sign-in screen, not the app shell. `undefined` until the adapter is mounted, or forever when no provider offers that id. */
+export function useRenownWalletAdapter<
+  T extends WalletController = WalletController,
+>(id: string): T | undefined {
+  const controllers = useSyncExternalStore(
+    subscribeWalletAdapterControllers,
+    getWalletAdapterControllers,
+    getServerWalletAdapterControllers,
+  );
+  const controller = controllers[id] as T | undefined;
+  // Re-render when the provider registers its activator (it does so in an
+  // effect, after this hook's first effect).
+  const activator = useSyncExternalStore(
+    subscribeWalletActivator,
+    getWalletActivator,
+    () => undefined,
+  );
+  const hasActivator = activator !== undefined;
+
+  useEffect(() => {
+    if (controller || !hasActivator) return;
+    const current = getWalletActivator();
+    if (!current) return;
+    // Rejections (no adapter loaded) are reported by the provider; the hook
+    // only needs to keep them from surfacing as unhandled.
+    void current().catch((error: unknown) =>
+      logger.error(error instanceof Error ? error.message : String(error)),
+    );
+  }, [controller, hasActivator, id]);
+
+  return controller;
+}

--- a/packages/reactor-browser/src/renown/wallet-provider.tsx
+++ b/packages/reactor-browser/src/renown/wallet-provider.tsx
@@ -22,6 +22,7 @@ import {
   failWalletActivation,
   setActiveWalletController,
   setWalletActivator,
+  setWalletAdapterController,
   setWalletDescriptors,
   whenWalletControllerReady,
 } from "./wallet-registry.js";
@@ -193,6 +194,7 @@ export function RenownWalletProvider({
     (meta: WalletAdapterMeta, controller: WalletController | undefined) => {
       if (controller) mountedRef.current.set(meta.id, { meta, controller });
       else mountedRef.current.delete(meta.id);
+      setWalletAdapterController(meta.id, controller);
       setActiveWalletController(
         mergeControllers(Array.from(mountedRef.current.values())),
       );

--- a/packages/reactor-browser/src/renown/wallet-provider.tsx
+++ b/packages/reactor-browser/src/renown/wallet-provider.tsx
@@ -17,7 +17,6 @@ import {
   type ComponentType,
   type ReactNode,
 } from "react";
-import { useUser } from "../hooks/renown.js";
 import {
   failWalletActivation,
   setActiveWalletController,
@@ -104,14 +103,13 @@ export interface RenownWalletProviderProps {
   children: ReactNode;
 }
 
-/** Drop-in provider for Renown in-page wallet sign-in: registers the login activator, lazy-mounts the configured adapters on first click, and merges their controllers for {@link useRenownAuth}. Full walkthrough + examples: the `@powerhousedao/reactor-browser` README ("Renown in-page sign-in") and the Academy Renown authentication guide. Pair with {@link useRenownLoginMethods} to build the login UI. */
+/** Drop-in provider for Renown in-page wallet sign-in: registers the login activator, lazy-mounts the configured adapters on first demand (login, logout, {@link useRenownWalletAdapter}, or an OAuth redirect return — not on a restored session), and merges their controllers for {@link useRenownAuth}. Full walkthrough + examples: the `@powerhousedao/reactor-browser` README ("Renown in-page sign-in") and the Academy Renown authentication guide. Pair with {@link useRenownLoginMethods} to build the login UI. */
 export function RenownWalletProvider({
   adapters: adaptersConfig,
   theme,
   children,
 }: RenownWalletProviderProps) {
   const [descriptors] = useState(() => adaptersConfig);
-  const user = useUser();
   // The snapshot above drops every array after the first; say so in dev.
   useEffect(() => {
     // `process` need not exist in a browser bundle.
@@ -136,15 +134,15 @@ export function RenownWalletProvider({
     () => descriptors?.map((descriptor) => descriptor.meta) ?? [],
     [descriptors],
   );
-  // Mount on a login click / OAuth redirect return, and latch on authentication so
-  // we stay mounted for the page's life — a logout->login remount breaks Privy's modal.
-  const [activated, setActivated] = useState(
+  // Mount on demand (login, logout, useRenownWalletAdapter) or on an OAuth
+  // redirect return — never merely because a user is signed in, so a returning
+  // visitor downloads no wallet code. Once mounted, stay mounted for the page's
+  // life: a logout->login remount breaks Privy's modal.
+  const [active, setActive] = useState(
     () =>
       typeof window !== "undefined" &&
       isWalletRedirectReturn(window.location.search, metas),
   );
-  if (user && !activated) setActivated(true);
-  const active = activated;
   const [adapters, setAdapters] = useState<WalletAdapter[] | null>(null);
   const mountedRef = useRef(new Map<string, MountedAdapter>());
   // Auto-completes sign-in from the session an adapter pushes on an OAuth return.
@@ -154,7 +152,7 @@ export function RenownWalletProvider({
   useEffect(() => {
     if (!descriptors) return;
     setWalletActivator(() => {
-      setActivated(true);
+      setActive(true);
       return whenWalletControllerReady();
     });
     return () => setWalletActivator(undefined);

--- a/packages/reactor-browser/src/renown/wallet-registry.ts
+++ b/packages/reactor-browser/src/renown/wallet-registry.ts
@@ -11,6 +11,7 @@ let controllerWaiters: Array<{
   reject: (error: Error) => void;
 }> = [];
 let walletActivator: (() => Promise<WalletController>) | undefined;
+const activatorListeners = new Set<() => void>();
 
 export function setActiveWalletController(
   controller: WalletController | undefined,
@@ -40,7 +41,16 @@ export function getActiveWalletController(): WalletController | undefined {
 export function setWalletActivator(
   activator: (() => Promise<WalletController>) | undefined,
 ): void {
+  if (activator === walletActivator) return;
   walletActivator = activator;
+  activatorListeners.forEach((listener) => listener());
+}
+
+// The provider registers the activator in an effect, after a child hook's first
+// effect has run, so a hook that activates on mount must wait for it.
+export function subscribeWalletActivator(listener: () => void): () => void {
+  activatorListeners.add(listener);
+  return () => activatorListeners.delete(listener);
 }
 
 export function getWalletActivator():
@@ -111,6 +121,62 @@ export function getServerWalletDescriptors(): readonly WalletAdapterDescriptor[]
 
 export function subscribeWalletDescriptors(listener: () => void): () => void {
   const { listeners } = descriptorStore();
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+// Per-adapter controllers, keyed by meta.id, for hosts that drive one adapter's
+// own surface (e.g. Privy's email OTP) rather than the merged controller.
+type AdapterControllers = Readonly<Record<string, WalletController>>;
+
+const NO_CONTROLLERS: AdapterControllers = Object.freeze({});
+
+interface ControllerStore {
+  controllers: AdapterControllers;
+  listeners: Set<() => void>;
+}
+
+const CONTROLLER_STORE = Symbol.for(
+  "@powerhousedao/reactor-browser:renown-wallet-adapter-controllers",
+);
+
+function controllerStore(): ControllerStore {
+  const host = globalThis as unknown as Record<
+    symbol,
+    ControllerStore | undefined
+  >;
+  return (host[CONTROLLER_STORE] ??= {
+    controllers: NO_CONTROLLERS,
+    listeners: new Set(),
+  });
+}
+
+export function setWalletAdapterController(
+  id: string,
+  controller: WalletController | undefined,
+): void {
+  const store = controllerStore();
+  if (store.controllers[id] === controller) return;
+  const next: Record<string, WalletController> = { ...store.controllers };
+  if (controller) next[id] = controller;
+  else delete next[id];
+  store.controllers = Object.freeze(next);
+  store.listeners.forEach((listener) => listener());
+}
+
+// Identity-stable while unchanged, so useSyncExternalStore does not loop.
+export function getWalletAdapterControllers(): AdapterControllers {
+  return controllerStore().controllers;
+}
+
+export function getServerWalletAdapterControllers(): AdapterControllers {
+  return NO_CONTROLLERS;
+}
+
+export function subscribeWalletAdapterControllers(
+  listener: () => void,
+): () => void {
+  const { listeners } = controllerStore();
   listeners.add(listener);
   return () => listeners.delete(listener);
 }

--- a/packages/reactor-browser/test/renown/wallet-activation.test.tsx
+++ b/packages/reactor-browser/test/renown/wallet-activation.test.tsx
@@ -1,0 +1,153 @@
+import type { IRenown, User } from "@renown/sdk";
+import type {
+  WalletAdapterDescriptor,
+  WalletController,
+  WalletSession,
+} from "@renown/sdk/wallet";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { addRenownEventHandler, setRenown } from "../../src/hooks/renown.js";
+import { RenownInitialUserProvider } from "../../src/renown/initial-user.js";
+import { logout } from "../../src/renown/session.js";
+import { useRenownAuth } from "../../src/renown/use-renown-auth.js";
+import { RenownWalletProvider } from "../../src/renown/wallet-provider.js";
+
+/* Adapters (and their wallet libraries) must mount on demand only: a restored
+   session by itself must not fetch any wallet code. */
+
+const ADDRESS = "0x1000000000000000000000000000000000000010" as const;
+const USER = {
+  did: `did:pkh:eip155:1:${ADDRESS}`,
+  address: ADDRESS,
+} as unknown as User;
+
+function fakeRenown(current: User | undefined) {
+  return {
+    status: current ? "authorized" : "not-authorized",
+    user: current,
+    on: () => () => undefined,
+    signIn: vi.fn(() => Promise.resolve(USER)),
+    logout: vi.fn(() => Promise.resolve()),
+  } as unknown as IRenown & {
+    signIn: ReturnType<typeof vi.fn>;
+    logout: ReturnType<typeof vi.fn>;
+  };
+}
+
+// Both readers: the hook store feeds useUser; window.ph is what session.ts uses.
+function install(renown: IRenown | undefined) {
+  setRenown(renown);
+  (window.ph ??= {}).renown = renown;
+}
+
+function fakeAdapter(redirectReturnParams: string[] = []) {
+  const session: WalletSession = {
+    address: ADDRESS,
+    chainId: 1,
+    signTypedData: () => Promise.resolve("0x" as `0x${string}`),
+  };
+  const controller = {
+    connect: vi.fn(() => Promise.resolve(session)),
+    disconnect: vi.fn(() => Promise.resolve()),
+    getSession: () => undefined,
+  } satisfies WalletController;
+  const load = vi.fn(() =>
+    Promise.resolve({
+      Provider: ({ children }: { children: ReactNode }) => <>{children}</>,
+      useController: () => controller,
+    }),
+  );
+  const descriptor: WalletAdapterDescriptor = {
+    meta: { id: "fake", redirectReturnParams, supportedMethods: ["email"] },
+    load,
+  };
+  return { descriptor, load, controller };
+}
+
+function LoginButton() {
+  const { login } = useRenownAuth();
+  return <button onClick={() => login(undefined, "email")}>login</button>;
+}
+
+function renderTree(descriptor: WalletAdapterDescriptor, user?: User) {
+  return render(
+    <RenownInitialUserProvider
+      initialAuth={
+        user ? { state: "authenticated", user } : { state: "anonymous" }
+      }
+    >
+      <RenownWalletProvider adapters={[descriptor]}>
+        <LoginButton />
+      </RenownWalletProvider>
+    </RenownInitialUserProvider>,
+  );
+}
+
+function setRedirectReturn(on: boolean) {
+  const url = new URL(window.location.href);
+  if (on) url.searchParams.set("fake_oauth_code", "abc");
+  else url.searchParams.delete("fake_oauth_code");
+  window.history.replaceState({}, "", url.toString());
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+beforeEach(() => {
+  addRenownEventHandler();
+});
+
+afterEach(() => {
+  install(undefined);
+  setRedirectReturn(false);
+});
+
+describe("RenownWalletProvider activation", () => {
+  it("mounts no adapter for a signed-in render with a restored session", async () => {
+    const renown = fakeRenown(USER);
+    install(renown);
+    const { descriptor, load } = fakeAdapter();
+    const screen = renderTree(descriptor, USER);
+    await expect.element(screen.getByRole("button")).toBeVisible();
+    await tick();
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it("logout() from a signed-in state activates, disconnects, then logs out", async () => {
+    const renown = fakeRenown(USER);
+    install(renown);
+    const { descriptor, load, controller } = fakeAdapter();
+    const screen = renderTree(descriptor, USER);
+    await expect.element(screen.getByRole("button")).toBeVisible();
+    expect(load).not.toHaveBeenCalled();
+
+    await logout();
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(controller.disconnect).toHaveBeenCalledTimes(1);
+    expect(renown.logout).toHaveBeenCalledTimes(1);
+  });
+
+  it("login() activates and completes sign-in", async () => {
+    const renown = fakeRenown(undefined);
+    install(renown);
+    const { descriptor, load, controller } = fakeAdapter();
+    const screen = renderTree(descriptor);
+    await expect.element(screen.getByRole("button")).toBeVisible();
+    expect(load).not.toHaveBeenCalled();
+
+    await screen.getByRole("button").click();
+
+    await vi.waitFor(() => expect(renown.signIn).toHaveBeenCalledTimes(1));
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(controller.connect).toHaveBeenCalledWith("email");
+  });
+
+  it("an OAuth redirect return still activates on mount", async () => {
+    install(fakeRenown(undefined));
+    setRedirectReturn(true);
+    const { descriptor, load } = fakeAdapter(["fake_oauth_code"]);
+    renderTree(descriptor);
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(1));
+  });
+});

--- a/packages/reactor-browser/test/renown/wallet-adapter.test.tsx
+++ b/packages/reactor-browser/test/renown/wallet-adapter.test.tsx
@@ -1,0 +1,89 @@
+import type { WalletController } from "@renown/sdk/wallet";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { useRenownWalletAdapter } from "../../src/renown/use-renown-wallet-adapter.js";
+import {
+  setWalletActivator,
+  setWalletAdapterController,
+} from "../../src/renown/wallet-registry.js";
+
+interface FakeController extends WalletController {
+  label: string;
+}
+
+function controller(label: string): FakeController {
+  return {
+    label,
+    connect: () => Promise.reject(new Error("unused")),
+    disconnect: () => Promise.resolve(),
+    getSession: () => undefined,
+  };
+}
+
+// Deliberately not wrapped in a provider: the hook reads the registry.
+function Probe({ id }: { id: string }) {
+  const adapter = useRenownWalletAdapter<FakeController>(id);
+  return <span data-testid="adapter">{adapter?.label ?? "none"}</span>;
+}
+
+afterEach(() => {
+  setWalletActivator(undefined);
+  setWalletAdapterController("privy", undefined);
+  setWalletAdapterController("rainbow", undefined);
+});
+
+describe("useRenownWalletAdapter", () => {
+  it("is undefined until the adapter publishes its controller", async () => {
+    const screen = render(<Probe id="privy" />);
+    await expect
+      .element(screen.getByTestId("adapter"))
+      .toHaveTextContent("none");
+    setWalletAdapterController("privy", controller("privy-ctl"));
+    await expect
+      .element(screen.getByTestId("adapter"))
+      .toHaveTextContent("privy-ctl");
+  });
+
+  it("returns only the adapter with the requested id", async () => {
+    setWalletAdapterController("rainbow", controller("rainbow-ctl"));
+    const screen = render(<Probe id="privy" />);
+    await expect
+      .element(screen.getByTestId("adapter"))
+      .toHaveTextContent("none");
+  });
+
+  it("activates the wallet tree on mount, even when the activator registers later", async () => {
+    const activator = vi.fn(() => Promise.resolve(controller("merged")));
+    const screen = render(<Probe id="privy" />);
+    await expect
+      .element(screen.getByTestId("adapter"))
+      .toHaveTextContent("none");
+    expect(activator).not.toHaveBeenCalled();
+    // The provider registers its activator in an effect after the child's.
+    setWalletActivator(activator);
+    await vi.waitFor(() => expect(activator).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not activate when the adapter is already mounted", async () => {
+    const activator = vi.fn(() => Promise.resolve(controller("merged")));
+    setWalletActivator(activator);
+    setWalletAdapterController("privy", controller("privy-ctl"));
+    const screen = render(<Probe id="privy" />);
+    await expect
+      .element(screen.getByTestId("adapter"))
+      .toHaveTextContent("privy-ctl");
+    expect(activator).not.toHaveBeenCalled();
+  });
+
+  it("clears the controller when the adapter unmounts", async () => {
+    setWalletAdapterController("privy", controller("privy-ctl"));
+    const screen = render(<Probe id="privy" />);
+    await expect
+      .element(screen.getByTestId("adapter"))
+      .toHaveTextContent("privy-ctl");
+    setWalletAdapterController("privy", undefined);
+    await expect
+      .element(screen.getByTestId("adapter"))
+      .toHaveTextContent("none");
+  });
+});

--- a/packages/renown/src/wallet/privy/adapter.ts
+++ b/packages/renown/src/wallet/privy/adapter.ts
@@ -259,7 +259,32 @@ export class PrivyCore {
   async disconnect(): Promise<void> {
     this.clearSession();
     if (!this.bindings) return;
-    await this.bindings.logout();
+    // When mounted on demand for this logout, Privy may still be restoring its
+    // session; its logout needs that to finish.
+    await this.whenReady();
+    // Re-read: the bridge may have unmounted during the wait.
+    const bindings = this.currentBindings();
+    if (!bindings) return;
+    await bindings.logout();
+  }
+
+  private currentBindings(): PrivyBindings | null {
+    return this.bindings;
+  }
+
+  private whenReady(timeoutMs = 10_000): Promise<void> {
+    if (this.state.ready) return Promise.resolve();
+    return new Promise((resolve) => {
+      const done = () => {
+        unsubscribe();
+        clearTimeout(timer);
+        resolve();
+      };
+      const unsubscribe = this.subscribeState((state) => {
+        if (state.ready) done();
+      });
+      const timer = setTimeout(done, timeoutMs);
+    });
   }
 }
 

--- a/packages/renown/src/wallet/privy/adapter.ts
+++ b/packages/renown/src/wallet/privy/adapter.ts
@@ -198,6 +198,12 @@ export class PrivyCore {
   private awaitSession(
     start: (fail: (error: unknown) => void) => void,
   ): Promise<WalletSession> {
+    // One login at a time: replacing `pending` would orphan the earlier promise.
+    if (this.pending) {
+      return Promise.reject(
+        new Error("PrivyAdapter: a login is already in progress"),
+      );
+    }
     return new Promise<WalletSession>((resolve, reject) => {
       this.pending = { resolve, reject };
       const fail = (error: unknown) => {

--- a/packages/renown/src/wallet/privy/adapter.ts
+++ b/packages/renown/src/wallet/privy/adapter.ts
@@ -6,6 +6,7 @@ import type {
 import type { SignCredentialTypedData } from "../../credential.js";
 import { LoginMethod, type WalletSession } from "../types.js";
 import type { PrivyLoginMethod } from "./meta.js";
+import type { PrivyAuthState, SendCodeOptions } from "./types.js";
 
 type Hex = `0x${string}`;
 type PrivyLoginMethodId = NonNullable<
@@ -14,7 +15,7 @@ type PrivyLoginMethodId = NonNullable<
 
 // Exhaustive over PrivyLoginMethod, so widening that union without adding the
 // Privy id here is a compile error.
-const PRIVY_METHOD_MAP: Record<PrivyLoginMethod, PrivyLoginMethodId> = {
+export const PRIVY_METHOD_MAP: Record<PrivyLoginMethod, PrivyLoginMethodId> = {
   [LoginMethod.WALLET]: "wallet",
   [LoginMethod.GOOGLE]: "google",
   [LoginMethod.APPLE]: "apple",
@@ -37,12 +38,23 @@ const PRIVY_OAUTH_PROVIDERS: Partial<
 export interface PrivyBindings {
   openLoginModal: (options?: LoginModalOptions) => void;
   initOAuth: (options: { provider: PrivyOAuthProviderId }) => Promise<void>;
+  sendCode: (options: {
+    email: string;
+    disableSignup?: boolean;
+  }) => Promise<void>;
+  loginWithCode: (options: { code: string }) => Promise<void>;
   logout: () => Promise<void>;
   signTypedData: (
     args: Parameters<SignCredentialTypedData>[0],
     address: Hex,
   ) => Promise<Hex>;
 }
+
+const INITIAL_STATE: PrivyAuthState = {
+  ready: false,
+  authenticated: false,
+  emailStatus: "initial",
+};
 
 interface PendingLogin {
   resolve(session: WalletSession): void;
@@ -58,6 +70,8 @@ export class PrivyCore {
   private pending: PendingLogin | null = null;
   private session: WalletSession | undefined = undefined;
   private listeners = new Set<(session: WalletSession | undefined) => void>();
+  private state: PrivyAuthState = INITIAL_STATE;
+  private stateListeners = new Set<(state: PrivyAuthState) => void>();
 
   constructor(supportedMethods: LoginMethod[]) {
     this.supportedMethods = supportedMethods;
@@ -88,6 +102,34 @@ export class PrivyCore {
 
   private emit(session: WalletSession | undefined): void {
     for (const listener of this.listeners) listener(session);
+  }
+
+  getState(): PrivyAuthState {
+    return this.state;
+  }
+
+  subscribeState(listener: (state: PrivyAuthState) => void): () => void {
+    this.stateListeners.add(listener);
+    return () => {
+      this.stateListeners.delete(listener);
+    };
+  }
+
+  // Called by the bridge whenever Privy's auth/OTP state changes. Identity-stable
+  // while unchanged so useSyncExternalStore consumers don't re-render.
+  syncState(next: PrivyAuthState): void {
+    const prev = this.state;
+    if (
+      prev.ready === next.ready &&
+      prev.authenticated === next.authenticated &&
+      prev.email === next.email &&
+      prev.emailStatus === next.emailStatus &&
+      prev.emailError === next.emailError
+    ) {
+      return;
+    }
+    this.state = next;
+    for (const listener of this.stateListeners) listener(next);
   }
 
   // Called by the bridge when the embedded wallet is available. Builds the
@@ -136,27 +178,26 @@ export class PrivyCore {
     this.pending = null;
   }
 
-  async connect(method?: LoginMethod): Promise<WalletSession> {
-    if (this.session) return this.session;
+  private requireBindings(): PrivyBindings {
     if (!this.bindings) {
       throw new Error(
         "PrivyAdapter not bound. Ensure the adapter Provider wraps the app.",
       );
     }
+    return this.bindings;
+  }
 
-    const chosen = method ?? this.supportedMethods.at(0);
-    if (!chosen) {
-      throw new Error("PrivyAdapter has no supported login methods configured");
+  private requireMethod(method: LoginMethod): void {
+    if (!this.supportedMethods.includes(method)) {
+      throw new Error(`PrivyAdapter does not support login method "${method}"`);
     }
-    // PRIVY_METHOD_MAP is total over the methods Privy can drive, so only the
-    // configured subset needs checking here.
-    if (!this.supportedMethods.includes(chosen)) {
-      throw new Error(`PrivyAdapter does not support login method "${chosen}"`);
-    }
-    const privyMethod = PRIVY_METHOD_MAP[chosen];
+  }
 
-    const bindings = this.bindings;
-    const oauthProvider = PRIVY_OAUTH_PROVIDERS[chosen];
+  // Resolves via syncFromEmbeddedWallet once the embedded wallet arrives, or
+  // rejects through handleLoginError / the start() failure.
+  private awaitSession(
+    start: (fail: (error: unknown) => void) => void,
+  ): Promise<WalletSession> {
     return new Promise<WalletSession>((resolve, reject) => {
       this.pending = { resolve, reject };
       const fail = (error: unknown) => {
@@ -164,16 +205,54 @@ export class PrivyCore {
         reject(error instanceof Error ? error : new Error(String(error)));
       };
       try {
-        // initOAuth navigates away, so this promise stays pending until the page
-        // unloads; syncFromEmbeddedWallet emits the session on the redirect back.
-        if (oauthProvider) {
-          bindings.initOAuth({ provider: oauthProvider }).catch(fail);
-        } else {
-          bindings.openLoginModal({ loginMethods: [privyMethod] });
-        }
+        start(fail);
       } catch (error) {
         fail(error);
       }
+    });
+  }
+
+  async connect(method?: LoginMethod): Promise<WalletSession> {
+    if (this.session) return this.session;
+    const bindings = this.requireBindings();
+
+    const chosen = method ?? this.supportedMethods.at(0);
+    if (!chosen) {
+      throw new Error("PrivyAdapter has no supported login methods configured");
+    }
+    // PRIVY_METHOD_MAP is total over the methods Privy can drive, so only the
+    // configured subset needs checking here.
+    this.requireMethod(chosen);
+    const privyMethod = PRIVY_METHOD_MAP[chosen];
+    const oauthProvider = PRIVY_OAUTH_PROVIDERS[chosen];
+
+    return this.awaitSession((fail) => {
+      // initOAuth navigates away, so this promise stays pending until the page
+      // unloads; syncFromEmbeddedWallet emits the session on the redirect back.
+      if (oauthProvider) {
+        bindings.initOAuth({ provider: oauthProvider }).catch(fail);
+      } else {
+        bindings.openLoginModal({ loginMethods: [privyMethod] });
+      }
+    });
+  }
+
+  async sendCode(email: string, options?: SendCodeOptions): Promise<void> {
+    this.requireMethod(LoginMethod.EMAIL);
+    await this.requireBindings().sendCode({
+      email,
+      disableSignup: options?.disableSignup,
+    });
+  }
+
+  async loginWithCode(code: string): Promise<WalletSession> {
+    if (this.session) return this.session;
+    this.requireMethod(LoginMethod.EMAIL);
+    const bindings = this.requireBindings();
+    // loginWithCode resolves on authentication; the wallet follows through the
+    // bridge (useWallets, or createWallet for a first login).
+    return this.awaitSession((fail) => {
+      bindings.loginWithCode({ code }).catch(fail);
     });
   }
 

--- a/packages/renown/src/wallet/privy/bridge.tsx
+++ b/packages/renown/src/wallet/privy/bridge.tsx
@@ -3,6 +3,7 @@ import {
   getEmbeddedConnectedWallet,
   useCreateWallet,
   useLogin,
+  useLoginWithEmail,
   useLoginWithOAuth,
   useLogout,
   usePrivy,
@@ -36,7 +37,7 @@ interface PrivyAdapterBridgeProps {
 // Captures the React-only Privy hooks and wires them into PrivyCore so the
 // class can drive Privy without owning React state. Mounted inside PrivyProvider.
 export function PrivyAdapterBridge({ core }: PrivyAdapterBridgeProps) {
-  const { ready, authenticated } = usePrivy();
+  const { ready, authenticated, user } = usePrivy();
   const { wallets } = useWallets();
   const { signTypedData } = useSignTypedData();
   const { logout } = useLogout();
@@ -55,12 +56,22 @@ export function PrivyAdapterBridge({ core }: PrivyAdapterBridgeProps) {
   const { initOAuth } = useLoginWithOAuth({
     onError: (error) => core.handleLoginError(error),
   });
+  // Headless email OTP for hosts drawing their own screens (see PrivyWalletController).
+  const {
+    sendCode,
+    loginWithCode,
+    state: emailState,
+  } = useLoginWithEmail({
+    onError: (error) => core.handleLoginError(error),
+  });
 
   // Privy returns fresh function references each render. A ref keeps the bind
   // stable so we bind once per core instead of re-binding every render.
   const fnsRef = useRef({
     openLoginModal,
     initOAuth,
+    sendCode,
+    loginWithCode,
     logout,
     signTypedData,
     createWallet,
@@ -69,11 +80,34 @@ export function PrivyAdapterBridge({ core }: PrivyAdapterBridgeProps) {
     fnsRef.current = {
       openLoginModal,
       initOAuth,
+      sendCode,
+      loginWithCode,
       logout,
       signTypedData,
       createWallet,
     };
-  }, [openLoginModal, initOAuth, logout, signTypedData, createWallet]);
+  }, [
+    openLoginModal,
+    initOAuth,
+    sendCode,
+    loginWithCode,
+    logout,
+    signTypedData,
+    createWallet,
+  ]);
+
+  useEffect(() => {
+    core.syncState({
+      ready,
+      authenticated,
+      email: user?.email?.address,
+      emailStatus: emailState.status,
+      emailError:
+        emailState.status === "error"
+          ? (emailState.error ?? undefined)
+          : undefined,
+    });
+  }, [core, ready, authenticated, user, emailState]);
 
   // One attempt per authenticated session, reset on logout.
   const creatingWalletRef = useRef(false);
@@ -82,6 +116,8 @@ export function PrivyAdapterBridge({ core }: PrivyAdapterBridgeProps) {
     return core.bind({
       openLoginModal: (opts) => fnsRef.current.openLoginModal(opts),
       initOAuth: (opts) => fnsRef.current.initOAuth(opts),
+      sendCode: (opts) => fnsRef.current.sendCode(opts),
+      loginWithCode: (opts) => fnsRef.current.loginWithCode(opts),
       logout: () => fnsRef.current.logout(),
       // Privy owns the embedded wallet keys, so showWalletUIs:false signs the
       // credential typed-data silently as part of login.

--- a/packages/renown/src/wallet/privy/client-config.ts
+++ b/packages/renown/src/wallet/privy/client-config.ts
@@ -1,0 +1,55 @@
+import type { PrivyClientConfig, WalletListEntry } from "@privy-io/react-auth";
+import type { Chain } from "viem";
+import type { LoginMethod } from "../types.js";
+import { PRIVY_METHOD_MAP } from "./adapter.js";
+import type { PrivyChain } from "./meta.js";
+
+// Privy's provider root fetches the WalletConnect explorer listings on mount
+// unless walletList needs none; externalWallets.* and loginMethods don't gate it.
+export const DEFAULT_WALLET_LIST: readonly WalletListEntry[] = [
+  "detected_ethereum_wallets",
+];
+
+export interface PrivyClientConfigInput {
+  methods: LoginMethod[];
+  mode: "light" | "dark";
+  accentColor?: `#${string}`;
+  chain?: PrivyChain;
+  walletList?: string[];
+}
+
+// Pure so the config shape is testable without mounting PrivyProvider.
+export function buildPrivyClientConfig({
+  methods,
+  mode,
+  accentColor,
+  chain,
+  walletList,
+}: PrivyClientConfigInput): PrivyClientConfig {
+  // PrivyChain is the structural subset every viem Chain satisfies.
+  const pinned = chain as Chain | undefined;
+  return {
+    // Only the configured methods, so Privy skips the connectors (e.g.
+    // WalletConnect) that the unlisted ones would initialize.
+    loginMethods: methods.map((method) => PRIVY_METHOD_MAP[method]),
+    appearance: {
+      // Privy generates its own light/dark variants from the accent.
+      theme: mode,
+      // Config arrives from JSON, so entries are unvalidated here.
+      walletList: [...(walletList ?? DEFAULT_WALLET_LIST)] as WalletListEntry[],
+      ...(accentColor ? { accentColor } : {}),
+    },
+    // Renown rejects a wallet on any chain but the one it issues on.
+    ...(pinned ? { defaultChain: pinned, supportedChains: [pinned] } : {}),
+    embeddedWallets: {
+      ethereum: { createOnLogin: "users-without-wallets" },
+      showWalletUIs: false,
+    },
+    // Social/email adapter only (external wallets go through the rainbow
+    // adapter), so don't init WalletConnect / fetch its registry on mount.
+    externalWallets: {
+      disableAllExternalWallets: true,
+      walletConnect: { enabled: false },
+    },
+  };
+}

--- a/packages/renown/src/wallet/privy/factory.ts
+++ b/packages/renown/src/wallet/privy/factory.ts
@@ -2,8 +2,10 @@
 // client module even though the descriptor entry reaches it lazily.
 "use client";
 
-import type { WalletAdapterImpl, WalletController } from "../types.js";
+import { useMemo } from "react";
+import type { WalletAdapterImpl } from "../types.js";
 import { PrivyCore } from "./adapter.js";
+import type { PrivyWalletController } from "./types.js";
 import {
   resolvePrivyMethods,
   type PHRenownPrivyAdapterConfig,
@@ -19,15 +21,24 @@ export function createPrivyAdapter(
   const Provider = createPrivyProvider(core, {
     appId: config.appId,
     clientId: config.clientId,
+    chain: config.chain,
   });
 
-  function useController(): WalletController {
-    return {
-      connect: (method) => core.connect(method),
-      disconnect: () => core.disconnect(),
-      getSession: () => core.getSession(),
-      subscribe: (listener) => core.subscribe(listener),
-    };
+  // Stable identity: the host publishes this to a registry on change.
+  function useController(): PrivyWalletController {
+    return useMemo<PrivyWalletController>(
+      () => ({
+        connect: (method) => core.connect(method),
+        disconnect: () => core.disconnect(),
+        getSession: () => core.getSession(),
+        subscribe: (listener) => core.subscribe(listener),
+        sendCode: (email, options) => core.sendCode(email, options),
+        loginWithCode: (code) => core.loginWithCode(code),
+        getState: () => core.getState(),
+        subscribeState: (listener) => core.subscribeState(listener),
+      }),
+      [],
+    );
   }
 
   return { Provider, useController };
@@ -35,5 +46,11 @@ export function createPrivyAdapter(
 
 export { PrivyCore } from "./adapter.js";
 export type { PrivyBindings } from "./adapter.js";
+export type {
+  PrivyAuthState,
+  PrivyEmailStatus,
+  PrivyWalletController,
+  SendCodeOptions,
+} from "./types.js";
 export { PrivyAdapterBridge } from "./bridge.js";
 export { createPrivyProvider } from "./provider.js";

--- a/packages/renown/src/wallet/privy/factory.ts
+++ b/packages/renown/src/wallet/privy/factory.ts
@@ -22,6 +22,7 @@ export function createPrivyAdapter(
     appId: config.appId,
     clientId: config.clientId,
     chain: config.chain,
+    walletList: config.walletList,
   });
 
   // Stable identity: the host publishes this to a registry on change.

--- a/packages/renown/src/wallet/privy/index.ts
+++ b/packages/renown/src/wallet/privy/index.ts
@@ -24,7 +24,11 @@ export {
   privyAdapterMeta,
   resolvePrivyMethods,
 } from "./meta.js";
-export type { PHRenownPrivyAdapterConfig, PrivyLoginMethod } from "./meta.js";
+export type {
+  PHRenownPrivyAdapterConfig,
+  PrivyChain,
+  PrivyLoginMethod,
+} from "./meta.js";
 // Type-only: lets a host type `useRenownWalletAdapter<PrivyWalletController>("privy")`
 // without pulling the factory (or @privy-io) into its bundle.
 export type {

--- a/packages/renown/src/wallet/privy/index.ts
+++ b/packages/renown/src/wallet/privy/index.ts
@@ -25,3 +25,11 @@ export {
   resolvePrivyMethods,
 } from "./meta.js";
 export type { PHRenownPrivyAdapterConfig, PrivyLoginMethod } from "./meta.js";
+// Type-only: lets a host type `useRenownWalletAdapter<PrivyWalletController>("privy")`
+// without pulling the factory (or @privy-io) into its bundle.
+export type {
+  PrivyAuthState,
+  PrivyEmailStatus,
+  PrivyWalletController,
+  SendCodeOptions,
+} from "./types.js";

--- a/packages/renown/src/wallet/privy/meta.ts
+++ b/packages/renown/src/wallet/privy/meta.ts
@@ -1,5 +1,12 @@
-import type { Chain } from "viem";
 import { LoginMethod, type WalletAdapterMeta } from "../types.js";
+
+/** Structural subset of viem's `Chain`, so any `viem/chains` / `wagmi/chains` export fits regardless of the host's viem version. */
+export interface PrivyChain {
+  id: number;
+  name: string;
+  nativeCurrency: { name: string; symbol: string; decimals: number };
+  rpcUrls: { default: { http: readonly string[] } };
+}
 
 // Login methods the Privy adapter can drive. adapter.ts maps each to a Privy
 // login-method id, so adding one here without mapping it fails to compile.
@@ -25,7 +32,7 @@ export interface PHRenownPrivyAdapterConfig {
   /** Login methods to offer; defaults to [google, email]. */
   methods?: PrivyLoginMethod[];
   /** Chain Renown issues credentials on (e.g. `mainnet` from `viem/chains`). Pins the embedded wallet to it: a wallet on another chain is a different DID and is rejected. */
-  chain?: Chain;
+  chain?: PrivyChain;
 }
 
 // Resolve config `methods` to the supported set, falling back to the default.

--- a/packages/renown/src/wallet/privy/meta.ts
+++ b/packages/renown/src/wallet/privy/meta.ts
@@ -1,3 +1,4 @@
+import type { Chain } from "viem";
 import { LoginMethod, type WalletAdapterMeta } from "../types.js";
 
 // Login methods the Privy adapter can drive. adapter.ts maps each to a Privy
@@ -23,6 +24,8 @@ export interface PHRenownPrivyAdapterConfig {
   clientId?: string;
   /** Login methods to offer; defaults to [google, email]. */
   methods?: PrivyLoginMethod[];
+  /** Chain Renown issues credentials on (e.g. `mainnet` from `viem/chains`). Pins the embedded wallet to it: a wallet on another chain is a different DID and is rejected. */
+  chain?: Chain;
 }
 
 // Resolve config `methods` to the supported set, falling back to the default.

--- a/packages/renown/src/wallet/privy/meta.ts
+++ b/packages/renown/src/wallet/privy/meta.ts
@@ -33,6 +33,8 @@ export interface PHRenownPrivyAdapterConfig {
   methods?: PrivyLoginMethod[];
   /** Chain Renown issues credentials on (e.g. `mainnet` from `viem/chains`). Pins the embedded wallet to it: a wallet on another chain is a different DID and is rejected. */
   chain?: PrivyChain;
+  /** Privy `appearance.walletList`. Defaults to `["detected_ethereum_wallets"]`: with external wallets disabled here (they go through the rainbow adapter), anything else makes Privy fetch the WalletConnect explorer listings (~163 KB) on mount. Set it only if you want those listings. */
+  walletList?: string[];
 }
 
 // Resolve config `methods` to the supported set, falling back to the default.

--- a/packages/renown/src/wallet/privy/provider.tsx
+++ b/packages/renown/src/wallet/privy/provider.tsx
@@ -4,12 +4,13 @@ import type { Chain } from "viem";
 import { normalizeWalletTheme, type WalletTheme } from "../types.js";
 import { PRIVY_METHOD_MAP, type PrivyCore } from "./adapter.js";
 import { PrivyAdapterBridge } from "./bridge.js";
+import type { PrivyChain } from "./meta.js";
 import { toPrivyAccentColor } from "./theme.js";
 
 interface PrivyProviderConfig {
   appId: string;
   clientId?: string;
-  chain?: Chain;
+  chain?: PrivyChain;
 }
 
 // Build the adapter Provider bound to a specific core + config. Mounts
@@ -27,7 +28,8 @@ export function createPrivyProvider(
   }) {
     const { mode, accentColor } = normalizeWalletTheme(theme);
     const accent = toPrivyAccentColor(accentColor);
-    const { chain } = config;
+    // PrivyChain is the structural subset every viem Chain satisfies.
+    const chain = config.chain as Chain | undefined;
     // Memoize so a new config object per render doesn't rebuild PrivyProvider's
     // context and cascade re-renders into descendants.
     const privyConfig = useMemo<PrivyClientConfig>(

--- a/packages/renown/src/wallet/privy/provider.tsx
+++ b/packages/renown/src/wallet/privy/provider.tsx
@@ -1,9 +1,9 @@
 import { useMemo, type ComponentType, type ReactNode } from "react";
-import { PrivyProvider, type PrivyClientConfig } from "@privy-io/react-auth";
-import type { Chain } from "viem";
+import { PrivyProvider } from "@privy-io/react-auth";
 import { normalizeWalletTheme, type WalletTheme } from "../types.js";
-import { PRIVY_METHOD_MAP, type PrivyCore } from "./adapter.js";
+import type { PrivyCore } from "./adapter.js";
 import { PrivyAdapterBridge } from "./bridge.js";
+import { buildPrivyClientConfig } from "./client-config.js";
 import type { PrivyChain } from "./meta.js";
 import { toPrivyAccentColor } from "./theme.js";
 
@@ -11,6 +11,7 @@ interface PrivyProviderConfig {
   appId: string;
   clientId?: string;
   chain?: PrivyChain;
+  walletList?: string[];
 }
 
 // Build the adapter Provider bound to a specific core + config. Mounts
@@ -28,33 +29,19 @@ export function createPrivyProvider(
   }) {
     const { mode, accentColor } = normalizeWalletTheme(theme);
     const accent = toPrivyAccentColor(accentColor);
-    // PrivyChain is the structural subset every viem Chain satisfies.
-    const chain = config.chain as Chain | undefined;
+    const { chain, walletList } = config;
     // Memoize so a new config object per render doesn't rebuild PrivyProvider's
     // context and cascade re-renders into descendants.
-    const privyConfig = useMemo<PrivyClientConfig>(
-      () => ({
-        // Only the configured methods, so Privy skips the connectors (e.g.
-        // WalletConnect) that the unlisted ones would initialize.
-        loginMethods: core.supportedMethods.map(
-          (method) => PRIVY_METHOD_MAP[method],
-        ),
-        // Privy generates its own light/dark variants from the accent.
-        appearance: { theme: mode, ...(accent ? { accentColor: accent } : {}) },
-        // Renown rejects a wallet on any chain but the one it issues on.
-        ...(chain ? { defaultChain: chain, supportedChains: [chain] } : {}),
-        embeddedWallets: {
-          ethereum: { createOnLogin: "users-without-wallets" as const },
-          showWalletUIs: false,
-        },
-        // Social/email adapter only (external wallets go through the rainbow
-        // adapter), so don't init WalletConnect / fetch its registry on mount.
-        externalWallets: {
-          disableAllExternalWallets: true,
-          walletConnect: { enabled: false },
-        },
-      }),
-      [mode, accent, chain],
+    const privyConfig = useMemo(
+      () =>
+        buildPrivyClientConfig({
+          methods: core.supportedMethods,
+          mode,
+          accentColor: accent,
+          chain,
+          walletList,
+        }),
+      [mode, accent, chain, walletList],
     );
 
     return (

--- a/packages/renown/src/wallet/privy/provider.tsx
+++ b/packages/renown/src/wallet/privy/provider.tsx
@@ -1,13 +1,15 @@
 import { useMemo, type ComponentType, type ReactNode } from "react";
 import { PrivyProvider, type PrivyClientConfig } from "@privy-io/react-auth";
+import type { Chain } from "viem";
 import { normalizeWalletTheme, type WalletTheme } from "../types.js";
-import type { PrivyCore } from "./adapter.js";
+import { PRIVY_METHOD_MAP, type PrivyCore } from "./adapter.js";
 import { PrivyAdapterBridge } from "./bridge.js";
 import { toPrivyAccentColor } from "./theme.js";
 
 interface PrivyProviderConfig {
   appId: string;
   clientId?: string;
+  chain?: Chain;
 }
 
 // Build the adapter Provider bound to a specific core + config. Mounts
@@ -25,12 +27,20 @@ export function createPrivyProvider(
   }) {
     const { mode, accentColor } = normalizeWalletTheme(theme);
     const accent = toPrivyAccentColor(accentColor);
+    const { chain } = config;
     // Memoize so a new config object per render doesn't rebuild PrivyProvider's
     // context and cascade re-renders into descendants.
     const privyConfig = useMemo<PrivyClientConfig>(
       () => ({
+        // Only the configured methods, so Privy skips the connectors (e.g.
+        // WalletConnect) that the unlisted ones would initialize.
+        loginMethods: core.supportedMethods.map(
+          (method) => PRIVY_METHOD_MAP[method],
+        ),
         // Privy generates its own light/dark variants from the accent.
         appearance: { theme: mode, ...(accent ? { accentColor: accent } : {}) },
+        // Renown rejects a wallet on any chain but the one it issues on.
+        ...(chain ? { defaultChain: chain, supportedChains: [chain] } : {}),
         embeddedWallets: {
           ethereum: { createOnLogin: "users-without-wallets" as const },
           showWalletUIs: false,
@@ -42,7 +52,7 @@ export function createPrivyProvider(
           walletConnect: { enabled: false },
         },
       }),
-      [mode, accent],
+      [mode, accent, chain],
     );
 
     return (

--- a/packages/renown/src/wallet/privy/types.ts
+++ b/packages/renown/src/wallet/privy/types.ts
@@ -1,0 +1,40 @@
+import type { WalletController, WalletSession } from "../types.js";
+
+// Host-facing types for the Privy controller. Free of @privy-io imports (type
+// ones included) so index.ts can re-export them without dragging the peer in.
+
+/** Privy's email OTP flow status, as reported by its `useLoginWithEmail`. */
+export type PrivyEmailStatus =
+  | "initial"
+  | "sending-code"
+  | "awaiting-code-input"
+  | "submitting-code"
+  | "done"
+  | "error";
+
+/** Privy auth state the bridge mirrors into the core, for hosts drawing their own sign-in screens. */
+export interface PrivyAuthState {
+  /** Privy has finished restoring any existing session. */
+  ready: boolean;
+  /** Privy holds a session (before Renown has issued a credential). */
+  authenticated: boolean;
+  /** The signed-in user's verified email, when logged in by email. */
+  email?: string;
+  emailStatus: PrivyEmailStatus;
+  emailError?: Error;
+}
+
+export interface SendCodeOptions {
+  /** Reject addresses with no Privy account instead of creating one. */
+  disableSignup?: boolean;
+}
+
+/** The Privy adapter's controller: `WalletController` plus the headless email OTP surface, so a host can draw its own sign-in screens without importing `@privy-io/react-auth`. */
+export interface PrivyWalletController extends WalletController {
+  /** Send a one-time code to `email`. */
+  sendCode(email: string, options?: SendCodeOptions): Promise<void>;
+  /** Verify the code; resolves with the embedded-wallet session, ready for `login(session)`. */
+  loginWithCode(code: string): Promise<WalletSession>;
+  getState(): PrivyAuthState;
+  subscribeState(listener: (state: PrivyAuthState) => void): () => void;
+}

--- a/packages/renown/test/wallet/privy-client-config.test.ts
+++ b/packages/renown/test/wallet/privy-client-config.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { buildPrivyClientConfig } from "../../src/wallet/privy/client-config.js";
+import { LoginMethod } from "../../src/wallet/types.js";
+
+const CHAIN = {
+  id: 1,
+  name: "Ethereum",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  rpcUrls: { default: { http: ["https://eth.example"] } },
+};
+
+describe("buildPrivyClientConfig", () => {
+  it("restricts Privy's modal to the configured methods", () => {
+    const config = buildPrivyClientConfig({
+      methods: [LoginMethod.EMAIL, LoginMethod.GOOGLE],
+      mode: "light",
+    });
+    expect(config.loginMethods).toEqual(["email", "google"]);
+  });
+
+  // Privy's provider root fetches the WalletConnect explorer listings (~163 KB)
+  // on mount for any other walletList, regardless of externalWallets.*.
+  it("defaults walletList to detected wallets only", () => {
+    const config = buildPrivyClientConfig({
+      methods: [LoginMethod.EMAIL],
+      mode: "light",
+    });
+    expect(config.appearance?.walletList).toEqual([
+      "detected_ethereum_wallets",
+    ]);
+    expect(config.externalWallets?.disableAllExternalWallets).toBe(true);
+    expect(config.externalWallets?.walletConnect?.enabled).toBe(false);
+  });
+
+  it("lets a host override walletList", () => {
+    const config = buildPrivyClientConfig({
+      methods: [LoginMethod.EMAIL],
+      mode: "light",
+      walletList: ["metamask", "wallet_connect"],
+    });
+    expect(config.appearance?.walletList).toEqual([
+      "metamask",
+      "wallet_connect",
+    ]);
+  });
+
+  it("pins the embedded wallet to the given chain", () => {
+    const config = buildPrivyClientConfig({
+      methods: [LoginMethod.EMAIL],
+      mode: "dark",
+      chain: CHAIN,
+    });
+    expect(config.defaultChain?.id).toBe(1);
+    expect(config.supportedChains?.map((c) => c.id)).toEqual([1]);
+  });
+
+  it("omits chain and accent when not given", () => {
+    const config = buildPrivyClientConfig({
+      methods: [LoginMethod.EMAIL],
+      mode: "dark",
+    });
+    expect(config.defaultChain).toBeUndefined();
+    expect(config.supportedChains).toBeUndefined();
+    expect(config.appearance).toEqual({
+      theme: "dark",
+      walletList: ["detected_ethereum_wallets"],
+    });
+  });
+
+  it("keeps embedded-wallet signing silent", () => {
+    const config = buildPrivyClientConfig({
+      methods: [LoginMethod.EMAIL],
+      mode: "light",
+      accentColor: "#0084ff",
+    });
+    expect(config.appearance?.accentColor).toBe("#0084ff");
+    expect(config.embeddedWallets).toEqual({
+      ethereum: { createOnLogin: "users-without-wallets" },
+      showWalletUIs: false,
+    });
+  });
+});

--- a/packages/renown/test/wallet/privy-core.test.ts
+++ b/packages/renown/test/wallet/privy-core.test.ts
@@ -93,6 +93,42 @@ describe("PrivyCore email OTP", () => {
   });
 });
 
+describe("PrivyCore disconnect", () => {
+  it("waits for Privy to be ready before logging out", async () => {
+    const core = new PrivyCore([LoginMethod.EMAIL]);
+    const b = bindings();
+    core.bind(b);
+    const pending = core.disconnect();
+    await Promise.resolve();
+    expect(b.logout).not.toHaveBeenCalled();
+    core.syncState({
+      ready: true,
+      authenticated: true,
+      emailStatus: "initial",
+    });
+    await pending;
+    expect(b.logout).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs out immediately when Privy is already ready", async () => {
+    const core = new PrivyCore([LoginMethod.EMAIL]);
+    const b = bindings();
+    core.bind(b);
+    core.syncState({
+      ready: true,
+      authenticated: true,
+      emailStatus: "initial",
+    });
+    await core.disconnect();
+    expect(b.logout).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op for the wallet when the bridge is not mounted", async () => {
+    const core = new PrivyCore([LoginMethod.EMAIL]);
+    await expect(core.disconnect()).resolves.toBeUndefined();
+  });
+});
+
 describe("PrivyCore state", () => {
   it("starts unready and notifies subscribers on change only", () => {
     const core = new PrivyCore([LoginMethod.EMAIL]);

--- a/packages/renown/test/wallet/privy-core.test.ts
+++ b/packages/renown/test/wallet/privy-core.test.ts
@@ -82,6 +82,23 @@ describe("PrivyCore email OTP", () => {
     await expect(pending).rejects.toThrow("boom");
   });
 
+  it("rejects a second login while one is still pending", async () => {
+    const core = new PrivyCore([LoginMethod.EMAIL]);
+    const b = bindings();
+    core.bind(b);
+    const first = core.loginWithCode("111111");
+    await expect(core.loginWithCode("222222")).rejects.toThrow(
+      /already in progress/,
+    );
+    await expect(core.connect(LoginMethod.EMAIL)).rejects.toThrow(
+      /already in progress/,
+    );
+    // The first attempt is untouched and still completes.
+    core.syncFromEmbeddedWallet(WALLET);
+    await expect(first).resolves.toMatchObject({ address: WALLET.address });
+    expect(b.loginWithCode).toHaveBeenCalledTimes(1);
+  });
+
   it("returns the existing session without calling Privy", async () => {
     const core = new PrivyCore([LoginMethod.EMAIL]);
     const b = bindings();

--- a/packages/renown/test/wallet/privy-core.test.ts
+++ b/packages/renown/test/wallet/privy-core.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  PrivyCore,
+  type PrivyBindings,
+} from "../../src/wallet/privy/adapter.js";
+import { LoginMethod } from "../../src/wallet/types.js";
+
+const WALLET = {
+  address: "0x1111111111111111111111111111111111111111",
+  chainId: "eip155:1",
+} as Parameters<PrivyCore["syncFromEmbeddedWallet"]>[0];
+
+function bindings(overrides: Partial<PrivyBindings> = {}): PrivyBindings {
+  return {
+    openLoginModal: vi.fn(),
+    initOAuth: vi.fn().mockResolvedValue(undefined),
+    sendCode: vi.fn().mockResolvedValue(undefined),
+    loginWithCode: vi.fn().mockResolvedValue(undefined),
+    logout: vi.fn().mockResolvedValue(undefined),
+    signTypedData: vi.fn().mockResolvedValue("0xsig"),
+    ...overrides,
+  };
+}
+
+describe("PrivyCore email OTP", () => {
+  it("rejects sendCode until the bridge binds", async () => {
+    const core = new PrivyCore([LoginMethod.EMAIL]);
+    await expect(core.sendCode("a@b.c")).rejects.toThrow(/not bound/);
+  });
+
+  it("rejects email calls when email is not a configured method", async () => {
+    const core = new PrivyCore([LoginMethod.GOOGLE]);
+    core.bind(bindings());
+    await expect(core.sendCode("a@b.c")).rejects.toThrow(/does not support/);
+    await expect(core.loginWithCode("123456")).rejects.toThrow(
+      /does not support/,
+    );
+  });
+
+  it("forwards sendCode with disableSignup", async () => {
+    const core = new PrivyCore([LoginMethod.EMAIL]);
+    const b = bindings();
+    core.bind(b);
+    await core.sendCode("a@b.c", { disableSignup: true });
+    expect(b.sendCode).toHaveBeenCalledWith({
+      email: "a@b.c",
+      disableSignup: true,
+    });
+  });
+
+  it("loginWithCode resolves with the session once the wallet arrives", async () => {
+    const core = new PrivyCore([LoginMethod.EMAIL]);
+    const b = bindings();
+    core.bind(b);
+    const pending = core.loginWithCode("123456");
+    expect(b.loginWithCode).toHaveBeenCalledWith({ code: "123456" });
+    // Wallet shows up through the bridge after Privy authenticates.
+    core.syncFromEmbeddedWallet(WALLET);
+    const session = await pending;
+    expect(session.address).toBe(WALLET.address);
+    expect(session.chainId).toBe(1);
+    expect(session.canSignSilently).toBe(true);
+    expect(core.getSession()).toBe(session);
+  });
+
+  it("loginWithCode rejects when Privy rejects the code", async () => {
+    const core = new PrivyCore([LoginMethod.EMAIL]);
+    core.bind(
+      bindings({
+        loginWithCode: vi.fn().mockRejectedValue(new Error("Invalid code")),
+      }),
+    );
+    await expect(core.loginWithCode("000000")).rejects.toThrow("Invalid code");
+    expect(core.getSession()).toBeUndefined();
+  });
+
+  it("loginWithCode rejects through the bridge's onError", async () => {
+    const core = new PrivyCore([LoginMethod.EMAIL]);
+    core.bind(bindings());
+    const pending = core.loginWithCode("123456");
+    core.handleLoginError(new Error("boom"));
+    await expect(pending).rejects.toThrow("boom");
+  });
+
+  it("returns the existing session without calling Privy", async () => {
+    const core = new PrivyCore([LoginMethod.EMAIL]);
+    const b = bindings();
+    core.bind(b);
+    core.syncFromEmbeddedWallet(WALLET);
+    const session = await core.loginWithCode("ignored");
+    expect(session.address).toBe(WALLET.address);
+    expect(b.loginWithCode).not.toHaveBeenCalled();
+  });
+});
+
+describe("PrivyCore state", () => {
+  it("starts unready and notifies subscribers on change only", () => {
+    const core = new PrivyCore([LoginMethod.EMAIL]);
+    expect(core.getState()).toEqual({
+      ready: false,
+      authenticated: false,
+      emailStatus: "initial",
+    });
+    const listener = vi.fn();
+    core.subscribeState(listener);
+    const next = {
+      ready: true,
+      authenticated: false,
+      emailStatus: "awaiting-code-input" as const,
+    };
+    core.syncState(next);
+    core.syncState({ ...next });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(core.getState()).toBe(next);
+  });
+
+  it("surfaces the OTP error", () => {
+    const core = new PrivyCore([LoginMethod.EMAIL]);
+    const error = new Error("Too many attempts");
+    core.syncState({
+      ready: true,
+      authenticated: false,
+      emailStatus: "error",
+      emailError: error,
+    });
+    expect(core.getState().emailError).toBe(error);
+  });
+});


### PR DESCRIPTION
Closes #2932

## Summary

Lets a host build its own email OTP sign-in screens against `@renown/sdk` / `@powerhousedao/reactor-browser/renown` without importing `@privy-io/react-auth` or mounting `PrivyProvider` itself, and stops wallet adapters from mounting merely because a session was restored.

### `@renown/sdk/wallet/privy`
- `PrivyCore` gains `sendCode(email, {disableSignup})`, `loginWithCode(code): Promise<WalletSession>` (resolves through the same pending → `syncFromEmbeddedWallet` path the modal uses) and a mirrored `PrivyAuthState` (`ready`, `authenticated`, `email`, `emailStatus`, `emailError`) via `getState`/`subscribeState`.
- `PrivyWalletController extends WalletController` with that surface; exported type-only from the light entry (peer-free `types.ts`, checked by `light-entries.test.ts`).
- Bridge captures `useLoginWithEmail` and syncs Privy state into the core.
- Provider passes `loginMethods` (configured methods only) and `defaultChain`/`supportedChains` from the new `chain?: PrivyChain` option — a structural subset of viem's `Chain`, so any `viem/chains`/`wagmi/chains` export fits regardless of the host's viem version.
- `disconnect()` waits for Privy `ready` (bounded) before `logout`, since Privy may be mounted on demand for the logout itself.
- `useController` result is memoized.

### `@powerhousedao/reactor-browser/renown`
- `useRenownWalletAdapter<T>(id)` — returns one mounted adapter's controller by `meta.id`, typed as its own surface; rendering it activates the wallet tree.
- Per-adapter controller store + activator subscription in the registry; `RenownWalletProvider` publishes each controller.
- **Activation no longer latches on `user`.** Adapters mount on `login()`, `logout()`, `useRenownWalletAdapter`, or an OAuth redirect return — never on a restored session — so a signed-in visitor on a page that never signs in/out downloads no wallet code. Once mounted they stay mounted (Privy modal remount concern unchanged).
- `logout()` activates when no controller is mounted so Privy's own logout runs (otherwise the next `connect()` would silently resume the stored Privy session); with no activator it just clears the Renown session.

### Connect / docs
- Connect passes the resolved chain to `privyAdapter` too.
- README section + academy guide section for headless sign-in.

## Host usage
```tsx
const privy = useRenownWalletAdapter<PrivyWalletController>("privy");
await privy.sendCode(email, { disableSignup: true });
login(await privy.loginWithCode(code));
```
with `privyAdapter({ appId, methods: ["email"], chain })`.

### WalletConnect listings fetch
`PrivyProvider`'s root component fetches `explorer-api.walletconnect.com` (~163 KB) on mount unless `appearance.walletList` needs no listings; `externalWallets.*` and `loginMethods` don't gate it, and the dashboard route doesn't help (Privy falls back to a bundled default projectId). The adapter now defaults `walletList` to `["detected_ethereum_wallets"]` (external wallets go through the rainbow adapter anyway) and exposes `walletList?: string[]` on `PHRenownPrivyAdapterConfig` for hosts that want the listings. Verified on the pfnur portal: 0 requests on `/login` vs the 163 KB fetch before. Config construction moved to a pure `buildPrivyClientConfig` so it is unit-tested (`privy-client-config.test.ts`).

## Test plan
- `@renown/sdk`: 177 tests (12 new in `privy-core.test.ts`, 6 in `privy-client-config.test.ts`), tsc, lint.
- `reactor-browser` renown suite: 35 tests — new `wallet-adapter.test.tsx` (hook) and `wallet-activation.test.tsx` (restored session mounts nothing; `logout()`/`login()` activate and complete; redirect return activates on mount).
- Connect typechecks (pre-existing `test/graphql-client` errors untouched).