### PR TITLE
Read pool collection memberships from the index, not from action shape

### DIFF
--- a/packages/reactor/src/cache/collection-membership-cache.ts
+++ b/packages/reactor/src/cache/collection-membership-cache.ts
@@ -1,18 +1,11 @@
 import type { IOperationIndex } from "./operation-index-types.js";
 
-/**
- * The read half of membership lookup. `IOperationIndex` satisfies it
- * directly, so a caller that must not serve a stale answer can depend on
- * this and be handed the index instead of a cache.
- */
-export interface ICollectionMembershipReader {
+export interface ICollectionMembershipCache {
   // Get collections for documents (lazy load from index if not cached)
   getCollectionsForDocuments(
     documentIds: string[],
   ): Promise<Record<string, string[]>>;
-}
 
-export interface ICollectionMembershipCache extends ICollectionMembershipReader {
   // Invalidate a document's cache entry (when membership changes)
   invalidate(documentId: string): void;
 }

--- a/packages/reactor/src/cache/collection-membership-cache.ts
+++ b/packages/reactor/src/cache/collection-membership-cache.ts
@@ -1,11 +1,18 @@
 import type { IOperationIndex } from "./operation-index-types.js";
 
-export interface ICollectionMembershipCache {
+/**
+ * The read half of membership lookup. `IOperationIndex` satisfies it
+ * directly, so a caller that must not serve a stale answer can depend on
+ * this and be handed the index instead of a cache.
+ */
+export interface ICollectionMembershipReader {
   // Get collections for documents (lazy load from index if not cached)
   getCollectionsForDocuments(
     documentIds: string[],
   ): Promise<Record<string, string[]>>;
+}
 
+export interface ICollectionMembershipCache extends ICollectionMembershipReader {
   // Invalidate a document's cache entry (when membership changes)
   invalidate(documentId: string): void;
 }

--- a/packages/reactor/src/core/reactor-builder.ts
+++ b/packages/reactor/src/core/reactor-builder.ts
@@ -571,7 +571,7 @@ export class ReactorBuilder {
           jobTracker,
           this.logger,
           resolver,
-          collectionMembershipCache,
+          operationIndex,
           this.executorConfig.jobTimeoutMs,
           this.executorConfig.deferredJobTtlMs,
         );

--- a/packages/reactor/src/executor/worker-pool-job-executor-manager.ts
+++ b/packages/reactor/src/executor/worker-pool-job-executor-manager.ts
@@ -1,6 +1,5 @@
-import type { OperationWithContext } from "@powerhousedao/shared/document-model";
 import type { ILogger } from "document-model";
-import type { ICollectionMembershipCache } from "../cache/collection-membership-cache.js";
+import type { ICollectionMembershipReader } from "../cache/collection-membership-cache.js";
 import type { IEventBus } from "../events/interfaces.js";
 import {
   ReactorEventTypes,
@@ -55,19 +54,6 @@ import type {
 export type WorkerFactory = (index: number) => IExecutorWorker;
 
 /**
- * Action types whose application invalidates the parent's collection
- * membership cache. Mirrors the in-process invalidation pattern in
- * `document-action-handler.ts` (the worker pool relocates that work to
- * the parent because the cache lives there).
- */
-const MEMBERSHIP_INVALIDATING_ACTIONS = new Set([
-  "ADD_RELATIONSHIP",
-  "REMOVE_RELATIONSHIP",
-  "UPDATE_RELATIONSHIP",
-  "DELETE_DOCUMENT",
-]);
-
-/**
  * Manages a pool of executor workers and dispatches jobs across them with
  * sticky-by-documentId routing. Replaces `SimpleJobExecutorManager` when
  * the worker pool is enabled.
@@ -77,10 +63,18 @@ const MEMBERSHIP_INVALIDATING_ACTIONS = new Set([
  *  - Emitting `JOB_RUNNING` and `JOB_WRITE_READY` events; the worker's
  *    local event bus is a no-op stub.
  *  - Maintaining the deferred-jobs map for `DocumentNotFoundError`.
- *  - Owning the authoritative `ICollectionMembershipCache` — workers do
- *    not query it. Each result enriches the outgoing `JOB_WRITE_READY`
- *    with `collectionMemberships` and invalidates targets named by
- *    relationship/delete operations before the lookup.
+ *  - Enriching the outgoing `JOB_WRITE_READY` with
+ *    `collectionMemberships`, read from the operation index after the
+ *    worker has committed. Must be handed the index itself, never a
+ *    caching reader: which documents a commit moves between collections
+ *    is not derivable from action shape, because joining a collection
+ *    also joins every group the joining document has referenced and that
+ *    set comes from selects run inside the commit. A parent-side cache
+ *    cannot learn it went stale, and a stale entry silently drops the
+ *    document's operations from the outbox of every remote subscribed to
+ *    the omitted collection. Costs one primary-key-prefix lookup on
+ *    `document_collections` per job that produced operations, on a
+ *    fire-and-forget path.
  *
  * @see Executor Worker Pool Design wiki page
  *   (Powerhouse board wiki id: d400d711-f07e-4389-a226-4e9fdd4fa8ba)
@@ -102,7 +96,7 @@ export class WorkerPoolJobExecutorManager implements IJobExecutorManager {
     private jobTracker: IJobTracker,
     private logger: ILogger,
     private resolver: IDocumentModelResolver,
-    private collectionMembershipCache: ICollectionMembershipCache,
+    private membershipReader: ICollectionMembershipReader,
     jobTimeoutMs: number = 30_000,
     deferredJobTtlMs: number = DEFAULT_DEFERRED_JOB_TTL_MS,
   ) {
@@ -367,22 +361,21 @@ export class WorkerPoolJobExecutorManager implements IJobExecutorManager {
     job: Job,
     payload: JobWriteReadyPayload,
   ): Promise<void> {
-    this.invalidateMembershipsFor(payload.operations);
-
     const documentIds = [
       ...new Set(payload.operations.map((op) => op.context.documentId)),
     ];
     let collectionMemberships: Record<string, string[]> = {};
-    try {
-      collectionMemberships =
-        await this.collectionMembershipCache.getCollectionsForDocuments(
-          documentIds,
+    if (documentIds.length > 0) {
+      try {
+        const found =
+          await this.membershipReader.getCollectionsForDocuments(documentIds);
+        collectionMemberships = fillMissingMemberships(documentIds, found);
+      } catch (error) {
+        this.logger.error(
+          "Failed to load collection memberships for JOB_WRITE_READY: @Error",
+          error,
         );
-    } catch (error) {
-      this.logger.error(
-        "Failed to load collection memberships for JOB_WRITE_READY: @Error",
-        error,
-      );
+      }
     }
 
     const event: JobWriteReadyEvent = {
@@ -395,19 +388,6 @@ export class WorkerPoolJobExecutorManager implements IJobExecutorManager {
       await this.eventBus.emit(ReactorEventTypes.JOB_WRITE_READY, event);
     } catch (error) {
       this.logger.error("Failed to emit JOB_WRITE_READY event: @Error", error);
-    }
-  }
-
-  private invalidateMembershipsFor(operations: OperationWithContext[]): void {
-    for (const op of operations) {
-      const actionType = op.operation.action.type;
-      if (!MEMBERSHIP_INVALIDATING_ACTIONS.has(actionType)) {
-        continue;
-      }
-      const target = extractMembershipTarget(op);
-      if (target) {
-        this.collectionMembershipCache.invalidate(target);
-      }
     }
   }
 
@@ -511,20 +491,19 @@ function isDuplicateModuleFailure(reason: unknown): boolean {
   );
 }
 
-function extractMembershipTarget(op: OperationWithContext): string | undefined {
-  const actionType = op.operation.action.type;
-  const input = op.operation.action.input as
-    | { targetId?: string; documentId?: string }
-    | undefined;
-  if (
-    actionType === "ADD_RELATIONSHIP" ||
-    actionType === "REMOVE_RELATIONSHIP" ||
-    actionType === "UPDATE_RELATIONSHIP"
-  ) {
-    return input?.targetId;
+/**
+ * Gives every requested document a key, empty when it belongs to no
+ * collection. The operation index omits documents with no rows while the
+ * membership cache defaulted them to `[]`, so this keeps the emitted
+ * `JobWriteReadyEvent.collectionMemberships` shape unchanged.
+ */
+function fillMissingMemberships(
+  documentIds: string[],
+  found: Record<string, string[]>,
+): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+  for (const documentId of documentIds) {
+    result[documentId] = found[documentId] ?? [];
   }
-  if (actionType === "DELETE_DOCUMENT") {
-    return input?.documentId ?? op.context.documentId;
-  }
-  return undefined;
+  return result;
 }

--- a/packages/reactor/src/executor/worker-pool-job-executor-manager.ts
+++ b/packages/reactor/src/executor/worker-pool-job-executor-manager.ts
@@ -1,5 +1,5 @@
 import type { ILogger } from "document-model";
-import type { ICollectionMembershipReader } from "../cache/collection-membership-cache.js";
+import type { IOperationIndex } from "../cache/operation-index-types.js";
 import type { IEventBus } from "../events/interfaces.js";
 import {
   ReactorEventTypes,
@@ -65,11 +65,12 @@ export type WorkerFactory = (index: number) => IExecutorWorker;
  *  - Maintaining the deferred-jobs map for `DocumentNotFoundError`.
  *  - Enriching the outgoing `JOB_WRITE_READY` with
  *    `collectionMemberships`, read from the operation index after the
- *    worker has committed. Must be handed the index itself, never a
- *    caching reader: which documents a commit moves between collections
- *    is not derivable from action shape, because joining a collection
- *    also joins every group the joining document has referenced and that
- *    set comes from selects run inside the commit. A parent-side cache
+ *    worker has committed. It takes the whole index rather than a
+ *    narrower read interface so that handing it a cache does not
+ *    compile: which documents a commit moves between collections is not
+ *    derivable from action shape, because joining a collection also
+ *    joins every group the joining document has referenced and that set
+ *    comes from selects run inside the commit. A parent-side cache
  *    cannot learn it went stale, and a stale entry silently drops the
  *    document's operations from the outbox of every remote subscribed to
  *    the omitted collection. Costs one primary-key-prefix lookup on
@@ -96,7 +97,7 @@ export class WorkerPoolJobExecutorManager implements IJobExecutorManager {
     private jobTracker: IJobTracker,
     private logger: ILogger,
     private resolver: IDocumentModelResolver,
-    private membershipReader: ICollectionMembershipReader,
+    private operationIndex: IOperationIndex,
     jobTimeoutMs: number = 30_000,
     deferredJobTtlMs: number = DEFAULT_DEFERRED_JOB_TTL_MS,
   ) {
@@ -368,7 +369,7 @@ export class WorkerPoolJobExecutorManager implements IJobExecutorManager {
     if (documentIds.length > 0) {
       try {
         const found =
-          await this.membershipReader.getCollectionsForDocuments(documentIds);
+          await this.operationIndex.getCollectionsForDocuments(documentIds);
         collectionMemberships = fillMissingMemberships(documentIds, found);
       } catch (error) {
         this.logger.error(

--- a/packages/reactor/test/executor/worker-pool-manager/unit.test.ts
+++ b/packages/reactor/test/executor/worker-pool-manager/unit.test.ts
@@ -4,7 +4,7 @@ import type {
   OperationWithContext,
 } from "@powerhousedao/shared/document-model";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ICollectionMembershipCache } from "../../../src/cache/collection-membership-cache.js";
+import type { ICollectionMembershipReader } from "../../../src/cache/collection-membership-cache.js";
 import { EventBus } from "../../../src/events/event-bus.js";
 import {
   ReactorEventTypes,
@@ -158,27 +158,23 @@ function makeWriteReady(
   return { operations: ops, jobMeta: job.meta };
 }
 
-function makeMembershipCache(
+function makeMembershipReader(
   initial: Record<string, string[]> = {},
-): ICollectionMembershipCache & {
-  invalidatedIds: string[];
+): ICollectionMembershipReader & {
   lookups: string[][];
 } {
-  const invalidatedIds: string[] = [];
   const lookups: string[][] = [];
   const data = new Map(Object.entries(initial));
   return {
-    invalidatedIds,
     lookups,
-    invalidate(documentId: string) {
-      invalidatedIds.push(documentId);
-      data.delete(documentId);
-    },
     getCollectionsForDocuments(documentIds: string[]) {
       lookups.push([...documentIds]);
       const out: Record<string, string[]> = {};
       for (const id of documentIds) {
-        out[id] = data.get(id) ?? [];
+        const collections = data.get(id);
+        if (collections !== undefined) {
+          out[id] = collections;
+        }
       }
       return Promise.resolve(out);
     },
@@ -201,14 +197,14 @@ describe("WorkerPoolJobExecutorManager", () => {
   let eventBus: EventBus;
   let queue: InMemoryQueue;
   let jobTracker: InMemoryJobTracker;
-  let cache: ReturnType<typeof makeMembershipCache>;
+  let membershipReader: ReturnType<typeof makeMembershipReader>;
   let createdWorkers: FakeWorker[];
 
   beforeEach(() => {
     eventBus = new EventBus();
     queue = new InMemoryQueue(eventBus, new NullDocumentModelResolver());
     jobTracker = new InMemoryJobTracker(eventBus);
-    cache = makeMembershipCache();
+    membershipReader = makeMembershipReader();
     createdWorkers = [];
   });
 
@@ -227,7 +223,7 @@ describe("WorkerPoolJobExecutorManager", () => {
       jobTracker,
       createMockLogger(),
       new NullDocumentModelResolver(),
-      cache,
+      membershipReader,
       jobTimeoutMs,
     );
   }
@@ -329,7 +325,9 @@ describe("WorkerPoolJobExecutorManager", () => {
 
   describe("success + writeReady", () => {
     it("emits JOB_WRITE_READY with collectionMemberships populated", async () => {
-      cache = makeMembershipCache({ "doc-1": ["coll-A", "coll-B"] });
+      membershipReader = makeMembershipReader({
+        "doc-1": ["coll-A", "coll-B"],
+      });
       const setNameOp = makeOpWithAction("doc-1", "SET_NAME", { name: "x" });
       const manager = buildManager(
         (i) =>
@@ -357,7 +355,7 @@ describe("WorkerPoolJobExecutorManager", () => {
       expect(event.collectionMemberships).toEqual({
         "doc-1": ["coll-A", "coll-B"],
       });
-      expect(cache.lookups).toEqual([["doc-1"]]);
+      expect(membershipReader.lookups).toEqual([["doc-1"]]);
       await manager.stop(true);
     });
 
@@ -387,51 +385,63 @@ describe("WorkerPoolJobExecutorManager", () => {
       await manager.stop(true);
     });
 
-    it("invalidates membership cache for ADD_RELATIONSHIP targetId", async () => {
-      cache = makeMembershipCache({
-        "doc-target": ["coll-old"],
-        "doc-parent": [],
-      });
-      const addRel = makeOpWithAction("doc-parent", "ADD_RELATIONSHIP", {
-        targetId: "doc-target",
-      });
+    it("queries memberships once per job, and not at all without operations", async () => {
+      membershipReader = makeMembershipReader({ "doc-1": ["coll-A"] });
+      const firstOp = makeOpWithAction("doc-1", "SET_NAME", { name: "x" });
+      const secondOp = makeOpWithAction("doc-1", "SET_NAME", { name: "y" });
       const manager = buildManager(
         (i) =>
           new FakeWorker({
             index: i,
             outcome: (job) => ({
               result: { job, success: true, duration: 1 },
-              writeReady: makeWriteReady(job, [addRel]),
+              writeReady:
+                job.id === "job-with-ops"
+                  ? makeWriteReady(job, [firstOp, secondOp])
+                  : makeWriteReady(job, []),
             }),
           }),
       );
       await manager.start(1);
 
-      const writeReadyPromise = new Promise<JobWriteReadyEvent>((resolve) => {
+      const seen = new Set<string>();
+      const bothEmitted = new Promise<void>((resolve) => {
         eventBus.subscribe(
           ReactorEventTypes.JOB_WRITE_READY,
-          (_t: number, data: JobWriteReadyEvent) => resolve(data),
+          (_t: number, data: JobWriteReadyEvent) => {
+            seen.add(data.jobId);
+            if (seen.has("job-with-ops") && seen.has("job-no-ops")) {
+              resolve();
+            }
+          },
         );
       });
 
       await queue.enqueue(
-        createTestJob({ id: "job-rel", documentId: "doc-parent" }),
+        createTestJob({ id: "job-with-ops", documentId: "doc-1" }),
       );
-      await writeReadyPromise;
-      expect(cache.invalidatedIds).toContain("doc-target");
+      await queue.enqueue(
+        createTestJob({ id: "job-no-ops", documentId: "doc-1" }),
+      );
+      await bothEmitted;
+
+      expect(membershipReader.lookups).toEqual([["doc-1"]]);
       await manager.stop(true);
     });
 
-    it("invalidates membership cache for DELETE_DOCUMENT", async () => {
-      cache = makeMembershipCache({ "doc-del": ["coll-old"] });
-      const delOp = makeOpWithAction("doc-del", "DELETE_DOCUMENT", {});
+    it("fills documents the reader omits with an empty collection list", async () => {
+      membershipReader = makeMembershipReader({ "doc-known": ["coll-A"] });
+      const knownOp = makeOpWithAction("doc-known", "SET_NAME", { name: "x" });
+      const unknownOp = makeOpWithAction("doc-unknown", "SET_NAME", {
+        name: "y",
+      });
       const manager = buildManager(
         (i) =>
           new FakeWorker({
             index: i,
             outcome: (job) => ({
               result: { job, success: true, duration: 1 },
-              writeReady: makeWriteReady(job, [delOp]),
+              writeReady: makeWriteReady(job, [knownOp, unknownOp]),
             }),
           }),
       );
@@ -445,10 +455,13 @@ describe("WorkerPoolJobExecutorManager", () => {
       });
 
       await queue.enqueue(
-        createTestJob({ id: "job-del", documentId: "doc-del" }),
+        createTestJob({ id: "job-fill", documentId: "doc-known" }),
       );
-      await writeReadyPromise;
-      expect(cache.invalidatedIds).toContain("doc-del");
+      const event = await writeReadyPromise;
+      expect(event.collectionMemberships).toEqual({
+        "doc-known": ["coll-A"],
+        "doc-unknown": [],
+      });
       await manager.stop(true);
     });
 

--- a/packages/reactor/test/executor/worker-pool-manager/unit.test.ts
+++ b/packages/reactor/test/executor/worker-pool-manager/unit.test.ts
@@ -3,6 +3,7 @@ import type {
   OperationContext,
   OperationWithContext,
 } from "@powerhousedao/shared/document-model";
+import type { ILogger } from "document-model";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ICollectionMembershipReader } from "../../../src/cache/collection-membership-cache.js";
 import { EventBus } from "../../../src/events/event-bus.js";
@@ -211,6 +212,7 @@ describe("WorkerPoolJobExecutorManager", () => {
   function buildManager(
     factory: (index: number) => FakeWorker,
     jobTimeoutMs = 30_000,
+    logger: ILogger = createMockLogger(),
   ): WorkerPoolJobExecutorManager {
     return new WorkerPoolJobExecutorManager(
       (i: number) => {
@@ -221,7 +223,7 @@ describe("WorkerPoolJobExecutorManager", () => {
       eventBus,
       queue,
       jobTracker,
-      createMockLogger(),
+      logger,
       new NullDocumentModelResolver(),
       membershipReader,
       jobTimeoutMs,
@@ -462,6 +464,52 @@ describe("WorkerPoolJobExecutorManager", () => {
         "doc-known": ["coll-A"],
         "doc-unknown": [],
       });
+      await manager.stop(true);
+    });
+
+    it("still emits JOB_WRITE_READY when the membership read fails", async () => {
+      const readError = new Error("index unavailable");
+      membershipReader = {
+        lookups: [],
+        getCollectionsForDocuments: () => Promise.reject(readError),
+      };
+      const logger = createMockLogger();
+      const errorSpy = vi.spyOn(logger, "error");
+      const op = makeOpWithAction("doc-1", "SET_NAME", { name: "x" });
+      const manager = buildManager(
+        (i) =>
+          new FakeWorker({
+            index: i,
+            outcome: (job) => ({
+              result: { job, success: true, duration: 1 },
+              writeReady: makeWriteReady(job, [op]),
+            }),
+          }),
+        30_000,
+        logger,
+      );
+      await manager.start(1);
+
+      const writeReadyPromise = new Promise<JobWriteReadyEvent>((resolve) => {
+        eventBus.subscribe(
+          ReactorEventTypes.JOB_WRITE_READY,
+          (_t: number, data: JobWriteReadyEvent) => resolve(data),
+        );
+      });
+
+      await queue.enqueue(
+        createTestJob({ id: "job-read-fails", documentId: "doc-1" }),
+      );
+      const event = await writeReadyPromise;
+
+      // An empty map makes the sync filter drop every operation in this job,
+      // so this pins a deliberate choice, not an incidental one.
+      expect(event.collectionMemberships).toEqual({});
+      expect(event.operations).toHaveLength(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to load collection memberships"),
+        readError,
+      );
       await manager.stop(true);
     });
 

--- a/packages/reactor/test/executor/worker-pool-manager/unit.test.ts
+++ b/packages/reactor/test/executor/worker-pool-manager/unit.test.ts
@@ -5,7 +5,7 @@ import type {
 } from "@powerhousedao/shared/document-model";
 import type { ILogger } from "document-model";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ICollectionMembershipReader } from "../../../src/cache/collection-membership-cache.js";
+import type { IOperationIndex } from "../../../src/cache/operation-index-types.js";
 import { EventBus } from "../../../src/events/event-bus.js";
 import {
   ReactorEventTypes,
@@ -159,11 +159,16 @@ function makeWriteReady(
   return { operations: ops, jobMeta: job.meta };
 }
 
-function makeMembershipReader(
+type FakeOperationIndex = IOperationIndex & { lookups: string[][] };
+
+/**
+ * The manager only ever calls `getCollectionsForDocuments`, so the rest of
+ * the index is left off. Absent documents are omitted rather than defaulted
+ * to `[]`, matching what the real index returns.
+ */
+function makeOperationIndex(
   initial: Record<string, string[]> = {},
-): ICollectionMembershipReader & {
-  lookups: string[][];
-} {
+): FakeOperationIndex {
   const lookups: string[][] = [];
   const data = new Map(Object.entries(initial));
   return {
@@ -179,7 +184,7 @@ function makeMembershipReader(
       }
       return Promise.resolve(out);
     },
-  };
+  } as unknown as FakeOperationIndex;
 }
 
 function findJobForBucket(bucket: number, numWorkers: number): string {
@@ -198,14 +203,14 @@ describe("WorkerPoolJobExecutorManager", () => {
   let eventBus: EventBus;
   let queue: InMemoryQueue;
   let jobTracker: InMemoryJobTracker;
-  let membershipReader: ReturnType<typeof makeMembershipReader>;
+  let operationIndex: FakeOperationIndex;
   let createdWorkers: FakeWorker[];
 
   beforeEach(() => {
     eventBus = new EventBus();
     queue = new InMemoryQueue(eventBus, new NullDocumentModelResolver());
     jobTracker = new InMemoryJobTracker(eventBus);
-    membershipReader = makeMembershipReader();
+    operationIndex = makeOperationIndex();
     createdWorkers = [];
   });
 
@@ -225,7 +230,7 @@ describe("WorkerPoolJobExecutorManager", () => {
       jobTracker,
       logger,
       new NullDocumentModelResolver(),
-      membershipReader,
+      operationIndex,
       jobTimeoutMs,
     );
   }
@@ -327,7 +332,7 @@ describe("WorkerPoolJobExecutorManager", () => {
 
   describe("success + writeReady", () => {
     it("emits JOB_WRITE_READY with collectionMemberships populated", async () => {
-      membershipReader = makeMembershipReader({
+      operationIndex = makeOperationIndex({
         "doc-1": ["coll-A", "coll-B"],
       });
       const setNameOp = makeOpWithAction("doc-1", "SET_NAME", { name: "x" });
@@ -357,7 +362,7 @@ describe("WorkerPoolJobExecutorManager", () => {
       expect(event.collectionMemberships).toEqual({
         "doc-1": ["coll-A", "coll-B"],
       });
-      expect(membershipReader.lookups).toEqual([["doc-1"]]);
+      expect(operationIndex.lookups).toEqual([["doc-1"]]);
       await manager.stop(true);
     });
 
@@ -388,7 +393,7 @@ describe("WorkerPoolJobExecutorManager", () => {
     });
 
     it("queries memberships once per job, and not at all without operations", async () => {
-      membershipReader = makeMembershipReader({ "doc-1": ["coll-A"] });
+      operationIndex = makeOperationIndex({ "doc-1": ["coll-A"] });
       const firstOp = makeOpWithAction("doc-1", "SET_NAME", { name: "x" });
       const secondOp = makeOpWithAction("doc-1", "SET_NAME", { name: "y" });
       const manager = buildManager(
@@ -427,12 +432,12 @@ describe("WorkerPoolJobExecutorManager", () => {
       );
       await bothEmitted;
 
-      expect(membershipReader.lookups).toEqual([["doc-1"]]);
+      expect(operationIndex.lookups).toEqual([["doc-1"]]);
       await manager.stop(true);
     });
 
-    it("fills documents the reader omits with an empty collection list", async () => {
-      membershipReader = makeMembershipReader({ "doc-known": ["coll-A"] });
+    it("fills documents the index omits with an empty collection list", async () => {
+      operationIndex = makeOperationIndex({ "doc-known": ["coll-A"] });
       const knownOp = makeOpWithAction("doc-known", "SET_NAME", { name: "x" });
       const unknownOp = makeOpWithAction("doc-unknown", "SET_NAME", {
         name: "y",
@@ -469,10 +474,10 @@ describe("WorkerPoolJobExecutorManager", () => {
 
     it("still emits JOB_WRITE_READY when the membership read fails", async () => {
       const readError = new Error("index unavailable");
-      membershipReader = {
+      operationIndex = {
         lookups: [],
         getCollectionsForDocuments: () => Promise.reject(readError),
-      };
+      } as unknown as FakeOperationIndex;
       const logger = createMockLogger();
       const errorSpy = vi.spyOn(logger, "error");
       const op = makeOpWithAction("doc-1", "SET_NAME", { name: "x" });

--- a/packages/reactor/test/integration/worker-pool/integration.test.ts
+++ b/packages/reactor/test/integration/worker-pool/integration.test.ts
@@ -4,6 +4,7 @@ import type {
   OperationWithContext,
 } from "@powerhousedao/shared/document-model";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OperationIndexEntry } from "../../../src/cache/operation-index-types.js";
 import { ReactorBuilder } from "../../../src/core/reactor-builder.js";
 import type { DocumentModelSource } from "../../../src/core/reactor-builder.js";
 import { fileURLToPath } from "node:url";
@@ -163,6 +164,29 @@ function makeOpWithAction(
   };
 }
 
+function makeIndexEntry(documentId: string): OperationIndexEntry {
+  const action: Action = {
+    id: `action-index-${documentId}`,
+    type: "SET_NAME",
+    scope: "global",
+    timestampUtcMs: "2024-01-01T00:00:00.000Z",
+    input: {},
+  } as Action;
+  return {
+    id: `op-index-${documentId}`,
+    index: 0,
+    timestampUtcMs: action.timestampUtcMs,
+    hash: "h",
+    skip: 0,
+    action,
+    documentId,
+    documentType: "test/type",
+    branch: "main",
+    scope: "global",
+    sourceRemote: "",
+  };
+}
+
 describe("Worker pool integration through ReactorBuilder", () => {
   let modules: InProcessReactorModule[] = [];
 
@@ -253,6 +277,56 @@ describe("Worker pool integration through ReactorBuilder", () => {
     expect(event.operations).toHaveLength(1);
     expect(event.collectionMemberships).toBeDefined();
     expect(event.collectionMemberships!["doc-mem"]).toEqual([]);
+  });
+
+  it("reads memberships the worker's commit created, not a cached answer", async () => {
+    const op = makeOpWithAction("doc-cascade", "SET_NAME");
+    const factory: WorkerFactory = (index) =>
+      new FakeWorker({
+        index,
+        executeImpl: (job) =>
+          Promise.resolve({
+            result: { job, success: true, duration: 1 },
+            writeReady: {
+              operations: [op],
+              jobMeta: job.meta,
+            } as JobWriteReadyPayload,
+          }),
+      });
+    const module = await buildReactor(1, factory);
+
+    const writeReadyFor = (jobId: string): Promise<JobWriteReadyEvent> =>
+      new Promise<JobWriteReadyEvent>((resolve) => {
+        module.eventBus.subscribe(
+          ReactorEventTypes.JOB_WRITE_READY,
+          (_t: number, data: JobWriteReadyEvent) => {
+            if (data.jobId === jobId) {
+              resolve(data);
+            }
+          },
+        );
+      });
+
+    const first = writeReadyFor("job-before-cascade");
+    await module.queue.enqueue(
+      makeJob({ id: "job-before-cascade", documentId: "doc-cascade" }),
+    );
+    const beforeEvent = await first;
+    expect(beforeEvent.collectionMemberships!["doc-cascade"]).toEqual([]);
+
+    const txn = module.operationIndex.start();
+    txn.write([makeIndexEntry("doc-cascade")]);
+    txn.addToCollection("coll-cascade", "doc-cascade");
+    await module.operationIndex.commit(txn);
+
+    const second = writeReadyFor("job-after-cascade");
+    await module.queue.enqueue(
+      makeJob({ id: "job-after-cascade", documentId: "doc-cascade" }),
+    );
+    const afterEvent = await second;
+    expect(afterEvent.collectionMemberships!["doc-cascade"]).toContain(
+      "coll-cascade",
+    );
   });
 
   it("reports numExecutors === numWorkers on the manager", async () => {


### PR DESCRIPTION
## The defect

In worker-pool mode the host keeps its own `CollectionMembershipCache` and decides what to invalidate by **inferring from action shape** (`MEMBERSHIP_INVALIDATING_ACTIONS`). That inference is wrong in both directions.

**Under-invalidates.** Three membership writes are never inferred:

- drive-container document creation
- joining a collection also joins every group the joining document has ever referenced
- `recordGroupReferences` joins named groups into the referencing document's collections

The latter two are **structurally uninferable**: the group set comes from `SELECT`s executed *inside* the commit, so no caller can predict it.

**Over-invalidates.** `UPDATE_RELATIONSHIP` (null post-write hook) and `DELETE_DOCUMENT` never write a `document_collections` row at all.

**Consequence.** A host cache entry for a group document goes stale permanently. A later job on that group emits `JobWriteReadyEvent.collectionMemberships` omitting a collection the group genuinely belongs to, and `filterByCollectionMembership` silently drops that document's operations from the outbox for every remote subscribed to that collection. Permissions diverge across reactors with no error and no retry.

The in-process equivalent is already fixed (`f5786b3a4`): the operation index reports what it mutated via `IOperationIndexTxn.getMembershipInvalidations()`. That mechanism is unreachable from the host, because the host and each worker hold separate cache instances.

## The fix

Delete the inference. Give the pool manager the operation index and have it read memberships directly, after the worker's commit.

- **The cache bought nothing on the host.** It had exactly one reader, `emitWriteReady`, invoked fire-and-forget. The replacement is a PK-prefix scan on `document_collections`, off the critical path.
- **Visibility is guaranteed.** The worker commits its index transaction before posting its `ResultMessage`, so a host query on receipt always sees the rows that job wrote, cascades included.
- **Correct by construction** for all three under-invalidated cases and any future write site, because no caller needs to know they exist.

### Changes

- `worker-pool-job-executor-manager.ts` — deleted `MEMBERSHIP_INVALIDATING_ACTIONS`, `invalidateMembershipsFor`, `extractMembershipTarget`, and the now-dead `OperationWithContext` import.
- **The constructor takes `IOperationIndex`, not a narrower read interface.** A one-method reader would be satisfied structurally by `CollectionMembershipCache` too, so rewiring the builder back to the cache would still compile and would silently restore the exact bug this removes. `CollectionMembershipCache` does not implement the rest of `IOperationIndex`, so that mistake is now a compile error. Verified by mutation: pointing `reactor-builder.ts:574` back at the cache fails with `TS2345: Argument of type 'CollectionMembershipCache' is not assignable to parameter of type 'IOperationIndex'`.
- **Shape normalization.** The two implementations disagree on absent documents: the cache filled every requested id defaulting to `[]`; the index creates a key only for documents that have rows. Filtering behaviour is identical, but the emitted event shape would change, so the manager fills absent ids with `[]`. It also skips the query entirely for a job with no operations.
- `reactor-builder.ts:574` — passes `operationIndex` instead of `collectionMembershipCache`. The `CollectionMembershipCache` construction and its use in `KyselyExecutionScope` are untouched: that instance still serves the in-process executor.
- **`collection-membership-cache.ts` is unchanged.** Because the manager depends on the whole index, no read-only supertype is needed.
- **In-process path: no edits.** This removes only the host-side inference that pool mode used as a substitute.

The class doc comment states why the manager takes the whole index rather than a narrower read interface.

## Tests

**New regression test** (`test/integration/worker-pool/integration.test.ts`) drives a `SET_NAME` job to deterministically populate the host with `doc-cascade -> []`, writes the membership out of band through `module.operationIndex`, then asserts the next job's event carries `coll-cascade`. `SET_NAME` is deliberately absent from the old invalidating set, so the inference provably cannot produce a pass. No timers.

**New failure-path test** (`test/executor/worker-pool-manager/unit.test.ts`) pins what a failed membership read emits: the event still emits, `collectionMemberships` is `{}`, and the failure is logged rather than thrown. See Risks — this path is newly reachable, and the test makes any future change to fail-the-emission a deliberate one rather than a silent one. `buildManager` gained an optional logger parameter so the test can assert the log.

**Unit tests** — the fake became `makeOperationIndex` and now *omits* absent keys, exercising the normalization rather than hiding it. Deleted the two tests asserting the removed inference; editing them to pass would make them meaningless. Added one pinning exactly one lookup per job with operations and zero without, so the per-job query cost cannot silently become N, plus one on the fill shape.

## Verification

`pnpm tsc --build` clean. `pnpm test` exit 0, 2760/2760 across 168 files. `pnpm lint` 0 errors, no warnings in touched files.

**Mutation-checked, twice:**

- Rewiring `reactor-builder.ts` back to the cache no longer typechecks (`TS2345`). Before the constructor was narrowed to `IOperationIndex`, the same rewiring compiled and turned the integration test red with `expected [] to include 'coll-cascade'` — the exact stale-cache failure mode.
- Returning early from the membership-read `catch` instead of emitting turns the new failure-path test red.

## Risks

- **A query on every job that produced operations,** where the cache previously amortized it to near-zero. One PK-prefix-indexed lookup on a fire-and-forget path; the lookup-count test pins it, and the query shape is documented in the class comment so any future move of `emitWriteReady` onto the critical path is a considered one.
- **Read failure yields `{}`**, and `filterByCollectionMembership` then returns `[]`. This is the pre-existing behaviour of the existing `catch` and is unchanged, but its *reachability* is not: a warm cache meant no query and therefore no error window, whereas now a transient database error drops that job's operations from every remote's outbox, logged but with no retry. That is the same silent divergence this PR exists to remove, arriving through a different door. The new failure-path test pins the current semantics; changing them to fail the emission is a separate decision.
- **No field is added** to any event or wire type, so no silent-drop risk from field-by-field re-projections across the worker boundary.

## Out of scope

The in-process path builds `pendingEvent.collectionMemberships` inside the execution scope via the scoped cache, while `postCommitMembershipInvalidations` are applied only after the scope closes. A document that both carries operations in a job and has its membership changed by that same job's commit could be served stale in that job's own event. Reachability is narrow: jobs are per-document, and the documents whose membership changes are usually not the ones carrying operations. This change makes pool mode structurally immune to that variant while the in-process path retains it; that asymmetry is a separate follow-up.

Relatedly, the worker's `SimpleJobExecutor` already computes `collectionMemberships` and `WorkerWriteReadyCapture` discards them. Shipping that value across the boundary instead of re-reading on the host would inherit exactly the scoped-cache staleness described above, so the host re-read is the more correct choice, not redundant work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
