### PR TITLE
fix(reactor-browser): keep the seeded Renown user when the SDK instance appears

### DIFF
--- a/packages/reactor-browser/src/hooks/renown.ts
+++ b/packages/reactor-browser/src/hooks/renown.ts
@@ -25,12 +25,23 @@ export function useDid() {
   return renown?.did;
 }
 
-// Structural equality for persisted users (plain JSON), so a re-parse of the
-// same credential keeps its object identity for did-keyed consumers.
-function sameUser(a: User | undefined, b: User | undefined): boolean {
+// Order-insensitive structural equality for plain JSON (what a persisted user
+// is): the cookie and localStorage paths build the same user with different key
+// order, and both must keep one object identity for did-keyed consumers.
+function jsonEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
-  if (!a || !b) return false;
-  return JSON.stringify(a) === JSON.stringify(b);
+  if (typeof a !== "object" || typeof b !== "object" || !a || !b) return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  const ra = a as Record<string, unknown>;
+  const rb = b as Record<string, unknown>;
+  const keys = Object.keys(ra).filter((k) => ra[k] !== undefined);
+  if (keys.length !== Object.keys(rb).filter((k) => rb[k] !== undefined).length)
+    return false;
+  return keys.every((k) => jsonEqual(ra[k], rb[k]));
+}
+
+function sameUser(a: User | undefined, b: User | undefined): boolean {
+  return jsonEqual(a, b);
 }
 
 // What the SDK says once it exists. Its `user` is a synchronous storage read,
@@ -58,22 +69,26 @@ export function useUser(): User | undefined {
   // paint; the SDK is authoritative after, so a logout/revoke clears it.
   const initialUser = useRenownInitialUser();
   const instance = renown ? renown : undefined;
-  // Tagged with the instance it came from so an instance swap resyncs in the
-  // same render — an effect would leave one frame of stale state.
+  // Tagged with the instance it came from. On a swap the value for this render
+  // is derived here (state alone would be one frame stale) and persisted after
+  // commit; the derivation is pure, so re-renders before that agree.
   const [tracked, setTracked] = useState<TrackedUser>(() => ({
     instance,
     user: instance ? resolveInstanceUser(instance, initialUser) : initialUser,
   }));
-  let current = tracked;
-  if (tracked.instance !== instance) {
-    current = {
-      instance,
-      user: instance
-        ? resolveInstanceUser(instance, tracked.user ?? initialUser)
-        : tracked.user,
-    };
-    setTracked(current);
-  }
+  const current: TrackedUser =
+    tracked.instance === instance
+      ? tracked
+      : {
+          instance,
+          user: instance
+            ? resolveInstanceUser(instance, tracked.user ?? initialUser)
+            : tracked.user,
+        };
+
+  useEffect(() => {
+    if (current !== tracked) setTracked(current);
+  }, [current, tracked]);
 
   useEffect(() => {
     if (!instance) return;

--- a/packages/reactor-browser/src/hooks/renown.ts
+++ b/packages/reactor-browser/src/hooks/renown.ts
@@ -25,6 +25,32 @@ export function useDid() {
   return renown?.did;
 }
 
+// Structural equality for persisted users (plain JSON), so a re-parse of the
+// same credential keeps its object identity for did-keyed consumers.
+function sameUser(a: User | undefined, b: User | undefined): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+// What the SDK says once it exists. Its `user` is a synchronous storage read,
+// so undefined with status "initial" means nothing was restored and a stale seed
+// (e.g. a cookie outliving localStorage) must go; during "checking"/"authorized"
+// the SDK owns a session it has not published yet, so the seed stands.
+function resolveInstanceUser(
+  instance: IRenown,
+  seed: User | undefined,
+): User | undefined {
+  const restored = instance.user;
+  if (restored) return sameUser(seed, restored) ? seed : restored;
+  return instance.status === "initial" ? undefined : seed;
+}
+
+interface TrackedUser {
+  instance: IRenown | undefined;
+  user: User | undefined;
+}
+
 /** Returns the current user from the renown instance, subscribing to user events */
 export function useUser(): User | undefined {
   const renown = useRenown();
@@ -32,20 +58,36 @@ export function useUser(): User | undefined {
   // paint; the SDK is authoritative after, so a logout/revoke clears it.
   const initialUser = useRenownInitialUser();
   const instance = renown ? renown : undefined;
-  const [user, setUser] = useState<User | undefined>(
-    instance ? instance.user : initialUser,
-  );
+  // Tagged with the instance it came from so an instance swap resyncs in the
+  // same render — an effect would leave one frame of stale state.
+  const [tracked, setTracked] = useState<TrackedUser>(() => ({
+    instance,
+    user: instance ? resolveInstanceUser(instance, initialUser) : initialUser,
+  }));
+  let current = tracked;
+  if (tracked.instance !== instance) {
+    current = {
+      instance,
+      user: instance
+        ? resolveInstanceUser(instance, tracked.user ?? initialUser)
+        : tracked.user,
+    };
+    setTracked(current);
+  }
 
   useEffect(() => {
-    if (instance) {
-      setUser(instance.user);
-      return instance.on("user", setUser);
-    }
+    if (!instance) return;
+    return instance.on("user", (user) =>
+      setTracked((prev) => ({
+        instance,
+        user: sameUser(prev.user, user) ? prev.user : user,
+      })),
+    );
   }, [instance]);
 
-  // useState captured only the first render, so defer to the seed until the SDK
-  // exists — that is what lands the post-mount localStorage read.
-  return instance ? user : (initialUser ?? user);
+  // Until the SDK exists the seed wins, which is what lands the post-mount
+  // localStorage read.
+  return instance ? current.user : (initialUser ?? current.user);
 }
 
 /** Returns the login status, subscribing to renown status events */

--- a/packages/reactor-browser/test/renown/use-user.test.tsx
+++ b/packages/reactor-browser/test/renown/use-user.test.tsx
@@ -18,14 +18,36 @@ import {
 const ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" as const;
 const DID = `did:pkh:eip155:1:${ADDRESS}`;
 
+const CREDENTIAL = {
+  type: ["VerifiableCredential"],
+  credentialSubject: { id: DID, address: ADDRESS, chainId: 1 },
+  proof: { type: "JwtProof2020", jwt: "eyJ.test.sig" },
+};
+
 function user(): User {
   return {
     did: DID,
     address: ADDRESS,
     networkId: "eip155",
     chainId: 1,
-    credential: undefined,
-  } as User;
+    credential: CREDENTIAL,
+  } as unknown as User;
+}
+
+// The same user as the cookie-session path builds it: different key order at
+// every level, so an order-sensitive comparison would call it a new user.
+function reorderedUser(): User {
+  return {
+    credential: {
+      proof: { jwt: "eyJ.test.sig", type: "JwtProof2020" },
+      credentialSubject: { chainId: 1, address: ADDRESS, id: DID },
+      type: ["VerifiableCredential"],
+    },
+    chainId: 1,
+    networkId: "eip155",
+    address: ADDRESS,
+    did: DID,
+  } as unknown as User;
 }
 
 // Minimal SDK stand-in: a synchronous `user`, a `status`, and a "user" emitter.
@@ -87,8 +109,8 @@ describe("useUser", () => {
 
     setRenown(null); // SDK building
     await tick();
-    // A fresh parse of the same credential: equal, different object.
-    setRenown(fakeInstance(user(), "authorized"));
+    // The same credential, re-parsed with different key order.
+    setRenown(fakeInstance(reorderedUser(), "authorized"));
     await tick();
 
     await expect.element(screen.getByTestId("did")).toHaveTextContent(DID);
@@ -113,6 +135,22 @@ describe("useUser", () => {
 
     expect(seen).not.toContain(undefined);
     expect(seen.at(-1)).toBe(refreshed);
+  });
+
+  it("takes a changed user even when only a nested field differs", async () => {
+    const seed = user();
+    const seen: (User | undefined)[] = [];
+    const screen = renderProbe(authenticated(seed), (u) => seen.push(u));
+    await expect.element(screen.getByTestId("did")).toHaveTextContent(DID);
+
+    const resigned = reorderedUser();
+    (resigned.credential as unknown as { proof: { jwt: string } }).proof.jwt =
+      "eyJ.new.sig";
+    setRenown(fakeInstance(resigned, "authorized"));
+    await tick();
+
+    expect(seen).not.toContain(undefined);
+    expect(seen.at(-1)).toBe(resigned);
   });
 
   it("drops a stale seed when the SDK restored nothing", async () => {
@@ -156,10 +194,11 @@ describe("useUser", () => {
 
     setRenown(null);
     await tick();
-    setRenown(fakeInstance(user(), "authorized"));
+    setRenown(fakeInstance(reorderedUser(), "authorized"));
     await tick();
 
     await expect.element(screen.getByTestId("did")).toHaveTextContent(DID);
     expect(seen.slice(seededAt)).not.toContain(undefined);
+    expect(seen.slice(seededAt).every((u) => u === seed)).toBe(true);
   });
 });

--- a/packages/reactor-browser/test/renown/use-user.test.tsx
+++ b/packages/reactor-browser/test/renown/use-user.test.tsx
@@ -1,0 +1,165 @@
+import type { IRenown, LoginStatus, User } from "@renown/sdk";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import {
+  addRenownEventHandler,
+  setRenown,
+  useUser,
+} from "../../src/hooks/renown.js";
+import {
+  RENOWN_INITIAL_UNKNOWN,
+  RenownInitialUserProvider,
+  type RenownInitialAuth,
+} from "../../src/renown/initial-user.js";
+
+/* useUser must never drop a seeded user for a frame when the SDK instance
+   appears: every did-keyed consumer would reset and refetch. */
+
+const ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" as const;
+const DID = `did:pkh:eip155:1:${ADDRESS}`;
+
+function user(): User {
+  return {
+    did: DID,
+    address: ADDRESS,
+    networkId: "eip155",
+    chainId: 1,
+    credential: undefined,
+  } as User;
+}
+
+// Minimal SDK stand-in: a synchronous `user`, a `status`, and a "user" emitter.
+function fakeInstance(current: User | undefined, status: LoginStatus) {
+  const listeners = new Set<(u: User | undefined) => void>();
+  const instance = {
+    user: current,
+    status,
+    on: (event: string, cb: (u: User | undefined) => void) => {
+      if (event === "user") listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+    emitUser(next: User | undefined) {
+      instance.user = next;
+      listeners.forEach((cb) => cb(next));
+    },
+  };
+  return instance as typeof instance & IRenown;
+}
+
+function Probe({ log }: { log: (u: User | undefined) => void }) {
+  const current = useUser();
+  log(current);
+  return <span data-testid="did">{current?.did ?? "none"}</span>;
+}
+
+function renderProbe(
+  initialAuth: RenownInitialAuth,
+  log: (u: User | undefined) => void,
+) {
+  return render(
+    <RenownInitialUserProvider initialAuth={initialAuth}>
+      <Probe log={log} />
+    </RenownInitialUserProvider>,
+  );
+}
+
+const authenticated = (u: User): RenownInitialAuth => ({
+  state: "authenticated",
+  user: u,
+});
+const tick = () => new Promise((resolve) => setTimeout(resolve, 30));
+
+beforeEach(() => {
+  addRenownEventHandler();
+  setRenown(undefined);
+});
+
+afterEach(() => {
+  setRenown(undefined);
+});
+
+describe("useUser", () => {
+  it("keeps the seed (and its identity) when the SDK restores the same user", async () => {
+    const seed = user();
+    const seen: (User | undefined)[] = [];
+    const screen = renderProbe(authenticated(seed), (u) => seen.push(u));
+    await expect.element(screen.getByTestId("did")).toHaveTextContent(DID);
+
+    setRenown(null); // SDK building
+    await tick();
+    // A fresh parse of the same credential: equal, different object.
+    setRenown(fakeInstance(user(), "authorized"));
+    await tick();
+
+    await expect.element(screen.getByTestId("did")).toHaveTextContent(DID);
+    expect(seen).not.toContain(undefined);
+    expect(seen.every((u) => u === seed)).toBe(true);
+  });
+
+  it("keeps the seed while the SDK is still checking, then takes the emitted user", async () => {
+    const seed = user();
+    const seen: (User | undefined)[] = [];
+    const screen = renderProbe(authenticated(seed), (u) => seen.push(u));
+    await expect.element(screen.getByTestId("did")).toHaveTextContent(DID);
+
+    const instance = fakeInstance(undefined, "checking");
+    setRenown(instance);
+    await tick();
+    await expect.element(screen.getByTestId("did")).toHaveTextContent(DID);
+
+    const refreshed = { ...user(), profile: { username: "alice" } } as User;
+    instance.emitUser(refreshed);
+    await tick();
+
+    expect(seen).not.toContain(undefined);
+    expect(seen.at(-1)).toBe(refreshed);
+  });
+
+  it("drops a stale seed when the SDK restored nothing", async () => {
+    const screen = renderProbe(authenticated(user()), () => undefined);
+    await expect.element(screen.getByTestId("did")).toHaveTextContent(DID);
+
+    setRenown(fakeInstance(undefined, "initial"));
+    await expect.element(screen.getByTestId("did")).toHaveTextContent("none");
+  });
+
+  it("clears on sign-out", async () => {
+    const instance = fakeInstance(user(), "authorized");
+    setRenown(instance);
+    const screen = renderProbe(authenticated(user()), () => undefined);
+    await expect.element(screen.getByTestId("did")).toHaveTextContent(DID);
+
+    instance.emitUser(undefined);
+    await expect.element(screen.getByTestId("did")).toHaveTextContent("none");
+  });
+
+  it("never blips through the client-only hydration sequence", async () => {
+    // First client render does not know (hydration must match SSR), then the
+    // localStorage seed lands, then the SDK instance appears.
+    const seen: (User | undefined)[] = [];
+    const seed = user();
+    const log = (u: User | undefined) => seen.push(u);
+    const screen = render(
+      <RenownInitialUserProvider initialAuth={RENOWN_INITIAL_UNKNOWN}>
+        <Probe log={log} />
+      </RenownInitialUserProvider>,
+    );
+    await expect.element(screen.getByTestId("did")).toHaveTextContent("none");
+
+    screen.rerender(
+      <RenownInitialUserProvider initialAuth={authenticated(seed)}>
+        <Probe log={log} />
+      </RenownInitialUserProvider>,
+    );
+    await expect.element(screen.getByTestId("did")).toHaveTextContent(DID);
+    const seededAt = seen.indexOf(seed);
+
+    setRenown(null);
+    await tick();
+    setRenown(fakeInstance(user(), "authorized"));
+    await tick();
+
+    await expect.element(screen.getByTestId("did")).toHaveTextContent(DID);
+    expect(seen.slice(seededAt)).not.toContain(undefined);
+  });
+});


### PR DESCRIPTION
## Problem

`useUser` dropped the seeded user for one render when the SDK instance appeared. It seeded `useState` from `useRenownInitialUser()` on the first render and re-synced from `instance.user` in an `[instance]` effect — so the render in which `instance` first became truthy returned the state captured on the first render. For client-only hosts that first render is `RENOWN_INITIAL_UNKNOWN` (hydration must match SSR), i.e. `undefined`.

Consumers saw `authenticated → resolving → authenticated` within ~20 ms; `useRenownAuthAsync` reported `state: "resolving"` with `user: undefined`, and every did-keyed thing downstream (query keys, identity cache boundaries, profile lookups) reset and refetched. Measured on the pfnur portal: every GraphQL query on `/statements` fired twice on load, plus a one-frame skeleton flash. `address`/`displayName`/`avatarUrl` in `useRenownAuth` blipped with it (pure derivations of `user`).

A second, related cost: `renown.user` is a synchronous `localStorage` read that re-parses JSON on every call, so the seed, `instance.user`, and each `"user"` event were distinct object identities for the same credential — anything keyed on the user object refetched even without the blip.

## Fix

`useUser` derives the user **during render** when the instance changes (state tagged with the instance it belongs to; recomputed in the same render on a swap), and only uses state for pushed `"user"` events.

- `instance.user` present → use it, but keep the seed's object identity when it is structurally the same credential.
- `instance.user` undefined → keep the seed while `status` is `"checking"`/`"authorized"` (the SDK owns a session it has not published yet); drop it when `status === "initial"` (nothing was restored — a stale cookie seed must not outlive localStorage).
- A `"user"` event equal to the current user keeps the current object.

`useLoginStatus` was checked for the same shape: it is `useSyncExternalStore` with a per-render snapshot, so it does not have it. `useRenownAuth` needs no change.

## Tests

`test/renown/use-user.test.tsx` (5):
- seed identity kept across `undefined → loading → instance` with a re-parsed equal user
- seed kept while `"checking"`, then the emitted user is taken
- stale seed dropped when the SDK restored nothing (`"initial"`)
- sign-out clears
- the client-only hydration sequence (`UNKNOWN → seed → instance`) never returns `undefined` after the seed lands

Against the previous `useUser`, 3 of the 5 fail (identity churn, checking-keeps-seed, hydration blip); the other two guard existing behavior. With the fix: reactor-browser renown suite 40/40, lint clean.